### PR TITLE
EOS-13487: Remove warnings related to MODULE_LICENSE() (#394)

### DIFF
--- a/motr/linux_kernel/m0tr_main.c
+++ b/motr/linux_kernel/m0tr_main.c
@@ -59,6 +59,14 @@ module_init(motr_init);
 module_exit(motr_exit);
 
 /*
+ * We are using Apache license for complete motr code but for MODULE_LICENSE
+ * marker there is no provision to mention Apache for this marker. But as this
+ * marker is necessary to remove the warnings, keeping this blank to make
+ * compiler happy.
+ */
+MODULE_LICENSE();
+
+/*
  *  Local variables:
  *  c-indentation-style: "K&R"
  *  c-basic-offset: 8

--- a/motr/st/linux_kernel/st_kmain.c
+++ b/motr/st/linux_kernel/st_kmain.c
@@ -31,6 +31,14 @@
 #include "motr/st/st.h"
 #include "motr/st/st_assert.h"
 
+/*
+ * We are using Apache license for complete motr code but for MODULE_LICENSE
+ * marker there is no provision to mention Apache for this marker. But as this
+ * marker is necessary to remove the warnings, keeping this blank to make
+ * compiler happy.
+ */
+MODULE_LICENSE();
+
 enum idx_service {
 	IDX_MOTR = 1,
 	IDX_CASS,

--- a/net/lnet/st/linux_kernel/m0lnetping_main.c
+++ b/net/lnet/st/linux_kernel/m0lnetping_main.c
@@ -342,6 +342,14 @@ static void __exit m0_netst_fini_k(void)
 module_init(m0_netst_init_k)
 module_exit(m0_netst_fini_k)
 
+/*
+ * We are using Apache license for complete motr code but for MODULE_LICENSE
+ * marker there is no provision to mention Apache for this marker. But as this
+ * marker is necessary to remove the warnings, keeping this blank to make
+ * compiler happy.
+ */
+MODULE_LICENSE();
+
 /** @} */ /* LNetDFS */
 
 /*

--- a/net/test/linux_kernel/node_k.c
+++ b/net/test/linux_kernel/node_k.c
@@ -26,6 +26,14 @@
 
 #include "net/test/node.h"
 
+/*
+ * We are using Apache license for complete motr code but for MODULE_LICENSE
+ * marker there is no provision to mention Apache for this marker. But as this
+ * marker is necessary to remove the warnings, keeping this blank to make
+ * compiler happy.
+ */
+MODULE_LICENSE();
+
 static char	    *addr = NULL;
 static char	    *addr_console = NULL;
 static unsigned long timeout = 3;

--- a/rpc/it/linux_kernel/m0rpcping_main.c
+++ b/rpc/it/linux_kernel/m0rpcping_main.c
@@ -38,6 +38,14 @@ M0_INTERNAL void cleanup_module(void)
 }
 
 /*
+ * We are using Apache license for complete motr code but for MODULE_LICENSE
+ * marker there is no provision to mention Apache for this marker. But as this
+ * marker is necessary to remove the warnings, keeping this blank to make
+ * compiler happy.
+ */
+MODULE_LICENSE();
+
+/*
  *  Local variables:
  *  c-indentation-style: "K&R"
  *  c-basic-offset: 8

--- a/ut/linux_kernel/m0ut_main.c
+++ b/ut/linux_kernel/m0ut_main.c
@@ -28,6 +28,14 @@
 #include "module/instance.h"  /* m0 */
 #include "ut/module.h"        /* m0_ut_module */
 
+/*
+ * We are using Apache license for complete motr code but for MODULE_LICENSE
+ * marker there is no provision to mention Apache for this marker. But as this
+ * marker is necessary to remove the warnings, keeping this blank to make
+ * compiler happy.
+ */
+MODULE_LICENSE();
+
 static char *tests;
 module_param(tests, charp, S_IRUGO);
 MODULE_PARM_DESC(tests, " list of tests to run in format"


### PR DESCRIPTION
Added blank MODULE_LICENCE("")
As for Apache there is no option available for kernel modules
and without it compiler is showing warnings.

Signed-off-by:Suvrat Joshi <suvrat.joshi@seagate.com>