### PR TITLE
EOS-13258: m0addb2dump: fixed an iterator initialization error

### DIFF
--- a/addb2/sit.c
+++ b/addb2/sit.c
@@ -205,7 +205,7 @@ static int it_init(struct m0_addb2_sit *it,
 	if (start != 0) {
 		result = header_read(it, h, start);
 	} else {
-		/* Search for the last frame on the stob. */
+		/* Search forward for the last frame on the stob. */
 		while (1) {
 			result = header_read(it, &header, h->he_offset + h->he_size);
 			if (result != 0 || header.he_seqno != h->he_seqno + 1)
@@ -214,6 +214,7 @@ static int it_init(struct m0_addb2_sit *it,
 		}
 
 		last_frame_end = h->he_offset + h->he_size;
+		/* Search backward */
 		while (1) {
 			result = header_read(it, &header, h->he_prev_offset);
 			if (result != 0 || header.he_seqno != h->he_seqno - 1)

--- a/addb2/sit.c
+++ b/addb2/sit.c
@@ -198,17 +198,30 @@ M0_INTERNAL int m0_addb2_storage_header(struct m0_stob *stob,
 static int it_init(struct m0_addb2_sit *it,
 		   struct m0_addb2_frame_header *h, m0_bindex_t start)
 {
-	struct m0_addb2_frame_header prev;
+	struct m0_addb2_frame_header header;
+	uint64_t                     last_frame_end;
 	int                          result;
 
 	if (start != 0) {
 		result = header_read(it, h, start);
 	} else {
+		/* Search for the last frame on the stob. */
 		while (1) {
-			result = header_read(it, &prev, h->he_prev_offset);
-			if (result != 0 || prev.he_seqno != h->he_seqno - 1)
+			result = header_read(it, &header, h->he_offset + h->he_size);
+			if (result != 0 || header.he_seqno != h->he_seqno + 1)
 				break;
-			*h = prev;
+			*h = header;
+		}
+
+		last_frame_end = h->he_offset + h->he_size;
+		while (1) {
+			result = header_read(it, &header, h->he_prev_offset);
+			if (result != 0 || header.he_seqno != h->he_seqno - 1)
+				break;
+			*h = header;
+			if (header.he_offset >= last_frame_end &&
+				header.he_prev_offset < last_frame_end)
+				break; /* Found the oldest frame. */
 		}
 	}
 	if (result == 0) {


### PR DESCRIPTION
Fixed an error "m0addb2dump: Cannot initialise iterator: -71: No such file
or directory" during the parsing of rotated ADDB stob file.

There are two reasons of this error:
- incorrect detection that ADDB stob is rotated
- sometimes ADDB stob header is not correct. It is a copy of the header
  of the non-last frame while there are newer frames located at the stob.

This patch has improvements of detection that ADDB stob is rotated
and detection of last frame on the stob.