### PR TITLE
EOS-12868: RPC message bulk boundary

### DIFF
--- a/cas/client.c
+++ b/cas/client.c
@@ -805,6 +805,7 @@ static int nreq_asmbl_prep(struct m0_cas_req *req, struct m0_cas_op *op)
 
 	M0_PRE(op->cg_rec.cr_nr == orig->cg_rec.cr_nr);
 	op->cg_id = orig->cg_id;
+	op->cg_flags = orig->cg_flags;
 	for (i = 0; i < orig->cg_rec.cr_nr; i++) {
 		rec = &op->cg_rec.cr_rec[i];
 		M0_ASSERT(M0_IS0(rec));

--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -182,6 +182,7 @@ static int cas_client_init(struct cl_ctx *cctx, const char *cl_ep_addr,
 	cl_rpc_ctx->rcx_fid                = &g_process_fid;
 
 	m0_fi_enable_once("m0_rpc_machine_init", "bulk_cutoff_4K");
+	m0_fi_enable_once("m0_rpc_machine_init", "bulk_boundary_16K");
 	rc = m0_rpc_client_start(cl_rpc_ctx);
 	M0_UT_ASSERT(rc == 0);
 
@@ -205,6 +206,7 @@ static void casc_ut_init(struct m0_rpc_server_ctx *sctx,
 
 	M0_SET0(&sctx->rsx_motr_ctx);
 	m0_fi_enable_once("m0_rpc_machine_init", "bulk_cutoff_4K");
+	m0_fi_enable_once("m0_rpc_machine_init", "bulk_boundary_16K");
 	rc = m0_rpc_server_start(sctx);
 	M0_UT_ASSERT(rc == 0);
 	rc = cas_client_init(cctx, cl_ep_addrs[0],

--- a/rpc/item.c
+++ b/rpc/item.c
@@ -473,6 +473,18 @@ m0_bcount_t m0_rpc_item_payload_size(struct m0_rpc_item *item)
 }
 
 M0_INTERNAL
+bool m0_rpc_item_bulk_boundary_reached(struct m0_rpc_item    *item,
+				       struct m0_rpc_machine *mach,
+				       m0_bcount_t            size)
+{
+	M0_PRE(item != NULL);
+	M0_PRE(mach != NULL);
+
+	return (m0_rpc_item_payload_size(item) + size > 
+		mach->rm_bulk_boundary);
+}
+
+M0_INTERNAL
 bool m0_rpc_item_max_payload_exceeded(struct m0_rpc_item    *item,
 				      struct m0_rpc_session *session)
 {

--- a/rpc/item.h
+++ b/rpc/item.h
@@ -318,6 +318,12 @@ M0_INTERNAL
 bool m0_rpc_item_max_payload_exceeded(struct m0_rpc_item    *item,
 				      struct m0_rpc_session *session);
 
+/* Checks whether item payload exceeds bulk boundary of RPC message */
+M0_INTERNAL
+bool m0_rpc_item_bulk_boundary_reached(struct m0_rpc_item    *item,
+				       struct m0_rpc_machine *mach,
+				       m0_bcount_t            size);
+
 /**
    Waits until item reaches in one of states specified in
    _states_ or absolute timeout specified by _timeout_ is

--- a/rpc/rpc_machine.c
+++ b/rpc/rpc_machine.c
@@ -153,6 +153,9 @@ M0_INTERNAL int m0_rpc_machine_init(struct m0_rpc_machine *machine,
 	/* Bulk transmission requires data to be page aligned. */
 	machine->rm_bulk_cutoff = M0_FI_ENABLED("bulk_cutoff_4K") ? 4096 :
 				  m0_align(max_msg_size / 2, m0_pagesize_get());
+	machine->rm_bulk_boundary = M0_FI_ENABLED("bulk_boundary_16K") ? 16384 :
+		m0_align(max_msg_size / 2, m0_pagesize_get());
+
 	machine->rm_stopping = false;
 	rc = M0_THREAD_INIT(&machine->rm_worker, struct m0_rpc_machine *,
 			    NULL, &rpc_worker_thread_fn, machine, "m0_rpc_worker");

--- a/rpc/rpc_machine.h
+++ b/rpc/rpc_machine.h
@@ -150,11 +150,20 @@ struct m0_rpc_machine {
 	struct m0_mutex_addb2             rm_lock_stats;
 
 	/**
-	 * RPC bulk cut-off value. If AT buffer size equals or bigger than
-	 * cut-off value, then it's transmitted via RPC bulk mechanism.
+	 * RPC bulk cut-off value. If size of individual AT buffer
+	 * equals or bigger than cut-off value, then it's transmitted
+	 * via RPC bulk mechanism.
 	 * @see m0_rpc_at_buf
 	 */
 	m0_bcount_t                       rm_bulk_cutoff;
+
+	/**
+	 * RPC message bulk boundary. If accumulated payload size of
+	 * RPC item equals or bigger than bulk boundary value, then
+	 * all sequential AT buffers are transmitted via RPC bulk mechanism.
+	 * @see m0_rpc_at_buf
+	 */
+	m0_bcount_t                       rm_bulk_boundary;
 };
 
 /**


### PR DESCRIPTION
Switch adaptive buffer transfer mechanism from inline to bulk
when RPC item size exceeds bulk boundary threshold. Bulk boundary
is set to the half of RPC message size.