### PR TITLE
EOS-13526 beck.c: filter bnodes based on generation identifier in beck tool

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -93,6 +93,8 @@ struct scanner {
 	 * exceed this value.
 	 */
 	m0_bcount_t	     s_max_reg_size;
+	/* Holds source metadata segment header generation identifier .*/
+	uint64_t	     s_gen;
 };
 
 struct stats {
@@ -268,6 +270,7 @@ static void *scanner_action(size_t len, enum action_opcode opc,
 			    const struct action_ops *ops);
 
 static void genadd(uint64_t gen);
+static void generation_print(uint64_t gen);
 
 static int  scanner_init   (struct scanner *s);
 static int  builder_init   (struct builder *b);
@@ -416,6 +419,7 @@ struct ctg_action {
 static struct scanner s;
 static struct builder b;
 static struct gen g[MAX_GEN] = {};
+static uint16_t gen_count = 0;
 
 static bool  dry_run = false;
 
@@ -534,12 +538,26 @@ int main(int argc, char **argv)
 
 static char iobuf[4*1024*1024];
 
-enum { DELTA = 10 };
+enum { DELTA = 60 };
+
+static void generation_print(uint64_t gen)
+{
+	time_t    ts = m0_time_seconds(gen);
+	struct tm tm;
+
+	localtime_r(&ts, &tm);
+	printf("%04d-%02d-%02d-%02d:%02d:%02d.%09lu",
+	       tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+	       tm.tm_hour, tm.tm_min, tm.tm_sec,
+	       m0_time_nanoseconds(gen));
+}
 
 static int scanner_init(struct scanner *s)
 {
 	int rc;
 
+	/** Initialising segment header generation identifier explicitly. */
+	s->s_seg = 0;
 	rc = getat(s, 0, s->s_chunk, sizeof s->s_chunk);
 	if (rc != 0)
 		M0_LOG(M0_FATAL, "Can not read first chunk");
@@ -564,8 +582,8 @@ static int scan(struct scanner *s)
 		if (!s->s_byte)
 			s->s_off &= ~0x7;
 		if (time(NULL) - lasttime > DELTA) {
-			printf("Offset: %15lli     Speed: %7.2f MB/s     "
-			       "Completion: %3i%%\n",
+			printf("\nOffset: %15lli     Speed: %7.2f MB/s     "
+			       "Completion: %3i%%",
 			       (long long)s->s_off,
 			       ((double)s->s_off - lastoff) /
 			       DELTA / 1024.0 / 1024.0,
@@ -574,7 +592,7 @@ static int scan(struct scanner *s)
 			lastoff  = s->s_off;
 		}
 	}
-	printf("%25s : %9s %9s %9s %9s\n",
+	printf("\n%25s : %9s %9s %9s %9s\n",
 	       "record", "found", "bad csum", "unaligned", "version");
 	for (i = 0; i < ARRAY_SIZE(rt); ++i) {
 		struct stats *s = &rt[i].r_stats;
@@ -606,19 +624,11 @@ static int scan(struct scanner *s)
 	}
 	if (dry_run)
 		printf("\n*bad kv count is not availabe in dry run mode\n");
-	printf("\ngenerations\n");
-	for (i = 0; i < ARRAY_SIZE(g); ++i) {
-		if (g[i].g_count > 0) {
-			time_t    ts = m0_time_seconds(g[i].g_gen);
-			struct tm tm;
 
-			localtime_r(&ts, &tm);
-			printf("%04d-%02d-%02d-%02d:%02d:%02d.%09lu : "
-			       "%9"PRId64"\n",
-			       tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-			       tm.tm_hour, tm.tm_min, tm.tm_sec,
-			       m0_time_nanoseconds(g[i].g_gen), g[i].g_count);
-		}
+	printf("\ngenerations\n");
+	for (i = 0; i < gen_count; ++i) {
+		generation_print(g[i].g_gen);
+		printf(" : %9"PRId64"\n", g[i].g_count);
 	}
 	return feof(s->s_file) ? 0 : result;
 }
@@ -859,6 +869,9 @@ static int bnode(struct scanner *s, struct rectype *r, char *buf)
 
 	if (!IS_IN_ARRAY(idx, bt) || bt[idx].b_type == 0)
 		idx = ARRAY_SIZE(bt) - 1;
+	genadd(node->bt_backlink.bli_gen);
+	if (s->s_gen != 0 && s->s_gen != node->bt_backlink.bli_gen)
+		return 0;
 	b = &bt[idx];
 	c = &b->b_stats;
 	c->c_node++;
@@ -870,7 +883,6 @@ static int bnode(struct scanner *s, struct rectype *r, char *buf)
 	} else
 		c->c_fanout += node->bt_num_active_key + 1;
 	c->c_maxlevel = max64(c->c_maxlevel, node->bt_level);
-	genadd(node->bt_backlink.bli_gen);
 	return 0;
 }
 
@@ -1084,6 +1096,12 @@ static void *action_alloc(size_t len, enum action_opcode opc,
 
 static int seghdr(struct scanner *s, struct rectype *r, char *buf)
 {
+	struct m0_be_seg_hdr *h   = (void *)buf;
+
+	s->s_gen = h->bh_gen;
+	printf("\nSource segment header generation\n");
+	generation_print(s->s_gen);
+
 	return 0;
 }
 
@@ -1107,12 +1125,18 @@ static int seghdr_ver(struct scanner *s, struct rectype *r, char *buf)
 static void genadd(uint64_t gen)
 {
 	int i;
+	if (gen_count >= ARRAY_SIZE(g))
+		return;
 
-	for (i = 0; i < ARRAY_SIZE(g); ++i) {
-		if (g[i].g_gen == gen || g[i].g_count == 0) {
+	for (i = 0; i < gen_count; ++i) {
+		if (g[i].g_gen == gen) {
 			g[i].g_count++;
 			break;
 		}
+	}
+	if (i == gen_count) {
+		g[gen_count].g_gen = gen;
+		g[gen_count++].g_count = 1;
 	}
 }
 
@@ -1294,6 +1318,9 @@ static int builder_init(struct builder *b)
 		m0_be_ut_backend_seg_add2(ub, b->b_size, true, NULL, &b->b_seg);
 		M0_ASSERT(b->b_seg != NULL);
 	}
+	printf("\nDestination segment header generation\n");
+	generation_print(b->b_seg->bs_gen);
+
 	result = m0_reqh_be_init(&b->b_reqh, b->b_seg);
 	if (result != 0)
 		return M0_ERR(result);


### PR DESCRIPTION
Following cases are covered:

1) If source segment header generation identifier is zero then process all the
bnodes.
2) If source segment header generation identifer is non-zero then process only
the bnodes with matching generation identifier.

Signed-off-by: Nikhil Kumar Birgade <nikhil.birgade@seagate.com>