### PR TITLE
EOS-13463: fix m0d crash for ctg delete operation after motr re…

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -1712,7 +1712,12 @@ static void ctg_act(struct action *act, struct m0_be_tx *tx)
 							  tx, &op, &ca->cta_key,
 							  &ca->cta_val),
 				       bo_u.u_btree.t_rc);
-		if (rc != 0)
+
+		if (rc == 0) {
+			m0_ctg_state_inc_update(tx, ca->cta_key.b_nob -
+						M0_CAS_CTG_KV_HDR_SIZE +
+						ca->cta_val.b_nob);
+		} else
 			M0_LOG(M0_DEBUG, "Failed to insert record rc=%d", rc);
 	}
 }

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -781,7 +781,7 @@ static uint64_t ctg_state_update(struct m0_be_tx *tx, uint64_t size,
 	return *recs_nr;
 }
 
-static void ctg_state_inc_update(struct m0_be_tx *tx, uint64_t size)
+M0_INTERNAL void m0_ctg_state_inc_update(struct m0_be_tx *tx, uint64_t size)
 {
 	(void)ctg_state_update(tx, size, true);
 }
@@ -885,7 +885,7 @@ static bool ctg_op_cb(struct m0_clink *clink)
 			ctg_memcpy(arena, ctg_op->co_val.b_addr,
 				   ctg_op->co_val.b_nob);
 			if (ctg_is_ordinary(ctg_op->co_ctg))
-				ctg_state_inc_update(tx,
+				m0_ctg_state_inc_update(tx,
 					ctg_op->co_key.b_nob -
 				       	M0_CAS_CTG_KV_HDR_SIZE +
 					ctg_op->co_val.b_nob);

--- a/cas/ctg_store.h
+++ b/cas/ctg_store.h
@@ -760,6 +760,9 @@ M0_INTERNAL int m0_ctg_meta_find_ctg(struct m0_cas_ctg    *meta,
 /** Get btree ops for ctg tree. */
 M0_INTERNAL const struct m0_be_btree_kv_ops *m0_ctg_btree_ops(void);
 
+/** Update number of records and record size in cas state. */
+M0_INTERNAL void m0_ctg_state_inc_update(struct m0_be_tx *tx, uint64_t size);
+
 /** @} end of cas-ctg-store group */
 #endif /* __MOTR_CAS_CTG_STORE_H__ */
 


### PR DESCRIPTION
Problem:   
In beck tool  "cs_rec_nr" and "cs_rec_size"  is not updated for "m0_cas_state".
Catalogue delete operation hits an assert as it expect these variables not to be zero.
Fix: 
Updated cs_recs_nr and cs_rec_size correctly.

  