### PR TITLE
EOS-13463: motr data recovery script changes to run mkfs on both nodes.

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -91,7 +91,7 @@ eval set -- "$TEMP"
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
-        --beck-only)     beck_only=true; shift ;;
+        --beck-only)         beck_only=true; shift ;;
         --clean-snapshot)    clean_snapshot=true; shift ;;
         --)                  shift; break ;;
         *)                   break ;;

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -329,7 +329,7 @@ get_cluster_configuration() {
         REMOTE_STORAGE_STATUS=1
         REMOTE_LV_SWAP_DEVICE="$(lvs -o path $REMOTE_MD_VOLUMEGROUP | grep $SWAP_DEVICE | awk '{ print $1 }' )"
         REMOTE_LV_MD_DEVICE="$(lvs -o path $REMOTE_MD_VOLUMEGROUP | grep $MD_DEVICE | awk '{ print $1 }')"
-				SINGLE_NODE_RUNNING='--single-node'
+        SINGLE_NODE_RUNNING='--single-node'
 
     else
         # remote ios is failed, can't access the remote storage, recovery not possible on this node

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -3,7 +3,7 @@
 PROG=${0##*/}
 # Creating the log file under /var/log/seagate/motr
 now=$(date +"%Y_%m_%d__%H_%M_%S")
-LOG_DIR="/var/log/seagate/motr"
+LOG_DIR="/var/log/seagate/motr/datarecovery"
 mkdir -p $LOG_DIR
 LOG_FILE="$LOG_DIR/motr_data_recovery_$now.log"
 touch $LOG_FILE
@@ -47,6 +47,7 @@ REMOTE_NODE_RECOVERY_STATE=0 # To determine the recovery state of remote node
 # Path to dir on local node where we can access remote metadata dir if remote node failed
 FAILOVER_MD_DIR=
 beck_only=false # Run only becktool in the script
+clean_snapshot=false # Removes MD_Snapshot if present and create lv_main_swap again
 ESEGV=134 # Error code for segment fault
 RSTATE0=0 # We do not need to perform any actions before starting recovery
 RSTATE2=2 # We need to do only create snapshot before starting recovery
@@ -54,6 +55,7 @@ RSTATE3=3 # We need to do all operations such as fsck, replay logs, create snaps
 CDF_FILENAME="/var/lib/hare/cluster.yaml" # Cluster defination file needed by prov-m0-reset script
 # HA conf argument file needed by prov-m0-reset script
 HA_ARGS_FILENAME="/opt/seagate/cortx/ha/conf/build-ees-ha-args.yaml"
+SINGLE_NODE_RUNNING=  # Will be set if only one node is running.
 
 usage() {
     cat <<EOF
@@ -62,8 +64,10 @@ Usage: $PROG [--option]
 Master script for the motr data recovery.
 
 Optional parameters.
-    --beck-only     Performs only beck utility.
-    -h, --help      Shows this help text and exit.
+    --beck-only      Performs only beck utility. Use this option only when snapshot
+                     is already present on system.
+    --clean-snapshot Removes MD_Snapshot if present and create lv_main_swap again
+    -h, --help       Shows this help text and exit.
 
 ***Exit codes used by functions in script*** :
  - If a function is executed successfully on both local node
@@ -77,6 +81,7 @@ EOF
 TEMP=$(getopt --options h \
               --longoptions help \
               --longoptions beck-only \
+              --longoptions clean-snapshot \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { echo "show usage"; exit 1; }
@@ -87,6 +92,7 @@ while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         --beck-only)     beck_only=true; shift ;;
+        --clean-snapshot)    clean_snapshot=true; shift ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
@@ -129,15 +135,8 @@ is_ios_running_on_remote_node() {
 # This function will initialize values of local and remote ioservices 
 # fid variable.
 get_ios_fid() {
-    proc_id=$(/opt/seagate/cortx/hare/bin/consul kv get --recurse \
-              m0conf/nodes/$LOCAL_NODE/processes | grep ios | \
-              awk 'BEGIN {FS="/"} {print $5}')
-    LOCAL_IOS_FID=$(printf '0x7200000000000001:0x%x\n' $proc_id)
-
-    proc_id=$(/opt/seagate/cortx/hare/bin/consul kv get --recurse \
-              m0conf/nodes/$REMOTE_NODE/processes | grep ios | \
-              awk 'BEGIN {FS="/"} {print $5}')
-    REMOTE_IOS_FID=$(printf '0x7200000000000001:0x%x\n' $proc_id)
+    LOCAL_IOS_FID=$(./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --get-fid ios $LOCAL_NODE $SINGLE_NODE_RUNNING)
+    REMOTE_IOS_FID=$(./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --get-fid ios $REMOTE_NODE $SINGLE_NODE_RUNNING)
 
     if [[ $LOCAL_IOS_FID == "0x7200000000000001:0x0" ]] || [[ $REMOTE_IOS_FID == "0x7200000000000001:0x0" ]];then
         die "Cannot get the ioservice fids from consul, please make sure \
@@ -330,6 +329,8 @@ get_cluster_configuration() {
         REMOTE_STORAGE_STATUS=1
         REMOTE_LV_SWAP_DEVICE="$(lvs -o path $REMOTE_MD_VOLUMEGROUP | grep $SWAP_DEVICE | awk '{ print $1 }' )"
         REMOTE_LV_MD_DEVICE="$(lvs -o path $REMOTE_MD_VOLUMEGROUP | grep $MD_DEVICE | awk '{ print $1 }')"
+				SINGLE_NODE_RUNNING='--single-node'
+
     else
         # remote ios is failed, can't access the remote storage, recovery not possible on this node
         die "***ERROR: Remote ioservice is not running and cannot access the remote storage, \
@@ -382,7 +383,7 @@ reinit_mkfs() {
 
     # command line for reinit cluster with mkfs
     m0drlog "Reinitializing the cluster with mkfs, Please wait may take few minutes"
-    run_cmd_on_local_node "./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --mkfs-only"
+    run_cmd_on_local_node "./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --mkfs-only $SINGLE_NODE_RUNNING"
     [[ $? -eq 0 ]] || die "***ERROR: Cluster reinitialization with mkfs failed***"
     m0drlog "Cluster reinitialization with mkfs is completed"
     sleep 3
@@ -434,8 +435,8 @@ replay_logs() {
     if [[ $LOCAL_NODE_RECOVERY_STATE == $RSTATE3 ]]; then
         if [[ $1 == 0 || $1 == 2 ]]; then
             m0drlog "Replaying journal logs on local node"
-            if run_cmd_on_local_node "$M0BETOOL \
-                be_recovery_run $MD_DIR/m0d-$LOCAL_IOS_FID/db"; then
+            if run_cmd_on_local_node "(cd $MD_DIR/datarecovery; $M0BETOOL \
+                be_recovery_run $MD_DIR/m0d-$LOCAL_IOS_FID/db;)"; then
                 m0drlog "Journal logs replayed successfully on local node"
             else
                 m0drlog "ERROR: Journal logs replay failed on local node"
@@ -453,8 +454,8 @@ replay_logs() {
     if [[ $REMOTE_STORAGE_STATUS == 0 ]] && [[ $REMOTE_NODE_RECOVERY_STATE == $RSTATE3 ]]; then
         if [[ $1 == 0 || $1 == 1 ]]; then
             m0drlog "Replaying journal logs on remote node"
-            if run_cmd_on_remote_node "$M0BETOOL \
-                be_recovery_run $MD_DIR/m0d-$REMOTE_IOS_FID/db"; then
+            if run_cmd_on_remote_node "(cd $MD_DIR/datarecovery; $M0BETOOL \
+                be_recovery_run $MD_DIR/m0d-$REMOTE_IOS_FID/db;)"; then
                 m0drlog "Journal logs replayed successfully on remote node"
             else
                 m0drlog "ERROR: Journal logs replay failed on remote node"
@@ -467,8 +468,8 @@ replay_logs() {
     elif [[ $REMOTE_NODE_RECOVERY_STATE == $RSTATE3 ]]; then
         if [[ $1 == 0 || $1 == 1 ]]; then
             m0drlog "Replaying journal logs for remote node from local node"
-            if run_cmd_on_local_node "$M0BETOOL \
-                be_recovery_run $FAILOVER_MD_DIR/m0d-$REMOTE_IOS_FID/db"; then
+            if run_cmd_on_local_node "(cd $FAILOVER_MD_DIR/datarecovery; $M0BETOOL \
+                be_recovery_run $FAILOVER_MD_DIR/m0d-$REMOTE_IOS_FID/db;)"; then
                 m0drlog "Journal logs replayed successfully for remote node from local node"
             else
                 m0drlog "ERROR: Journal logs replay failed for remote node"
@@ -537,7 +538,10 @@ run_fsck() {
 
     # Try to mount the metadata device on /var/motr on both nodes
     if [[ $LOCAL_NODE_RECOVERY_STATE == $RSTATE3 ]]; then
-        if ! run_cmd_on_local_node "mount $LOCAL_MOTR_DEVICE $MD_DIR"; then
+        if run_cmd_on_local_node "mount $LOCAL_MOTR_DEVICE $MD_DIR"; then
+            # create directory "datarecovery" in /var/motr if not exist to store traces
+            run_cmd_on_local_node "mkdir -p $MD_DIR/datarecovery"
+        else
             run_cmd_on_local_node "mkfs.ext4 $LOCAL_MOTR_DEVICE"
             run_cmd_on_local_node "mount $LOCAL_MOTR_DEVICE $MD_DIR"
             (( exec_status|=1));
@@ -545,13 +549,19 @@ run_fsck() {
     fi
 
     if [[ $REMOTE_STORAGE_STATUS == 0 ]] && [[ $REMOTE_NODE_RECOVERY_STATE == $RSTATE3 ]]; then
-        if ! run_cmd_on_remote_node "mount $REMOTE_MOTR_DEVICE $MD_DIR"; then
+        if run_cmd_on_remote_node "mount $REMOTE_MOTR_DEVICE $MD_DIR"; then
+            # create directory "datarecovery" in /var/motr if not exist to store traces
+            run_cmd_on_remote_node "mkdir -p $MD_DIR/datarecovery"
+        else
             run_cmd_on_remote_node "mkfs.ext4 $REMOTE_MOTR_DEVICE"
             run_cmd_on_remote_node "mount $REMOTE_MOTR_DEVICE $MD_DIR"
             (( exec_status|=2));
         fi
     elif [[ $REMOTE_NODE_RECOVERY_STATE == $RSTATE3 ]]; then
-        if ! run_cmd_on_local_node "mount $REMOTE_MOTR_DEVICE $FAILOVER_MD_DIR"; then
+        if run_cmd_on_local_node "mount $REMOTE_MOTR_DEVICE $FAILOVER_MD_DIR"; then
+            # create directory "datarecovery" in /var/motr if not exist to store traces
+            run_cmd_on_local_node "mkdir -p $FAILOVER_MD_DIR/datarecovery"
+        else
             run_cmd_on_local_node "mkfs.ext4 $REMOTE_MOTR_DEVICE"
             run_cmd_on_local_node "mount $REMOTE_MOTR_DEVICE $FAILOVER_MD_DIR"
             (( exec_status|=2));
@@ -721,17 +731,23 @@ run_becktool() {
     if ! mountpoint -q $MD_DIR; then
         run_cmd_on_local_node "mount $LOCAL_MOTR_DEVICE $MD_DIR";
         [[ $? -eq 0 ]] || die "Cannot mount metadata device on /var/motr on local node"
+        # create directory "datarecovery" in /var/motr if not exist to store traces
+        run_cmd_on_local_node "mkdir -p $MD_DIR/datarecovery"
     fi
 
     if [[ $REMOTE_STORAGE_STATUS == 0 ]]; then
         if ! run_cmd_on_remote_node "mountpoint -q $MD_DIR"; then
             run_cmd_on_remote_node "mount $REMOTE_MOTR_DEVICE $MD_DIR";
             [[ $? -eq 0 ]] || die "Cannot mount metadata device on /var/motr on remote node"
+            # create directory "datarecovery" in /var/motr if not exist to store traces
+            run_cmd_on_remote_node "mkdir -p $MD_DIR/datarecovery"
         fi
     else
         if ! mountpoint -q $FAILOVER_MD_DIR; then
             run_cmd_on_local_node "mount $REMOTE_MOTR_DEVICE $FAILOVER_MD_DIR"
             [[ $? -eq 0 ]] || die "Cannot mount metadata device on failover dir on local node"
+            # create directory "datarecovery" in /var/motr if not exist to store traces
+            run_cmd_on_local_node "mkdir -p $FAILOVER_MD_DIR/datarecovery"
         fi
     fi
 
@@ -744,14 +760,15 @@ run_becktool() {
         DEST_DOMAIN_DIR="$MD_DIR/m0d-$LOCAL_IOS_FID"
 
         m0drlog "Running Becktool on local node"
-        run_cmd_on_local_node "$BECKTOOL -s $SOURCE_IMAGE \
-                               -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs"
+        run_cmd_on_local_node "(cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
+                               -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)"
         cmd_exit_status=$?
         # restart the execution of command if exit code is ESEGV error
         while [[ $cmd_exit_status == $ESEGV ]];
         do
-            run_cmd_on_local_node "$BECKTOOL -s $SOURCE_IMAGE \
-                                   -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs"
+            m0drlog "Restarting Becktool on local node"
+            run_cmd_on_local_node "(cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
+                                   -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)"
             cmd_exit_status=$?
         done
 
@@ -771,16 +788,17 @@ run_becktool() {
 
             m0drlog "Running Becktool on remote node"
             # Below statement is for logging purpose
-            echo "Running '$BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs'" >> ${LOG_FILE}
+            echo "Running '(cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)'" >> ${LOG_FILE}
             run_cmd_on_remote_node "bash -s" <<-EOF
-            $BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs
+            (cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)
 EOF
             cmd_exit_status=$?
             # restart the execution of command if exit code is ESEGV error
             while [[ $cmd_exit_status == $ESEGV ]];
             do
+                m0drlog "Restarting Becktool on remote node"
                 run_cmd_on_remote_node "bash -s" <<-EOF
-                $BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs
+                (cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)
 EOF
                 cmd_exit_status=$?
             done
@@ -795,15 +813,16 @@ EOF
 
             m0drlog "Running Becktool for remote node from local node"
             # Below statement is for logging purpose
-            echo "Running '$BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs'" >> ${LOG_FILE}
-            run_cmd_on_local_node "$BECKTOOL -s $SOURCE_IMAGE \
-                                   -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs"
+            echo "Running '(cd $FAILOVER_MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)'" >> ${LOG_FILE}
+            run_cmd_on_local_node "(cd $FAILOVER_MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
+                                   -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)"
             cmd_exit_status=$?
             # restart the execution of command if exit code is ESEGV error
             while [[ $cmd_exit_status == $ESEGV ]];
             do
-                run_cmd_on_local_node "$BECKTOOL -s $SOURCE_IMAGE \
-                                       -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs"
+                m0drlog "Restarting Becktool for remote node from local node"
+                run_cmd_on_local_node "(cd $FAILOVER_MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
+                                       -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs;)"
                 cmd_exit_status=$?
             done
 
@@ -831,6 +850,7 @@ EOF
                                         die "ERROR: Becktool failed on remote node";
                                       }
             m0drlog "Becktool completed on remote node"
+            cleanup_stobs_dir
             return $exec_status
         else
             pkill -9 m0beck; run_cmd_on_remote_node "pkill -9 m0beck";
@@ -850,6 +870,7 @@ EOF
                                         die "ERROR: Becktool failed on local node";
                                      }
             m0drlog "Becktool completed on local node"
+            cleanup_stobs_dir
             return $exec_status
         else
             pkill -9 m0beck; ((exec_status|=2));
@@ -882,17 +903,31 @@ is_user_root_user # check the script is running with root access
 
 shutdown_services
 
-run_cmd_on_local_node "./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --start-consul"
+run_cmd_on_local_node "./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --start-consul $SINGLE_NODE_RUNNING"
 
 get_cluster_configuration
 
-run_cmd_on_local_node "./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --stop-consul"
+run_cmd_on_local_node "./prov-m0-reset $CDF_FILENAME $HA_ARGS_FILENAME --stop-consul $SINGLE_NODE_RUNNING"
 
-# Execute becktool only in the script if option --beck-only is set
+# Execute becktool only in the script if option --beck-only is set.
+# Use --beck-only option only when snapshot is already present on the system.
 if $beck_only ; then
     m0drlog "Running only becktool in the recovery script"
     run_becktool
     exit $?
+fi
+
+# Only remove MD_Snapshot if present and create lv_main_swap again
+if $clean_snapshot ; then
+    m0drlog "Removing MD_Snapshot if present and create lv_main_swap again"
+    remove_snapshot                # remove snapshot on both nodes
+    remove_snapshot_status=$?
+    [[ remove_snapshot_status -eq 0 ]] || { die "ERROR: Remove snapshot failed with code $remove_snapshot_status"; }
+
+    create_swap                    # recreate swap on both nodes
+    create_swap_status=$?
+    [[ create_swap_status -eq 0 ]] || { die "ERROR: Create swap failed with code $create_swap_status"; }
+    exit 0
 fi
 
 run_fsck                       # run fsck on both nodes

--- a/scripts/install/opt/seagate/cortx/motr/libexec/prov-m0-reset
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/prov-m0-reset
@@ -29,10 +29,10 @@ Mandatory parameters:
 
 Optional parameters:
   --mkfs-only           run mkfs on motr meta data devices.
-  --single-node          run mkfs from single node only.
+  --single-node         run mkfs from single node only.
   --start-consul        start consul
   --stop-consul         stop  consul
-  --get-fid       <service-name> <node-name>  get fid of service
+  --get-fid             <service-name> <node-name>  get fid of service
 Note: parameters can be specified either directly via cmd-line options
 or via a yaml file, e.g.:
 

--- a/scripts/install/opt/seagate/cortx/motr/libexec/prov-m0-reset
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/prov-m0-reset
@@ -52,7 +52,7 @@ TEMP=$(getopt --options h,i: \
               --longoptions start-consul \
               --longoptions stop-consul \
               --longoptions mkfs-only,single-node:, \
-	      --longoptions get-fid \
+              --longoptions get-fid \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -171,8 +171,8 @@ reset() {
     while ssh $rnode 'mountpoint /var/motr && ! umount /var/motr'; do sleep 1; done
 
     echo "Formatting volumes $lvolume and $rvolume ..."
-   # mkfs.ext4 $lvolume
-   # mkfs.ext4 $rvolume
+    mkfs.ext4 $lvolume
+    mkfs.ext4 $rvolume
 
     echo 'Mounting /var/motr on both the nodes...'
     mkdir -p /var/motr &&
@@ -221,11 +221,11 @@ reset() {
        sleep 5
     done
 
-   # echo 'Importing /var/lib/hare/consul-conf-exported.json...'
-   # for i in {1..10}; do
-   #     /opt/seagate/cortx/hare/bin/consul kv import \
-   #         @/var/lib/hare/consul-conf-exported.json && break || sleep 5
-   # done
+    echo 'Importing /var/lib/hare/consul-conf-exported.json...'
+    for i in {1..10}; do
+        /opt/seagate/cortx/hare/bin/consul kv import \
+            @/var/lib/hare/consul-conf-exported.json && break || sleep 5
+    done
 }
 
 get_fid() {
@@ -235,7 +235,7 @@ get_fid() {
     # wait until consul becomes available for returning the data
     while ! [[ `/opt/seagate/cortx/hare/bin/consul kv get --recurse m0conf/nodes/$node/processes | grep $service` ]]
     do
-	echo "Trying to fetch fid again"
+	      echo "Trying to fetch fid again"
         sleep 2
     done
     

--- a/scripts/install/opt/seagate/cortx/motr/libexec/prov-m0-reset
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/prov-m0-reset
@@ -29,8 +29,10 @@ Mandatory parameters:
 
 Optional parameters:
   --mkfs-only           run mkfs on motr meta data devices.
+  --single-node          run mkfs from single node only.
   --start-consul        start consul
   --stop-consul         stop  consul
+  --get-fid       <service-name> <node-name>  get fid of service
 Note: parameters can be specified either directly via cmd-line options
 or via a yaml file, e.g.:
 
@@ -49,7 +51,8 @@ TEMP=$(getopt --options h,i: \
               --longoptions left-volume:,right-volume: \
               --longoptions start-consul \
               --longoptions stop-consul \
-              --longoptions mkfs-only \
+              --longoptions mkfs-only,single-node:, \
+	      --longoptions get-fid \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -65,8 +68,10 @@ rnode=pod-c2
 lvolume=/dev/sdb
 rvolume=/dev/sdc
 mkfs_only=
+single_node=false
 start_consul_only=
 stop_consul_only=
+get_fid_only=
 
 while true; do
     case "$1" in
@@ -82,6 +87,8 @@ while true; do
         --start-consul)      start_consul_only=true; shift ;;
         --stop-consul)       stop_consul_only=true; shift  ;;
         --mkfs-only)         mkfs_only=true; shift ;;
+        --single-node)       single_node=true; shift 2 ;;
+        --get-fid)           get_fid_only=true; shift ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
@@ -164,8 +171,8 @@ reset() {
     while ssh $rnode 'mountpoint /var/motr && ! umount /var/motr'; do sleep 1; done
 
     echo "Formatting volumes $lvolume and $rvolume ..."
-    mkfs.ext4 $lvolume
-    mkfs.ext4 $rvolume
+   # mkfs.ext4 $lvolume
+   # mkfs.ext4 $rvolume
 
     echo 'Mounting /var/motr on both the nodes...'
     mkdir -p /var/motr &&
@@ -214,17 +221,24 @@ reset() {
        sleep 5
     done
 
-    echo 'Importing /var/lib/hare/consul-conf-exported.json...'
-    for i in {1..10}; do
-        /opt/seagate/cortx/hare/bin/consul kv import \
-            @/var/lib/hare/consul-conf-exported.json && break || sleep 5
-    done
+   # echo 'Importing /var/lib/hare/consul-conf-exported.json...'
+   # for i in {1..10}; do
+   #     /opt/seagate/cortx/hare/bin/consul kv import \
+   #         @/var/lib/hare/consul-conf-exported.json && break || sleep 5
+   # done
 }
 
 get_fid() {
     service=$1
-    node=$2
+    node=$2     
 
+    # wait until consul becomes available for returning the data
+    while ! [[ `/opt/seagate/cortx/hare/bin/consul kv get --recurse m0conf/nodes/$node/processes | grep $service` ]]
+    do
+	echo "Trying to fetch fid again"
+        sleep 2
+    done
+    
     proc_id=$(/opt/seagate/cortx/hare/bin/consul kv get --recurse \
               m0conf/nodes/$node/processes | grep $service | \
               awk 'BEGIN {FS="/"} {print $5}')
@@ -239,7 +253,23 @@ get_proc_state() {
     echo $state
 }
 
+run_cmd() {
+    local node=$1; shift
+    local cmd=$*
+    ssh $node $cmd
+}
+
+get_leader() {
+    /opt/seagate/cortx/hare/bin/consul kv get leader
+}
+
 m0_mkfs() {
+    local node1=$lnode
+    local node2=$rnode
+    if $single_node; then
+        node1=$(/opt/seagate/cortx/hare/libexec/node-name)
+        node2=$(/opt/seagate/cortx/hare/libexec/node-name)
+    fi
 
     local confd_fid_c1=$(get_fid 'confd' $lnode)
     local ios_fid_c1=$(get_fid 'ios' $lnode)
@@ -247,14 +277,14 @@ m0_mkfs() {
     local confd_fid_c2=$(get_fid 'confd' $rnode)
     local ios_fid_c2=$(get_fid 'ios' $rnode)
 
-    systemctl is-active --quiet m0d@$confd_fid_c1 ||
-    systemctl is-active --quiet m0d@$ios_fid_c1 ||
-    systemctl is-active --quiet m0d@$confd_fid_c2 ||
-    systemctl is-active --quiet m0d@$ios_fid_c2 &&
+    run_cmd $node1 "systemctl is-active --quiet m0d@$confd_fid_c1" ||
+    run_cmd $node1 "systemctl is-active --quiet m0d@$ios_fid_c1" ||
+    run_cmd $node2 "systemctl is-active --quiet m0d@$confd_fid_c2" ||
+    run_cmd $node2 "systemctl is-active --quiet m0d@$ios_fid_c2" &&
         die 'Active m0d instances found, please stop all the m0d instances'
 
     echo "Starting motr-mkfs@$confd_fid_c1 (confd)"
-    sudo systemctl start motr-mkfs@$confd_fid_c1
+    run_cmd $node1 "sudo systemctl start motr-mkfs@$confd_fid_c1"
     while [[ $(get_proc_state $confd_fid_c1) != M0_CONF_HA_PROCESS_STOPPED ]]; do
         sleep 1
     done
@@ -262,15 +292,15 @@ m0_mkfs() {
     echo "Started motr-mkfs@$confd_fid_c1 (confd)"
 
     echo "Starting m0d@$confd_fid_c1 (confd)"
-    sudo systemctl start m0d@$confd_fid_c1
-    while [[ `systemctl is-active m0d@$confd_fid_c1` != 'active' ]]; do
+    run_cmd $node1 "sudo systemctl start m0d@$confd_fid_c1"
+    while [[ $(run_cmd $node1 "systemctl is-active m0d@$confd_fid_c1") != 'active' ]]; do
        sleep 5
     done
     sleep 5
     echo "Started m0d@$confd_fid_c1 (confd)"
 
     echo "Starting motr-mkfs@$confd_fid_c2 (confd)"
-    sudo systemctl start motr-mkfs@$confd_fid_c2
+    run_cmd $node2 "sudo systemctl start motr-mkfs@$confd_fid_c2"
     while [[ $(get_proc_state $confd_fid_c2) != M0_CONF_HA_PROCESS_STOPPED ]]; do
         sleep 1
     done
@@ -278,15 +308,15 @@ m0_mkfs() {
     echo "Started motr-mkfs@$confd_fid_c2 (confd)"
 
     echo "Starting m0d@$confd_fid_c2 (confd)"
-    sudo systemctl start m0d@$confd_fid_c2
-    while [[ `systemctl is-active m0d@$confd_fid_c2` != 'active' ]]; do
+    run_cmd $node2 "sudo systemctl start m0d@$confd_fid_c2"
+    while [[ $(run_cmd $node2 "systemctl is-active m0d@$confd_fid_c2") != 'active' ]]; do
        sleep 5
     done
     sleep 5
     echo "Started m0d@$confd_fid_c2 (confd)"
 
     echo "Starting motr-mkfs@$ios_fid_c1 (ios)"
-    sudo systemctl start motr-mkfs@$ios_fid_c1
+    run_cmd $node1 "sudo systemctl start motr-mkfs@$ios_fid_c1"
     while [[ $(get_proc_state $ios_fid_c1) != M0_CONF_HA_PROCESS_STOPPED ]]; do
         sleep 1
     done
@@ -294,7 +324,7 @@ m0_mkfs() {
     echo "Started motr-mkfs@$ios_fid_c1 (ios)"
 
     echo "Starting motr-mkfs@$ios_fid_c2 (ios)"
-    sudo systemctl start motr-mkfs@$ios_fid_c2
+    run_cmd $node2 "sudo systemctl start motr-mkfs@$ios_fid_c2"
     while [[ $(get_proc_state $ios_fid_c2) != M0_CONF_HA_PROCESS_STOPPED ]]; do
         sleep 1
     done
@@ -302,26 +332,26 @@ m0_mkfs() {
     echo "Started motr-mkfs@$ios_fid_c2 (ios)"
 
     echo "Starting m0d@$ios_fid_c1 (ios)"
-    sudo systemctl start m0d@$ios_fid_c1
-    while [[ `systemctl is-active m0d@$ios_fid_c1` != 'active' ]]; do
+    run_cmd $node1 "sudo systemctl start m0d@$ios_fid_c1"
+    while [[ $(run_cmd $node1 "systemctl is-active m0d@$ios_fid_c1") != 'active' ]]; do
        sleep 5
     done
     sleep 5
     echo "Started m0d@$ios_fid_c1 (ios)"
 
     echo "Starting m0d@$ios_fid_c2 (ios)"
-    sudo systemctl start m0d@$ios_fid_c2
-    while [[ `systemctl is-active m0d@$ios_fid_c2` != 'active' ]]; do
+    run_cmd $node2 "sudo systemctl start m0d@$ios_fid_c2"
+    while [[ $(run_cmd $node2 "systemctl is-active m0d@$ios_fid_c2") != 'active' ]]; do
         sleep 5
     done
     echo "Started m0d@$ios_fid_c2 (ios)"
     sleep 15
 
     echo "Stopping m0d@$ios_fid_c1, m0d@$ios_fid_c2, m0d@$confd_fid_c1, m0d@$confd_fid_c2"
-    sudo systemctl stop m0d@$ios_fid_c1
-    sudo systemctl stop m0d@$ios_fid_c2
-    sudo systemctl stop m0d@$confd_fid_c1
-    sudo systemctl stop m0d@$confd_fid_c2
+    run_cmd $node1 "sudo systemctl stop m0d@$ios_fid_c1"
+    run_cmd $node2 "sudo systemctl stop m0d@$ios_fid_c2"
+    run_cmd $node1 "sudo systemctl stop m0d@$confd_fid_c1"
+    run_cmd $node2 "sudo systemctl stop m0d@$confd_fid_c2"
 
     echo -n "Waiting for all m0d services to stop"
     while [[ `pgrep m0d` ]]; do
@@ -331,105 +361,51 @@ m0_mkfs() {
 }
 
 start_consul() {
-    local local_node=$(cat /var/lib/hare/node-name)
+    local node1=$lnode
+    local node2=$rnode
+    if $single_node; then
+        node1=$(/opt/seagate/cortx/hare/libexec/node-name)
+        node2=$(/opt/seagate/cortx/hare/libexec/node-name)
+    fi
 
     echo 'Adding ip addresses..'
-    sudo ifconfig $iface:c1 $ip1
-    sudo ifconfig $iface:c2 $ip2
+    run_cmd $node1 "sudo ifconfig $iface:c1 $ip1"
+    run_cmd $node2 "sudo ifconfig $iface:c2 $ip2"
 
     echo 'Adding lnet interfaces..'
-    sudo modprobe lnet # Its possible that lnet module is not loaded.
-    sudo lnetctl net add --net $net_type --if $iface:c1
-    sudo lnetctl net add --net $net_type --if $iface:c2
+    # Its possible that lnet module is not loaded.
+    run_cmd $node1 "sudo modprobe lnet"
+    run_cmd $node2 "sudo modprobe lnet"
+
+    run_cmd $node1 "sudo lnetctl net add --net $net_type --if $iface:c1"
+    run_cmd $node2 "sudo lnetctl net add --net $net_type --if $iface:c2"
 
     echo 'Restarting motr-kernel..'
-    sudo systemctl restart motr-kernel
+    run_cmd $node1 "sudo systemctl restart motr-kernel"
+    run_cmd $node2 "sudo systemctl restart motr-kernel"
 
     echo 'Modifying Consul systemd units..'
-    sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
-                              /usr/lib/systemd/system/hare-consul-agent-c1.service
-    sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
-                              /usr/lib/systemd/system/hare-consul-agent-c2.service
+    run_cmd $node1 "sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
+                        /usr/lib/systemd/system/hare-consul-agent-c1.service"
+    run_cmd $node2 "sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
+                        /usr/lib/systemd/system/hare-consul-agent-c2.service"
 
-    sudo systemctl reset-failed
-    sudo systemctl daemon-reload
-
-    echo 'Starting Consul agents..'
-    sudo systemctl start hare-consul-agent-c1
-    sudo systemctl start hare-consul-agent-c2
-
-    while [[ `systemctl is-active hare-consul-agent-c1` != 'active' ||
-             `systemctl is-active hare-consul-agent-c2` != 'active' ]]; do
-           sleep 5
-    done
-    echo 'Started Consul agents..'
-    # An issue is observed if we try to fetch data from Consul immediately
-    # after stating Consul services. So, let's wait for 10 more secs.
-    sleep 10
-}
-
-stop_consul() {
-    echo 'Stopping Consul agents..'
-    sudo systemctl stop hare-consul-agent-c2
-    sudo systemctl stop hare-consul-agent-c1
-
-    echo 'Deleting lnet interfaces..'
-    sudo lnetctl net del --net $net_type --if $iface:c1
-    sudo lnetctl net del --net $net_type --if $iface:c2
-
-    echo 'Restarting motr-kernel..'
-    sudo systemctl restart motr-kernel
-
-    echo 'Restoring Consul systemd units..'
-    sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
-                                  /usr/lib/systemd/system/hare-consul-agent-c1.service
-    sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
-                                  /usr/lib/systemd/system/hare-consul-agent-c2.service
-
-    sudo systemctl daemon-reload
-    sudo systemctl reset-failed
-
-    echo 'Removing ipaddresses..'
-    ip addr del $ip1/24 dev $iface:c1
-    ip addr del $ip2/24 dev $iface:c1
-}
-
-mkfs() {
-    local local_node=$(cat /var/lib/hare/node-name)
-
-    echo 'Adding ip addresses..'
-    sudo ifconfig $iface:c1 $ip1
-    sudo ifconfig $iface:c2 $ip2
-
-    echo 'Adding lnet interfaces..'
-    sudo modprobe lnet # Its possible that lnet module is not loaded.
-    sudo lnetctl net add --net $net_type --if $iface:c1
-    sudo lnetctl net add --net $net_type --if $iface:c2
-
-    echo 'Restarting motr-kernel..'
-    sudo systemctl restart motr-kernel
-
-    echo 'Modifying Consul systemd units..'
-    sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
-                              /usr/lib/systemd/system/hare-consul-agent-c1.service
-    sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
-                              /usr/lib/systemd/system/hare-consul-agent-c2.service
-
-    sudo systemctl reset-failed
-    sudo systemctl daemon-reload
+    run_cmd $node1 "sudo systemctl reset-failed"
+    run_cmd $node2 "sudo systemctl reset-failed"
+    run_cmd $node1 "sudo systemctl daemon-reload"
+    run_cmd $node2 "sudo systemctl daemon-reload"
 
     echo 'Starting Consul agents..'
-    sudo systemctl start hare-consul-agent-c1
-    sudo systemctl start hare-consul-agent-c2
+    run_cmd $node1 "sudo systemctl start hare-consul-agent-c1"
+    run_cmd $node2 "sudo systemctl start hare-consul-agent-c2"
 
-    while [[ `systemctl is-active hare-consul-agent-c1` != 'active' ||
-             `systemctl is-active hare-consul-agent-c2` != 'active' ]]; do
-           sleep 5
+    while [[ ($(get_leader) != $lnode) && ($(get_leader) != $rnode) ]]; do
+        sleep 1
     done
 
     # An issue is observed if we try to fetch data from Consul immediately
     # after stating Consul services. So, let's wait till consul becomes available.
-    sleep 5
+    sleep 10
     while ! [[ `/opt/seagate/cortx/hare/bin/consul kv get --recurse m0conf/nodes/srvnode-1 | grep confd` ]]
     do
         sleep 2
@@ -440,13 +416,60 @@ mkfs() {
         sleep 2
     done
     echo 'Started Consul agents..'
+}
+
+stop_consul() {
+    local node1=$lnode
+    local node2=$rnode
+    if $single_node; then
+        node1=$(/opt/seagate/cortx/hare/libexec/node-name)
+        node2=$(/opt/seagate/cortx/hare/libexec/node-name)
+    fi
+		
+    echo 'Stopping Consul agents..'
+    run_cmd $node2 "sudo systemctl stop hare-consul-agent-c2"
+    run_cmd $node1 "sudo systemctl stop hare-consul-agent-c1"
+
+    echo 'Deleting lnet interfaces..'
+    run_cmd $node1 "sudo lnetctl net del --net $net_type --if $iface:c1"
+    run_cmd $node2 "sudo lnetctl net del --net $net_type --if $iface:c2"
+
+    echo 'Restarting motr-kernel..'
+    run_cmd $node1 "sudo systemctl restart motr-kernel"
+    run_cmd $node2 "sudo systemctl restart motr-kernel"
+
+    echo 'Restoring Consul systemd units..'
+    run_cmd $node1 "sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
+                        /usr/lib/systemd/system/hare-consul-agent-c1.service"
+    run_cmd $node2 "sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
+                        /usr/lib/systemd/system/hare-consul-agent-c2.service"
+
+    run_cmd $node1 "sudo systemctl daemon-reload"
+    run_cmd $node2 "sudo systemctl daemon-reload"
+    run_cmd $node1 "sudo systemctl reset-failed"
+    run_cmd $node2 "sudo systemctl reset-failed"
+
+    echo 'Removing ipaddresses..'
+    run_cmd $node1 "ip addr del $ip1/24 dev $iface:c1"
+    run_cmd $node2 "ip addr del $ip2/24 dev $iface:c1"
+}
+
+mkfs() {
+    local node1=$lnode
+    local node2=$rnode
+    if $single_node; then
+        node1=$(/opt/seagate/cortx/hare/libexec/node-name)
+        node2=$(/opt/seagate/cortx/hare/libexec/node-name)
+    fi
+
+    start_consul
 
     echo 'Starting Hax..'
-    sudo systemctl start hare-hax-c1
-    sudo systemctl start hare-hax-c2
+    run_cmd $node1 "sudo systemctl start hare-hax-c1"
+    run_cmd $node2 "sudo systemctl start hare-hax-c2"
 
-    while [[ `systemctl is-active hare-hax-c1` != 'active' ||
-             `systemctl is-active hare-hax-c2` != 'active' ]]; do
+    while [[ $(run_cmd $node1 "systemctl is-active hare-hax-c1") != 'active' ||
+             $(run_cmd $node2 "systemctl is-active hare-hax-c2") != 'active' ]]; do
         sleep 5
     done
     echo 'Started Hax..'
@@ -456,42 +479,21 @@ mkfs() {
     echo 'Motr mkfs done..'
 
     echo 'Stopping Hax..'
-    sudo systemctl stop hare-hax-c2
-    sudo systemctl stop hare-hax-c1
+    run_cmd $node2 "sudo systemctl stop hare-hax-c2"
+    run_cmd $node1 "sudo systemctl stop hare-hax-c1"
 
-    echo 'Stopping Consul agents..'
-    sudo systemctl stop hare-consul-agent-c2
-    sudo systemctl stop hare-consul-agent-c1
-
-    echo 'Deleting lnet interfaces..'
-    sudo lnetctl net del --net $net_type --if $iface:c1
-    sudo lnetctl net del --net $net_type --if $iface:c2
-
-    echo 'Restarting motr-kernel..'
-    sudo systemctl restart motr-kernel
-
-    echo 'Restoring Consul systemd units..'
-    sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
-                                  /usr/lib/systemd/system/hare-consul-agent-c1.service
-    sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
-                                  /usr/lib/systemd/system/hare-consul-agent-c2.service
-
-    sudo systemctl daemon-reload
-    sudo systemctl reset-failed
-
-    echo 'Removing ipaddresses..'
-    ip addr del $ip1/24 dev $iface:c1
-    ip addr del $ip2/24 dev $iface:c1
+    stop_consul
 }
+
 
 if [[ $start_consul_only ]]; then
     start_consul
-    echo "start consul"
 elif [[ $stop_consul_only ]]; then
     stop_consul
-    echo "stop consul"
 elif [[ $mkfs_only ]]; then
     mkfs
+elif [[ $get_fid_only ]]; then
+    get_fid $3 $4
 else
     reset
 fi

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -43,7 +43,7 @@ DEFAULT_INPUT_DIRS_GLOB='/var/motr*'
 IN_DIR=
 CORE_DIR=/var/crash    # path from where m0reportbug will collect cores
 RECOVERY_SCRIPT_DIR=/opt/seagate/cortx/motr/libexec    # dir containing recovery traces and scripts
-RECOVERY_LOG_DIR=/var/log/seagate/motr    # dir containing recovery log/logs
+RECOVERY_LOG_DIR=/var/log/seagate/motr/datarecovery    # dir containing recovery log/logs
 LIVE_CORE_DIR=/var/log/seagate/motr
 
 readonly START_DIR=$PWD


### PR DESCRIPTION
Changed prov-m0-reset to support running mkfs on both the nodes so
that LVM snapshot reflects the correct data on both the nodes.

Signed-off-by: Shashank Parulekar <Shashank.Parulekar@seagate.com>