### PR TITLE
EOS-8251: workaround fix for FOM HUNG

### DIFF
--- a/fop/fom.h
+++ b/fop/fom.h
@@ -346,7 +346,7 @@ struct m0_fom_domain_ops {
 	 *  @todo fom timeout implementation.
 	 */
 	bool   (*fdo_time_is_out)(const struct m0_fom_domain *dom,
-				  const struct m0_fom *fom);
+				  struct m0_fom *fom);
 };
 
 /**
@@ -531,6 +531,7 @@ struct m0_fom {
 	int                       fo_log[32];
 #endif
 	uint64_t                  fo_magic;
+	uint32_t                  fo_hung_cnt;
 };
 
 static inline struct m0_be_tx *m0_fom_tx(struct m0_fom *fom)


### PR DESCRIPTION
after reaching limit of hung message
hung_fom_notify() calls m0_fom_ready()
to move fom from waitq to runq so fom_exec
checks hung limit  and move fom phase to
M0_FOPH_FAILURE.