### PR TITLE
EOS-10455: Motr crashes observed after data network was down

### DIFF
--- a/motr/setup.c
+++ b/motr/setup.c
@@ -2484,7 +2484,18 @@ static int cs_level_enter(struct m0_module *module)
 	int                     rc;
 
 	M0_ENTRY("cctx=%p level=%d level_name=%s", cctx, level, level_name);
-	if (gotsignal)
+	/** If a signal is recieved in CS_LEVEL_REQH_STOP_WORKAROUND,
+	  * m0_module_fini is called, In m0_module_fini
+	  * CS_LEVEL_RPC_MACHINES_INIT would assert because there are
+	  * active ongoing connection.
+	  * ideally connections are closed in cs_ha_fini during
+	  * cs_level_leave:: CS_LEVEL_REQH_STOP_WORKAROUND.
+	  * In cs_level_enter::CS_LEVEL_REQH_STOP_WORKAROUND, it does nothing
+	  * so just skip the error in CS_LEVEL_REQH_STOP_WORKAROUND
+	  * which will be handled in the next state. during fini, cs_ha_fini
+	  * is called before CS_LEVEL_RPC_MACHINES_INIT
+	 */
+	if (gotsignal && level != CS_LEVEL_REQH_STOP_WORKAROUND)
 		return M0_ERR(-EINTR);
 	switch (level) {
 	case CS_LEVEL_MOTR_INIT:

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -2535,6 +2535,10 @@ static int cs_level_enter(struct m0_module *module)
 			cs_ha_connect(cctx);
 		return M0_RC(0);
 	case CS_LEVEL_REQH_STOP_WORKAROUND:
+		/** During cs_level_enter, if signal is recieved, then
+		  * signal handling is skipped and handled in the next state,
+		  * before adding any change refer comments in gotsignal.
+		  */
 		return M0_RC(0);
 	case CS_LEVEL_RCONFC_INIT_START:
 		if (cctx->cc_no_conf)


### PR DESCRIPTION
If a signal is recieved in CS_LEVEL_REQH_STOP_WORKAROUND, m0_module_fini
is called, In m0_module_fini CS_LEVEL_RPC_MACHINES_INIT would assert
because there are active ongoing connection.
ideally connections are closed in cs_ha_fini, because
CS_LEVEL_REQH_STOP_WORKAROUND was not called, cs_ha_fini was never called.
Solution: In cs_level_enter::CS_LEVEL_REQH_STOP_WORKAROUND, it does
nothing, skip the error in CS_LEVEL_REQH_STOP_WORKAROUND which will be handled
in the next state. during fini, cs_ha_fini is called before
CS_LEVEL_RPC_MACHINES_INIT

/lib64/libmotr.so.1(m0_arch_backtrace+0x2f)[0x7f859e446baf]
/lib64/libmotr.so.1(m0_arch_panic+0xf3)[0x7f859e446d93]
/lib64/libmotr.so.1(+0x32a414)[0x7f859e437414]
/lib64/libmotr.so.1(m0_rpc_machine_fini+0x2c5)[0x7f859e4ca5a5]
/lib64/libmotr.so.1(+0x34890c)[0x7f859e45590c]
/lib64/libmotr.so.1(m0_module_fini+0x76)[0x7f859e486a96]
/lib64/libmotr.so.1(m0_cs_setup_env+0x4e)[0x7f859e45922e]
/usr/bin/m0d[0x4011a0]