### PR TITLE
EOS-8618 Proper finalization of herd link and context in case of confd failure

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -562,6 +562,13 @@ Tests:
     polltime : 30
     timeout  : 1800
 
+  - id       : 61spiel-multi-confd
+    script   : spiel_multiple_confd.sh
+    dir      : src/spiel/st/
+    executor : Xperior::Executor::MotrTest
+    sandbox  : /var/mero/sandbox.61spiel-multi-confd
+    polltime : 30
+    timeout  : 1800
 
 
 # 25 min

--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -446,7 +446,7 @@ Tests:
     executor : Xperior::Executor::MotrTest
     sandbox  : /var/motr/sandbox.47motr_client
     polltime : 30
-    timeout  : 1800
+    timeout  : 3600
 
   - id       : 48motr-raid0-io
     script   : motr_raid0_st.sh

--- a/conf/confd_fom.c
+++ b/conf/confd_fom.c
@@ -113,6 +113,7 @@ static int conf_fetch_tick(struct m0_fom *fom)
 	struct m0_conf_fetch_resp  *r;
 	struct m0_confd            *confd;
 	int                         rc;
+	M0_ENTRY("fom = %p", fom);
 
 	if (m0_fom_phase(fom) < M0_FOPH_NR)
 		return m0_fom_tick_generic(fom);
@@ -131,6 +132,8 @@ static int conf_fetch_tick(struct m0_fom *fom)
 	r->fr_ver = confd->d_cache->ca_ver;
 	M0_ASSERT(r->fr_ver != M0_CONF_VER_UNKNOWN);
 	m0_fom_phase_moveif(fom, rc, M0_FOPH_SUCCESS, M0_FOPH_FAILURE);
+	M0_LEAVE("rc=%d", rc);
+
 	return M0_FSO_AGAIN;
 }
 

--- a/conf/rconfc.c
+++ b/conf/rconfc.c
@@ -2073,7 +2073,9 @@ static bool rconfc_conductor_disconnect_cb(struct m0_clink *clink)
 	struct m0_rconfc *rconfc = M0_AMB(rconfc, clink, rc_conductor_clink);
 
 	M0_ENTRY("rconfc = %p", rconfc);
+	m0_rconfc_lock(rconfc);
 	rconfc_ast_post(rconfc, rconfc_conductor_disconnected_ast);
+	m0_rconfc_unlock(rconfc);
 	M0_LEAVE();
 	return true;
 }
@@ -2136,7 +2138,9 @@ static bool rconfc_unpinned_cb(struct m0_clink *link)
 	M0_ENTRY("rconfc = %p", rconfc);
 	M0_PRE(rconfc_state(rconfc) == M0_RCS_CONDUCTOR_DRAIN);
 	m0_clink_del(link);
+	m0_rconfc_lock(rconfc);
 	rconfc_ast_post(rconfc, rconfc_conductor_drain);
+	m0_rconfc_unlock(rconfc);
 	M0_LEAVE();
 	return false;
 }

--- a/conf/rconfc.h
+++ b/conf/rconfc.h
@@ -327,6 +327,8 @@ struct m0_rconfc {
 	int                       rc_datum;
 	/** AST to be posted when user requests rconfc to stop. */
 	struct m0_sm_ast          rc_stop_ast;
+	/** AST to be posted for cctx_fini. */
+	struct m0_sm_ast          rc_cctx_fini_ast;
 	/** A list of confc instances used during election. */
 	struct m0_tl              rc_herd;
 	/** A list of confd servers running the elected version. */

--- a/conf/rconfc_internal.h
+++ b/conf/rconfc_internal.h
@@ -35,11 +35,11 @@
 */
 
 enum confc_state {
-	CONFC_IDLE,       /**< The confd is connected to with no reading      */
-	CONFC_ARMED,      /**< Reading version from the confd has started     */
-	CONFC_OPEN,       /**< The confd was used to engage conductor         */
-	CONFC_FAILED,     /**< Reading failure registered with the confd      */
-	CONFC_DEAD,       /**< The confd has failed to establish connection   */
+	CONFC_IDLE,       /**< 0 The confd is connected to with no reading      */
+	CONFC_ARMED,      /**< 1 Reading version from the confd has started     */
+	CONFC_OPEN,       /**< 2 The confd was used to engage conductor         */
+	CONFC_FAILED,     /**< 3 Reading failure registered with the confd      */
+	CONFC_DEAD,       /**< 4 The confd has failed to establish connection   */
 };
 
 /* -------------- Read lock context ----------------- */

--- a/conf/rconfc_link_fom.c
+++ b/conf/rconfc_link_fom.c
@@ -94,8 +94,9 @@ static void rconfc_link_fom_clink_cleanup_fini(struct rconfc_link *lnk)
 static void rconfc_link_fom_fini(struct m0_fom *fom)
 {
 	struct rconfc_link *lnk = M0_AMB(lnk, fom, rl_fom);
+	M0_ENTRY("lnk=%p state=%d ep=%s ",
+		 lnk, lnk->rl_state, lnk->rl_confd_addr);
 
-	M0_ENTRY("lnk=%p", lnk);
 	m0_fom_fini(fom);
 	m0_rconfc_lock(lnk->rl_rconfc);
 	m0_mutex_lock(&lnk->rl_rconfc->rc_herd_lock);

--- a/motr/st/utils/m0kv_start.sh
+++ b/motr/st/utils/m0kv_start.sh
@@ -52,7 +52,7 @@ function m0kv_cmd_start()
 	local cmdline="$exec $args $all"
 	if [ $verbose == 1 ]; then
 		echo "Running m0kv command line tool..."
-		echo "$cmdline" > /dev/tty
+		echo "$cmdline"
 	fi
 	eval $cmdline || {
 		err=$?

--- a/motr/st/utils/motr_client_st.sh
+++ b/motr/st/utils/motr_client_st.sh
@@ -139,6 +139,7 @@ main()
 {
 	local rc
 
+	mkdir -p $MOTR_M0T1FS_TEST_DIR
 	echo "Motr system tests start:"
 	echo "Test log will be stored in $MOTR_TEST_LOGFILE."
 

--- a/motr/st/utils/motr_cmd.sh
+++ b/motr/st/utils/motr_cmd.sh
@@ -75,7 +75,7 @@ cmd_exec="$dir/$1"
 cmd="$cmd_exec $cmd_args"
 
 # Run it
-echo "# $cmd" >/dev/tty
+echo "# $cmd"
 
 eval $cmd || {
 	echo "Failed to run command $1"

--- a/motr/st/utils/motr_st_inc.sh
+++ b/motr/st/utils/motr_st_inc.sh
@@ -80,7 +80,7 @@ motr_st_run_debugger()
     local binary=$2
     shift 2
 
-    echo "gdb $gdbinit --args $binary $@"  >/dev/tty
+    echo "gdb $gdbinit --args $binary $@"
     gdb $gdbinit $gdbparams --args $binary $@
 }
 
@@ -171,7 +171,7 @@ function motr_st_start_u()
 		motr_st_run_debugger $debugger $st_u
 	else
 		echo Running system tests ...
-		echo "# $st_u" >/dev/tty
+		echo "# $st_u"
 		eval $st_u || {
 			echo "Failed to run Motr ST !!"
 			return 1
@@ -205,7 +205,7 @@ function motr_st_list_tests ()
 
 	# Run it
 	echo Running system tests ...
-	echo "# $st_u" >/dev/tty
+	echo "# $st_u"
 	eval $st_u || {
 		echo "Failed to run Motr ST !!"
 		return 1

--- a/scripts/st.d/67spiel-multi-confd
+++ b/scripts/st.d/67spiel-multi-confd
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+
+exec $SUDO "$M0_SRC_DIR/spiel/st/spiel_multiple_confd.sh"


### PR DESCRIPTION
- Separate ast for rconfc_cctx_fini().
- check if lnk is failed and in the finalization fom before initializes a ctx.
- check if lnk is failed or armed, or queued for finalization before ctx finalization.

Signed-off-by: Hua Huang <hua.huang@seagate.com>