### PR TITLE
EOS-7119: ADDB: Limit record file size to MOTR_MOD_ADDB_RECORD_SIZE

### DIFF
--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -1600,9 +1600,11 @@ int m0_client_init(struct m0_client **m0c_p,
 
 	if (conf->mc_is_addb_init) {
 		char buf[64];
+		/** Client addb record file size set to 1G" */
+		m0_bcount_t size = 1ULL >> 30;
 		sprintf(buf, "linuxstob:./addb_%d", (int)m0_pid());
 		rc = m0_reqh_addb2_init(&m0c->m0c_reqh, buf,
-					0xaddbf11e, true, true);
+					0xaddbf11e, true, true, size);
 	}
 	/* publish the allocated client instance */
 	*m0c_p = m0c;

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -1601,7 +1601,7 @@ int m0_client_init(struct m0_client **m0c_p,
 	if (conf->mc_is_addb_init) {
 		char buf[64];
 		/** Client addb record file size set to 1G" */
-		m0_bcount_t size = 1ULL >> 30;
+		m0_bcount_t size = 1ULL << 30;
 		sprintf(buf, "linuxstob:./addb_%d", (int)m0_pid());
 		rc = m0_reqh_addb2_init(&m0c->m0c_reqh, buf,
 					0xaddbf11e, true, true, size);

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -1614,7 +1614,8 @@ static int cs_storage_setup(struct m0_motr *cctx)
 	}
 
 	rc = m0_reqh_addb2_init(&rctx->rc_reqh, rctx->rc_addb_stlocation,
-				M0_ADDB2_STOB_DOM_KEY, mkfs, force);
+				M0_ADDB2_STOB_DOM_KEY, mkfs, force,
+				rctx->rc_addb_record_file_size);
 	if (rc != 0)
 		goto cleanup_stob;
 
@@ -2292,6 +2293,11 @@ static int _args_parse(struct m0_motr *cctx, int argc, char **argv)
 				LAMBDA(void, (void)
 				{
 					rctx->rc_fis_enabled = true;
+				})),
+			M0_NUMBERARG('r', "ADDB Record storage size",
+				LAMBDA(void, (int64_t size)
+				{
+					rctx->rc_addb_record_file_size = size;
 				})),
 			);
 	/* generate reqh fid in case it is all-zero */

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -2297,7 +2297,18 @@ static int _args_parse(struct m0_motr *cctx, int argc, char **argv)
 			M0_NUMBERARG('r', "ADDB Record storage size",
 				LAMBDA(void, (int64_t size)
 				{
-					rctx->rc_addb_record_file_size = size;
+					if ((size == 0) ||
+					    ((size >= MIN_ADDB2_RECORD_SIZE) &&
+					     (size <= MAX_ADDB2_RECORD_SIZE) &&
+					     (size % BLK_SIZE == 0))) {
+						rctx->rc_addb_record_file_size = size;
+					} else {
+						M0_LOG(M0_ERROR, "Invalid ADDB record size. "
+						       "Record size can be 0. If non-zero then "
+						       "it should be in the range (10M, 10G) bytes"
+						       "and multiple of 4096 bytes.\n");
+						rc = -EINVAL;
+					}
 				})),
 			);
 	/* generate reqh fid in case it is all-zero */

--- a/motr/setup.h
+++ b/motr/setup.h
@@ -340,7 +340,7 @@ struct m0_reqh_context {
 	/** Enable Fault Injection Service */
 	bool                         rc_fis_enabled;
 
-	/** ADDB Record Max record size" */
+	/** ADDB Record Max record size in bytes */
 	m0_bcount_t                  rc_addb_record_file_size;
 };
 

--- a/motr/setup.h
+++ b/motr/setup.h
@@ -339,6 +339,9 @@ struct m0_reqh_context {
 
 	/** Enable Fault Injection Service */
 	bool                         rc_fis_enabled;
+
+	/** ADDB Record Max record size" */
+	m0_bcount_t                  rc_addb_record_file_size;
 };
 
 /**

--- a/reqh/reqh.c
+++ b/reqh/reqh.c
@@ -58,10 +58,6 @@
    @{
  */
 
-enum {
-	/** ADDB Record Max record size in bytes (10G) */
-	DEFAULT_ADDB2_RECORD_SIZE = 10737418240,
-};
 /**
    Tlist descriptor for reqh services.
  */

--- a/reqh/reqh.c
+++ b/reqh/reqh.c
@@ -59,6 +59,7 @@
  */
 
 enum {
+	/** ADDB Record Max record size in bytes (10G) */
 	DEFAULT_ADDB2_RECORD_SIZE = 10737418240,
 };
 /**

--- a/reqh/reqh.c
+++ b/reqh/reqh.c
@@ -58,6 +58,9 @@
    @{
  */
 
+enum {
+	DEFAULT_ADDB2_RECORD_SIZE = 10737418240,
+};
 /**
    Tlist descriptor for reqh services.
  */
@@ -339,12 +342,15 @@ M0_INTERNAL int m0_reqhs_init(void)
 
 #ifndef __KERNEL__
 M0_INTERNAL int m0_reqh_addb2_init(struct m0_reqh *reqh, const char *location,
-				   uint64_t key, bool mkfs, bool force)
+				   uint64_t key, bool mkfs, bool force,
+				   m0_bcount_t size)
 {
 	struct m0_addb2_sys *sys  = m0_fom_dom()->fd_addb2_sys;
 	struct m0_addb2_sys *gsys = m0_addb2_global_get();
 	int                  result;
 
+	if (size == 0)
+		size = DEFAULT_ADDB2_RECORD_SIZE;
 	/**
 	 * @todo replace size constant (10GB)  with a value from confc.
 	 */
@@ -364,7 +370,8 @@ M0_INTERNAL int m0_reqh_addb2_init(struct m0_reqh *reqh, const char *location,
 
 #else /* !__KERNEL__ */
 M0_INTERNAL int m0_reqh_addb2_init(struct m0_reqh *reqh, const char *location,
-				   uint64_t key, bool mkfs, bool force)
+				   uint64_t key, bool mkfs, bool force,
+				   m0_bcount_t size)
 {
 	struct m0_addb2_sys *sys = m0_fom_dom()->fd_addb2_sys;
 	int                  result;

--- a/reqh/reqh.h
+++ b/reqh/reqh.h
@@ -279,7 +279,8 @@ M0_INTERNAL void m0_reqh_be_fini(struct m0_reqh *reqh);
 M0_INTERNAL void m0_reqh_layouts_cleanup(struct m0_reqh *reqh);
 
 M0_INTERNAL int m0_reqh_addb2_init(struct m0_reqh *reqh, const char *location,
-				   uint64_t key, bool mkfs, bool force);
+				   uint64_t key, bool mkfs, bool force,
+				   m0_bcount_t size);
 M0_INTERNAL void m0_reqh_addb2_fini(struct m0_reqh *reqh);
 
 M0_INTERNAL int m0_reqh_addb2_submit(struct m0_reqh *reqh,

--- a/reqh/reqh.h
+++ b/reqh/reqh.h
@@ -60,6 +60,17 @@
    @{
  */
 
+enum {
+	/** ADDB Record Max record size in bytes (10G) */
+	DEFAULT_ADDB2_RECORD_SIZE = 10ULL << 30,
+	/** Min ADDB Record record size in bytes (10M) */
+	MIN_ADDB2_RECORD_SIZE = 10ULL << 20,
+	/** Max ADDB Record record size in bytes (10G) */
+	MAX_ADDB2_RECORD_SIZE = 10ULL << 30,
+	/** ADDB Record size should be multiple of 4K Bytes*/
+	BLK_SIZE = 4ULL << 10
+};
+
 struct m0_fop;
 struct m0_rpc_machine;
 struct m0_addb2_storage;

--- a/scripts/install/etc/sysconfig/motr
+++ b/scripts/install/etc/sysconfig/motr
@@ -151,4 +151,6 @@ MOTR_TRACED_KEEP_LOGS_NUM=2
 # for developers to quickly test their local changes w/o creating and installing
 # an rpm package each time.
 #MOTR_DEVEL_WORKDIR_PATH=/home/devvm/motr
+
+#MOTR ADDB Record Max record size in bytes (10G)
 MOTR_MOD_ADDB_RECORD_SIZE=10737418240

--- a/scripts/install/etc/sysconfig/motr
+++ b/scripts/install/etc/sysconfig/motr
@@ -151,3 +151,4 @@ MOTR_TRACED_KEEP_LOGS_NUM=2
 # for developers to quickly test their local changes w/o creating and installing
 # an rpm package each time.
 #MOTR_DEVEL_WORKDIR_PATH=/home/devvm/motr
+MOTR_MOD_ADDB_RECORD_SIZE=10737418240

--- a/scripts/install/usr/libexec/cortx-motr/motr-server
+++ b/scripts/install/usr/libexec/cortx-motr/motr-server
@@ -199,7 +199,7 @@ m0_server()
     # show actual exec commands in log file
     set -x
 
-    addb_opts+=" -r ${MOTR_MOD_ADDB_RECORD_SIZE}"
+    addb_opts=" -r ${MOTR_MOD_ADDB_RECORD_SIZE}"
     exec $binary -e $service_ep \
                     -A linuxstob:${addbstob_dir}addb-stobs \
                     -f $proc_fid $stob_type $stob_path $MOTR_M0D_OPTS \

--- a/scripts/install/usr/libexec/cortx-motr/motr-server
+++ b/scripts/install/usr/libexec/cortx-motr/motr-server
@@ -199,11 +199,12 @@ m0_server()
     # show actual exec commands in log file
     set -x
 
+    addb_opts+=" -r ${MOTR_MOD_ADDB_RECORD_SIZE}"
     exec $binary -e $service_ep \
                     -A linuxstob:${addbstob_dir}addb-stobs \
                     -f $proc_fid $stob_type $stob_path $MOTR_M0D_OPTS \
                        $be_seg0_path $be_seg_path \
-                       $stob_opts $cmd_opts $MOTR_M0D_EXTRA_OPTS
+                       $stob_opts $cmd_opts $addb_opts $MOTR_M0D_EXTRA_OPTS
 }
 
 


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>