### PR TITLE
EOS-13784 m0provision: backup motr conf file and is restored after node replaced

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/conf/setup.yaml
+++ b/scripts/install/opt/seagate/cortx/motr/conf/setup.yaml
@@ -37,6 +37,15 @@ core:
     reset:
         script: /usr/sbin/m0provision
         args:
-            - reset
+
+    backup:
+        files:
+             - /etc/sysconfig/motr
+
+    post_update:
+        script: /usr/sbin/m0provision
+        args:
+            - config
+
 support_bundle:
     - /opt/seagate/cortx/motr/libexec/m0reportbug-bundler


### PR DESCRIPTION
/etc/sysconfig/motr is added to backup in-case of node replacement
this is restored.
Also added post update conf, which will be called after rpm is updated.
It is needed in case any config parameters are updated in the new
rpm package.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>