### PR TITLE
m0_filesystem_stats: use minion id instead of hostname in consul query

### DIFF
--- a/utils/spiel/m0_filesystem_stats
+++ b/utils/spiel/m0_filesystem_stats
@@ -150,12 +150,25 @@ if [ $rc -ne 0 ] ; then
 fi
 }
 
+get_hostname()
+{
+        host=" "
+        if [[ -f /etc/salt/minion_id ]] ; then
+            host=$(cat /etc/salt/minion_id)
+        fi
+
+        if [ -z $host ] ; then
+           host="localhost"
+        fi
+        echo $host
+}
+
 # Get endpoints of local node's processes that run service(s) of given type.
 get_endpoints_of() {
 	local svc_type=$1
 
 	$consul_query_cmd |
-        awk -F/ -v host=$(hostname --fqdn) -v svc_type=$svc_type '
+        awk -F/ -v host=$(get_hostname) -v svc_type=$svc_type '
 	$3 != host { next }
 	$6 ~ /^endpoint:/ { sub(/^endpoint:/, "", $6); endpoints[$5] = $6 }
 	$6 == "services" && match($7, "^" svc_type ":") { match_p[$5] = 1 }

--- a/utils/spiel/m0_filesystem_stats
+++ b/utils/spiel/m0_filesystem_stats
@@ -157,7 +157,7 @@ get_hostname()
             host=$(cat /etc/salt/minion_id)
         fi
 
-        if [ -z $host ] ; then
+        if [[ -z "$host" ]] ; then
            host=$(hostname --fqdn)
         fi
         echo $host
@@ -245,6 +245,8 @@ Usage: $SCRIPT_NAME [options]
     -p, --profile          profile endpoint address
 
     -l, --libmotr_path     libmotr path
+
+    -t, --timeout          timeout in seconds
 
     -h, --help             this help
 

--- a/utils/spiel/m0_filesystem_stats
+++ b/utils/spiel/m0_filesystem_stats
@@ -158,7 +158,7 @@ get_hostname()
         fi
 
         if [ -z $host ] ; then
-           host="localhost"
+           host=$(hostname --fqdn)
         fi
         echo $host
 }


### PR DESCRIPTION
hostname was used to get the current host endpoints from consul,
in the recent builds, consul sends minion_id instead of hostname
so server and client endpoints were not recieved.
Solution: use minion_id instead of hostname.