### PR TITLE
EOS-6023 net/lnet: remove LNID cache

### DIFF
--- a/net/lnet/linux_kernel/klnet_core.c
+++ b/net/lnet/linux_kernel/klnet_core.c
@@ -1777,6 +1777,7 @@ M0_INTERNAL void nlx_core_nidstrs_put(struct nlx_core_domain *lcdom,
 
 	for (i = 0; (*nidary)[i] != NULL; ++i)
 		m0_free((*nidary)[i]);
+	m0_free(*nidary);
 	*nidary = NULL;
 }
 

--- a/net/lnet/linux_kernel/klnet_drv.c
+++ b/net/lnet/linux_kernel/klnet_drv.c
@@ -1153,8 +1153,8 @@ static int nlx_dev_ioctl_nidstr_encode(struct m0_lnet_dev_nid_encdec_params *p)
 static int nlx_dev_ioctl_nidstrs_get(struct nlx_kcore_domain *kd,
 				     struct m0_lnet_dev_nidstrs_get_params *p)
 {
-	char * const *nidstrs;
-	int rc = nlx_kcore_nidstrs_get(&nidstrs);
+	char **nidstrs;
+	int rc = nlx_core_nidstrs_get(NULL, &nidstrs);
 	char *buf;
 	m0_bcount_t sz;
 	int i;
@@ -1164,20 +1164,20 @@ static int nlx_dev_ioctl_nidstrs_get(struct nlx_kcore_domain *kd,
 	for (i = 0, sz = 1; nidstrs[i] != NULL; ++i)
 		sz += strlen(nidstrs[i]) + 1;
 	if (sz > p->dng_size) {
-		nlx_kcore_nidstrs_put(&nidstrs);
+		nlx_core_nidstrs_put(NULL, &nidstrs);
 		return M0_ERR_INFO(-EFBIG, "sz=%"PRIu64" p->dng_size=%"PRIu64,
 				   sz, p->dng_size);
 	}
 	NLX_ALLOC(buf, sz);
 	if (buf == NULL) {
-		nlx_kcore_nidstrs_put(&nidstrs);
+		nlx_core_nidstrs_put(NULL, &nidstrs);
 		return M0_ERR(-ENOMEM);
 	}
 	for (i = 0, sz = 0; nidstrs[i] != NULL; ++i) {
 		strcpy(&buf[sz], nidstrs[i]);
 		sz += strlen(nidstrs[i]) + 1;
 	}
-	nlx_kcore_nidstrs_put(&nidstrs);
+	nlx_core_nidstrs_put(NULL, &nidstrs);
 	if (copy_to_user((void __user *) p->dng_buf, buf, sz))
 		rc = -EFAULT;
 	else

--- a/net/lnet/lnet.h
+++ b/net/lnet/lnet.h
@@ -144,13 +144,13 @@ M0_INTERNAL int m0_net_lnet_ep_addr_net_cmp(const char *addr1,
    @param addrs A NULL-terminated (like argv) array of NID strings is returned.
  */
 M0_INTERNAL int m0_net_lnet_ifaces_get(struct m0_net_domain *dom,
-				       char *const **addrs);
+				       char ***addrs);
 
 /**
    Releases the string array returned by m0_net_lnet_ifaces_get().
  */
 M0_INTERNAL void m0_net_lnet_ifaces_put(struct m0_net_domain *dom,
-					char *const **addrs);
+					char ***addrs);
 
 /* init and fini functions for motr init */
 M0_INTERNAL int m0_net_lnet_init(void);

--- a/net/lnet/lnet_core.h
+++ b/net/lnet/lnet_core.h
@@ -494,14 +494,14 @@ static void nlx_core_ep_addr_encode(struct nlx_core_domain *lcdom,
    @param lcdom Domain pointer.
    @param nidary A NULL-terminated (like argv) array of NID strings is returned.
  */
-static int nlx_core_nidstrs_get(struct nlx_core_domain *lcdom,
-				char * const **nidary);
+static int nlx_core_nidstrs_get(struct nlx_core_domain   *lcdom,
+				char                   ***nidary);
 
 /**
    Releases the string array returned by nlx_core_nidstrs_get().
  */
-static void nlx_core_nidstrs_put(struct nlx_core_domain *lcdom,
-				 char * const **nidary);
+static void nlx_core_nidstrs_put(struct nlx_core_domain   *lcdom,
+				 char                   ***nidary);
 
 /**
    Starts a transfer machine. Internally this results in

--- a/net/lnet/lnet_main.c
+++ b/net/lnet/lnet_main.c
@@ -944,7 +944,7 @@ M0_INTERNAL int m0_net_lnet_ep_addr_net_cmp(const char *addr1,
 M0_EXPORTED(m0_net_lnet_ep_addr_net_cmp);
 
 M0_INTERNAL int m0_net_lnet_ifaces_get(struct m0_net_domain *dom,
-				       char *const **addrs)
+				       char ***addrs)
 {
 	struct nlx_xo_domain *dp;
 
@@ -955,7 +955,7 @@ M0_INTERNAL int m0_net_lnet_ifaces_get(struct m0_net_domain *dom,
 M0_EXPORTED(m0_net_lnet_ifaces_get);
 
 M0_INTERNAL void m0_net_lnet_ifaces_put(struct m0_net_domain *dom,
-					char *const **addrs)
+					char ***addrs)
 {
 	struct nlx_xo_domain *dp;
 

--- a/net/lnet/st/ping.h
+++ b/net/lnet/st/ping.h
@@ -38,54 +38,54 @@ struct nlx_ping_ops {
    Context for a ping client or server.
  */
 struct nlx_ping_ctx {
-	const struct nlx_ping_ops	     *pc_ops;
-	struct m0_net_xprt		     *pc_xprt;
-	struct m0_net_domain		      pc_dom;
-	const char		             *pc_network; /* "addr@interface" */
-	uint32_t                              pc_pid;
-	uint32_t			      pc_portal;
-	int32_t			              pc_tmid; /* initialized to < 0 */
-	const char			     *pc_rnetwork;
-	uint32_t                              pc_rpid;
-	uint32_t			      pc_rportal;
-	int32_t			              pc_rtmid;
-	int32_t				      pc_status;
-	uint32_t		              pc_nr_bufs;
-	uint32_t		              pc_nr_recv_bufs;
-	uint32_t		              pc_segments;
-	uint32_t		              pc_seg_size;
-        uint32_t                              pc_seg_shift;
-	int                                   pc_min_recv_size;
-	int                                   pc_max_recv_msgs;
-	uint64_t			      pc_bulk_size;
-	struct m0_net_buffer		     *pc_nbs;
-	const struct m0_net_buffer_callbacks *pc_buf_callbacks;
-	struct m0_bitmap		      pc_nbbm;
-	struct m0_net_transfer_mc	      pc_tm;
-	struct m0_mutex			      pc_mutex;
-	struct m0_cond			      pc_cond;
-	struct m0_list			      pc_work_queue;
-	const char		             *pc_ident;
-	const char		             *pc_compare_buf;
-	int                                   pc_bulk_timeout;
-	int                                   pc_msg_timeout;
-	int                                   pc_server_bulk_delay;
-	int                                   pc_dom_debug;
-	int                                   pc_tm_debug;
-	bool                                  pc_ready;
-	char * const *                        pc_interfaces;
-	bool                                  pc_sync_events;
-	struct m0_chan                        pc_wq_chan;
-	struct m0_clink                       pc_wq_clink;
-	uint64_t                              pc_wq_signal_count;
-	struct m0_chan                        pc_net_chan;
-	struct m0_clink                       pc_net_clink;
-	uint64_t                              pc_net_signal_count;
-	uint64_t                              pc_blocked_count;
-        uint64_t                              pc_worked_count;
-	struct m0_atomic64                    pc_errors;
-	struct m0_atomic64                    pc_retries;
-	int                                   pc_verbose;
+	const struct nlx_ping_ops	      *pc_ops;
+	struct m0_net_xprt		      *pc_xprt;
+	struct m0_net_domain		       pc_dom;
+	const char		              *pc_network; /* "addr@interface" */
+	uint32_t                               pc_pid;
+	uint32_t			       pc_portal;
+	int32_t			               pc_tmid; /* initialized to < 0 */
+	const char			      *pc_rnetwork;
+	uint32_t                               pc_rpid;
+	uint32_t			       pc_rportal;
+	int32_t			               pc_rtmid;
+	int32_t				       pc_status;
+	uint32_t		               pc_nr_bufs;
+	uint32_t		               pc_nr_recv_bufs;
+	uint32_t		               pc_segments;
+	uint32_t		               pc_seg_size;
+        uint32_t                               pc_seg_shift;
+	int                                    pc_min_recv_size;
+	int                                    pc_max_recv_msgs;
+	uint64_t			       pc_bulk_size;
+	struct m0_net_buffer		      *pc_nbs;
+	const struct m0_net_buffer_callbacks  *pc_buf_callbacks;
+	struct m0_bitmap		       pc_nbbm;
+	struct m0_net_transfer_mc	       pc_tm;
+	struct m0_mutex			       pc_mutex;
+	struct m0_cond			       pc_cond;
+	struct m0_list			       pc_work_queue;
+	const char		              *pc_ident;
+	const char		              *pc_compare_buf;
+	int                                    pc_bulk_timeout;
+	int                                    pc_msg_timeout;
+	int                                    pc_server_bulk_delay;
+	int                                    pc_dom_debug;
+	int                                    pc_tm_debug;
+	bool                                   pc_ready;
+	char                                 **pc_interfaces;
+	bool                                   pc_sync_events;
+	struct m0_chan                         pc_wq_chan;
+	struct m0_clink                        pc_wq_clink;
+	uint64_t                               pc_wq_signal_count;
+	struct m0_chan                         pc_net_chan;
+	struct m0_clink                        pc_net_clink;
+	uint64_t                               pc_net_signal_count;
+	uint64_t                               pc_blocked_count;
+        uint64_t                               pc_worked_count;
+	struct m0_atomic64                     pc_errors;
+	struct m0_atomic64                     pc_retries;
+	int                                    pc_verbose;
 };
 
 struct nlx_ping_client_params {

--- a/net/lnet/st/ping.h
+++ b/net/lnet/st/ping.h
@@ -38,35 +38,35 @@ struct nlx_ping_ops {
    Context for a ping client or server.
  */
 struct nlx_ping_ctx {
-	const struct nlx_ping_ops	      *pc_ops;
-	struct m0_net_xprt		      *pc_xprt;
-	struct m0_net_domain		       pc_dom;
-	const char		              *pc_network; /* "addr@interface" */
+	const struct nlx_ping_ops             *pc_ops;
+	struct m0_net_xprt                    *pc_xprt;
+	struct m0_net_domain                   pc_dom;
+	const char                            *pc_network;/* "addr@interface" */
 	uint32_t                               pc_pid;
-	uint32_t			       pc_portal;
-	int32_t			               pc_tmid; /* initialized to < 0 */
-	const char			      *pc_rnetwork;
+	uint32_t                               pc_portal;
+	int32_t                                pc_tmid; /* initialized to < 0 */
+	const char                            *pc_rnetwork;
 	uint32_t                               pc_rpid;
-	uint32_t			       pc_rportal;
-	int32_t			               pc_rtmid;
-	int32_t				       pc_status;
-	uint32_t		               pc_nr_bufs;
-	uint32_t		               pc_nr_recv_bufs;
-	uint32_t		               pc_segments;
-	uint32_t		               pc_seg_size;
-        uint32_t                               pc_seg_shift;
+	uint32_t                               pc_rportal;
+	int32_t                                pc_rtmid;
+	int32_t                                pc_status;
+	uint32_t                               pc_nr_bufs;
+	uint32_t                               pc_nr_recv_bufs;
+	uint32_t                               pc_segments;
+	uint32_t                               pc_seg_size;
+	uint32_t                               pc_seg_shift;
 	int                                    pc_min_recv_size;
 	int                                    pc_max_recv_msgs;
-	uint64_t			       pc_bulk_size;
-	struct m0_net_buffer		      *pc_nbs;
+	uint64_t                               pc_bulk_size;
+	struct m0_net_buffer                  *pc_nbs;
 	const struct m0_net_buffer_callbacks  *pc_buf_callbacks;
-	struct m0_bitmap		       pc_nbbm;
-	struct m0_net_transfer_mc	       pc_tm;
-	struct m0_mutex			       pc_mutex;
-	struct m0_cond			       pc_cond;
-	struct m0_list			       pc_work_queue;
-	const char		              *pc_ident;
-	const char		              *pc_compare_buf;
+	struct m0_bitmap                       pc_nbbm;
+	struct m0_net_transfer_mc              pc_tm;
+	struct m0_mutex                        pc_mutex;
+	struct m0_cond                         pc_cond;
+	struct m0_list                         pc_work_queue;
+	const char                            *pc_ident;
+	const char                            *pc_compare_buf;
 	int                                    pc_bulk_timeout;
 	int                                    pc_msg_timeout;
 	int                                    pc_server_bulk_delay;
@@ -82,7 +82,7 @@ struct nlx_ping_ctx {
 	struct m0_clink                        pc_net_clink;
 	uint64_t                               pc_net_signal_count;
 	uint64_t                               pc_blocked_count;
-        uint64_t                               pc_worked_count;
+	uint64_t                               pc_worked_count;
 	struct m0_atomic64                     pc_errors;
 	struct m0_atomic64                     pc_retries;
 	int                                    pc_verbose;

--- a/net/lnet/ulnet_core.c
+++ b/net/lnet/ulnet_core.c
@@ -402,10 +402,6 @@
      a pointer to each nul-terminated NID string, until the number of
      strings returned by the ioctl request have been populated.
 
-   Currently, the kernel implementation caches the NID strings once; the user
-   space core can assume this behavior and cache the result per domain,
-   but may need to change in the future if the kernel implementation changes.
-
    @see @ref LNetDRVDLD-lspec-nids "Corresponding device layer behavior"
 
    @subsection ULNetCoreDLD-lspec-state State Specification
@@ -577,8 +573,7 @@ static unsigned nlx_ucore_nidstrs_thunk = 128;
    Routine to fetch the NID strings from the device driver.
    The subroutine does not modify the domain private structure.
    @param ud Ucore domain. Only the fd field is required to
-   be set, as this subroutine could be used during domain initialization
-   to cache the NID strings.
+   be set.
    @param nidary A NULL-terminated (like argv) array of NID strings is returned.
  */
 static int nlx_ucore_nidstrs_get(struct nlx_ucore_domain *ud, char ***nidary)

--- a/net/lnet/ulnet_core.h
+++ b/net/lnet/ulnet_core.h
@@ -44,12 +44,6 @@ struct nlx_ucore_domain {
 	m0_bcount_t                     ud_max_buffer_segment_size;
 	/** Cached maximum number of buffer segments. */
 	int32_t                         ud_max_buffer_segments;
-	/** Cached NID strings.  If LNet were to support dynamically configured
-	    NIDs, then this simple caching would have to be re-addressed.
-	 */
-        char                          **ud_nidstrs;
-	/** Number of references to the NID strings */
-	struct m0_atomic64              ud_nidstrs_refcount;
 	/** File descriptor to the kernel device. */
 	int                             ud_fd;
 };

--- a/net/lnet/ut/linux_kernel/klnet_ut.c
+++ b/net/lnet/ut/linux_kernel/klnet_ut.c
@@ -403,7 +403,7 @@ static void ktest_core_ep_addr(void)
 		},
 	};
 	char buf[M0_NET_LNET_XEP_ADDR_LEN];
-	char * const *nidstrs;
+	char **nidstrs;
 	int rc;
 	int i;
 

--- a/net/lnet/ut/lnet_ut.c
+++ b/net/lnet/ut/lnet_ut.c
@@ -275,27 +275,27 @@ enum {
 	UT_PAGE_SHIFT = 12
 };
 struct ut_data {
-	int                            _debug_;
-	struct m0_net_tm_callbacks     tmcb;
-	struct m0_net_domain           dom1;
-	struct m0_net_transfer_mc      tm1;
-	struct m0_clink                tmwait1;
-	struct m0_net_buffer_callbacks buf_cb1;
-	struct m0_net_buffer           bufs1[UT_BUFS1];
-	size_t                         buf_size1;
-	m0_bcount_t                    buf_seg_size1;
-	struct m0_net_domain           dom2;
-	struct m0_net_transfer_mc      tm2;
-	struct m0_clink                tmwait2;
-	struct m0_net_buffer_callbacks buf_cb2;
-	struct m0_net_buffer           bufs2[UT_BUFS2];
-	size_t                         buf_size2;
-	m0_bcount_t                    buf_seg_size2;
-	struct m0_net_qstats           qs;
-	char * const                  *nidstrs1;
-	char * const                  *nidstrs2;
-	struct nlx_core_buf_desc       cbd1;
-	struct nlx_core_buf_desc       cbd2;
+	int                              _debug_;
+	struct m0_net_tm_callbacks       tmcb;
+	struct m0_net_domain             dom1;
+	struct m0_net_transfer_mc        tm1;
+	struct m0_clink                  tmwait1;
+	struct m0_net_buffer_callbacks   buf_cb1;
+	struct m0_net_buffer             bufs1[UT_BUFS1];
+	size_t                           buf_size1;
+	m0_bcount_t                      buf_seg_size1;
+	struct m0_net_domain             dom2;
+	struct m0_net_transfer_mc        tm2;
+	struct m0_clink                  tmwait2;
+	struct m0_net_buffer_callbacks   buf_cb2;
+	struct m0_net_buffer             bufs2[UT_BUFS2];
+	size_t                           buf_size2;
+	m0_bcount_t                      buf_seg_size2;
+	struct m0_net_qstats             qs;
+	char                           **nidstrs1;
+	char                           **nidstrs2;
+	struct nlx_core_buf_desc         cbd1;
+	struct nlx_core_buf_desc         cbd2;
 };
 
 #ifdef __KERNEL__
@@ -441,7 +441,7 @@ static void ut_test_framework(ut_test_fw_body_t body,
 do {									\
 	struct m0_net_domain *dom = &td->dom ## which;			\
 	struct m0_net_transfer_mc *tm = &td->tm ## which;		\
-	char * const **nidstrs = &td->nidstrs ## which;			\
+	char ***nidstrs = &td->nidstrs ## which;			\
 	M0_UT_ASSERT(!m0_net_domain_init(dom, &m0_net_lnet_xprt));	\
 	M0_UT_ASSERT(!m0_net_lnet_ifaces_get(dom, nidstrs));		\
 	M0_UT_ASSERT(*nidstrs != NULL && **nidstrs != NULL);		\
@@ -724,7 +724,7 @@ static void test_tm_startstop(void)
 		.ntc_event_cb = ut_tm_ecb,
 	};
 	static struct m0_clink tmwait1;
-	char * const *nidstrs;
+	char **nidstrs;
 	const char *nid_to_use;
 	char epstr[M0_NET_LNET_XEP_ADDR_LEN];
 	char badportal_epstr[M0_NET_LNET_XEP_ADDR_LEN];

--- a/net/test/user_space/common_u.c
+++ b/net/test/user_space/common_u.c
@@ -121,10 +121,10 @@ void m0_net_test_u_print_bsize(double bsize)
 
 void m0_net_test_u_lnet_info(void)
 {
-	struct m0_net_domain  dom;
-	int		      rc;
-	char * const	     *nidstrs;
-	int		      i;
+	struct m0_net_domain   dom;
+	int		       rc;
+	char                 **nidstrs;
+	int		       i;
 
 	M0_SET0(&dom);
 	rc = m0_net_domain_init(&dom, &m0_net_lnet_xprt);


### PR DESCRIPTION
Currently we have a list of LNIDs, which is cached during m0tr.ko module
insertion. During the failover, LNID is added in runtime to LNet
configuration, which currently lifts the requirement to re-insert
m0tr.ko kernel module (and hence, the restart of all the Motr-processes
running on the node as well). This slows down the failover/failback time
considerably.

Solution: get rid of the LNIDs caching in m0tr.ko kernel module.
Instead, LNIDs are queried from LNET every time they are needed.

Signed-off-by: Maksym Medvied <max.medved@seagate.com>