### PR TITLE
EOS-13707: not posting ast to cancel DIX_NEXT operation

### DIFF
--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -1074,7 +1074,8 @@ M0_INTERNAL int m0__idx_cancel(struct m0_op_idx *oi)
 	 * Do no post cancel ast when oi completion/fail
 	 * already called and for not handled types.
 	 */
-	if (!M0_IN(dreq->dr_type, (DIX_CREATE,
+	if (!M0_IN(dreq->dr_type, (DIX_NEXT,
+				   DIX_CREATE,
 				   DIX_DELETE,
 				   DIX_CCTGS_LOOKUP)) &&
 	    !oi->oi_in_completion)


### PR DESCRIPTION
m0_op_wait after m0_op_cancel() wait continiusly for state
M0_OS_STABLE or M0_OS_FAILED for DIX_NEXT index operation.
DIX_NEXT operation has launched but not completed/failed
it is ongoing, It is expected that posted ast to cancel
operation should cancel ongoing DIX_NEXT operation
as seen op->dg_completed_nr < rop->dg_cas_reqs_nr.

sm group oi->oi_sm_grp could not call
any posted ast callback, it observed sm group
waiting at m0_chan_wait for corresponding
loc_handler_thread.

This issue observed with st "26motr-user-kernel-tests"
if run in iterations and seen only for DIX_NEXT operation
so not posting ast to cancel DIX_NEXT operation.

Signed-off-by: Vishwas Bhat <vishwas.bhat@seagate.com>