### PR TITLE
EOS-13878 scripts: use MOTR_M0D_IOS_BESEG_SIZE for ioservice

### DIFF
--- a/scripts/install/usr/libexec/cortx-motr/motr-server
+++ b/scripts/install/usr/libexec/cortx-motr/motr-server
@@ -98,6 +98,7 @@ m0_server()
     local proc_fid="<$(m0_get_proc_fid_for $service)>"
     local be_seg0_path=
     local be_seg_path=
+    local be_seg_size=
 
     # @todo
     # These BE segment devices needs to pass through Motr configuration
@@ -109,6 +110,9 @@ m0_server()
 
     if [[ -n $MOTR_BE_SEG_PATH && -b $MOTR_BE_SEG_PATH ]]; then
         be_seg_path=" -B $MOTR_BE_SEG_PATH "
+        if [[ -n $MOTR_M0D_IOS_BESEG_SIZE ]]; then
+            be_seg_size=" -z $MOTR_M0D_IOS_BESEG_SIZE"
+        fi
     fi
 
     # mds and rms are expected to read local configuration until the
@@ -202,7 +206,7 @@ m0_server()
     exec $binary -e $service_ep \
                     -A linuxstob:${addbstob_dir}addb-stobs \
                     -f $proc_fid $stob_type $stob_path $MOTR_M0D_OPTS \
-                       $be_seg0_path $be_seg_path \
+                       $be_seg0_path $be_seg_path $be_seg_size \
                        $stob_opts $cmd_opts $MOTR_M0D_EXTRA_OPTS
 }
 


### PR DESCRIPTION
Currently be seg size MOTR_M0D_IOS_BESEG_SIZE from /etc/sysconfig/motr
not being used and default value of 8GB is used due to a bug in
motr-server script, which checks for "^ios" regex in systemd unit file,
which is no longer used with hare based cluster.
The following crash is observed,

 #3  0x00007fca296780b4 in m0_panic (ctx=ctx@entry=0x7fca29a72020 <__pctx.8247>) at lib/assert.c:52
 #4  0x00007fca295bdf20 in mem_alloc (zonemask=2, size=<optimized out>, tx=0x7fc84c2266b8, btree=0x40000015f210) at be/btree.c:127
 #5  btree_save (tree=tree@entry=0x40000015f210, tx=tx@entry=0x7fc84c2266b8, op=op@entry=0x7fc92bffe460,
    key=key@entry=0x7fc92bffe6d0, val=val@entry=0x7fc92bffe6e0, anchor=anchor@entry=0x0, optype=optype@entry=BTREE_SAVE_INSERT,
    zonemask=zonemask@entry=2) at be/btree.c:1453
 #6  0x00007fca295bdfe8 in be_btree_insert (tree=tree@entry=0x40000015f210, tx=tx@entry=0x7fc84c2266b8,
    op=op@entry=0x7fc92bffe460, key=key@entry=0x7fc92bffe6d0, val=val@entry=0x7fc92bffe6e0, anchor=anchor@entry=0x0,
    zonemask=zonemask@entry=2) at be/btree.c:1907
 #7  0x00007fca295bf018 in m0_be_btree_insert (tree=tree@entry=0x40000015f210, tx=tx@entry=0x7fc84c2266b8,
    op=op@entry=0x7fc92bffe460, key=key@entry=0x7fc92bffe6d0, val=val@entry=0x7fc92bffe6e0) at be/btree.c:1938
 #8  0x00007fca295f7931 in cob_table_insert (tree=0x40000015f210, tx=tx@entry=0x7fc84c2266b8, key=key@entry=0x7fc92bffe6d0,
    val=val@entry=0x7fc92bffe6e0) at cob/cob.c:721
 #9  0x00007fca295fa5cf in m0_cob_name_add (cob=cob@entry=0x7fc9241ffc50, nskey=nskey@entry=0x7fc9241ffdc0,
    nsrec=nsrec@entry=0x7fc92bffe8e0, tx=tx@entry=0x7fc84c2266b8) at cob/cob.c:1640
 #10 0x00007fca295fa85a in m0_cob_create (cob=0x7fc9241ffc50, nskey=0x7fc9241ffdc0, nsrec=nsrec@entry=0x7fc92bffe8e0,
    fabrec=fabrec@entry=0x0, omgrec=omgrec@entry=0x0, tx=tx@entry=0x7fc84c2266b8) at cob/cob.c:1428
 #11 0x00007fca2966b097 in m0_cc_cob_setup (cc=cc@entry=0x7fc84c2265d0, cdom=<optimized out>, attr=attr@entry=0x7fc92bffec20,
    ctx=ctx@entry=0x7fc84c2266b8) at ioservice/cob_foms.c:1058
 #12 0x00007fca2966b275 in cc_cob_create (attr=0x7fc92bffec20, cc=0x7fc84c2265d0, fom=0x7fc84c2265f0) at ioservice/cob_foms.c:1016
 #13 cob_stob_create (fom=fom@entry=0x7fc84c2265f0, attr=attr@entry=0x7fc92bffec20) at ioservice/cob_foms.c:517
 #14 0x00007fca2966c40b in cob_ops_fom_tick (fom=0x7fc84c2265f0) at ioservice/cob_foms.c:767
 #15 0x00007fca2964c24b in fom_exec (fom=0x7fc84c2265f0) at fop/fom.c:785
 #16 loc_handler_thread (th=0x1b5c1e0) at fop/fom.c:925
 #17 0x00007fca2967e50e in m0_thread_trampoline (arg=arg@entry=0x1b5c1e8) at lib/thread.c:117
 #18 0x00007fca2968875d in uthread_trampoline (arg=0x1b5c1e8) at lib/user_space/uthread.c:98
 #19 0x00007fca28e36ea5 in start_thread () from /lib64/libpthread.so.0
 #20 0x00007fca27f278cd in clone () from /lib64/libc.so.6

So for LDR R1, as LVM paths are passed only for ioservices, at the
same place be seg size is applied.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>