### PR TITLE
EOS-13891 beck: handle segment header generation identifier corruption case

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -480,7 +480,7 @@ int main(int argc, char **argv)
 		   M0_FLAGARG('n', "Dry Run.", &dry_run),
 		   M0_FLAGARG('p', "Print Generation Identifier.",
 			      &print_gen_id),
-		   M0_FORMATARG('g', "Get Generation Identifier.", "%"PRIu64,
+		   M0_FORMATARG('g', "Generation Identifier.", "%"PRIu64,
 				&s.s_gen),
 		   M0_FLAGARG('V', "Version info.", &version),
 		   M0_STRINGARG('a', "stob domain path",
@@ -534,8 +534,9 @@ int main(int argc, char **argv)
 		fclose(s.s_file);
 		return EX_OK;
 	}
-	if (s.s_gen != 0) {
+	if (gen_id != 0)
 		s.s_gen_found = true;
+	if (s.s_gen != 0) {
 		printf("\nReceived source segment header generation id\n");
 		generation_id_print(s.s_gen);
 	}
@@ -972,6 +973,8 @@ static int btree(struct scanner *s, struct rectype *r, char *buf)
 	if (!s->s_gen_found) {
 		s->s_gen_found = true;
 		s->s_gen = tree->bb_backlink.bli_gen;
+		printf("\nBeck will use latest generation id found in btree\n");
+		generation_id_print(s->s_gen);
 	}
 	b = &bt[idx];
 	b->b_stats.c_tree++;
@@ -984,7 +987,7 @@ static int btree_check(struct scanner *s, struct rectype *r, char *buf)
 	int                 idx  = tree->bb_backlink.bli_type;
 
 	if (!IS_IN_ARRAY(idx, bt) || bt[idx].b_type == 0)
-		return M0_ERR(-ENOENT);
+		return -ENOENT;
 
 	return generation_id_verify(s, tree->bb_backlink.bli_gen);
 }
@@ -1017,6 +1020,8 @@ static int bnode(struct scanner *s, struct rectype *r, char *buf)
 	if (!s->s_gen_found) {
 		s->s_gen_found = true;
 		s->s_gen = node->bt_backlink.bli_gen;
+		printf("\nBeck will use latest generation id found in bnode\n");
+		generation_id_print(s->s_gen);
 	}
 	b = &bt[idx];
 	c = &b->b_stats;
@@ -1038,7 +1043,7 @@ static int bnode_check(struct scanner *s, struct rectype *r, char *buf)
 	int                 idx  = node->bt_backlink.bli_type;
 
 	if (!IS_IN_ARRAY(idx, bt) || bt[idx].b_type == 0)
-		return M0_ERR(-ENOENT);
+		return -ENOENT;
 
 	return generation_id_verify(s, node->bt_backlink.bli_gen);
 }
@@ -1485,6 +1490,7 @@ static int builder_init(struct builder *b)
 	}
 	printf("\nDestination segment header generation\n");
 	generation_id_print(b->b_seg->bs_gen);
+	printf("\n");
 	/*
 	 * Flush immediately to avoid losing this information within other lines
 	 * coming on the screen at the same time.


### PR DESCRIPTION
If generation identifier is found in segment header one then only, update
the s_gen_found field in scanner. If the generation identifier of segment 
header one is corrupted then use the generation identifier provided in 
command line input of beck tool till valid generation identifier is found in 
btree/bnode.
Updated the description for 'g' parameter which is used for storing command
line generation identifier input.
Removed M0_ERR from bnode_check() and btree_check(), since it was flooding
script log with error messages that can be avoided.
Added prints for printing generation id once valid generation identifier is found
in btree or bnode. 
Added extra line after printing destination segment generation identifier for better
display in log file.

Signed-off-by: Nikhil Kumar Birgade <nikhil.birgade@seagate.com>