### PR TITLE
m0trace: typo fix in --help

### DIFF
--- a/utils/trace/m0trace
+++ b/utils/trace/m0trace
@@ -1396,7 +1396,7 @@ regex.
 
 Example:
 
-  m0trace -M 'Sesstion created'
+  m0trace -M 'Session created'
   m0trace -M 'slot \x+ nr_items [1-3]'
 
 =item B<-h|--help>


### PR DESCRIPTION
Signed-off-by: Maksym Medvied <max.medved@seagate.com>