### PR TITLE
EOS-14082: fix failed to resume lv_meta_data while removing the snapshot

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -931,6 +931,8 @@ EOF
         fi
     fi
 
+    m0drlog "Wait 5 minutes to flush any outstanding IO"
+    sleep 5m
     cleanup_stobs_dir
 
     return $exec_status

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -447,18 +447,18 @@ replay_logs_and_get_gen_id_of_seg0() {
             else
                 m0drlog "ERROR: Journal logs replay failed on local node"
                 (( exec_status|=1));
-        fi
+            fi
 
-        m0drlog "Get generation id of local node from segment 1"
-        LOCAL_SEG_GEN_ID="$($BECKTOOL -s $MD_DIR/m0d-$LOCAL_IOS_FID/db/o/100000000000000:2a -p)"
-        LOCAL_SEG_GEN_ID=$(echo $LOCAL_SEG_GEN_ID | cut -d "(" -f2 | cut -d ")" -f1)
-
-        if [[ $LOCAL_SEG_GEN_ID -eq 0 ]]; then
-            m0drlog "Get generation id of local node from segment 0"
-            LOCAL_SEG_GEN_ID="$($BECKTOOL -s $MD_DIR/m0d-$LOCAL_IOS_FID/db/o/100000000000000:29 -p)"
+            m0drlog "Get generation id of local node from segment 1"
+            LOCAL_SEG_GEN_ID="$($BECKTOOL -s $MD_DIR/m0d-$LOCAL_IOS_FID/db/o/100000000000000:2a -p)"
             LOCAL_SEG_GEN_ID=$(echo $LOCAL_SEG_GEN_ID | cut -d "(" -f2 | cut -d ")" -f1)
-        fi
-        echo "segment genid : ($LOCAL_SEG_GEN_ID)"  >  $MD_DIR/m0d-$LOCAL_IOS_FID/gen_id
+
+            if [[ $LOCAL_SEG_GEN_ID -eq 0 ]]; then
+                m0drlog "Get generation id of local node from segment 0"
+                LOCAL_SEG_GEN_ID="$($BECKTOOL -s $MD_DIR/m0d-$LOCAL_IOS_FID/db/o/100000000000000:29 -p)"
+                LOCAL_SEG_GEN_ID=$(echo $LOCAL_SEG_GEN_ID | cut -d "(" -f2 | cut -d ")" -f1)
+            fi
+            echo "segment genid : ($LOCAL_SEG_GEN_ID)"  >  $MD_DIR/m0d-$LOCAL_IOS_FID/gen_id
         else
             m0drlog "ERROR: Mount failed! Can't replay journal logs on local node..."
             (( exec_status|=1));

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -681,6 +681,7 @@ remove_snapshot() {
     m0drlog "Running remove snapshot on local node"
     run_cmd_on_local_node "pvscan --cache"; # Ensure that volumes configs are synced
     LV_SNAPSHOT="$( lvs -o path $LOCAL_MD_VOLUMEGROUP | grep $SNAPSHOT )"
+
     run_cmd_on_local_node "lvremove -f $LV_SNAPSHOT"
     [[ $? -eq 0 ]] || { (( exec_status|=1)); }
 
@@ -931,13 +932,41 @@ EOF
         fi
     fi
 
-    m0drlog "Wait 5 minutes to flush any outstanding IO"
-    sleep 5m
     cleanup_stobs_dir
 
     return $exec_status
 }
+#flush the any outstanding IO
+flush_io(){
 
+    m0drlog "flush outstanding IO from buffers"
+
+    LV_SNAPSHOT="$( lvs -o path $LOCAL_MD_VOLUMEGROUP | grep $SNAPSHOT )"
+    LV_MD_DEVICE="$( lvs -o path $LOCAL_MD_VOLUMEGROUP | grep $MD_DEVICE )"
+
+    run_cmd_on_local_node "blockdev --flushbufs $LV_MD_DEVICE"
+    run_cmd_on_local_node "blockdev --flushbufs $LV_SNAPSHOT"
+
+    if [[ $REMOTE_STORAGE_STATUS == 0 ]]; then
+
+        LV_SNAPSHOT=$(run_cmd_on_remote_node "lvs -o path $REMOTE_MD_VOLUMEGROUP | \
+                        grep $SNAPSHOT" )
+        LV_MD_DEVICE=$(run_cmd_on_remote_node "lvs -o path $REMOTE_MD_VOLUMEGROUP | \
+                        grep $MD_DEVICE" )
+        run_cmd_on_remote_node "blockdev --flushbufs $LV_MD_DEVICE"
+        run_cmd_on_remote_node "blockdev --flushbufs $LV_SNAPSHOT"
+    else
+        LV_SNAPSHOT=$(run_cmd_on_local_node "lvs -o path $REMOTE_MD_VOLUMEGROUP | \
+                        grep $SNAPSHOT" )
+        LV_MD_DEVICE=$(run_cmd_on_local_node "lvs -o path $REMOTE_MD_VOLUMEGROUP | \
+                        grep $MD_DEVICE" )
+        run_cmd_on_local_node "blockdev --flushbufs $LV_MD_DEVICE"
+        run_cmd_on_local_node "blockdev --flushbufs $LV_SNAPSHOT"
+    fi
+
+    m0drlog "Wait 5 minutes to flush any outstanding IO"
+    sleep 5m
+}
 # ------------------------- script start --------------------------------
 
 is_user_root_user # check the script is running with root access
@@ -1001,6 +1030,8 @@ reinit_mkfs                    # reinit mkfs only on both nodes
 run_becktool                   # run becktool on both nodes
 run_becktool_status=$?
 [[ run_becktool_status -eq 0 ]] || { die "ERROR: Run becktool failed with code $run_becktool_status"; }
+
+flush_io                        # flush io on both the nodes
 
 remove_snapshot                # remove snapshot on both nodes
 remove_snapshot_status=$?


### PR DESCRIPTION
Issue:
   Recovery script exited with description
   "Device vg_metadata_srvnode--2-lv_raw_metadata-real (253:22) is used by
   another device. Failed to resume lv_raw_metadata."
   Able to delete the snapshot manually after this.

Fix:
   Suspecting that the problem is related to outstanding IOs not getting flushed
   to the device.  Flushed buffer for snapshot and metadata devices 
   To be sure also added 5 minutes delay to flush out outstanding IOs.

Fixed alignment in replay_logs_and_get_gen_id_of_seg0()