### PR TITLE
EOS-13842: unique RPC id across cluster

### DIFF
--- a/rpc/rpc_internal.h
+++ b/rpc/rpc_internal.h
@@ -80,8 +80,11 @@ M0_INTERNAL int m0_rpc_item_dispatch(struct m0_rpc_item *item);
 
 M0_INTERNAL void m0_rpc_oneway_item_post_locked(const struct m0_rpc_conn *conn,
 						struct m0_rpc_item *item);
-
-M0_INTERNAL uint64_t m0_rpc_id_generate(void);
+/**
+ * Takes a unique fid and hashes it with id generated from timestamp seed to
+ * generate clusterwide unique RPC id.
+ */
+M0_INTERNAL uint64_t m0_rpc_id_generate(const struct m0_fid *uniq_fid);
 
 M0_INTERNAL int m0_rpc_service_start(struct m0_reqh *reqh);
 M0_INTERNAL void m0_rpc_service_stop(struct m0_reqh *reqh);

--- a/rpc/session_foms.c
+++ b/rpc/session_foms.c
@@ -30,6 +30,7 @@
 #include "stob/stob.h"
 #include "net/net.h"
 #include "rpc/rpc_internal.h"
+#include "reqh/reqh_service.h"
 
 /**
    @addtogroup rpc_session
@@ -184,6 +185,7 @@ M0_INTERNAL int m0_rpc_fom_conn_establish_tick(struct m0_fom *fom)
 	struct m0_rpc_session                *session0;
 	struct m0_rpc_conn                   *conn;
 	struct m0_rpc_conn                   *est_conn;
+	struct m0_fid                        *uniq_fid;
 	static struct m0_fom_timeout         *fom_timeout = NULL;
 	int                                   rc;
 
@@ -238,6 +240,7 @@ M0_INTERNAL int m0_rpc_fom_conn_establish_tick(struct m0_fom *fom)
 		   See [4] at end of this function. */
 	}
 
+	uniq_fid = &fom->fo_service->rs_service_fid;
 	machine = item->ri_rmachine;
 	m0_rpc_machine_lock(machine);
 	est_conn = m0_rpc_machine_find_conn(machine, item);
@@ -266,7 +269,7 @@ M0_INTERNAL int m0_rpc_fom_conn_establish_tick(struct m0_fom *fom)
 		rc = m0_rpc_rcv_conn_init(conn, ctx->cec_sender_ep, machine,
 					  &header->osr_uuid);
 		if (rc == 0) {
-			conn->c_sender_id = m0_rpc_id_generate();
+			conn->c_sender_id = m0_rpc_id_generate(uniq_fid);
 			conn_state_set(conn, M0_RPC_CONN_ACTIVE);
 		}
 	}
@@ -321,6 +324,7 @@ M0_INTERNAL int m0_rpc_fom_session_establish_tick(struct m0_fom *fom)
 	struct m0_rpc_session                   *session;
 	struct m0_rpc_conn                      *conn;
 	struct m0_rpc_machine                   *machine;
+	struct m0_fid                           *uniq_fid;
 	int                                      rc;
 
 	M0_ENTRY("fom: %p", fom);
@@ -388,10 +392,11 @@ M0_INTERNAL int m0_rpc_fom_session_establish_tick(struct m0_fom *fom)
 		rc = M0_RC(-ECONNREFUSED);
 		goto out2;
 	}
+	uniq_fid = &fom->fo_service->rs_service_fid;
 	rc = m0_rpc_session_init_locked(session, conn);
 	if (rc == 0) {
 		do {
-			session->s_session_id = m0_rpc_id_generate();
+			session->s_session_id = m0_rpc_id_generate(uniq_fid);
 		} while (session->s_session_id <= SESSION_ID_MIN ||
 			 session->s_session_id >  SESSION_ID_MAX);
 		session_state_set(session, M0_RPC_SESSION_IDLE);

--- a/rpc/session_utils.c
+++ b/rpc/session_utils.c
@@ -33,6 +33,7 @@
 #include "lib/bitstring.h"
 #include "lib/finject.h"       /* M0_FI_ENABLED */
 #include "lib/uuid.h"
+#include "lib/hash.h"          /* m0_hash() */
 #include "fop/fop.h"
 #include "reqh/reqh.h"
 #include "rpc/rpc_internal.h"
@@ -92,7 +93,7 @@ M0_INTERNAL int m0_rpc__fop_post(struct m0_fop *fop,
 	return M0_RC(m0_rpc__post_locked(item));
 }
 
-M0_INTERNAL uint64_t m0_rpc_id_generate(void)
+M0_INTERNAL uint64_t m0_rpc_id_generate(const struct m0_fid *uniq_fid)
 {
 	static struct m0_atomic64 cnt;
 	uint64_t                  id;
@@ -103,6 +104,8 @@ M0_INTERNAL uint64_t m0_rpc_id_generate(void)
 		millisec = m0_time_nanoseconds(m0_time_now()) * 1000000;
 		id = (millisec << 10) | (m0_atomic64_get(&cnt) & 0x3FF);
 	} while (id == 0 || id == UINT64_MAX);
+
+	id = m0_hash(m0_fid_hash(uniq_fid) + id);
 
 	return id;
 }

--- a/rpc/session_utils.c
+++ b/rpc/session_utils.c
@@ -103,9 +103,8 @@ M0_INTERNAL uint64_t m0_rpc_id_generate(const struct m0_fid *uniq_fid)
 		m0_atomic64_inc(&cnt);
 		millisec = m0_time_nanoseconds(m0_time_now()) * 1000000;
 		id = (millisec << 10) | (m0_atomic64_get(&cnt) & 0x3FF);
+		id = m0_hash(m0_fid_hash(uniq_fid) + id);
 	} while (id == 0 || id == UINT64_MAX);
-
-	id = m0_hash(m0_fid_hash(uniq_fid) + id);
 
 	return id;
 }


### PR DESCRIPTION
Now RPC ids are generated by hashing the unique fid of reqh service
with the timestamp seed to make the RPC id unique across the cluster.

This change is required to mitigate the case when RPC ids collide
due to them generated at the same local time across different systems
with unsynchronized clocks.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>