### PR TITLE
EOS-14158 m0betool: create BE log file without m0mkfs

### DIFF
--- a/be/domain.c
+++ b/be/domain.c
@@ -359,9 +359,9 @@ static const struct m0_be_0type m0_be_0type_seg = {
 	.b0_fini = be_0type_seg_fini,
 };
 
-static void be_domain_log_cleanup(const char           *stob_domain_location,
-				  struct m0_be_log_cfg *log_cfg,
-				  bool                  create)
+M0_INTERNAL void
+be_domain_log_cleanup(const char *stob_domain_location,
+		      struct m0_be_log_cfg *log_cfg, bool create)
 {
 	const char *location_add = "-log";
 	char       *location;

--- a/be/domain.h
+++ b/be/domain.h
@@ -175,6 +175,9 @@ enum {
 
 M0_INTERNAL void m0_be_domain_module_setup(struct m0_be_domain *dom,
 					   const struct m0_be_domain_cfg *cfg);
+M0_INTERNAL void
+be_domain_log_cleanup(const char *stob_domain_location,
+		      struct m0_be_log_cfg *log_cfg, bool create);
 
 /*
  * Temporary solution until segment I/O is implemented using direct I/O.

--- a/be/tool/main.c
+++ b/be/tool/main.c
@@ -41,22 +41,29 @@
 
 
 static const char *betool_help = ""
-"Usage: m0betool [cmd] [path]\n"
+"Usage: m0betool [cmd] [path] [size]\n"
 "where [cmd] is one from (without quotes):\n"
 "- 'st mkfs'\n"
 "- 'st run'\n"
 "- 'be_recovery_run'\n"
+"- 'create_be_log'\n"
 "\n"
 "Use case for 'st mkfs' and 'st run': run 'st mkfs' once to initialise \n"
 "BE data structures, then run 'st run' and kill m0betool process during \n"
 "'st run' execution. When 'st run' is called next time BE recovery will \n"
 "replay BE log and 'st run' should be able to continue without any issues. \n"
+"create_be_log will create BE log file with custom size. \n"
 "This is an ST for BE recovery.\n"
 "\n"
 "'be_recovery_run' runs BE recovery.\n"
 "\n"
 "'path' parameter is an optional path to BE domain stob domain location.\n"
 "Default BE domain stob domain location is used when this parameter is absent:"
+"\n"
+"'create_be_log' create BE log file without mkfs.\n"
+"\n"
+"'path' and 'size' mandatory arguments for create_be_log. 'size' in bytes. \n"
+"Usage: m0betool create_be_log <path> <size> \n"
 "\n";
 
 static void be_recovery_run(char *path)
@@ -80,17 +87,55 @@ static void be_recovery_run(char *path)
 	m0_betool_m0_fini();
 }
 
+static void create_be_log(char *path, uint64_t size)
+{
+	struct m0_be_ut_backend ut_be = {};
+	struct m0_be_domain_cfg cfg = {};
+	char                    location[0x100] = {};
+	int                     rc;
+
+	m0_betool_m0_init();
+	m0_be_ut_backend_cfg_default(&cfg);
+
+	if (path != NULL) {
+		snprintf((char *)&location, ARRAY_SIZE(location),
+			 "linuxstob:%s", path);
+		cfg.bc_stob_domain_location = (char *)&location;
+	}
+	cfg.bc_log.lc_store_cfg.lsc_size = size;
+	cfg.bc_log.lc_store_cfg.lsc_stob_dont_zero = false;
+
+	rc = m0_be_ut_backend_init_cfg_create(&ut_be, &cfg, true);
+	M0_ASSERT_INFO(rc == 0, "rc=%d", rc);
+
+	m0_betool_m0_fini();
+}
+
 int main(int argc, char *argv[])
 {
 	struct m0_be_domain_cfg  cfg = {};
 	char                    *path;
 	int                      rc;
+	uint64_t                 size;
 
 	if (argc > 1 && m0_streq(argv[1], "be_recovery_run")) {
 		path = argc > 2 ? argv[2] : NULL;
 		be_recovery_run(path);
 		return EXIT_SUCCESS;
 	}
+
+	if (argc > 1 && m0_streq(argv[1], "create_be_log")) {
+		if (argc > 3) {
+			path = argv[2];
+			size = atoi(argv[3]);
+		} else {
+			printf("%s", betool_help);
+			return EXIT_FAILURE;
+		}
+		create_be_log(path, size);
+		return EXIT_SUCCESS;
+	}
+
 	if (argc == 3 && m0_streq(argv[1], "st") &&
 	    (m0_streq(argv[2], "mkfs") || m0_streq(argv[2], "run"))) {
 		if (m0_streq(argv[2], "mkfs") == 0)

--- a/be/ut/helper.c
+++ b/be/ut/helper.c
@@ -400,40 +400,24 @@ check_mkfs:
 
 
 M0_INTERNAL int
-m0_be_ut_backend_init_cfg_create(struct m0_be_ut_backend *ut_be,
-				 const struct m0_be_domain_cfg *cfg,
-				 bool mkfs)
+m0_be_ut_backend_log_resize(struct m0_be_ut_backend *ut_be,
+			    const struct m0_be_domain_cfg *cfg)
 {
 	struct m0_be_domain     *dom;
 	struct m0_be_domain_cfg *c;
 	int                      rc = 0;
 
-	m0_bob_init(&m0_ut_be_backend_bobtype, ut_be);
-
-	ut_be->but_sm_groups_unlocked = false;
-	m0_mutex_init(&ut_be->but_sgt_lock);
-
-	if (cfg == NULL)
-		m0_be_ut_backend_cfg_default(&ut_be->but_dom_cfg);
-	else
-		/*
-		 * Make a copy of `cfg': it can be an automatic variable,
-		 * which scope we should not rely on.
-		 */
-		ut_be->but_dom_cfg = *cfg;
+	M0_PRE(cfg != NULL);
+	ut_be->but_dom_cfg = *cfg;
 
 	c = &ut_be->but_dom_cfg;
 	dom = &ut_be->but_dom;
-
-	/* Create reqh, if necessary. */
-	if (c->bc_engine.bec_reqh == NULL)
-		m0_be_ut_reqh_create(&c->bc_engine.bec_reqh);
 
 	/* Use m0_be_ut_backend's stob domain location, if possible. */
 	if (ut_be->but_stob_domain_location != NULL)
 		c->bc_stob_domain_location = ut_be->but_stob_domain_location;
 
-	c->bc_mkfs_mode = mkfs;
+	c->bc_mkfs_mode = true;
 
 	c->bc_log.lc_got_space_cb = m0_be_engine_got_log_space_cb;
 	c->bc_log.lc_full_cb      = m0_be_engine_full_log_cb;
@@ -442,12 +426,8 @@ m0_be_ut_backend_init_cfg_create(struct m0_be_ut_backend *ut_be,
 	be_domain_log_cleanup(c->bc_stob_domain_location, &c->bc_log, c->bc_mkfs_mode);
 
 	rc = m0_be_log_create(m0_be_domain_log(dom), &c->bc_log);
-	M0_ASSERT(rc == 0);
 
 	m0_be_log_close(m0_be_domain_log(dom));
-
-	if (ut_be->but_sgt_lock.m_owner)
-		m0_mutex_fini(&ut_be->but_sgt_lock);
 
 	return rc;
 }

--- a/be/ut/helper.h
+++ b/be/ut/helper.h
@@ -76,9 +76,8 @@ M0_INTERNAL int m0_be_ut_backend_init_cfg(struct m0_be_ut_backend *ut_be,
 					  bool mkfs);
 
 M0_INTERNAL int
-m0_be_ut_backend_init_cfg_create(struct m0_be_ut_backend *ut_be,
-				 const struct m0_be_domain_cfg *cfg,
-				 bool mkfs);
+m0_be_ut_backend_log_resize(struct m0_be_ut_backend *ut_be,
+			    const struct m0_be_domain_cfg *cfg);
 
 M0_INTERNAL void
 m0_be_ut_backend_seg_add2(struct m0_be_ut_backend	   *ut_be,

--- a/be/ut/helper.h
+++ b/be/ut/helper.h
@@ -75,6 +75,11 @@ M0_INTERNAL int m0_be_ut_backend_init_cfg(struct m0_be_ut_backend *ut_be,
 					  const struct m0_be_domain_cfg *cfg,
 					  bool mkfs);
 
+M0_INTERNAL int
+m0_be_ut_backend_init_cfg_create(struct m0_be_ut_backend *ut_be,
+				 const struct m0_be_domain_cfg *cfg,
+				 bool mkfs);
+
 M0_INTERNAL void
 m0_be_ut_backend_seg_add2(struct m0_be_ut_backend	   *ut_be,
 			  m0_bcount_t			    size,

--- a/motr/st/utils/be_log_resize.sh
+++ b/motr/st/utils/be_log_resize.sh
@@ -1,22 +1,22 @@
-#!/bin/basih
+#!/bin/bash
 
 # Script to set BE log size
-# 1.parse hctl status output
+# 1. parse hctl status output
 # 2. list size of existing services log file
 # 3. set new size using m0betool
 # 4. list size of all io services log file
 
 M0D_LIST_FID=""
-BE_LOG_SIZE=268435456
+BE_LOG_SIZE=$((256 * 1024 * 1024))
 
 function usage()
 {
-   echo "be_log_set.sh [-s <be_log_size>]"
+   echo "be_log_resize.sh [-s <be_log_size>]"
    echo "Options:"
    echo "    '-s <size>'  BE log size to change"
    echo "Example.."
-   echo "./be_log_set.sh"
-   echo "./tune_addb.sh -s <BE log size to change>"
+   echo "./be_log_resize.sh"
+   echo "./be_log_resize.sh -s <BE log size to change>"
    exit 1
 }
 
@@ -25,37 +25,31 @@ change_be_log_size() {
     	local log_file="/var/motr/m0d-${fid}/db-log/o/0:28"
     	local db_file="/var/motr/m0d-${fid}/db"
 	echo "Before setting BE log size log_file=$log_file"
-	ls -lsh $log_file
+	[[ -f "$log_file" ]] && ls -lsh $log_file
 	echo "db_file=$db_file"
 	echo "m0betool create_be_log $db_file $BE_LOG_SIZE"
 	m0betool create_be_log $db_file $BE_LOG_SIZE
 	[[ $? -ne 0 ]] && echo "Failed" && exit 1
 	echo "After setting BE log size log_file=$log_file"
-	ls -lsh $log_file
+	[[ -f "$log_file" ]] && ls -lsh $log_file
     done
 }
 
 _local_params() {
     local addr="([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+)"
     local host
-    local M0D_LIST_NET_ADDR
 
     if [[ $(cat /var/lib/hare/node-name) == "srvnode-1" ]]; then
 	host="srvnode-1"
     elif [[ $(cat /var/lib/hare/node-name) == "srvnode-2" ]]; then
 	host="srvnode-2"
     else
-	exit 1
+	echo "cluster node srvnode-1/srvnode-2 not found" && exit 1
     fi
 
     STATUS=$(hctl status)
-    CLUSTER_PROFILE=`echo "$STATUS" | grep profile | awk '{print $2}'`
     NODE_IP=$(echo "$STATUS" | grep "$host" -A 1 | grep -E -o "$addr")
-    M0D_LIST_NET_ADDR=$(echo "$STATUS" | grep $NODE_IP | grep ioservice | 
-                        grep started | awk '{print $4}')
-    NUM_M0D_ACTIVE=$(echo "$STATUS" | grep $NODE_IP | grep ioservice |
-		     grep started | wc -l)
-    M0D_LIST_FID=$(echo "$STATUS" | grep ${NODE_IP} |  grep "\[.*\].*ioservice" |
+    M0D_LIST_FID=$(echo "$STATUS" | grep "${NODE_IP}" |  grep "\[.*\].*ioservice" |
                    awk '{print $3}')
 }
 
@@ -72,9 +66,9 @@ while getopts "$OPTIONS_STRING" OPTION; do
         esac
 done
 
+[[ -z "$BE_LOG_SIZE" ]] && usage
 
-#####
-[[ -z $BE_LOG_SIZE ]] && usage
+[[ -z $(ps uax | grep m0d) ]] && echo "m0ds not started" && exit 1
 
  _local_params
 
@@ -82,7 +76,7 @@ which m0betool > /dev/null
 [[ $? -ne 0 ]] && echo "export m0betool" && exit 1
 
 echo "BE_LOG_SIZE=$BE_LOG_SIZE"
-change_be_log_size $BE_LOG_SIZE
+change_be_log_size "$BE_LOG_SIZE"
 [[ $? -ne 0 ]] && echo "Failed to set log size $BE_LOG_SIZE" && exit 1
 
 echo "Successful"

--- a/motr/st/utils/be_log_resize.sh
+++ b/motr/st/utils/be_log_resize.sh
@@ -27,8 +27,8 @@ change_be_log_size() {
 	echo "Before setting BE log size log_file=$log_file"
 	[[ -f "$log_file" ]] && ls -lsh $log_file
 	echo "db_file=$db_file"
-	echo "m0betool create_be_log $db_file $BE_LOG_SIZE"
-	m0betool create_be_log $db_file $BE_LOG_SIZE
+	echo "m0betool be_log_resize $db_file $BE_LOG_SIZE"
+	m0betool be_log_resize $db_file $BE_LOG_SIZE
 	[[ $? -ne 0 ]] && echo "Failed" && exit 1
 	echo "After setting BE log size log_file=$log_file"
 	[[ -f "$log_file" ]] && ls -lsh $log_file

--- a/motr/st/utils/be_log_set.sh
+++ b/motr/st/utils/be_log_set.sh
@@ -1,0 +1,88 @@
+#!/bin/basih
+
+# Script to set BE log size
+# 1.parse hctl status output
+# 2. list size of existing services log file
+# 3. set new size using m0betool
+# 4. list size of all io services log file
+
+M0D_LIST_FID=""
+BE_LOG_SIZE=268435456
+
+function usage()
+{
+   echo "be_log_set.sh [-s <be_log_size>]"
+   echo "Options:"
+   echo "    '-s <size>'  BE log size to change"
+   echo "Example.."
+   echo "./be_log_set.sh"
+   echo "./tune_addb.sh -s <BE log size to change>"
+   exit 1
+}
+
+change_be_log_size() {
+    for fid in $M0D_LIST_FID; do
+    	local log_file="/var/motr/m0d-${fid}/db-log/o/0:28"
+    	local db_file="/var/motr/m0d-${fid}/db"
+	echo "Before setting BE log size log_file=$log_file"
+	ls -lsh $log_file
+	echo "db_file=$db_file"
+	echo "m0betool create_be_log $db_file $BE_LOG_SIZE"
+	m0betool create_be_log $db_file $BE_LOG_SIZE
+	[[ $? -ne 0 ]] && echo "Failed" && exit 1
+	echo "After setting BE log size log_file=$log_file"
+	ls -lsh $log_file
+    done
+}
+
+_local_params() {
+    local addr="([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+)"
+    local host
+    local M0D_LIST_NET_ADDR
+
+    if [[ $(cat /var/lib/hare/node-name) == "srvnode-1" ]]; then
+	host="srvnode-1"
+    elif [[ $(cat /var/lib/hare/node-name) == "srvnode-2" ]]; then
+	host="srvnode-2"
+    else
+	exit 1
+    fi
+
+    STATUS=$(hctl status)
+    CLUSTER_PROFILE=`echo "$STATUS" | grep profile | awk '{print $2}'`
+    NODE_IP=$(echo "$STATUS" | grep "$host" -A 1 | grep -E -o "$addr")
+    M0D_LIST_NET_ADDR=$(echo "$STATUS" | grep $NODE_IP | grep ioservice | 
+                        grep started | awk '{print $4}')
+    NUM_M0D_ACTIVE=$(echo "$STATUS" | grep $NODE_IP | grep ioservice |
+		     grep started | wc -l)
+    M0D_LIST_FID=$(echo "$STATUS" | grep ${NODE_IP} |  grep "\[.*\].*ioservice" |
+                   awk '{print $3}')
+}
+
+OPTIONS_STRING="s:h"
+while getopts "$OPTIONS_STRING" OPTION; do
+        case "$OPTION" in
+                s)
+                        BE_LOG_SIZE="$OPTARG"
+                        ;;
+                *)
+                        usage
+                        exit 1
+                        ;;
+        esac
+done
+
+
+#####
+[[ -z $BE_LOG_SIZE ]] && usage
+
+ _local_params
+
+which m0betool > /dev/null
+[[ $? -ne 0 ]] && echo "export m0betool" && exit 1
+
+echo "BE_LOG_SIZE=$BE_LOG_SIZE"
+change_be_log_size $BE_LOG_SIZE
+[[ $? -ne 0 ]] && echo "Failed to set log size $BE_LOG_SIZE" && exit 1
+
+echo "Successful"


### PR DESCRIPTION
Added "create_be_log" flag to create BE log file without m0mkfs.
'path' and 'size' are mandatory arguments and size should be in bytes.

Co-authored-by: Vikram Jadhav <vikram.jadhav@seagate.com>
Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>