### PR TITLE
[EOS-14191] To reduce failover/failback time kill m0d processes

### DIFF
--- a/scripts/install/usr/lib/systemd/system/m0d@.service
+++ b/scripts/install/usr/lib/systemd/system/m0d@.service
@@ -32,5 +32,5 @@ Environment=SHELL=/bin/bash
 EnvironmentFile=/etc/sysconfig/m0d-%i
 Group=motr
 ExecStart=/usr/libexec/cortx-motr/motr-server m0d-%i
-ExecStop=/bin/bash -c "/usr/bin/echo 'killing PID : ${MAINPID}'"
+ExecStop=/usr/bin/echo 'killing PID : ${MAINPID}'
 ExecStop=/bin/kill -9 $MAIN_PID

--- a/scripts/install/usr/lib/systemd/system/m0d@.service
+++ b/scripts/install/usr/lib/systemd/system/m0d@.service
@@ -32,5 +32,5 @@ Environment=SHELL=/bin/bash
 EnvironmentFile=/etc/sysconfig/m0d-%i
 Group=motr
 ExecStart=/usr/libexec/cortx-motr/motr-server m0d-%i
-ExecStop=/usr/bin/echo 'killing PID : ${MAINPID}'
+ExecStop=/usr/bin/echo 'shutting down process : ${MAINPID}'
 ExecStop=/bin/kill -9 $MAIN_PID

--- a/scripts/install/usr/lib/systemd/system/m0d@.service
+++ b/scripts/install/usr/lib/systemd/system/m0d@.service
@@ -32,3 +32,5 @@ Environment=SHELL=/bin/bash
 EnvironmentFile=/etc/sysconfig/m0d-%i
 Group=motr
 ExecStart=/usr/libexec/cortx-motr/motr-server m0d-%i
+ExecStop=/bin/bash -c "/usr/bin/echo 'killing PID : ${MAINPID}'"
+ExecStop=/bin/kill -9 $MAIN_PID


### PR DESCRIPTION
    - added ExecStop=/bin/kill -9 {PID} in m0d@service

Signed-off-by: Vinoth <Vinoth.V@.seagate.com>