### PR TITLE
m0reportbug: Collects journal logs even though there is nothing in li…

### DIFF
--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -728,6 +728,10 @@ systemd_journal() {
     local nr_boots=$(journalctl --list-boot | wc -l)
     if ((nr_boots > NR_BOOTS_MAX)); then
         nr_boots=$NR_BOOTS_MAX
+    elif (($nr_boots == 0)); then
+        # Collects the journal logs eventhough there is no reboots
+	# happened on the system
+        nr_boots=1
     fi
     local outdir=$(readlink -f .)
     for ((i = 0; i < nr_boots; ++i)); do


### PR DESCRIPTION
…st boot

We used to collect journalctl logs for last N boots listed into
`journalctl --lit-boots` but on some node it has been observed that
list-boots doesn't list anything. Started collection of journal logs
with boot id `0` (which is current boot) in such cases.