### PR TITLE
Update the parser of 'm0conf/profiles/' Consul key prefix

### DIFF
--- a/utils/spiel/m0_filesystem_stats
+++ b/utils/spiel/m0_filesystem_stats
@@ -205,7 +205,9 @@ main()
 	fi
 
 	if [ -z $profile_addr ] ; then
-		profile_addr=$($consul_query_cmd | grep profiles: | sed -n -e 's/^.*\(profiles:\)/\1/p'  | awk '{print $1}'| sed 's/^[^:]*://' | sed 's/:/,/')
+		# Obtain the fid of the _first_ profile from Consul KV.
+		profile_addr=$($consul_path kv get -keys 'm0conf/profiles/' |
+				head -1 | cut -d/ -f3)
 	fi
 
 	if [ -z $client_addr ] ; then


### PR DESCRIPTION
When support of multiple SNS pools was added to Hare, [Consul KV schema][4/KV] had been modified.

[4/KV]: https://github.com/Seagate/cortx-hare/blob/main/rfc/4/README.md

Update the code that obtains profile fid from Consul KV.

⚠️ **NOTE:** this patch depends on https://github.com/Seagate/cortx-hare/pull/1373, which should be merged first.

---

Related Jira ticket: [EOS-13951](https://jts.seagate.com/browse/EOS-13951)