### PR TITLE
EOS-14161: m0_fop_put() was missing from some UTs

### DIFF
--- a/iscservice/ut/service_ut.c
+++ b/iscservice/ut/service_ut.c
@@ -63,6 +63,11 @@ struct remote_invoke_var {
 	struct m0_chan      riv_chan;
 } remote_call_info;
 
+static void req_fop_prepare(struct m0_fop *req_fop,
+                            uint32_t       buf_type,
+                            struct m0_fid *fid,
+			    uint32_t       f_type);
+
 static void isc_item_cb(struct m0_rpc_item *item)
 {
 	struct m0_fop *req_fop;
@@ -548,7 +553,8 @@ enum fop_processing_phase {
 	FPP_INVALID,
 };
 
-static uint32_t remote_invocation_async(int exp_rc, uint32_t buf_type,
+static uint32_t remote_invocation_async(struct m0_fid *fid,
+                                        int exp_rc, uint32_t buf_type,
 					uint32_t phase, struct m0_fop **arg_fop)
 {
 	struct m0_fop        *reply_fop;
@@ -563,7 +569,11 @@ static uint32_t remote_invocation_async(int exp_rc, uint32_t buf_type,
 		arg_fop[0] = m0_alloc(sizeof arg_fop[0][0]);
 		M0_UT_ASSERT(arg_fop[0] != NULL);
 		m0_fop_init(arg_fop[0], &m0_fop_isc_fopt,
-			    &remote_call_info.riv_req, m0_fop_release);
+			    NULL, m0_fop_release);
+		rc = m0_fop_data_alloc(*arg_fop);
+		M0_ASSERT(rc == 0);
+		req_fop_prepare(*arg_fop, buf_type, fid, FT_NEITHER_IO);
+
 		arg_fop[0]->f_item.ri_ops = &isc_item_ops;
 		arg_fop[0]->f_item.ri_session = &isc_ut_cctx.rcx_session;
 		rc = m0_rpc_post(&arg_fop[0]->f_item);
@@ -593,7 +603,7 @@ static uint32_t remote_invocation_async(int exp_rc, uint32_t buf_type,
 	return FPP_INVALID;
 }
 
-static void req_fop_prepare2(struct m0_fop *req_fop,
+static void req_fop_prepare(struct m0_fop *req_fop,
 			     uint32_t       buf_type,
 			     struct m0_fid *fid,
 			     uint32_t       f_type)
@@ -645,59 +655,6 @@ static void req_fop_prepare2(struct m0_fop *req_fop,
 	M0_UT_ASSERT(rc == 0);
 }
 
-static void req_fop_prepare(uint32_t buf_type, struct m0_fid *fid,
-			    uint32_t f_type)
-{
-	struct m0_fop_isc     *fop_isc;
-	struct m0_buf         *data;
-	struct m0_rpc_machine *rmach;
-	char                  *in_buf;
-	uint32_t               size;
-	int                    rc;
-
-	M0_SET0(&remote_call_info);
-	fop_isc = &remote_call_info.riv_req;
-	data = &remote_call_info.riv_data;
-	*data = M0_BUF_INIT0;
-	size = 0;
-	rmach = &isc_ut_cctx.rcx_rpc_machine;
-	fop_isc->fi_comp_id = *fid;
-	m0_rpc_at_init(&fop_isc->fi_args);
-	switch (f_type) {
-	case FT_NEITHER_IO:
-	case FT_NO_INPUT:
-		break;
-	case FT_NO_OUTPUT:
-		in_buf    = m0_strdup(fixed_str);
-		M0_UT_ASSERT(in_buf != NULL);
-		m0_buf_init(data, (void *)in_buf, strlen(fixed_str));
-		break;
-	case FT_BOTH_IO:
-		size = buf_type == BT_INLINE ? INLINE_LEN : INBULK_LEN;
-		atut__bufdata_alloc(data, size, rmach);
-		memset(data->b_addr, 'a', data->b_nob);
-		break;
-	default:
-		M0_UT_ASSERT(false);
-	}
-	rc = m0_rpc_at_add(&fop_isc->fi_args, data,
-			   &isc_ut_cctx.rcx_connection);
-	M0_UT_ASSERT(rc == 0);
-	m0_rpc_at_init(&fop_isc->fi_ret);
-	if (M0_FI_ENABLED("at_mismatch")) {
-		rc = m0_rpc_at_recv(&fop_isc->fi_ret,
-				    &isc_ut_cctx.rcx_connection,
-				    M0_RPC_AT_UNKNOWN_LEN, false);
-	} else {
-		rc = m0_rpc_at_recv(&fop_isc->fi_ret,
-				    &isc_ut_cctx.rcx_connection,
-				    size, false);
-		M0_UT_ASSERT(ergo(size == INBULK_LEN,
-			     (fop_isc->fi_ret.ab_type == M0_RPC_AT_BULK_RECV)));
-	}
-	M0_UT_ASSERT(rc == 0);
-}
-
 /* Sets the conditions required to invoke the particular error path. */
 static void ret_codes_precond(int exp_rc, uint32_t buf_type, struct m0_fid *fid)
 {
@@ -713,7 +670,6 @@ static void ret_codes_precond(int exp_rc, uint32_t buf_type, struct m0_fid *fid)
 		m0_isc_comp_unregister(fid);
 		break;
 	case -ENOMEM:
-		req_fop_prepare(buf_type, fid, FT_BOTH_IO);
 		m0_fi_enable("isc_comp_launch", "oom");
 		break;
 	case -EPROTO:
@@ -721,16 +677,13 @@ static void ret_codes_precond(int exp_rc, uint32_t buf_type, struct m0_fid *fid)
 		remote_call_info.riv_req.fi_comp_id = *fid;
 		break;
 	case -EPERM:
-		req_fop_prepare(buf_type, fid, FT_BOTH_IO);
 		m0_fi_enable("string_update", "comp_error");
 		break;
 	case -ENOMSG:
 		m0_fi_enable("req_fop_prepare", "at_mismatch");
-		req_fop_prepare(buf_type, fid, FT_BOTH_IO);
 		m0_fi_enable("string_update", "at_mismatch");
 		break;
 	case 0:
-		req_fop_prepare(buf_type, fid, FT_BOTH_IO);
 		rc = m0_isc_comp_register(string_update, "string_update", fid);
 		M0_UT_ASSERT(M0_IN(rc, (0, -EEXIST)));
 		break;
@@ -772,7 +725,7 @@ static void ret_codes_postcond(int exp_rc, void *arg)
 	m0_rpc_at_fini(&remote_call_info.riv_req.fi_ret);
 }
 
-static void remote_invocation2(struct m0_fid *fid, int exp_rc, uint32_t f_type)
+static void remote_invocation(struct m0_fid *fid, int exp_rc, uint32_t f_type, uint32_t buf_type)
 {
 	struct m0_fop         *req_fop;
 	struct m0_fop         *reply_fop;
@@ -791,7 +744,12 @@ static void remote_invocation2(struct m0_fid *fid, int exp_rc, uint32_t f_type)
 	rc = m0_fop_data_alloc(req_fop);
 	M0_ASSERT(rc == 0);
 
-	req_fop_prepare2(req_fop, BT_INBULK, fid, f_type);
+	if (M0_IN(exp_rc, (-EINVAL, -ENOMEM, -EPERM, -ENOMSG, 0))) {
+		req_fop_prepare(req_fop, buf_type, fid, f_type);
+	} else {
+		struct m0_fop_isc *fop_isc = m0_fop_data(req_fop);
+		fop_isc->fi_comp_id = *fid;
+	}
 
 	rc = m0_rpc_post_sync(req_fop, &isc_ut_cctx.rcx_session, NULL,
 			      M0_TIME_IMMEDIATELY);
@@ -830,57 +788,6 @@ static void remote_invocation2(struct m0_fid *fid, int exp_rc, uint32_t f_type)
 	m0_fop_put_lock(req_fop);
 }
 
-static void remote_invocation(int exp_rc, uint32_t f_type)
-{
-	struct m0_fop         arg_fop;
-	struct m0_fop        *reply_fop;
-	struct m0_fop_isc_rep repl;
-	struct m0_fop_isc    *req;
-	struct m0_buf        *recv_buf;
-	struct m0_isc_comp   *comp;
-	int                   ret_rc;
-	int                   rc;
-	int                   i;
-
-	M0_SET0(&arg_fop);
-
-	m0_fop_init(&arg_fop, &m0_fop_isc_fopt, &remote_call_info.riv_req,
-		    m0_fop_release);
-	rc = m0_rpc_post_sync(&arg_fop, &isc_ut_cctx.rcx_session, NULL,
-			      M0_TIME_IMMEDIATELY);
-	M0_UT_ASSERT(rc == 0);
-	reply_fop = m0_rpc_item_to_fop(arg_fop.f_item.ri_reply);
-	repl = *(struct m0_fop_isc_rep *)m0_fop_data(reply_fop);
-	M0_UT_ASSERT(repl.fir_rc == exp_rc);
-	req = m0_fop_data(&arg_fop);
-	recv_buf = &remote_call_info.riv_recv_buf;
-	ret_rc = m0_rpc_at_rep_get(&req->fi_ret, &repl.fir_ret, recv_buf);
-	/* Ensure that a valid cookie is returned. */
-	comp = m0_cookie_of(&repl.fir_comp_cookie, struct m0_isc_comp, ic_gen);
-	if (!M0_IN(repl.fir_rc, (-ENOENT, -EINVAL))) {
-		M0_UT_ASSERT(comp != NULL);
-		M0_UT_ASSERT(m0_fid_eq(&comp->ic_fid, &req->fi_comp_id));
-	} else if (f_type != FT_NO_INPUT)
-		M0_UT_ASSERT(comp == NULL);
-	switch (f_type) {
-	case FT_NEITHER_IO:
-	case FT_NO_OUTPUT:
-		M0_UT_ASSERT(ret_rc == 0);
-		break;
-	case FT_NO_INPUT:
-		M0_UT_ASSERT(ret_rc == 0);
-		M0_UT_ASSERT(m0_buf_streq(recv_buf, fixed_str));
-		break;
-	case FT_BOTH_IO:
-		for (i = 0; i < recv_buf->b_nob; ++i) {
-			M0_UT_ASSERT(((uint8_t *)recv_buf->b_addr)[i] ==
-				       'b');
-		}
-		break;
-	}
-	m0_rpc_at_fini(&repl.fir_ret);
-}
-
 static uint32_t expected_output(uint32_t f_type)
 {
 	switch (f_type) {
@@ -906,7 +813,7 @@ static void comp_remote_invoke(struct comp_req_aux *cra, uint32_t f_type)
 	fid_get(cra->cra_name, &fid);
 	rc = m0_isc_comp_register(cra->cra_comp, cra->cra_name, &fid);
 	M0_UT_ASSERT(rc == 0);
-	remote_invocation2(&fid, exp_rc, f_type);
+	remote_invocation(&fid, exp_rc, f_type, BT_INBULK);
 	m0_isc_comp_unregister(&fid);
 }
 
@@ -973,14 +880,13 @@ static void test_remote_waiting(void)
 	M0_UT_ASSERT(rc == 0);
 	isc_ut_client_start();
 	vis_entry_init(BARRIER_CNT);
-	req_fop_prepare(BT_INLINE, &fid, FT_NEITHER_IO);
 	/* Prepare to wait for reply fop. */
 	m0_mutex_init(&remote_call_info.riv_guard);
 	m0_chan_init(&remote_call_info.riv_chan, &remote_call_info.riv_guard);
 	m0_clink_init(&waiter, NULL);
 	m0_clink_add_lock(&remote_call_info.riv_chan, &waiter);
 	waiter.cl_is_oneshot = true;
-	phase = remote_invocation_async(0, BT_INLINE, FPP_SEND,
+	phase = remote_invocation_async(&fid, 0, BT_INLINE, FPP_SEND,
 					&arg_fop);
 	/* Spin till the fom is executed. */
 	while (vis_ent.ve_count == 0);
@@ -994,7 +900,8 @@ static void test_remote_waiting(void)
 
 	/* Wait for reply fop. */
 	m0_chan_wait(&waiter);
-	phase = remote_invocation_async(0, BT_INLINE, phase, &arg_fop);
+	phase = remote_invocation_async(&fid, 0, BT_INLINE, phase, &arg_fop);
+	m0_fop_put0_lock(arg_fop);
 	M0_UT_ASSERT(phase == FPP_COMPLETE);
 	isc_ut_client_stop();
 	isc_ut_server_stop();
@@ -1032,7 +939,7 @@ static void test_remote_err_path(void)
 	for (j = BT_INLINE; j < BT_INBULK + 1; ++j) {
 		for (i = 0; i < ARRAY_SIZE(ret_codes); ++i) {
 			ret_codes_precond(ret_codes[i], j, &fid);
-			remote_invocation(ret_codes[i], FT_BOTH_IO);
+			remote_invocation(&fid, ret_codes[i], FT_BOTH_IO, j);
 			ret_codes_postcond(ret_codes[i], &fid);
 		}
 	}

--- a/motr/magic.h
+++ b/motr/magic.h
@@ -820,6 +820,9 @@ enum m0_magic_satchel {
 	/* pending_item_tl::td_head_magic (doss doze dose) */
 	M0_RPC_ITEM_PENDING_CACHE_HEAD_MAGIC = 0x33D055D02ED05E77,
 
+	/* pending_item_tl::td_head_magic (solid el cache) */
+	M0_RPC_ITEM_XID_LIST_HEAD_MAGIC = 0x335011de1cac4e77,
+
 	/* m0_rpc_item_source::ri_magic (ACCESSIBLE AC) */
 	M0_RPC_ITEM_SOURCE_MAGIC = 0x33ACCE551B1EAC77,
 

--- a/rpc/item.c
+++ b/rpc/item.c
@@ -1678,7 +1678,13 @@ M0_INTERNAL void m0_rpc_item_xid_list_init(struct m0_rpc_session *session)
 
 M0_INTERNAL void m0_rpc_item_xid_list_fini(struct m0_rpc_session *session)
 {
+	struct m0_rpc_item *item;
+
 	M0_PRE(m0_rpc_machine_is_locked(session->s_conn->c_rpc_machine));
+	m0_tl_for(xidl, &session->s_xid_list, item) {
+		M0_LOG(M0_ERROR, "item="ITEM_FMT" ri_sm.sm_state=%d",
+		       ITEM_ARG(item), item->ri_sm.sm_state);
+	} m0_tl_endfor;
 	xidl_tlist_fini(&session->s_xid_list);
 }
 

--- a/rpc/item.c
+++ b/rpc/item.c
@@ -533,7 +533,9 @@ static bool rpc_item_needs_xid(const struct m0_rpc_item *item)
 		      (M0_RPC_CONN_ESTABLISH_OPCODE,
 		       M0_RPC_CONN_ESTABLISH_REP_OPCODE,
 		       M0_RPC_CONN_TERMINATE_OPCODE,
-		       M0_RPC_CONN_TERMINATE_REP_OPCODE));
+		       M0_RPC_CONN_TERMINATE_REP_OPCODE,
+		       M0_RPC_PING_OPCODE,
+		       M0_RPC_PING_REPLY_OPCODE));
 }
 
 M0_INTERNAL void m0_rpc_item_xid_min_update(struct m0_rpc_item *item)
@@ -544,13 +546,8 @@ M0_INTERNAL void m0_rpc_item_xid_min_update(struct m0_rpc_item *item)
 	         "osr_session_xid_min=%"PRIu64,
 		 ITEM_ARG(item), item->ri_header.osr_xid,
 		 item->ri_header.osr_session_xid_min);
-	if (item->ri_session == NULL) {
-		M0_LOG(M0_WARN, "item->ri_session == NULL. "
-		       "rpc-packet-encdec-ut case only. "
-		       "Must not be present in production.");
-		return;
-	}
 	if (rpc_item_needs_xid(item)) {
+		M0_ASSERT(item->ri_session != NULL);
 		M0_ASSERT(!(M0_IN(item->ri_header.osr_xid, (0, UINT64_MAX))));
 		item->ri_header.osr_session_xid_min =
 			xidl_tlist_is_empty(&item->ri_session->s_xid_list) ? 1 :

--- a/rpc/item.h
+++ b/rpc/item.h
@@ -232,6 +232,10 @@ struct m0_rpc_item {
 	uint64_t			 ri_magic;
 	/** Link for m0_rpc_item_cache::ric_items. */
 	struct m0_tlink			 ri_cache_link;
+	/** Link for m0_rpc_session::s_xid_list. */
+	struct m0_tlink			 ri_xid_link;
+	/** xid was assigned in this process, i.e. item is in ri_xid_link. */
+	bool 			         ri_xid_assigned_here;
 	/** After this time item can be safely removed from reply cache */
 	m0_time_t			 ri_cache_deadline;
 };
@@ -594,10 +598,14 @@ M0_INTERNAL void m0_rpc_item_cache_purge(struct m0_rpc_item_cache *ic);
 /** Deletes all items from the cache. */
 M0_INTERNAL void m0_rpc_item_cache_clear(struct m0_rpc_item_cache *ic);
 
+M0_INTERNAL void m0_rpc_item_xid_list_init(struct m0_rpc_session *session);
+M0_INTERNAL void m0_rpc_item_xid_list_fini(struct m0_rpc_session *session);
+
 /** Initialises the pending item cache. */
 M0_INTERNAL void m0_rpc_item_pending_cache_init(struct m0_rpc_session *session);
 /** Finalises the pending item cache. */
 M0_INTERNAL void m0_rpc_item_pending_cache_fini(struct m0_rpc_session *session);
+
 /**
  * Adds item to the pending item cache only if it is not already present
  * there. It is going to be present there in case of resend.

--- a/rpc/item_internal.h
+++ b/rpc/item_internal.h
@@ -50,6 +50,7 @@ M0_INTERNAL bool m0_rpc_item_is_request(const struct m0_rpc_item *item);
 M0_INTERNAL bool m0_rpc_item_is_reply(const struct m0_rpc_item *item);
 
 M0_INTERNAL void m0_rpc_item_xid_assign(struct m0_rpc_item *item);
+M0_INTERNAL void m0_rpc_item_xid_min_update(struct m0_rpc_item *item);
 
 M0_INTERNAL void m0_rpc_item_sm_init(struct m0_rpc_item *item,
 				     enum m0_rpc_item_dir dir);

--- a/rpc/onwire.h
+++ b/rpc/onwire.h
@@ -95,6 +95,8 @@ struct m0_rpc_item_header2 {
 	struct m0_uint128 osr_uuid;
 	uint64_t          osr_sender_id;
 	uint64_t          osr_session_id;
+	/** @see m0_rpc_session::s_xid_list, m0_rpc_item_xid_min_update(). */
+	uint64_t          osr_session_xid_min;
 	uint64_t          osr_xid;
 	struct m0_cookie  osr_cookie;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);

--- a/rpc/packet.c
+++ b/rpc/packet.c
@@ -341,6 +341,7 @@ M0_INTERNAL int m0_rpc_packet_encode_using_cursor(struct m0_rpc_packet *packet,
 			uint64_t item_sm_id = m0_sm_id_get(&item->ri_sm);
 
 			m0_rpc_item_xid_assign(item);
+			m0_rpc_item_xid_min_update(item);
 			M0_ADDB2_ADD(M0_AVI_RPC_ITEM_ID_ASSIGN,
 				     item_sm_id,
 				     (uint64_t)item->ri_type->rit_opcode,

--- a/rpc/session.c
+++ b/rpc/session.c
@@ -252,6 +252,7 @@ M0_INTERNAL int m0_rpc_session_init_locked(struct m0_rpc_session *session,
 		M0_LOG(M0_ERROR, "Session %p initialisation failed: %d",
 		       session, rc);
 	m0_rpc_item_pending_cache_init(session);
+	m0_rpc_item_xid_list_init(session);
 
 	return M0_RC(rc);
 }
@@ -317,6 +318,7 @@ M0_INTERNAL void m0_rpc_session_fini_locked(struct m0_rpc_session *session)
 	m0_rpc_item_cache_fini(&session->s_reply_cache);
 	m0_rpc_item_cache_fini(&session->s_req_cache);
 	m0_rpc_item_pending_cache_fini(session);
+	m0_rpc_item_xid_list_fini(session);
 	if (rpc_session_tlink_is_in(session))
 		m0_rpc_conn_remove_session(session);
 	__session_fini(session);

--- a/rpc/session.h
+++ b/rpc/session.h
@@ -331,6 +331,14 @@ struct m0_rpc_session {
 	uint64_t                  s_xid;
 
 	/**
+	 * List of all rpc items in the session that have xid and are going to
+	 * be sent.
+	 * Items in the list are in osr_xid increasing order.
+	 * @see m0_rpc_item:ri_xid_link, m0_rpc_item_xid_min_update(), xidl.
+	 */
+	struct m0_tl              s_xid_list;
+
+	/**
 	 * Replies to resend if needed.
 	 * This cache is protected with rpc machine lock.
 	 */


### PR DESCRIPTION
 Problem:
    1) arg_fop was getting allocated on stack in remote_invocation() that
       way same fop was getting re-used on futher remote_invocation call,
       that was causing to stuck in m0_tlist_invarient().

    2) m0_fop_put() was missingfom in some of sub ut's of "isc-service-ut"
       which was casuing to panic in rpc_session_fini() since m0_fop_fini()
       is not called where deletion of xid happen from session->xid_list.
    ```
      #0 in raise () from /lib64/libc.so.6
      #1 in abort () from /lib64/libc.so.6
      #2 in m0_arch_panic () at lib/user_space/uassert.c:131
      #3 in m0_panic () at lib/assert.c:52
      #4 in m0_list_fini () at lib/list.c:38
      #5 in m0_tlist_fini () at lib/tlist.c:56
      #6 in xidl_tlist_fini () at rpc/item.c:85
      #7 in m0_rpc_item_xid_list_fini () at rpc/item.c:1682
      #8 in m0_rpc_session_fini_locked () at rpc/session.c:321
      #9 in m0_rpc_session_fini () at rpc/session.c:304
      #1 in m0_rpc_session_destroy ()at rpc/session.c:567
    ```

    Solution:
    1) Used heap allocation for fop_arg instead of stack allocation.
    2) Added m0_fop_put0_locked() at missing places.
    3) Fixing up "remote-comp-signature" ut reveiled other two ut failures
       due to similar reason, fixed those as well.
