### PR TITLE
EOS-14172 EOS-14166: rpc fop needs m0_fop_put()

### DIFF
--- a/m0t1fs/linux_kernel/file_internal.h
+++ b/m0t1fs/linux_kernel/file_internal.h
@@ -1797,6 +1797,10 @@ struct target_ioreq {
 
 	/** Fop when the ti_req_type == TI_COB_CREATE. */
 	struct cc_req_fop              ti_cc_fop;
+
+	/** flag to indicate if cc_fop is used */
+	bool                           ti_cc_fop_inited;
+
 	/** Resulting IO fops are sent on this rpc session. */
 	struct m0_rpc_session         *ti_session;
 

--- a/motr/client.h
+++ b/motr/client.h
@@ -524,46 +524,46 @@
  * Operation codes for entity, object and index.
  */
 enum m0_entity_opcode {
-	M0_EO_INVALID,
-	M0_EO_CREATE,
-	M0_EO_DELETE,
-	M0_EO_SYNC,
-	M0_EO_OPEN,
-	M0_EO_GETATTR,
-	M0_EO_SETATTR,
-	M0_EO_LAYOUT_GET,
-	M0_EO_LAYOUT_SET,
-	M0_EO_NR
+	M0_EO_INVALID,    /* 0 */
+	M0_EO_CREATE,     /* 1 */
+	M0_EO_DELETE,     /* 2 */
+	M0_EO_SYNC,       /* 3 */
+	M0_EO_OPEN,       /* 4 */
+	M0_EO_GETATTR,    /* 5 */
+	M0_EO_SETATTR,    /* 6 */
+	M0_EO_LAYOUT_GET, /* 7 */
+	M0_EO_LAYOUT_SET, /* 8 */
+	M0_EO_NR          /* 9 */
 } M0_XCA_ENUM;
 
 /** Object operation codes. */
 enum m0_obj_opcode {
 	/** Read object data. */
-	M0_OC_READ = M0_EO_NR + 1,
+	M0_OC_READ = M0_EO_NR + 1,  /* 10 */
 	/** Write object data. */
-	M0_OC_WRITE,
+	M0_OC_WRITE,                /* 11 */
 	/** Pre-allocate space. */
-	M0_OC_ALLOC,
+	M0_OC_ALLOC,                /* 12 */
 	/** De-allocate space, consecutive reads will return 0s. */
-	M0_OC_FREE,
-	M0_OC_NR
+	M0_OC_FREE,                 /* 13 */
+	M0_OC_NR                    /* 14 */
 } M0_XCA_ENUM;
 
 /* Index operation codes. */
 enum m0_idx_opcode {
 	/** Lookup a value with the given key. */
-	M0_IC_GET = M0_OC_NR + 1,
+	M0_IC_GET = M0_OC_NR + 1,  /* 15 */
 	/** Insert or update the value, given a key. */
-	M0_IC_PUT,
+	M0_IC_PUT,                 /* 16 */
 	/** Delete the value, if any, for the given key. */
-	M0_IC_DEL,
+	M0_IC_DEL,                 /* 17 */
 	/** Given a key, return the next key and its value. */
-	M0_IC_NEXT,
+	M0_IC_NEXT,                /* 18 */
 	/** Check an index for an existence. */
-	M0_IC_LOOKUP,
+	M0_IC_LOOKUP,              /* 19 */
 	/** Given an index id, get the list of next indices. */
-	M0_IC_LIST,
-	M0_IC_NR
+	M0_IC_LIST,                /* 20 */
+	M0_IC_NR                   /* 21 */
 } M0_XCA_ENUM;
 
 /**

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -36,6 +36,8 @@
 #include "sns/parity_repair.h"   /* m0_sns_repair_spare_map*/
 #include "fd/fd.h"               /* m0_fd_fwd_map m0_fd_bwd_map */
 #include "motr/addb.h"
+#include "rpc/item.h"
+#include "rpc/rpc_internal.h"
 
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_CLIENT
 #include "lib/trace.h"           /* M0_LOG */
@@ -357,7 +359,7 @@ M0_INTERNAL bool nw_xfer_request_invariant(const struct nw_xfer_request *xfer)
 void target_ioreq_fini(struct target_ioreq *ti)
 {
 	struct m0_op_io *ioo;
-	unsigned int            opcode;
+	unsigned int     opcode;
 
 	M0_ENTRY("target_ioreq %p", ti);
 
@@ -389,6 +391,13 @@ void target_ioreq_fini(struct target_ioreq *ti)
 
 	if (ti->ti_dgvec != NULL)
 		dgmode_rwvec_dealloc_fini(ti->ti_dgvec);
+	if (ti->ti_cc_fop_inited) {
+		struct m0_rpc_item *item = &ti->ti_cc_fop.crf_fop.f_item;
+		M0_LOG(M0_DEBUG, "item="ITEM_FMT" osr_xid=%"PRIu64,
+				  ITEM_ARG(item), item->ri_header.osr_xid);
+		ti->ti_cc_fop_inited = false;
+		m0_fop_put_lock(&ti->ti_cc_fop.crf_fop);
+	}
 
 	m0_free(ti);
 	M0_LEAVE();
@@ -976,9 +985,12 @@ static const struct target_ioreq_ops tioreq_ops = {
 
 static int target_cob_fop_prepare(struct target_ioreq *ti)
 {
+	int rc;
+	M0_ENTRY("ti=%p type=%d", ti, ti->ti_req_type);
 	M0_PRE(M0_IN(ti->ti_req_type, (TI_COB_CREATE, TI_COB_TRUNCATE)));
 
-	return ioreq_cc_fop_init(ti);
+	rc = ioreq_cc_fop_init(ti);
+	return M0_RC(rc);
 }
 
 /**
@@ -1022,6 +1034,7 @@ static int target_ioreq_init(struct target_ioreq    *ti,
 	ti->ti_dgvec     = NULL;
 	ti->ti_req_type  = TI_NONE;
 	M0_SET0(&ti->ti_cc_fop);
+	ti->ti_cc_fop_inited = false;
 
 	/*
 	 * Target object is usually in ONLINE state unless explicitly
@@ -1447,7 +1460,6 @@ static void nw_xfer_req_complete(struct nw_xfer_request *xfer, bool rmw)
 		    ti->ti_req_type == TI_COB_CREATE &&
 		    ioreq_sm_state(ioo) == IRS_WRITE_COMPLETE) {
 			ti->ti_req_type = TI_NONE;
-			m0_fop_put_lock(&ti->ti_cc_fop.crf_fop);
 			continue;
 		}
 
@@ -1455,8 +1467,6 @@ static void nw_xfer_req_complete(struct nw_xfer_request *xfer, bool rmw)
 		    ti->ti_req_type == TI_COB_TRUNCATE &&
 		    ioreq_sm_state(ioo) == IRS_TRUNCATE_COMPLETE) {
 			ti->ti_req_type = TI_NONE;
-			if (ti->ti_trunc_ivec.iv_vec.v_nr > 0)
-				m0_fop_put_lock(&ti->ti_cc_fop.crf_fop);
 		}
 
 		m0_tl_teardown(iofops, &ti->ti_iofops, irfop) {
@@ -1607,6 +1617,8 @@ static int nw_xfer_req_dispatch(struct nw_xfer_request *xfer)
 			 * An error returned by rpc post has been ignored.
 			 * It will be handled in the respective bottom half.
 			 */
+			M0_LOG(M0_DEBUG, "item="ITEM_FMT" osr_xid=%"PRIu64,
+				ITEM_ARG(item), item->ri_header.osr_xid);
 			rc = m0_rpc_post(item);
 			M0_CNT_INC(nr_dispatched);
 			m0_op_io_to_rpc_map(ioo, item);
@@ -1621,6 +1633,10 @@ static int nw_xfer_req_dispatch(struct nw_xfer_request *xfer)
 				 * ignored. It will be handled in the
 				 * io_bottom_half().
 				 */
+				M0_LOG(M0_DEBUG, "item="ITEM_FMT
+						 " osr_xid=%"PRIu64,
+						 ITEM_ARG(item),
+						 item->ri_header.osr_xid);
 				rc = m0_rpc_post(item);
 				M0_CNT_INC(nr_dispatched);
 				m0_op_io_to_rpc_map(ioo, item);

--- a/motr/pg.h
+++ b/motr/pg.h
@@ -761,6 +761,10 @@ struct target_ioreq {
 	struct m0_tl                   ti_iofops;
 	/** Fop when the ti_req_type == TI_COB_CREATE|TI_COB_TRUNCATE. */
 	struct cc_req_fop              ti_cc_fop;
+
+	/** flag to indicate if cc_fop is used */
+	bool                           ti_cc_fop_inited;
+
 	/** Resulting IO fops are sent on this rpc session. */
 	struct m0_rpc_session         *ti_session;
 

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -624,9 +624,8 @@ again:
 	m0_op_launch(ops, 1);
 
 	/* wait */
-	rc = m0_op_wait(ops[0], M0_BITS(M0_OS_FAILED,
-					       M0_OS_STABLE),
-			       M0_TIME_NEVER);
+	rc = m0_op_wait(ops[0], M0_BITS(M0_OS_FAILED, M0_OS_STABLE),
+			M0_TIME_NEVER);
 	op_rc = ops[0]->op_sm.sm_rc;
 
 	/* fini and release */

--- a/motr/st/utils/motr_utils_st.sh
+++ b/motr/st/utils/motr_utils_st.sh
@@ -324,9 +324,10 @@ main()
 		error_handling $? "Failed to copy object"
 	}
 	mkdir $MOTR_TRACE_DIR
-	P=8
+
 	N=1
 	K=0
+	P=8
 	test_with_N_K $N $K $P
 	if [ $rc -ne "0" ]
 	then
@@ -337,6 +338,7 @@ main()
 
 	N=1
 	K=2
+	P=8
 	test_with_N_K $N $K $P
 	rc=$?
 	if [ $rc -ne "0" ]
@@ -348,6 +350,7 @@ main()
 
 	N=4
 	K=2
+	P=8
 	test_with_N_K $N $K $P
 	rc=$?
 	echo $rc


### PR DESCRIPTION
- target_ioreq::ti_cc_fop is used in some cases.
  It is initialized and then be m0_rpc_post().
  It needs m0_fop_put() in all cases.
- A flag target_ioreq::ti_cc_fop_inited is used to do put
  for this fop, to avoid leakage.
- More debug messages added.

Signed-off-by: Hua Huang <hua.huang@seagate.com>