### PR TITLE
EOS-14164 rconfc: rpc session fini from failed read lock request moved to failure ast callback

### DIFF
--- a/conf/rconfc.c
+++ b/conf/rconfc.c
@@ -1215,7 +1215,7 @@ static void _failure_ast_cb(struct m0_sm_group *grp M0_UNUSED,
 			    struct m0_sm_ast   *ast)
 {
 	struct m0_rconfc *rconfc = ast->sa_datum;
-	struct rlock_ctx *rlx =rconfc->rc_rlock_ctx;
+	struct rlock_ctx *rlx    = rconfc->rc_rlock_ctx;
 
 	/*
 	 * RPC connection to RM may be lost, or there is no remote RM

--- a/conf/rconfc.c
+++ b/conf/rconfc.c
@@ -1215,7 +1215,17 @@ static void _failure_ast_cb(struct m0_sm_group *grp M0_UNUSED,
 			    struct m0_sm_ast   *ast)
 {
 	struct m0_rconfc *rconfc = ast->sa_datum;
+	struct rlock_ctx *rlx =rconfc->rc_rlock_ctx;
 
+	/*
+	 * RPC connection to RM may be lost, or there is no remote RM
+	 * service anymore to respond to read lock request, so need to
+	 * handle this to prevent read lock context from further
+	 * communication attempts
+	 */
+	M0_ASSERT(rlock_ctx_is_online(rlx));
+	if (!M0_FI_ENABLED("rlock_req_failed"))
+		rlock_ctx_creditor_unset(rlx);
 	rconfc_fail(rconfc, rconfc->rc_datum);
 }
 
@@ -2734,14 +2744,6 @@ static void rconfc_read_lock_complete(struct m0_rm_incoming *in, int32_t rc)
 	rlx = rconfc->rc_rlock_ctx;
 	if (rc != 0) {
 		M0_LOG(M0_ERROR, "Read lock request failed with rc = %d", rc);
-		/*
-		 * RPC connection to RM may be lost, or there is no remote RM
-		 * service anymore to respond to read lock request, so need to
-		 * handle this to prevent read lock context from further
-		 * communication attempts
-		 */
-		M0_ASSERT(rlock_ctx_is_online(rlx));
-		rlock_ctx_creditor_unset(rlx);
 	}
 
 	if (M0_FI_ENABLED("rlock_req_failed"))

--- a/conf/ut/rconfc.c
+++ b/conf/ut/rconfc.c
@@ -247,6 +247,7 @@ static void test_start_failures(void)
 	m0_rconfc_fini(&rconfc);
 
 	m0_fi_enable_once("rconfc_read_lock_complete", "rlock_req_failed");
+	m0_fi_enable_once("_failure_ast_cb", "rlock_req_failed");
 	rc = m0_rconfc_init(&rconfc, &profile, &m0_conf_ut_grp, &mach, NULL,
 			    NULL);
 	M0_UT_ASSERT(rc == 0);

--- a/motr/ut/cs_ut_main.c
+++ b/motr/ut/cs_ut_main.c
@@ -661,6 +661,7 @@ static void test_cs_ut_rconfc_fatal(void)
 	/* Imitate issue with read lock acquisition. */
 	m0_fi_enable_once("cs_rconfc_fatal_cb", "ut_signal");
 	m0_fi_enable_once("rconfc_read_lock_complete", "rlock_req_failed");
+	m0_fi_enable_once("_failure_ast_cb", "rlock_req_failed");
 	cs_ut_write_lock_trigger(reqh);
 	sleep(1);
 	/* Make sure SIGUSR2 has been got. */


### PR DESCRIPTION
- Issue: rconfc-ut:no-rms finalizes rpc session before finilazing all rpc items in it
- rpc session fini happens in rconfc_read_lock_complete() callback for failed
  read lock request which is called by outreq_fini(). Then, outreq_fini() is finalizing
  rpc items.
- rlock_ctx_creditor_unset is moved to rconfc failure ast callback, so outreq_fini()
  will finilaze rpc items then rconf failure callback will call rlock_ctx_creditor_unset
  to finilaze rpc session
- fix rconfc-ut:start-fail ut failing by adding FI to pass rlock_ctx_creditor_unset from
  failure callback

Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>