### PR TITLE
EOS-14385 free-space-monitor: cluster size IEM alerts are not received

### DIFF
--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -133,7 +133,8 @@ def print_iem(usage_percentage):
     evt_id = iem_event_id
     msg = f"Cluster size {usage_percentage}"
     msg_b = msg.encode('utf-8')
-    libmotr.m0_motr_iem(ctypes.c_char_p(file_parm_b), function_parm, line_num,
+    libmotr.m0_time_init()
+    libmotr.m0_iem(ctypes.c_char_p(file_parm_b), function_parm, line_num,
                         sev_id, mod_id, evt_id, ctypes.c_char_p(msg_b))
 
 


### PR DESCRIPTION
- free-space-monitor service is calling m0_motr_iem but this API has
  been renamed as m0_iem.
- initialise m0_time_init() before calling m0_iem if calling through
  python C extention because m0_init is not called from python code.