### PR TITLE
EOS-14169 call m0_fop_put() for cc fop in target_ioreq_fini()

### DIFF
--- a/m0t1fs/linux_kernel/file.c
+++ b/m0t1fs/linux_kernel/file.c
@@ -3557,6 +3557,7 @@ err:
 		M0_LOG(M0_INFO, "[%p] target_ioreq deleted for "FID_F,
 		       req, FID_P(&ti->ti_fid));
 		target_ioreq_fini(ti);
+		m0_free0(&ti);
 		++iommstats.d_target_ioreq_nr;
 	} m0_htable_endfor;
 
@@ -4451,6 +4452,7 @@ static void io_request_fini(struct io_request *req)
 		 * are already finalized in nw_xfer_req_complete().
 		 */
 		target_ioreq_fini(ti);
+		m0_free(ti);
 		++iommstats.d_target_ioreq_nr;
 	} m0_htable_endfor;
 
@@ -4749,7 +4751,6 @@ static void target_ioreq_fini(struct target_ioreq *ti)
 	m0_varr_fini(&ti->ti_pageattrs);
 	if (ti->ti_dgvec != NULL)
 		dgmode_rwvec_dealloc_fini(ti->ti_dgvec);
-	m0_free(ti);
 	M0_LEAVE();
 }
 

--- a/m0t1fs/linux_kernel/file_internal.h
+++ b/m0t1fs/linux_kernel/file_internal.h
@@ -1765,6 +1765,9 @@ struct cc_req_fop {
 	struct m0_sm_ast     crf_ast;
 
 	struct target_ioreq *crf_tioreq;
+
+	/* A flag to indicate if a m0_fop_init() has called on this crf_fop */
+	bool                 crf_initialized;
 };
 
 /**

--- a/m0t1fs/linux_kernel/fsync.c
+++ b/m0t1fs/linux_kernel/fsync.c
@@ -285,7 +285,7 @@ int m0t1fs_fsync_core(struct m0t1fs_inode *inode, enum m0_fsync_mode mode)
 	M0_PRE(fi.wait_for_reply != NULL);
 	M0_PRE(fi.fop_fini != NULL);
 
-	m0_tlist_init(&fpf_tl, &pending_fops);
+	fpf_tlist_init(&pending_fops);
 
 	/*
 	 * find the inode's list services with pending transactions
@@ -471,7 +471,7 @@ int m0t1fs_sync_fs(struct super_block *sb, int wait)
 
 	csb = M0T1FS_SB(sb);
 
-	m0_tlist_init(&fpf_tl, &pending_fops);
+	fpf_tlist_init(&pending_fops);
 
 	/*
 	 *  loop over all services associated with this super block,


### PR DESCRIPTION
When running ./m0t1fs/linux_kernel/st/m0t1fs_spare_space_reserve.sh,
the client fill write many files into Motr and finally, server
will return -ENOSPC error to client. In this case, some cc fop (COB
Create fop) is not properly finalized.
A flag added to indicate that cc fop is initialized and m0_fop_put()
is needed when doing ti finalization.

Signed-off-by: Hua Huang <hua.huang@seagate.com>