### PR TITLE
motr dep: readline and readline-devel dependency for m0hsm tool

### DIFF
--- a/scripts/provisioning/roles/motr-build/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-build/vars/RedHat.yml
@@ -47,6 +47,8 @@ motr_build_deps_pkgs:
   - python-ply
   - python-devel
   - PyYAML                # required only for tests (m0hagen)
+  - readline              # required for m0hsm tool
+  - readline-devel        # required for m0hsm tool
   - rpm-build
   - systemd-devel
 


### PR DESCRIPTION
Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>