### PR TITLE
EOS-14409 be/tool/beck: provide option to resume scan

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -79,6 +79,7 @@ struct scanner {
 	FILE		    *s_file;
 	off_t		     s_off;
 	off_t		     s_pos;
+	off_t		     s_recstartoff;
 	bool		     s_byte;
 	off_t		     s_size;
 	struct m0_be_seg    *s_seg;
@@ -878,6 +879,7 @@ static int recdo(struct scanner *s, const struct m0_format_tag *tag,
 		return M0_RC(-EINVAL);
 
 	buf = alloca(size);
+	s->s_recstartoff = s->s_off;
 	result = get(s, buf, size);
 	if (result == 0) {
 		if (memcmp(tag, &r->r_tag, sizeof *tag) == 0) {
@@ -1120,7 +1122,7 @@ static int emap_proc(struct scanner *s, struct btype *b,
 			m0_free(emap_act);
 			continue;
 		}
-		emap_act->emap_act.a_scan_off = s->s_off;
+		emap_act->emap_act.a_scan_off = s->s_recstartoff;
 		qput(s->s_q, &emap_act->emap_act);
 	}
 	return ret;
@@ -1894,7 +1896,7 @@ static int ctg_proc(struct scanner *s, struct btype *b,
 		ca->cta_key = kl[i];
 		ca->cta_val = vl[i];
 		ca->cta_ismeta = ismeta;
-		ca->cta_act.a_scan_off = s->s_off;
+		ca->cta_act.a_scan_off = s->s_recstartoff;
 		qput(s->s_q, (struct action *)ca);
 	}
 	return 0;
@@ -2210,7 +2212,7 @@ static int cob_proc(struct scanner *s, struct btype *b,
 		if ((format_header_verify(ca->coa_val.b_addr,
 					  M0_FORMAT_TYPE_COB_NSREC) == 0) &&
 		    (m0_format_footer_verify(ca->coa_valdata, false) == 0)) {
-			ca->coa_act.a_scan_off = s->s_off;
+			ca->coa_act.a_scan_off = s->s_recstartoff;
 			qput(s->s_q, (struct action *)ca);
 		}
 		else {

--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -522,9 +522,6 @@ int main(int argc, char **argv)
 	if (dry_run)
 		printf("Running in read-only mode.\n");
 
-	if (offset_fname == NULL && !dry_run)
-		errx(EX_USAGE, "Specify file to save scan offset (-r).");
-
 	if (b.b_dom_path == NULL && !dry_run && !print_gen_id)
 		errx(EX_USAGE, "Specify domain path (-d).");
 	if (spath != NULL) {
@@ -573,6 +570,9 @@ int main(int argc, char **argv)
 		printf("Cannot find any segment header generation identifer");
 		return EX_DATAERR;
 	}
+
+	if (offset_fname == NULL && !dry_run)
+		errx(EX_USAGE, "Specify file to save scan offset (-r).");
 	/*
 	 * Skip builder related calls for dry run as we will not be building a
 	 * new segment.

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -816,7 +816,7 @@ run_becktool() {
         m0drlog "Running Becktool on local node"
         run_cmd_on_local_node "(cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
                                -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs -g $LOCAL_SEG_GEN_ID \
-                               -r $MD_DIR/lscan_offset;)"
+                               -r $MD_DIR/scan_offset;)"
         cmd_exit_status=$?
         # restart the execution of command if exit code is ESEGV or OOM error
         while [[ $cmd_exit_status == $ESEGV ]] || [[ $cmd_exit_status == $EOOM ]];
@@ -824,7 +824,7 @@ run_becktool() {
             m0drlog "Restarting Becktool on local node"
             run_cmd_on_local_node "(cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
                                    -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs -g $LOCAL_SEG_GEN_ID \
-                                   -r $MD_DIR/lscan_offset -R;)"
+                                   -r $MD_DIR/scan_offset -R;)"
             cmd_exit_status=$?
         done
 
@@ -846,12 +846,12 @@ run_becktool() {
             # Below statement is for logging purpose
             echo "Running '(cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
                             -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs \
-                            -g $REMOTE_SEG_GEN_ID -r $MD_DIR/rscan_offset;)'" \
+                            -g $REMOTE_SEG_GEN_ID -r $MD_DIR/scan_offset;)'" \
                             >> ${LOG_FILE}
             run_cmd_on_remote_node "bash -s" <<-EOF
             (cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
              -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs \
-             -g $REMOTE_SEG_GEN_ID -r $MD_DIR/rscan_offset;)
+             -g $REMOTE_SEG_GEN_ID -r $MD_DIR/scan_offset;)
 EOF
             cmd_exit_status=$?
             # restart the execution of command if exit code is ESEGV or OOM error
@@ -861,7 +861,7 @@ EOF
                 run_cmd_on_remote_node "bash -s" <<-EOF
                 (cd $MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
                  -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs \
-                 -g $REMOTE_SEG_GEN_ID -r $MD_DIR/rscan_offset -R;)
+                 -g $REMOTE_SEG_GEN_ID -r $MD_DIR/scan_offset -R;)
 EOF
                 cmd_exit_status=$?
             done
@@ -878,10 +878,10 @@ EOF
             # Below statement is for logging purpose
             echo "Running '(cd $FAILOVER_MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
                             -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs \
-                            -g $REMOTE_SEG_GEN_ID -r $MD_DIR/rscan_offset;)'" >> ${LOG_FILE}
+                            -g $REMOTE_SEG_GEN_ID -r $FAILOVER_MD_DIR/scan_offset;)'" >> ${LOG_FILE}
             run_cmd_on_local_node "(cd $FAILOVER_MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
                                     -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs \
-                                    -g $REMOTE_SEG_GEN_ID -r $MD_DIR/rscan_offset;)"
+                                    -g $REMOTE_SEG_GEN_ID -r $FAILOVER_MD_DIR/scan_offset;)"
             cmd_exit_status=$?
             # restart the execution of command if exit code is ESEGV or OOM error
             while [[ $cmd_exit_status == $ESEGV ]] || [[ $cmd_exit_status == $EOOM ]];
@@ -889,7 +889,7 @@ EOF
                 m0drlog "Restarting Becktool for remote node from local node"
                 run_cmd_on_local_node "(cd $FAILOVER_MD_DIR/datarecovery; $BECKTOOL -s $SOURCE_IMAGE \
                                         -d $DEST_DOMAIN_DIR/db -a $DEST_DOMAIN_DIR/stobs \
-                                        -g $REMOTE_SEG_GEN_ID -r $MD_DIR/rscan_offset -R;)"
+                                        -g $REMOTE_SEG_GEN_ID -r $FAILOVER_MD_DIR/scan_offset -R;)"
                 cmd_exit_status=$?
             done
 


### PR DESCRIPTION
Problem:
Beck tool crashes when run into out of memory.  Motr recovery script relaunches beck which starts scan from offset 0 again. This can cause recovery run to take longer time.

Solution:
Save offset of  metadata record currently being processed by builder. This offset indicates previous metadata records are processed and are in persistent state. Beck tool relaunch can start from saved offset.
1. beck tool is updated to,
  a.  take command line argument's for file name to save scan offset and enable scan resume from saved offset.
  b.  save current metadata record offset periodically.
2. motr recovery script change to,
  a. provide file name to save scan offset.
  b. enable scan resume on beck tool relaunch.
  c. relaunch beck tool on Out Of Memory exit code in addition to previous SEG fault. 