### PR TITLE
EOS-14338 scripts: Changes to gen-src-skel to modify licence header

### DIFF
--- a/scripts/gen-src-skel
+++ b/scripts/gen-src-skel
@@ -92,7 +92,7 @@ my %cli_option;
 my @target_file_names;
 my $top_src_dir;
 my $src_prefix;
-my $licence_file = 'LICENCE';
+my $licence_file = 'scripts/licence_header';
 my $user_name;
 my $user_email;
 my $copyright_header;
@@ -107,16 +107,11 @@ sub build_copyright_header
     $copyright =~ s/^/ * /gxms;
     $copyright =~ s/\s+$//gxms;
 
-    my $dt = DateTime->now;
-    my $current_date = $dt->day . '-' . $dt->month_abbr . '-' . $dt->year;
-
     return <<"END_COPYRIGHT"
 /* -*- C -*- */
 /*
 $copyright
  *
- * Original author: $user_name <$user_email>
- * Original creation date: $current_date
  */
 END_COPYRIGHT
 }

--- a/scripts/licence_header
+++ b/scripts/licence_header
@@ -1,0 +1,16 @@
+Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+For any questions about this software or licensing,
+please email opensource@seagate.com or cortx-questions@seagate.com.


### PR DESCRIPTION
The file scripts/gen-src-skel was using license from top cortx-motr directory to generate header.
This needed to be changed as the licence in header was modifed for newer files.

Added a new file scripts/licence_header which has the required header text.
scripts/gen-src-skel now uses this file to add header text.
