### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ Motr
         :target: https://github.com/pujamudaliar/cortx-motr/blob/main/LICENCE
         :alt: License Badge
 
-Motr is a distributed object storage system, targeting `exascale <https://en.wikipedia.org/wiki/Exascale_computing>`_
-configurations. Its main roots are Lustre file system, NFSv4 and database technology. It must be noted that traditional file system properties (hierarchical directory namespace, strong POSIX consistency guarantees, &c.) are no longer desirable or achievable at exascale. Instead, Motr is a more general storage system that provides an optional file system interface. This allows wider range of deployments, including cloud.
+At the core of `CORTX <https://github.com/Seagate/cortx>`_ lies Motr.  Motr is a distributed object storage system, targeting `mass capacity storage <https://www.seagate.com/products/storage/object-storage-software/>`_
+configurations. To ensure the most efficient storage utilization, Motr interacts directly with block devices (i.e. it does not _layer_ on a local file system).  The Motr design was heavily influenced by the Lustre file system, NFSv4 and database technology. It must be noted that traditional file system properties (hierarchical directory namespace, strong POSIX consistency guarantees, &c.) are no longer desirable or achievable at mass capacity. Instead, Motr is a more general storage system that provides an optional file system interface. This allows wider range of deployments, including cloud.
 
 Get to know
 ===========
@@ -35,7 +35,7 @@ Get to know
 
 Surfing
 =======
-Refer `Reading - list <https://github.com/Seagate/cortx-motr/blob/main/doc/reading-list.md>`_ for complete information.
+Refer to `Reading - list <https://github.com/Seagate/cortx-motr/blob/main/doc/reading-list.md>`_ for complete information.
 
 - $ make doc
 


### PR DESCRIPTION
Had a conversation with a community member who was looking for our C-API and confused because this mentioned Lustre and they thought this was not the right thing.  So I made some edits to make it more obvious that this is where people come for ‘libcortx’.  Also the person thought this file implied that motr was using Lustre or was a part of Lustre so I made it obvious that motr itself is not _based_ on Lustre but rather that the motr design is inspired by Lustre.