### PR TITLE
Problem: Motr clients start before Motr IOS process starts functional

### DIFF
--- a/motr/m0d.c
+++ b/motr/m0d.c
@@ -212,27 +212,26 @@ start_m0d:
 	if (rc != 0)
 		goto cleanup1;
 
-#ifdef HAVE_SYSTEMD
-	/*
-	 * From the systemd's point of view, service can be considered as
-	 * started when it can handle incoming connections, which is already
-	 * true before m0_cs_start() is called. otherwise, if sd_notify() is
-	 * called after m0_cs_start() it leads to a deadlock, because different
-	 * m0d instances will wait for each other forever.
-	 */
-	rc = sd_notify(0, "READY=1");
-	if (rc < 0)
-		warnx("systemd READY notification failed, rc=%d\n", rc);
-	else if (rc == 0)
-		warnx("systemd notifications not allowed\n");
-	else
-		warnx("systemd READY notification successfull\n");
-#endif
 	rc = m0_cs_start(&motr_ctx);
 	if (rc == 0) {
 		/* For st/m0d-signal-test.sh */
 		m0_console_printf("Started\n");
 		m0_console_flush();
+
+#ifdef HAVE_SYSTEMD
+		/*
+	 	 * From the systemd's point of view, service can be considered as
+	 	 * started when it can handle incoming connections, which is true
+	 	 * after m0_cs_start() is called.
+	 	 */
+		rc = sd_notify(0, "READY=1");
+		if (rc < 0)
+			warnx("systemd READY notification failed, rc=%d\n", rc);
+		else if (rc == 0)
+			warnx("systemd notifications not allowed\n");
+		else
+			warnx("systemd READY notification successfull\n");
+#endif
 		result = cs_wait_signal();
 		if (gotsignal)
 			warnx("got signal %d", gotsignal);

--- a/scripts/install/usr/lib/systemd/system/m0d@.service
+++ b/scripts/install/usr/lib/systemd/system/m0d@.service
@@ -25,7 +25,7 @@ After=motr-kernel.service
 Before=motr-trace@%i.service
 
 [Service]
-Type=simple
+Type=notify
 TimeoutStopSec=5min
 Restart=no
 Environment=SHELL=/bin/bash


### PR DESCRIPTION
Pacemaker starts Motr clients after Motr servers processes, but since
pacemaker returns success after systemd process successfully starts.
In this case Motr server may not be started fully and functional to
cater requests and accepts requests from Motr client.

Solution:
Move sd_notify() after m0_cs_start(). It will make sure that when
systemd gets READY event from m0d all Motr internal services are started.

Motr server connects to all Motr internal services from other instance
of Motr servers asynchronously.

Ref: EOS-13872
