### PR TITLE
EOS-14408: Combine HW and VM motr master data recovery script

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -151,7 +151,9 @@ get_ios_fid() {
         id=$(m0confgen -f xcode -t json /etc/motr/confd.xc |  jq -r --arg "IP" "$ip" '.[] | select(.objid|startswith("process")) |  select(.endpoint == $IP) | .objid' | cut -d '-' -f2)
         fid=$(printf '0x7200000000000001:%#x\n' $id)
 
-        if [[ "$fid" == $(cat /etc/sysconfig/m0d-0x7200000000000001\:0x* | grep $LOCAL_NODE -B 1 | grep FID | cut -f 2 -d "=" | tr -d \') ]]; then
+        local_node_fids=$(cat /etc/sysconfig/m0d-0x7200000000000001\:0x* | grep $LOCAL_NODE -B 1 | grep FID | cut -f 2 -d "=" | tr -d \')
+
+        if echo $local_node_fids | grep $fid > /dev/null; then
             LOCAL_IOS_FID=$fid
         else
             REMOTE_IOS_FID=$fid

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -1016,7 +1016,7 @@ flush_io(){
     fi
 
     m0drlog "Wait 5 minutes to flush any outstanding IO"
-    # sleep 5m
+    sleep 5m
 }
 # ------------------------- script start --------------------------------
 

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -36,8 +36,8 @@ REMOTE_LV_MD_DEVICE=
 SNAPSHOT="MD_Snapshot" # Snapshot name
 LOCAL_NODE=            # Local node hostname
 REMOTE_NODE=           # Remote node hostname
-LOCAL_IOS_FID=""         # Local ioservice fid
-REMOTE_IOS_FID=""       # Remote ioservice fid
+LOCAL_IOS_FID="0x7200000000000001:0x0" # Local ioservice fid
+REMOTE_IOS_FID="0x7200000000000001:0x0" # Remote ioservice fid
 # REMOTE_STORAGE_STATUS is used to determine remote storage is accessibility,
 # If value is 0 then remote storage is accessible on remote node,
 # If value 1 then remote storage is accessible via local node.

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -432,6 +432,7 @@ reinit_mkfs() {
         run_cmd_on_local_node "systemctl reset-failed"
         run_cmd_on_remote_node "systemctl reset-failed"
         run_cmd_on_local_node "hctl bootstrap --mkfs /var/lib/hare/cluster.yaml"
+        [[ $? -eq 0 ]] || die "***ERROR: Cluster reinitialization with mkfs failed***"
         run_cmd_on_local_node "hctl status" # verify status
         sleep 3
         run_cmd_on_local_node "hctl shutdown"


### PR DESCRIPTION
Problem:
Current motr master data recovery script doesn't support recovery on VM.

Solution:
Added support for hctl commands which will be being used to do cluster
operations on the VM.
Added code to save the m0trace files to /var/motr/datarecovery location
which will be generated while getting generation id of seg0/seg1 using m0beck.
Added code to get the local and remote motr device path from the `mount`
if script is executed on the VM.
To get the ioservice fids /etc/motr/confd.xc is used.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>