### PR TITLE
 EOS-14327 motr-free-space-monitor: Added loop to retry on output parse failure

### DIFF
--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -39,10 +39,7 @@ USAGE_PERCENTAGE = "usedprct"
 AVAILABLE = "available"
 USED = "used"
 SIZE = "size"
-FS_ERR_INVL = 1
-FS_ERR_RETRY = 2
-FS_ERR_TIMEOUT = 3
-IEM_ERR_FILE = 4
+FS_SYSTEMD_FAILED = 1
 conf = {}
 
 with open("/etc/sysconfig/motr-free-space-monitor") as f:
@@ -65,15 +62,7 @@ iem_work_dir = conf['WORK_DIR'].replace('"', '')
 iem_keep_trace_nr = int(conf['KEEP_TRACE_NUM'])
 log = logging.getLogger('IEM AlertLogs')
 log.setLevel(logging.ERROR)
-GET_STORAGE_DETAILS_CMD = '/usr/bin/m0_filesystem_stats -d ' + '-t ' + fs_stat_timeout
 GET_STORAGE_DETAILS_CMD = 'hctl status --json'
-
-def cleanup_m0trace():
-    trace_filename = iem_work_dir + "/m0trace.*"
-    traces = sorted(glob.iglob(trace_filename), key=os.path.getctime)
-    for cleanup in traces[:-iem_keep_trace_nr]:
-        os.remove(cleanup)
-
 
 def execute_command(command):
     rc = 0
@@ -86,7 +75,6 @@ def execute_command(command):
             pass
         rc = process.returncode
         if not process.stdout or rc != 0:
-            cleanup_m0trace()
             time.sleep(iem_alert_check_interval)
             continue
         console_output = json.loads(process.stdout.decode('utf-8'))
@@ -94,16 +82,11 @@ def execute_command(command):
         if not capacity_info:
             continue
         return capacity_info
-        #return re.sub(' +', ' ', process.stdout.decode('utf-8')).split('\n')
 
-    error_str = {FS_ERR_INVL: "Invalid Arguments",
-                 FS_ERR_TIMEOUT: "Command Timedout",
-                 FS_ERR_RETRY: "Server Busy"}
-    default = "Returned with error:" + str(rc)
-    msg = error_str.get(rc, default)
+    msg = " Returned with error " + str(rc)
     log.error(f"Failed to process command after {iem_max_retry} retry '{command}':{msg}")
     print(process.stderr.decode('utf-8'))
-    sys.exit(rc)
+    sys.exit(FS_SYSTEMD_FAILED)
 
 
 def read_cluster_size():
@@ -111,7 +94,9 @@ def read_cluster_size():
     for count in range(0, iem_max_retry):
         capacity_info = execute_command(GET_STORAGE_DETAILS_CMD)
         if not capacity_info:
-            return None
+            time.sleep(iem_alert_check_interval)
+            storage_detail = None
+            continue
         storage_detail = {}
         storage_detail[SIZE] = capacity_info[TOTAL_SPACE]
         storage_detail[USED] = (capacity_info[TOTAL_SPACE] -
@@ -124,6 +109,7 @@ def read_cluster_size():
         storage_detail[USAGE_PERCENTAGE] = round(100 - (capacity_info[FREE_SPACE] /
                                                         capacity_info[TOTAL_SPACE])
                                                  * 100, 2)
+        break
     return storage_detail
 
 
@@ -175,26 +161,24 @@ if __name__ == '__main__':
                     local_libmotr = motr_src_path + '/' + "motr/.libs/libmotr.so"
                     if os.path.isfile(local_libmotr):
                         LIBMOTR_PATH = local_libmotr
-                        GET_STORAGE_DETAILS_CMD = GET_STORAGE_DETAILS_CMD + ' -l ' + LIBMOTR_PATH
                     else:
                         log.error("Could not find libmotr.so")
-                        sys.exit(IEM_ERR_FILE)
+                        sys.exit(FS_SYSTEMD_FAILED)
 
     try:
         libmotr = ctypes.CDLL(LIBMOTR_PATH)
     except Exception as e:
-        log.error(f"Failed to process command {e}")
-        sys.exit(IEM_ERR_FILE)
+        log.error(f"Failed to open libmotr with exception {e}")
+        sys.exit(FS_SYSTEMD_FAILED)
 
-    cleanup_m0trace()
     cluster_usage_prev = 0
     while True:
         send_iem = False
         wait_time = iem_alert_check_interval
         cluster_size = read_cluster_size()
         if not cluster_size:
-                log.error("Could not read filesystem stats")
-                sys.exit(IEM_ERR_FILE)
+                log.error("hctl status could not read filesystem stats")
+                sys.exit(FS_SYSTEMD_FAILED)
 
         cluster_usage_percentage = cluster_size[USAGE_PERCENTAGE]
         if cluster_usage_percentage > iem_min_threshold:

--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -44,6 +44,8 @@ FS_ERR_RETRY = 2
 FS_ERR_TIMEOUT = 3
 IEM_ERR_FILE = 4
 conf = {}
+max_retry_count = 10
+retry_counter = 0
 
 with open("/etc/sysconfig/motr-free-space-monitor") as f:
     for config in f.read().splitlines():
@@ -189,9 +191,14 @@ if __name__ == '__main__':
         wait_time = iem_alert_check_interval
         cluster_size = read_cluster_size()
         if not cluster_size:
-            log.error("Could not read filesystem stats")
-            time.sleep(30)
-            continue
+            if retry_counter < max_retry_count:
+                retry_counter += 1
+                log.error("Could not read filesystem stats, will retry after 30 seconds")
+                time.sleep(30)
+                continue
+            else:
+                log.error("Reached to max retry count, terminating process")
+                sys.exit(IEM_ERR_FILE)
 
         cluster_usage_percentage = cluster_size[USAGE_PERCENTAGE]
         if cluster_usage_percentage > iem_min_threshold:

--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -190,7 +190,8 @@ if __name__ == '__main__':
         cluster_size = read_cluster_size()
         if not cluster_size:
             log.error("Could not read filesystem stats")
-            sys.exit(IEM_ERR_FILE)
+            time.sleep(30)
+            continue
 
         cluster_usage_percentage = cluster_size[USAGE_PERCENTAGE]
         if cluster_usage_percentage > iem_min_threshold:

--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -44,8 +44,6 @@ FS_ERR_RETRY = 2
 FS_ERR_TIMEOUT = 3
 IEM_ERR_FILE = 4
 conf = {}
-max_retry_count = 10
-retry_counter = 0
 
 with open("/etc/sysconfig/motr-free-space-monitor") as f:
     for config in f.read().splitlines():
@@ -109,19 +107,23 @@ def execute_command(command):
 
 
 def read_cluster_size():
-    capacity_info = execute_command(GET_STORAGE_DETAILS_CMD)
-    if not capacity_info:
-        return None
-    storage_detail = {}
-    storage_detail[SIZE] = capacity_info[TOTAL_SPACE]
-    storage_detail[USED] = (capacity_info[TOTAL_SPACE] -
-                            capacity_info[FREE_SPACE])
-    storage_detail[AVAILABLE] = capacity_info[FREE_SPACE]
-    if not capacity_info[TOTAL_SPACE]:
-        return None
-    storage_detail[USAGE_PERCENTAGE] = round(100 - (capacity_info[FREE_SPACE] /
-                                                    capacity_info[TOTAL_SPACE])
-                                             * 100, 2)
+    storage_detail = None
+    for count in range(0, iem_max_retry):
+        capacity_info = execute_command(GET_STORAGE_DETAILS_CMD)
+        if not capacity_info:
+            return None
+        storage_detail = {}
+        storage_detail[SIZE] = capacity_info[TOTAL_SPACE]
+        storage_detail[USED] = (capacity_info[TOTAL_SPACE] -
+                                capacity_info[FREE_SPACE])
+        storage_detail[AVAILABLE] = capacity_info[FREE_SPACE]
+        if not capacity_info[TOTAL_SPACE]:
+            time.sleep(iem_alert_check_interval)
+            storage_detail = None
+            continue
+        storage_detail[USAGE_PERCENTAGE] = round(100 - (capacity_info[FREE_SPACE] /
+                                                        capacity_info[TOTAL_SPACE])
+                                                 * 100, 2)
     return storage_detail
 
 
@@ -191,13 +193,7 @@ if __name__ == '__main__':
         wait_time = iem_alert_check_interval
         cluster_size = read_cluster_size()
         if not cluster_size:
-            if retry_counter < max_retry_count:
-                retry_counter += 1
-                log.error("Could not read filesystem stats, will retry after 30 seconds")
-                time.sleep(30)
-                continue
-            else:
-                log.error("Reached to max retry count, terminating process")
+                log.error("Could not read filesystem stats")
                 sys.exit(IEM_ERR_FILE)
 
         cluster_usage_percentage = cluster_size[USAGE_PERCENTAGE]


### PR DESCRIPTION
    In motr-free-space-monitor `hctl status --json` is called to get cluster
    size but sometime it might happen that it failed to parse or cluster size
    is zero in such case trying again to get cluster size upto max retry count.

    Removed other un-necessasry things like cleanup_motrace() and other error codes.

    Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>
