### PR TITLE
EOS-14450: Added changes to resize addb stobs without mkfs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -910,11 +910,13 @@ motr_libexec_SCRIPTS = \
     scripts/install$(motrdir)/libexec/motr_data_recovery.sh \
     scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
     scripts/install$(motrdir)/libexec/motr_cfg.sh
+    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
 EXTRA_DIST += $(motr_libexec_SCRIPTS)
 
 motr_crondir = $(sysconfdir)/cron.hourly
 motr_cron_SCRIPTS = \
-    scripts/install$(motrdir)/libexec/m0trace_logrotate.sh
+    scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
+    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
 EXTRA_DIST += $(motr_cron_SCRIPTS)
     
 motr_confdir = $(motrdir)/conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -909,7 +909,7 @@ motr_libexec_SCRIPTS = \
     scripts/install$(motrdir)/libexec/m0_ha_sim \
     scripts/install$(motrdir)/libexec/motr_data_recovery.sh \
     scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
-    scripts/install$(motrdir)/libexec/motr_cfg.sh
+    scripts/install$(motrdir)/libexec/motr_cfg.sh \
     scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
 EXTRA_DIST += $(motr_libexec_SCRIPTS)
 

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -222,6 +222,7 @@ fi
 %attr(0770, motr, motr) %{_localstatedir}/motr
 %config %attr(0664, motr, motr) %{_sysconfdir}/sysconfig/*
 %config %attr(0755, root, root) %{_sysconfdir}/cron.hourly/m0trace*
+%config %attr(0755, root, root) %{_sysconfdir}/cron.hourly/m0addb*
 %{_sysconfdir}/systemd/system/*
 %{_sysconfdir}/security/limits.d/90-motr.conf
 /opt/seagate/cortx/motr/*

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -1614,7 +1614,7 @@ static int cs_storage_setup(struct m0_motr *cctx)
 	}
 
 	rc = m0_reqh_addb2_init(&rctx->rc_reqh, rctx->rc_addb_stlocation,
-				M0_ADDB2_STOB_DOM_KEY, mkfs, force,
+				M0_ADDB2_STOB_DOM_KEY, true, force,
 				rctx->rc_addb_record_file_size);
 	if (rc != 0)
 		goto cleanup_stob;
@@ -2244,8 +2244,10 @@ static int _args_parse(struct m0_motr *cctx, int argc, char **argv)
 				})),
 			M0_STRINGARG('A', "ADDB storage domain location",
 				LAMBDA(void, (const char *s)
-				{
-					rctx->rc_addb_stlocation = s;
+				{    
+                                        char tmp_buf[128];
+                                        sprintf(tmp_buf, "%s-%d", s, (int)m0_pid());
+                                        rctx->rc_addb_stlocation = strdup(tmp_buf);	
 				})),
 			M0_STRINGARG('d', "Device configuration file",
 				LAMBDA(void, (const char *s)

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# script is used to delete the old motr addb stobs
+# argument1: <number of latest addb stob dir to retain>
+# Default number of latest addb stob dir is 2
+# ./m0addb_logrotate.sh 2
+
+usage() { 
+        echo "Usage: bash $(basename $0) [--help|-h]
+                     [-n LogDirCount]
+Retain recent modified directories of given count and remove older motr addb stob directories.
+where:
+-n            number of latest addb stob directories to retain 
+              Physical : Default count of addb stob directories are 2+2 first directories
+              virtual  : Default count of log dirs is 2
+--help|-h     display this help and exit" 1>&2; 
+        exit 1; 
+}
+
+get_platform() 
+{
+    plt=$(systemd-detect-virt)
+ 
+    if [[ $plt = "none" ]]; then
+        plt="physical"
+    else
+        plt="virtual"
+    fi
+
+    echo "$plt"
+}
+
+check_param() 
+{
+    PARAM=$1
+    echo "PARAM: $PARAM"
+    if [[ -n $PARAM ]]; then
+        retval="OK"
+    else
+        echo "PARAM is empty"
+        retval="continue"
+    fi
+
+    echo $retval
+}
+
+platform=$(get_platform)
+echo "Server type is $platform"
+
+# max addb stob directories count in each log directory
+log_dirs_max_count=2
+# have hard coded the log path, 
+# Need to get it from config file 
+motr_logdirs=`ls -d /var/motr*`
+
+while getopts ":n:" option; do
+    case "${option}" in
+        n)
+            log_dirs_max_count=${OPTARG}
+            if [[ -z ${log_dirs_max_count} ]]; then
+              usage
+            fi
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [[ $platform = "virtual" ]]; then
+    log_dirs_max_count=2
+else
+    log_dirs_max_count=`expr $log_dirs_max_count + 2`
+fi
+
+echo "Max log dir count: $log_dirs_max_count"
+echo "ADDB Log directory: $motr_logdirs"
+
+# check for log directory entries
+for motr_logdir in $motr_logdirs ; do
+    [[ $(check_param $motr_logdir) = "continue" ]] && continue || echo "$motr_logdir"
+
+    # get the log directory of each m0d instance
+    log_dirs=`find $motr_logdir -maxdepth 1 -type d -name m0d-\*`
+
+    [[ $(check_param $log_dirs) = "continue" ]] && continue || echo "$log_dirs"
+
+    # iterate through all log directories of each m0d instance
+    for log_dir in $log_dirs ; do
+        # get the no. of stob dir count
+        addb_dirs=`find $log_dir -maxdepth 1 -type d -name "addb-stobs-*"`
+        addb_dirs_count=`echo "$addb_dirs" | grep -v "^$" | wc -l`
+
+        echo "## found $addb_dirs_count dir(s) in log directory $log_dir ##"
+
+        # check addb stob dir count is greater than max dir  count
+        if [[ $addb_dirs_count -gt $log_dirs_max_count ]]; then
+            # get dirs sort by date - older will come on top
+            remove_dir_count=`expr $addb_dirs_count - $log_dirs_max_count`
+
+            echo "## ($remove_dir_count) dir(s) can be removed from \
+                           log directory($log_dir) ##"               
+
+            # get the dirs sorted by time modified 
+            # (most recently modified comes last), that 
+            # is older dirs comes first
+            echo "LOG_DIR is $log_dir"
+            
+            if [[ $platform = "physical" ]]; then
+                peserve_dirs=`expr $log_dirs_max_count - 2`
+                dirs_to_remove=`ls -tr "$log_dir" | grep addb-stobs- | \
+                                     head -n -$peserve_dirs | awk 'NR>2'`
+            else
+                dirs_to_remove=`ls -tr "$log_dir" | grep addb-stobs- | \
+                                     head -n $remove_dir_count`
+            fi
+
+            for dir in $dirs_to_remove ; do
+                # remove only if dir not sym dir
+                if !  [[ -L "$log_dir/$dir" ]]; then
+                    echo "$log_dir/$dir"
+                    rm -rf "$log_dir/$dir"
+                    if [[ $? -ne 0 ]]; then
+                       echo "Unable to remove directory $dir"
+                    fi
+                fi
+            done
+        else
+            echo "## No dirs to remove ##"
+        fi
+    done
+done

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -35,19 +35,6 @@ where:
         exit 1; 
 }
 
-get_platform() 
-{
-    plt=$(systemd-detect-virt)
- 
-    if [[ $plt = "none" ]]; then
-        plt="physical"
-    else
-        plt="virtual"
-    fi
-
-    echo "$plt"
-}
-
 check_param() 
 {
     PARAM=$1
@@ -61,9 +48,6 @@ check_param()
 
     echo $retval
 }
-
-platform=$(get_platform)
-echo "Server type is $platform"
 
 # max addb stob directories count in each log directory
 log_dirs_max_count=2
@@ -85,11 +69,7 @@ while getopts ":n:" option; do
     esac
 done
 
-if [[ $platform = "virtual" ]]; then
-    log_dirs_max_count=2
-else
-    log_dirs_max_count=`expr $log_dirs_max_count + 2`
-fi
+log_dirs_max_count=2
 
 echo "Max log dir count: $log_dirs_max_count"
 echo "ADDB Log directory: $motr_logdirs"
@@ -124,14 +104,8 @@ for motr_logdir in $motr_logdirs ; do
             # is older dirs comes first
             echo "LOG_DIR is $log_dir"
             
-            if [[ $platform = "physical" ]]; then
-                peserve_dirs=`expr $log_dirs_max_count - 2`
-                dirs_to_remove=`ls -tr "$log_dir" | grep addb-stobs- | \
-                                     head -n -$peserve_dirs | awk 'NR>2'`
-            else
-                dirs_to_remove=`ls -tr "$log_dir" | grep addb-stobs- | \
+            dirs_to_remove=`ls -tr "$log_dir" | grep addb-stobs- | \
                                      head -n $remove_dir_count`
-            fi
 
             for dir in $dirs_to_remove ; do
                 # remove only if dir not sym dir

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -86,7 +86,7 @@ for motr_logdir in $motr_logdirs ; do
     # iterate through all log directories of each m0d instance
     for log_dir in $log_dirs ; do
         # get the no. of stob dir count
-        addb_dirs=`find $log_dir -maxdepth 1 -type d -name "addb-stobs-*"`
+        addb_dirs=`find $log_dir -maxdepth 1 -type d -name "addb-stobs*"`
         addb_dirs_count=`echo "$addb_dirs" | grep -v "^$" | wc -l`
 
         echo "## found $addb_dirs_count dir(s) in log directory $log_dir ##"
@@ -104,7 +104,7 @@ for motr_logdir in $motr_logdirs ; do
             # is older dirs comes first
             echo "LOG_DIR is $log_dir"
             
-            dirs_to_remove=`ls -tr "$log_dir" | grep addb-stobs- | \
+            dirs_to_remove=`ls -tr "$log_dir" | grep addb-stobs | \
                                      head -n $remove_dir_count`
 
             for dir in $dirs_to_remove ; do

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -29,8 +29,7 @@ usage() {
 Retain recent modified directories of given count and remove older motr addb stob directories.
 where:
 -n            number of latest addb stob directories to retain 
-              Physical : Default count of addb stob directories are 2+2 first directories
-              virtual  : Default count of log dirs is 2
+              Default count of addb stob directories is 2
 --help|-h     display this help and exit" 1>&2; 
         exit 1; 
 }

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -719,21 +719,24 @@ addb() {
     local m0addb2dump=$(path m0addb2dump)
     (outdir=$(readlink -f .)/$outdir
      cd "$IN_DIR"
-     find . -type d -name addb-stobs | cut -c3- | while read dir; do
-         find $dir/o -type f -name \*:2 | while read path; do
-             path=$(readlink -f $path)  # convert to absolute path
-             mkdir -p $outdir$(dirname $path)
-             ##
-             ## Note that m0addb2dump needs absolute path.
-             ## If relative path is provided, m0addb2dump fails:
-             ##
-             ## > lt-m0addb2dump: Cannot create stob: -2: No such file
-             ## > or directory
-             $m0addb2dump $path | tail -$ADDB_TAIL | _xz >$outdir$path.xz
-             touch -r $path $outdir$path.xz
-             echo $path.xz
+     for pid in `pgrep m0d`; do
+         find . -type d -name addb-stobs-$pid | cut -c3- | while read dir; do
+	    find $dir/o -type f -name \*:2 | while read path; do
+               path=$(readlink -f $path) # convert to absolute path
+               mkdir -p $outdir$(dirname $path)
+               ##
+               ## Note that m0addb2dump needs absolute path.
+               ## If relative path is provided, m0addb2dump fails:
+               ##
+               ## > lt-m0addb2dump: Cannot create stob: -2: No such file
+               ## > or directory
+               $m0addb2dump $path | tail -$ADDB_TAIL | _xz >$outdir$path.xz
+               touch -r $path $outdir$path.xz
+               echo $path.xz
+            done
          done
      done)
+
 }
 
 addb-files() {
@@ -748,12 +751,14 @@ addb-files() {
        fi
     done
 
-    for file_path in $(find ${IN_DIR}/m0d-*/addb-stobs/o  -name "100000000000000:2" 2>/dev/null); do
-        if [ -f "$file_path" ]; then
-            ios_fid=$(echo $file_path | cut -d '/' -f4 | cut -d '-' -f2)
-            [[ $(hctl status | grep 'ioservice' | grep  $ios_fid  2>/dev/null) ]] &&
-                 cat $file_path | _xz > addb_files/$IN_DIR/m0d_addb__${ios_fid}.xz
-        fi
+    for pid in `pgrep m0d`; do
+        for file_path in $(find ${IN_DIR}/m0d-*/addb-stobs-$pid/o  -name "100000000000000:2" 2>/dev/null); do
+            if [ -f "$file_path" ]; then
+                ios_fid=$(echo $file_path | cut -d '/' -f4 | cut -d '-' -f2)
+                [[ $(hctl status | grep 'ioservice' | grep  $ios_fid  2>/dev/null) ]] &&
+                     cat $file_path | _xz > addb_files/$IN_DIR/m0d_addb__${ios_fid}.xz
+            fi
+        done
     done
 }
 

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -754,9 +754,8 @@ addb-files() {
     for pid in `pgrep m0d`; do
         for file_path in $(find ${IN_DIR}/m0d-*/addb-stobs-$pid/o  -name "100000000000000:2" 2>/dev/null); do
             if [ -f "$file_path" ]; then
-                ios_fid=$(echo $file_path | cut -d '/' -f4 | cut -d '-' -f2)
-                [[ $(hctl status | grep 'ioservice' | grep  $ios_fid  2>/dev/null) ]] &&
-                     cat $file_path | _xz > addb_files/$IN_DIR/m0d_addb__${ios_fid}.xz
+                fid=$(echo $file_path | cut -d '/' -f4 | cut -d '-' -f2)
+                cat $file_path | _xz > addb_files/$IN_DIR/m0d_addb__${fid}.xz
             fi
         done
     done


### PR DESCRIPTION
1. Generate new addb-stobs directory during every m0d restart instead of during mkfs only.
2. The newly generated addb-stob directory is appended with the server pid. i.e addb-stobs-$PID
3. Limit number of addb-stob directories in m0d directory to 2.