### PR TITLE
scripts: fix client id name

### DIFF
--- a/addb2/dump.c
+++ b/addb2/dump.c
@@ -1170,11 +1170,11 @@ struct m0_addb2__id_intrp ids[] = {
 	{ M0_AVI_CLIENT_COB_REQ,      "cob-req-state", { &dec, &cob_req_state },
 	  { "cob_id", "cob_state" } },
 	{ M0_AVI_CLIENT_TO_COB_REQ,   "client-to-cob", { &dec, &dec },
-	  { "id", "cob_id" } },
+	  { "client_id", "cob_id" } },
 	{ M0_AVI_CLIENT_COB_REQ_TO_RPC, "cob-to-rpc",  { &dec, &dec },
 	  { "cob_id", "rpc_id" } },
 	{ M0_AVI_CLIENT_TO_IOO,       "client-to-ioo", { &dec, &dec },
-	  { "id", "ioo_id" } },
+	  { "client_id", "ioo_id" } },
 	{ M0_AVI_IOO_TO_RPC,   "ioo-to-rpc",    { &dec, &dec },
 	  { "ioo_id", "rpc_id" } },
 

--- a/scripts/addb-py/chronometry/addb2db.py
+++ b/scripts/addb-py/chronometry/addb2db.py
@@ -197,7 +197,7 @@ class client_to_dix(BaseModel):
 
 class client_to_cob(BaseModel):
     pid       = IntegerField()
-    id        = IntegerField()
+    client_id = IntegerField()
     cob_id    = IntegerField()
 
 class cob_to_rpc(BaseModel):
@@ -207,7 +207,7 @@ class cob_to_rpc(BaseModel):
 
 class client_to_ioo(BaseModel):
     pid       = IntegerField()
-    id        = IntegerField()
+    client_id = IntegerField()
     ioo_id    = IntegerField()
 
 class ioo_to_rpc(BaseModel):


### PR DESCRIPTION
Problem:
As a result of the renaming we have got an inconsistency
between scripts that builds database and timelines scripts
for ioo and dix operations: prior ones use short 'id' as a
client id while latter ones use long 'client_id'.

Solution:
Proper way is to use the long form as it corresponds to
the common antities mapping approach that was implemented
initially. Current fix implements it. Now only long form
of client id is used.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>