### PR TITLE
[EOS-14777] Suppress warning during motr rpm update and update

### DIFF
--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -267,7 +267,8 @@ getent passwd motr >/dev/null || useradd --system --shell /sbin/nologin \
 %post -e
 /sbin/depmod -a
 systemctl daemon-reload
-/usr/sbin/m0provision config > /var/log/motr-rpm-conf-update.log
+echo $(date) &> /var/log/motr-rpm-conf-update.log
+/usr/sbin/m0provision config &>> /var/log/motr-rpm-conf-update.log
 
 if [ x%%{?no_trace_logs} != x ] ; then
     /bin/sed -i -r -e "s/(MOTR_TRACED_KMOD=)yes/\1no/" /etc/sysconfig/motr

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -157,6 +157,38 @@ set_key_value() # ARG1 [KEY] ARG2 [VALUE] ARG3 [FILE]
 
 }
 
+chk_key_value()
+{
+    _key=$1
+    _value=$2
+    ret=1 # 0: value are same 1: value are different
+    IFS=$'\n'
+    for CFG_LINE in `cat $ETC_SYSCONFIG_MOTR`; do       
+        if [[ "$CFG_LINE" == "#"* ]]; then
+
+            # If key is commented then still we need to update
+            # /etc/sysconfig/motr
+            if [[ "$CFG_LINE" == *"$_key="* ]]; then
+                ret=1
+                break
+            fi 
+            dbg "Commented line [$CFG_LINE]"
+        else
+            IFS='='; CFG_LINE_ARRAY=($CFG_LINE); unset IFS;
+            local KEY=${CFG_LINE_ARRAY[0]}
+            local VALUE=${CFG_LINE_ARRAY[1]}
+            KEY=$(echo $KEY | xargs)
+            VALUE=$(echo $VALUE | xargs)
+            if [[ "$KEY" == "$_key" && "$VALUE" == "$_value" ]];then
+                ret=0
+                break  
+            fi
+        fi
+    done
+    unset $IFS
+    echo $ret
+}
+
 do_m0provision_action()
 {
     local CFG_LINE=""
@@ -213,7 +245,13 @@ do_m0provision_action()
             VALUE=$(echo $VALUE | xargs)
             if [ "$KEY" != "" ]; then
                 msg "Updating KEY [$KEY]; VALUE [$VALUE]"
-                set_key_value $KEY "$VALUE" $ETC_SYSCONFIG_MOTR
+                # update /etc/sysconfig/motr file
+                # only when the key values are different
+                # from motr.conf file
+                res=$(chk_key_value $KEY "$VALUE")
+                if [[ $ret -ne 0 ]];then
+                    set_key_value $KEY "$VALUE" $ETC_SYSCONFIG_MOTR
+                fi
             else
                 dbg "Not processing [$CFG_LINE]"
             fi

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -172,6 +172,11 @@ main() {
         warn "$RECOVERY_SCRIPT_DIR: no such directory"
     fi
 
+    # Collect rpm-update-logs
+    if [ -f /var/log/motr-rpm-conf-update.log ]; then
+        cp -pv /var/log/motr-rpm-conf-update.log $OUT_DATA_DIR/
+    fi
+
     popd >/dev/null
     tar --remove-files -cJf $OUT_DATA_DIR{.tar.xz,}
     local files=$OUT_DATA_DIR.tar.xz
@@ -766,6 +771,10 @@ systemd_journal() {
     for ((i = 0; i < nr_boots; ++i)); do
         journalctl -b -$i 2>>$REPORT | _xz >$outdir/systemd-journal_$i.xz
     done
+
+    if [ -z $nr_boots ]; then
+        journalctl 2>>$REPORT | _xz > $outdir/systemd-journal.xz
+    fi
 }
 
 usage() {


### PR DESCRIPTION
            userconfig only if key-value are different
     - modified  m0tr_cfg.sh to update /etc/sysconfig/motr
       only when therer is a change in values of config params
     - redirected warnings to motr-rpm-conf-update.log

Signed-off-by: Vinoth <root@ssc-vm-c-0971.colo.seagate.com>