### PR TITLE
EOS-14186: MOTR_M0D_IOS_BESEG_SIZE should be minimum of metadata volumes

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -160,29 +160,33 @@ set_key_value() # ARG1 [KEY] ARG2 [VALUE] ARG3 [FILE]
 do_m0provision_action()
 {
     local CFG_LINE=""
+    local LVM_SIZE_MIN=0
     local LVM_SIZE=0
 
+    if [ ! -x /usr/sbin/lvs ]; then
+        err "lvs command not available."
+    fi
+
     msg "Configuring host [`hostname -f`]"
-    MD_DEVICES=($(lvs -o lv_path | grep "lv_raw_metadata" | grep srvnode  | sort -u))
+    MD_DEVICES=($(lvs -o lv_path 2>/dev/null | grep "lv_raw_metadata" | grep srvnode  | sort -u))
 
     for i in ${MD_DEVICES[@]};
     do
-        LVM_SIZE_ITR=$(lvs $i -o LV_SIZE \
+        LVM_SIZE=$(lvs $i -o LV_SIZE \
                        --noheadings --units b --nosuffix | xargs)
-        ANY_ERR=$(echo $LVM_SIZE_ITR | grep -i ERROR | wc -l)
+        ANY_ERR=$(echo $LVM_SIZE | grep -i ERROR | wc -l)
         if [[ ( "$ANY_ERR" != "0" ) || ( -z "$LVM_SIZE" ) ]]; then
             err "lvs $i command failed."
-            msg "[$LVM_SIZE]"
-	fi
-	if [[ "$LVM_SIZE_ITR" -lt "$LVM_SIZE" || "$LVM_SIZE" -eq 0 ]]; then
-	    LVM_SIZE=$LVM_SIZE_ITR
+            msg "[$LVM_SIZE_MIN]"
+	elif [[ "$LVM_SIZE" -lt "$LVM_SIZE_MIN" || "$LVM_SIZE_MIN" -eq 0 ]]; then
+	    LVM_SIZE_MIN=$LVM_SIZE
 	fi
     done
-    if [ "$LVM_SIZE" -eq 0 ]; then
-	 err "lvs size invalid [$LVM_SIZE]"
+    if [ "$LVM_SIZE_MIN" -eq 0 ]; then
+	 err "lvs size invalid [$LVM_SIZE_MIN]"
     else
-         msg "LVM_SIZE = $LVM_SIZE"
-         sed -i "s/MOTR_M0D_IOS_BESEG_SIZE=.*/MOTR_M0D_IOS_BESEG_SIZE=$LVM_SIZE/g" $MOTR_CONF_FILE
+         msg "LVM_SIZE_MIN = $LVM_SIZE_MIN"
+         sed -i "s/MOTR_M0D_IOS_BESEG_SIZE=.*/MOTR_M0D_IOS_BESEG_SIZE=$LVM_SIZE_MIN/g" $MOTR_CONF_FILE
     fi
 
     SALT_OPT=$(salt-call --local grains.get virtual)

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -163,19 +163,26 @@ do_m0provision_action()
     local LVM_SIZE=0
 
     msg "Configuring host [`hostname -f`]"
+    MD_DEVICES=($(lvs -o lv_path | grep "lv_raw_metadata" | grep srvnode | sort -u))
 
-    MD_DEVICE=$(lvs -o lv_path | grep "lv_raw_metadata" | head -1)
-    if [[ $? -eq 0 && $MD_DEVICE != "" ]];then
-        LVM_SIZE=$(lvs $MD_DEVICE  -o LV_SIZE \
-              --noheadings --units b --nosuffix | xargs)
-
-        ANY_ERR=$(echo $LVM_SIZE | grep -i ERROR | wc -l)
+    for i in ${MD_DEVICES[@]};
+    do
+        LVM_SIZE_ITR=$(lvs $i -o LV_SIZE \
+                       --noheadings --units b --nosuffix | xargs)
+        ANY_ERR=$(echo $LVM_SIZE_ITR | grep -i ERROR | wc -l)
         if [[ ( "$ANY_ERR" != "0" ) || ( -z $LVM_SIZE ) ]]; then
-            err "lvs $MD_DEVICE command failed."
+            err "lvs $i command failed."
             msg "[$LVM_SIZE]"
-        elif [[ $LVM_SIZE -ne 0 ]];then
-            sed -i "s/MOTR_M0D_IOS_BESEG_SIZE=.*/MOTR_M0D_IOS_BESEG_SIZE=$LVM_SIZE/g" $MOTR_CONF_FILE
-        fi
+	fi
+	if [[ $LVM_SIZE_ITR -lt $LVM_SIZE -o $LVM_SIZE -eq 0 ]]; then
+	    LVM_SIZE=$LVM_SIZE_ITR
+	fi
+    done
+    if [ $LVM_SIZE -eq 0 ]; then
+	 err "lvs size invalid [$LVM_SIZE]"
+    else
+         msg "LVM_SIZE = $LVM_SIZE"
+         sed -i "s/MOTR_M0D_IOS_BESEG_SIZE=.*/MOTR_M0D_IOS_BESEG_SIZE=$LVM_SIZE/g" $MOTR_CONF_FILE
     fi
 
     SALT_OPT=$(salt-call --local grains.get virtual)

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -163,12 +163,12 @@ do_m0provision_action()
     local LVM_SIZE_MIN=0
     local LVM_SIZE=0
 
+    msg "Configuring host [`hostname -f`]"
     if [ ! -x /usr/sbin/lvs ]; then
         err "lvs command not available."
+    else
+        MD_DEVICES=($(lvs -o lv_path 2>/dev/null | grep "lv_raw_metadata" | grep srvnode  | sort -u))
     fi
-
-    msg "Configuring host [`hostname -f`]"
-    MD_DEVICES=($(lvs -o lv_path 2>/dev/null | grep "lv_raw_metadata" | grep srvnode  | sort -u))
 
     for i in ${MD_DEVICES[@]};
     do

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -224,7 +224,6 @@ do_m0provision_action()
              else
                  err "This setup configuration seems invalid"
                  err "Difference between metadata volume size is beyond tolerance level, [ $LVM_SIZE_MAX > $LVM_SIZE_MIN ]"
-                 die $ERR_NOT_IMPLEMENTED
              fi 
         fi
     fi 

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -223,7 +223,7 @@ do_m0provision_action()
                  sed -i "s/MOTR_M0D_IOS_BESEG_SIZE=.*/MOTR_M0D_IOS_BESEG_SIZE=$LVM_SIZE_MIN/g" $MOTR_CONF_FILE
              else
                  err "This setup configuration seems invalid"
-                 err "Difference between metadata volume size is beyond tolerance level, $diff_per > $MAX_DIFF_TOLERANCE"
+                 err "Difference between metadata volume size is beyond tolerance level, [ $LVM_SIZE_MAX > $LVM_SIZE_MIN ]"
                  die $ERR_NOT_IMPLEMENTED
              fi 
         fi

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -163,22 +163,22 @@ do_m0provision_action()
     local LVM_SIZE=0
 
     msg "Configuring host [`hostname -f`]"
-    MD_DEVICES=($(lvs -o lv_path | grep "lv_raw_metadata" | grep srvnode | sort -u))
+    MD_DEVICES=($(lvs -o lv_path | grep "lv_raw_metadata" | grep srvnode  | sort -u))
 
     for i in ${MD_DEVICES[@]};
     do
         LVM_SIZE_ITR=$(lvs $i -o LV_SIZE \
                        --noheadings --units b --nosuffix | xargs)
         ANY_ERR=$(echo $LVM_SIZE_ITR | grep -i ERROR | wc -l)
-        if [[ ( "$ANY_ERR" != "0" ) || ( -z $LVM_SIZE ) ]]; then
+        if [[ ( "$ANY_ERR" != "0" ) || ( -z "$LVM_SIZE" ) ]]; then
             err "lvs $i command failed."
             msg "[$LVM_SIZE]"
 	fi
-	if [[ $LVM_SIZE_ITR -lt $LVM_SIZE -o $LVM_SIZE -eq 0 ]]; then
+	if [[ "$LVM_SIZE_ITR" -lt "$LVM_SIZE" || "$LVM_SIZE" -eq 0 ]]; then
 	    LVM_SIZE=$LVM_SIZE_ITR
 	fi
     done
-    if [ $LVM_SIZE -eq 0 ]; then
+    if [ "$LVM_SIZE" -eq 0 ]; then
 	 err "lvs size invalid [$LVM_SIZE]"
     else
          msg "LVM_SIZE = $LVM_SIZE"

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -163,13 +163,8 @@ lvm_size_percentage_diff()
     MIN=$2
     local percent=0
 
-    if [ $MAX -eq $MIN ]; then
-       percent=0
-    fi
-
    percent=$((100 * ($MAX - $MIN)/$MAX))
    echo $percent
-
 }
 
 do_m0provision_action()
@@ -179,6 +174,7 @@ do_m0provision_action()
     local LVM_SIZE_MAX=0
     local MAX_DIFF_TOLERANCE=5
     local LVM_SIZE=0
+    local MD_DEVICE_CNT=0
 
     msg "Configuring host [`hostname -f`]"
     if [ ! -x /usr/sbin/lvs ]; then
@@ -186,20 +182,6 @@ do_m0provision_action()
     else
         MD_DEVICES=($(lvs -o lv_path 2>/dev/null | grep "lv_raw_metadata" | grep srvnode  | sort -u))
 
-        # Initializing MIN and MAX to first lvm size in the list. 
-        if [ ${#MD_DEVICES[@]} -ne 0 ]; then
-            LVM_SIZE=$(lvs ${MD_DEVICES[0]} -o LV_SIZE \
-                           --noheadings --units b --nosuffix | xargs)
-            ANY_ERR=$(echo $LVM_SIZE | grep -i ERROR | wc -l)
-            if [[ ( "$ANY_ERR" != "0" ) || ( -z "$LVM_SIZE" ) ]]; then
-                err "lvs $i command failed."
-                msg "[$LVM_SIZE]"
-            else 
-                LVM_SIZE_MIN=$LVM_SIZE
-                LVM_SIZE_MAX=$LVM_SIZE
-            fi
-        fi
-    
         for i in ${MD_DEVICES[@]};
         do
             LVM_SIZE=$(lvs $i -o LV_SIZE \
@@ -208,11 +190,16 @@ do_m0provision_action()
             if [[ ( "$ANY_ERR" != "0" ) || ( -z "$LVM_SIZE" ) ]]; then
                 err "lvs $i command failed."
                 msg "[$LVM_SIZE]"
-    	elif [[ "$LVM_SIZE" -lt "$LVM_SIZE_MIN" ]]; then
-    	    LVM_SIZE_MIN=$LVM_SIZE
+            elif [[ "$MD_DEVICE_CNT" -eq 0 ]]; then
+                # Initializing MIN and MAX to the first lvm size in the list. 
+                LVM_SIZE_MIN=$LVM_SIZE
+                LVM_SIZE_MAX=$LVM_SIZE
+            elif [[ "$LVM_SIZE" -lt "$LVM_SIZE_MIN" ]]; then
+                LVM_SIZE_MIN=$LVM_SIZE
             elif [[ "$LVM_SIZE" -gt "$LVM_SIZE_MAX" ]]; then
                 LVM_SIZE_MAX=$LVM_SIZE
             fi
+            MD_DEVICE_CNT=`expr $MD_DEVICE_CNT + 1` 
         done
         if [[ "$LVM_SIZE_MIN" -eq 0 || "$LVM_SIZE_MAX" -eq 0 ]]; then
             err "lvm size invalid [$LVM_SIZE_MIN]"


### PR DESCRIPTION
Sometime it might happened that size of metadata volumes is not symmetric.
Size of node-2 volume could be smaller that node-1 volume, in such cases
should be consider minimum volume size for MOTR_M0D_IOS_BESEG_SIZE. Modified
motr_cfg.sh accordingly.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>
Signed-off-by: Yeshpal Jain <yeshpal.jain@seagate.com>