### PR TITLE
EOS-14915: change m0trace log location to /var/log/seagate/motr

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/conf/motr.conf
+++ b/scripts/install/opt/seagate/cortx/motr/conf/motr.conf
@@ -7,6 +7,7 @@
 # Ex. MOTR_TEST_ARRAY_STRING=val1 val2 val3
 # The file must end with an empty line
 
+MOTR_M0D_TRACE_DIR='/var/log/seagate/motr/trace'
 MOTR_M0D_MIN_RPC_RECVQ_LEN=512
 MOTR_M0D_MAX_RPC_MSG_SIZE=524288
 MOTR_M0D_IOS_BUFFER_POOL_SIZE=512

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -52,7 +52,13 @@ check_param()
 log_dirs_max_count=2
 # have hard coded the log path, 
 # Need to get it from config file 
-motr_logdirs=`ls -d /var/motr*`
+ADDB_RECORD_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
+ADDB_DIR="${ADDB_RECORD_DIR%\'}"
+ADDB_DIR="${ADDB_DIR#\'}"
+addb_rec_dirs=`ls -d $ADDB_DIR`
+if [ -n "$ADDB_DIR" ]; then
+    addb_rec_dirs="$addb_rec_dirs $ADDB_DIR"
+fi
 
 while getopts ":n:" option; do
     case "${option}" in
@@ -71,14 +77,14 @@ done
 log_dirs_max_count=2
 
 echo "Max log dir count: $log_dirs_max_count"
-echo "ADDB Log directory: $motr_logdirs"
+echo "ADDB Log directory: $addb_rec_dirs"
 
 # check for log directory entries
-for motr_logdir in $motr_logdirs ; do
-    [[ $(check_param $motr_logdir) = "continue" ]] && continue || echo "$motr_logdir"
+for addb_rec_dir in $addb_rec_dirs ; do
+    [[ $(check_param $addb_rec_dir) = "continue" ]] && continue || echo "$addb_rec_dir"
 
     # get the log directory of each m0d instance
-    log_dirs=`find $motr_logdir -maxdepth 1 -type d -name m0d-\*`
+    log_dirs=`find $addb_rec_dir -maxdepth 1 -type d -name m0d-\*`
 
     [[ $(check_param $log_dirs) = "continue" ]] && continue || echo "$log_dirs"
 

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0trace_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0trace_logrotate.sh
@@ -59,6 +59,12 @@ log_files_max_count=5
 # have hard coded the log path, 
 # Need to get it from config file 
 motr_logdirs=`ls -d /var/motr*`
+M0TR_M0D_TRACE_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
+M0D_TRACE_DIR="${M0TR_M0D_TRACE_DIR%\'}"
+M0D_TRACE_DIR="${M0D_TRACE_DIR#\'}"
+if [ -n "$M0D_TRACE_DIR" ]; then
+    motr_logdirs="$motr_logdirs $M0D_TRACE_DIR"
+fi
 
 while getopts ":n:" option; do
     case "${option}" in

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -45,6 +45,7 @@ CORE_DIRS=("/var/crash/" "/var/log/crash/") # path from where m0reportbug will c
 RECOVERY_SCRIPT_DIR=/opt/seagate/cortx/motr/libexec    # dir containing recovery traces and scripts
 RECOVERY_LOG_DIR=/var/log/seagate/motr/datarecovery    # dir containing recovery log/logs
 LIVE_CORE_DIR=/var/log/seagate/motr
+M0TR_M0D_TRACE_DIR=/var/log/seagate/motr/trace
 
 readonly START_DIR=$PWD
 
@@ -172,6 +173,22 @@ main() {
         warn "$RECOVERY_SCRIPT_DIR: no such directory"
     fi
 
+    # Collects traces of m0d process(confd, ios) only
+    M0TR_M0D_TRACE_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
+    M0D_TRACE_DIR="${M0TR_M0D_TRACE_DIR%\'}"
+    M0D_TRACE_DIR="${M0D_TRACE_DIR#\'}"
+
+    if [ -d $M0D_TRACE_DIR ]; then
+        IN_DIR=${M0D_TRACE_DIR}
+        local label="m0traces $IN_DIR"
+        echo -n "$label... " >&2
+        section "[$label]" >>$REPORT
+        local t=$(date +%s)
+        m0traces >>$REPORT
+        echo "OK$(_time $t)" >&2
+    else
+        warn "$M0TR_M0D_TRACE_DIR: no such directory"
+    fi
     popd >/dev/null
     # Collect rpm-update-logs
     if [ -f /var/log/motr-rpm-conf-update.log ]; then

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -178,7 +178,7 @@ main() {
     M0D_TRACE_DIR="${M0TR_M0D_TRACE_DIR%\'}"
     M0D_TRACE_DIR="${M0D_TRACE_DIR#\'}"
 
-    if [ -d $M0D_TRACE_DIR ]; then
+    if [[ -d "$M0D_TRACE_DIR" ]]; then
         IN_DIR=${M0D_TRACE_DIR}
         local label="m0traces $IN_DIR"
         echo -n "$label... " >&2
@@ -189,6 +189,24 @@ main() {
     else
         warn "$M0TR_M0D_TRACE_DIR: no such directory"
     fi
+
+    # Collects addb record files for process(confd, ios and s3server)
+    ADDB_RECORD_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
+    ADDB_DIR="${ADDB_RECORD_DIR%\'}"
+    ADDB_DIR="${ADDB_DIR#\'}"
+
+    if [[ -d "$ADDB_DIR" ]]; then
+        IN_DIR=${ADDB_DIR}
+        local label="addb-files $IN_DIR"
+        echo -n "$label... " >&2
+        section "[$label]" >>$REPORT
+        local t=$(date +%s)
+        addb-files >>$REPORT
+        echo "OK$(_time $t)" >&2
+    else
+        warn "$ADDB_DIR: no such directory"
+    fi
+
     popd >/dev/null
     # Collect rpm-update-logs
     if [ -f /var/log/motr-rpm-conf-update.log ]; then
@@ -776,7 +794,7 @@ addb-files() {
     for pid in `pgrep m0d`; do
         for file_path in $(find ${IN_DIR}/m0d-*/addb-stobs-$pid/o  -name "100000000000000:2" 2>/dev/null); do
             if [ -f "$file_path" ]; then
-                fid=$(echo $file_path | cut -d '/' -f4 | cut -d '-' -f2)
+                fid=$(echo $file_path | cut -d '/' -f7 | cut -d '-' -f2)
                 cat $file_path | _xz > addb_files/$IN_DIR/m0d_addb__${fid}.xz
             fi
         done


### PR DESCRIPTION
- This is done as a precautionary measure, as trace buffers data is seen
  on meta-data segment.