### PR TITLE
EOS-8362: fix sporadic panics at m0_balloc_load_extents()

### DIFF
--- a/balloc/balloc.c
+++ b/balloc/balloc.c
@@ -70,7 +70,6 @@ struct balloc_allocation_context {
 	uint32_t		       bac_status;  /* allocation status */
 };
 
-/** XXX @todo rewrite using M0_BE_OP_SYNC() */
 static inline int btree_lookup_sync(struct m0_be_btree  *tree,
 			       const struct m0_buf *key,
 			       struct m0_buf       *val)
@@ -1252,7 +1251,6 @@ M0_INTERNAL int m0_balloc_load_extents(struct m0_balloc *cb,
 				       struct m0_balloc_group_info *grp)
 {
 	struct m0_be_btree	  *db_ext = &cb->cb_db_group_extents;
-	struct m0_be_btree_cursor  cursor;
 	struct m0_buf              key;
 	struct m0_buf              val;
 	struct m0_lext            *ex;
@@ -1285,8 +1283,6 @@ M0_INTERNAL int m0_balloc_load_extents(struct m0_balloc *cb,
 		return M0_RC(0);
 	}
 
-	m0_be_btree_cursor_init(&cursor, db_ext);
-
 	spare_range.e_start = grp->bgi_spare.bzp_range.e_start;
 	spare_range.e_end = (grp->bgi_groupno + 1) << cb->cb_sb.bsb_gsbits;
 	m0_ext_init(&spare_range);
@@ -1305,13 +1301,14 @@ M0_INTERNAL int m0_balloc_load_extents(struct m0_balloc *cb,
 	grp->bgi_spare.bzp_freeblocks = 0;
 	for (i = 0; i < group_fragments_get(grp) +
 	     group_spare_fragments_get(grp); i++, ex++) {
-		key = (struct m0_buf)M0_BUF_INIT_PTR(&next_key);
-		rc = m0_be_btree_cursor_get_sync(&cursor, &key, true);
+		ex->le_ext.e_end = next_key;
+		key = M0_BUF_INIT_PTR(&ex->le_ext.e_end);
+		val = M0_BUF_INIT_PTR(&ex->le_ext.e_start);
+		rc = M0_BE_OP_SYNC_RET(op, m0_be_btree_lookup_slant(db_ext, &op,
+								    &key, &val),
+				       bo_u.u_btree.t_rc);
 		if (rc != 0)
 			break;
-		m0_be_btree_cursor_kv_get(&cursor, &key, &val);
-		ex->le_ext.e_end   = *(m0_bindex_t*)key.b_addr;
-		ex->le_ext.e_start = *(m0_bindex_t*)val.b_addr;
 		m0_ext_init(&ex->le_ext);
 		if (m0_ext_is_partof(&normal_range, &ex->le_ext)) {
 			m0_list_add_tail(group_normal_ext(grp),
@@ -1332,7 +1329,6 @@ M0_INTERNAL int m0_balloc_load_extents(struct m0_balloc *cb,
 		next_key = ex->le_ext.e_end + 1;
 		/* balloc_debug_dump_extent("loading...", ex); */
 	}
-	m0_be_btree_cursor_fini(&cursor);
 
 	if (i != group_fragments_get(grp) + group_spare_fragments_get(grp))
 		M0_LOG(M0_ERROR, "fragments mismatch: i=%llu frags=%lld",
@@ -1584,29 +1580,37 @@ static int balloc_alloc_db_update(struct m0_balloc *motr, struct m0_be_tx *tx,
 	if (cur->e_end == tgt->e_end) {
 		key = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_end);
 
-		/* at the head of a free extent */
 		rc = btree_delete_sync(db, tx, &key);
 		if (rc != 0)
 			return M0_RC(rc);
 
 		if (cur->e_start < tgt->e_start) {
-			/* A smaller extent still exists */
+			/* +--------------+--------------------+ */
+			/* |   cur free   |     allocated      | */
+			/* |      |  tgt  |                    | */
+			/* +------+-------+--------------------+ */
 			cur->e_end = tgt->e_start;
 			key = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_end);
 			val = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_start);
 			rc = btree_insert_sync(db, tx, &key, &val);
 			if (rc != 0)
 				return M0_RC(rc);
-			maxchunk = max_check(maxchunk, m0_ext_length(cur));
 		} else {
+			/* +-------------+---------------------+ */
+			/* |   cur free  |      allocated      | */
+			/* |     tgt     |                     | */
+			/* +-------------+---------------------+ */
 			le = container_of(cur, struct m0_lext, le_ext);
 			lext_del(le);
 			zp->bzp_fragments--;
 		}
 	} else {
-		struct m0_ext next = *cur;
+		struct m0_ext new = *cur;
 
-		/* in the middle of a free extent. Cut it. */
+		/* +-----------------------------------+ */
+		/* |              cur free             | */
+		/* |     tgt    |                      | */
+		/* +------------+----------------------+ */
 		cur->e_start = tgt->e_end;
 
 		key = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_end);
@@ -1615,16 +1619,17 @@ static int balloc_alloc_db_update(struct m0_balloc *motr, struct m0_be_tx *tx,
 		if (rc != 0)
 			return M0_RC(rc);
 
-		maxchunk = max_check(maxchunk, m0_ext_length(cur));
-
-		if (next.e_start < tgt->e_start) {
-			/* there is still a head */
-			next.e_end = tgt->e_start;
-			le = lext_create(&next);
+		if (new.e_start < tgt->e_start) {
+			/* +-----------------------------------+ */
+			/* |              cur free             | */
+			/* |  new  |   tgt   |                 | */
+			/* +-------+---------+-----------------+ */
+			new.e_end = tgt->e_start;
+			le = lext_create(&new);
 			if (le == NULL)
 				return M0_RC(-ENOMEM);
-			key = (struct m0_buf)M0_BUF_INIT_PTR(&next.e_end);
-			val = (struct m0_buf)M0_BUF_INIT_PTR(&next.e_start);
+			key = (struct m0_buf)M0_BUF_INIT_PTR(&new.e_end);
+			val = (struct m0_buf)M0_BUF_INIT_PTR(&new.e_start);
 			rc = btree_insert_sync(db, tx, &key, &val);
 			if (rc != 0) {
 				m0_free(le);
@@ -1633,7 +1638,6 @@ static int balloc_alloc_db_update(struct m0_balloc *motr, struct m0_be_tx *tx,
 			lcur = container_of(cur, struct m0_lext, le_ext);
 			m0_list_add_before(&lcur->le_link, &le->le_link);
 			zp->bzp_fragments++;
-			maxchunk = max_check(maxchunk, m0_ext_length(&next));
 		}
 	}
 	zp->bzp_maxchunk = maxchunk;
@@ -1718,7 +1722,11 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 
 	if (!found) {
 		if (frags == 0) {
-			/* no fragments at all */
+			/*       No free fragments at all:       */
+			/* +-----------------------------------+ */
+			/* |              allocated            | */
+			/* |       |     tgt free     |        | */
+			/* +-------+------------------+--------+ */
 			le = lext_create(tgt);
 			if (le == NULL)
 				return M0_RC(-ENOMEM);
@@ -1735,7 +1743,11 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 		} else {
 			/* at the tail */
 			if (cur->e_end < tgt->e_start) {
-				/* to be the last one, standalone */
+				/*    To be the last one, standalone:    */
+				/* +-----------+-----------------------+ */
+				/* |    cur    |                       | */
+				/* |           |  |      tgt free      | */
+				/* +-----------+--+--------------------+ */
 				le = lext_create(tgt);
 				if (le == NULL)
 					return M0_RC(-ENOMEM);
@@ -1750,13 +1762,16 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 				++zp->bzp_fragments;
 				maxchunk = max_check(maxchunk, m0_ext_length(tgt));
 			} else {
+				/* +-----------+-----------------------+ */
+				/* |    cur    |-->                    | */
+				/* |           |       tgt free        | */
+				/* +-----------+-----------------------+ */
 				M0_ASSERT(cur->e_end == tgt->e_start);
 				key = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_end);
 				rc = btree_delete_sync(db, tx, &key);
 				if (rc != 0)
 					return M0_RC(rc);
 				cur->e_end = tgt->e_end;
-				key = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_end);
 				val = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_start);
 				rc = btree_insert_sync(db, tx, &key, &val);
 				if (rc != 0)
@@ -1767,7 +1782,11 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 	} else if (found && pre == NULL) {
 		/* on the head */
 		if (tgt->e_end < cur->e_start) {
-			/* to be the first one */
+			/*       To be the first one:            */
+			/* +---------------+-------------------+ */
+			/* |               |     cur free      | */
+			/* | |   tgt   |   |                   | */
+			/* +-+---------+---+-------------------+ */
 			le = lext_create(tgt);
 			if (le == NULL)
 				return M0_RC(-ENOMEM);
@@ -1782,7 +1801,11 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 			++zp->bzp_fragments;
 			maxchunk = max_check(maxchunk, m0_ext_length(tgt));
 		} else {
-			/* join with the first one */
+			/*      Join with the first one:         */
+			/* +---------------+-------------------+ */
+			/* |            <--|     cur free      | */
+			/* |     |   tgt   |                   | */
+			/* +-----+---------+-------------------+ */
 			M0_ASSERT(tgt->e_end == cur->e_start);
 			cur->e_start = tgt->e_start;
 			key = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_end);
@@ -1796,7 +1819,11 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 		/* in the middle */
 		if (pre->e_end == tgt->e_start &&
 		    tgt->e_end == cur->e_start) {
-			/* joint with both */
+			/*        Joint with both:               */
+			/* +-------+-------+-------------------+ */
+			/* |  pre  |--> <--|    cur free       | */
+			/* |       |  tgt  |                   | */
+			/* +-------+-------+-------------------+ */
 			key = (struct m0_buf)M0_BUF_INIT_PTR(&pre->e_end);
 			rc = btree_delete_sync(db, tx, &key);
 			if (rc != 0)
@@ -1812,20 +1839,27 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 			--zp->bzp_fragments;
 			maxchunk = max_check(maxchunk, m0_ext_length(cur));
 		} else if (pre->e_end == tgt->e_start) {
-			/* joint with prev */
+			/*          Joint with prev:             */
+			/* +-------+----------+----------------+ */
+			/* |  pre  |-->       |    cur free    | */
+			/* |       |  tgt  |                   | */
+			/* +-------+-------+-------------------+ */
 			key = (struct m0_buf)M0_BUF_INIT_PTR(&pre->e_end);
 			rc = btree_delete_sync(db, tx, &key);
 			if (rc != 0)
 				return M0_RC(rc);
 			pre->e_end = tgt->e_end;
-			key = (struct m0_buf)M0_BUF_INIT_PTR(&pre->e_end);
 			val = (struct m0_buf)M0_BUF_INIT_PTR(&pre->e_start);
 			rc = btree_insert_sync(db, tx, &key, &val);
 			if (rc != 0)
 				return M0_RC(rc);
 			maxchunk = max_check(maxchunk, m0_ext_length(pre));
 		} else if (tgt->e_end == cur->e_start) {
-			/* joint with current */
+			/*        Joint with current:            */
+			/* +-------+----------+----------------+ */
+			/* |  pre  |       <--|    cur free    | */
+			/* |          |  tgt  |                | */
+			/* +----------+-------+----------------+ */
 			cur->e_start = tgt->e_start;
 			key = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_end);
 			val = (struct m0_buf)M0_BUF_INIT_PTR(&cur->e_start);
@@ -1834,7 +1868,11 @@ static int balloc_free_db_update(struct m0_balloc *motr,
 				return M0_RC(rc);
 			maxchunk = max_check(maxchunk, m0_ext_length(cur));
 		} else {
-			/* add a new one */
+			/*           Add a new one:              */
+			/* +-------+------------+--------------+ */
+			/* |  pre  |            |   cur free   | */
+			/* |          |  tgt  |                | */
+			/* +----------+-------+----------------+ */
 			le = lext_create(tgt);
 			if (le == NULL)
 				return M0_RC(-ENOMEM);

--- a/be/btree.c
+++ b/be/btree.c
@@ -206,7 +206,7 @@ static void btree_pair_release(struct m0_be_btree *btree,
 
 static struct btree_node_pos be_btree_get_btree_node(
 					struct m0_be_btree_cursor *it,
-					void *key, bool slant);
+					const void *key, bool slant);
 
 static void be_btree_delete_key_from_node(struct m0_be_btree *tree,
 					  struct m0_be_tx *tx,
@@ -1099,7 +1099,7 @@ static struct m0_be_bnode *node_pop(struct m0_be_btree_cursor *it, int *idx)
 *   @return struct btree_node_pos.
 */
 struct btree_node_pos
-be_btree_get_btree_node(struct m0_be_btree_cursor *it, void *key, bool slant)
+be_btree_get_btree_node(struct m0_be_btree_cursor *it, const void *key, bool slant)
 {
 	int 			 idx;
 	struct m0_be_btree 	*tree = it->bc_tree;
@@ -1982,15 +1982,20 @@ M0_INTERNAL void m0_be_btree_delete(struct m0_be_btree *tree,
 	M0_LEAVE("tree=%p", tree);
 }
 
-M0_INTERNAL void m0_be_btree_lookup(struct m0_be_btree *tree,
-				    struct m0_be_op *op,
-				    const struct m0_buf *key,
-				    struct m0_buf *dest_value)
+static void be_btree_lookup(struct m0_be_btree *tree,
+			    struct m0_be_op *op,
+			    const struct m0_buf *key_in,
+			    struct m0_buf *key_out,
+			    struct m0_buf *value)
 {
-	struct be_btree_key_val  *kv;
-	m0_bcount_t        vsize;
+	struct m0_be_btree_cursor  it;
+	struct btree_node_pos      kp;
+	struct be_btree_key_val   *kv;
+	m0_bcount_t                ksize;
+	m0_bcount_t                vsize;
 
-	M0_ENTRY("tree=%p", tree);
+	M0_ENTRY("tree=%p key_in=%p key_out=%p value=%p",
+		 tree, key_in, key_out, value);
 	M0_PRE(tree->bb_root != NULL && tree->bb_ops != NULL);
 
 	btree_op_fill(op, tree, NULL, M0_BBO_LOOKUP, NULL);
@@ -1998,20 +2003,47 @@ M0_INTERNAL void m0_be_btree_lookup(struct m0_be_btree *tree,
 	m0_be_op_active(op);
 	m0_rwlock_read_lock(btree_rwlock(tree));
 
-	kv = be_btree_search(tree, key->b_addr);
-	if (kv != NULL) {
+	it.bc_tree = tree;
+	kp = be_btree_get_btree_node(&it, key_in->b_addr,
+			    /* slant: */ key_out == NULL ? false : true);
+	if (kp.bnp_node) {
+		kv = &kp.bnp_node->bt_kv_arr[kp.bnp_index];
+
 		vsize = be_btree_vsize(tree, kv->btree_val);
-		if (vsize < dest_value->b_nob)
-			dest_value->b_nob = vsize;
-		/* XXX handle vsize > dest_value->b_nob */
-		memcpy(dest_value->b_addr, kv->btree_val, dest_value->b_nob);
+		if (vsize < value->b_nob)
+			value->b_nob = vsize;
+		/* XXX handle vsize > value->b_nob */
+		memcpy(value->b_addr, kv->btree_val, value->b_nob);
+
+		if (key_out != NULL) {
+			ksize = be_btree_ksize(tree, kv->btree_key);
+			if (ksize < key_out->b_nob)
+				key_out->b_nob = ksize;
+			memcpy(key_out->b_addr, kv->btree_key, key_out->b_nob);
+		}
 		op_tree(op)->t_rc = 0;
 	} else
 		op_tree(op)->t_rc = -ENOENT;
 
 	m0_rwlock_read_unlock(btree_rwlock(tree));
 	m0_be_op_done(op);
-	M0_LEAVE();
+	M0_LEAVE("rc=%d", op_tree(op)->t_rc);
+}
+
+M0_INTERNAL void m0_be_btree_lookup(struct m0_be_btree *tree,
+				    struct m0_be_op *op,
+				    const struct m0_buf *key,
+				    struct m0_buf *value)
+{
+	be_btree_lookup(tree, op, key, NULL, value);
+}
+
+M0_INTERNAL void m0_be_btree_lookup_slant(struct m0_be_btree *tree,
+					  struct m0_be_op *op,
+					  struct m0_buf *key,
+					  struct m0_buf *value)
+{
+	be_btree_lookup(tree, op, key, key, value);
 }
 
 M0_INTERNAL void m0_be_btree_maxkey(struct m0_be_btree *tree,

--- a/be/btree.h
+++ b/be/btree.h
@@ -417,6 +417,19 @@ M0_INTERNAL void m0_be_btree_lookup(struct m0_be_btree *tree,
 				    struct m0_buf *dest_value);
 
 /**
+ * Looks up for a record with the closest key >= given @key.
+ * The result is copied into provided @key and @value buffers.
+ *
+ * -ENOENT is set to @op->bo_u.u_btree.t_rc if not found.
+ *
+ * @see m0_be_btree_create() regarding @op structure "mission".
+ */
+M0_INTERNAL void m0_be_btree_lookup_slant(struct m0_be_btree *tree,
+					  struct m0_be_op *op,
+					  struct m0_buf *key,
+					  struct m0_buf *value);
+
+/**
  * Looks up for a maximum key value in the given @tree.
  *
  * @see m0_be_btree_create() regarding @op structure "mission".

--- a/stob/io.c
+++ b/stob/io.c
@@ -314,7 +314,7 @@ M0_INTERNAL void m0_stob_iovec_sort(struct m0_stob_io *stob)
 	struct m0_bufvec   *bvec = &stob->si_user;
 	int                 i;
 	bool                exchanged;
-	bool                different_count;
+	bool                separate_v_count;
 
 #define SWAP_NEXT(arr, idx)			\
 ({						\
@@ -327,7 +327,7 @@ M0_INTERNAL void m0_stob_iovec_sort(struct m0_stob_io *stob)
 	_arr[_idx + 1] = _tmp;			\
 })
 
-	different_count = ivec->iv_vec.v_count != bvec->ov_vec.v_count;
+	separate_v_count = ivec->iv_vec.v_count != bvec->ov_vec.v_count;
 
 	/*
 	 * Bubble sort the index vectores.
@@ -341,7 +341,7 @@ M0_INTERNAL void m0_stob_iovec_sort(struct m0_stob_io *stob)
 				SWAP_NEXT(ivec->iv_index, i);
 				SWAP_NEXT(ivec->iv_vec.v_count, i);
 				SWAP_NEXT(bvec->ov_buf, i);
-				if (different_count)
+				if (separate_v_count)
 					SWAP_NEXT(bvec->ov_vec.v_count, i);
 				exchanged = true;
 			}


### PR DESCRIPTION
The usage of m0_be_btree_cursor_*() API at m0_balloc_load_extents()
without any external locking on btree may lead to panics:

```
ERROR  [balloc/balloc.c:1312:m0_balloc_load_extents]  Invalid extent
FATAL  [lib/assert.c:48:m0_panic]  panic: (0) at m0_balloc_load_extents() (balloc/balloc.c:1313)  [git: cortx1.0-rc1-15-g1611636]

m0_panic (ctx) at lib/assert.c:50
m0_balloc_load_extents (cb, grp) at balloc/balloc.c:1313
balloc_regular_allocator (bac) at balloc/balloc.c:2335
balloc_allocate_internal (req, tx, ctx) at balloc/balloc.c:2488
balloc_alloc (ballroom, tx, count, out, alloc_zone) at balloc/balloc.c:2678
stob_ad_balloc (adom, adom, alloc_type, out, count=256, tx) at stob/ad.c:1058
stob_ad_write_prepare (map, src, adom, io) at stob/ad.c:1846
stob_ad_io_launch_prepare (io) at stob/ad.c:1940
m0_stob_io_prepare (io, obj, tx, scope) at stob/io.c:176
m0_stob_io_prepare_and_launch (io, obj, tx, scope) at stob/io.c:224
io_launch (fom) at ioservice/io_foms.c:1816
in m0_io_fom_cob_rw_tick (fom) at ioservice/io_foms.c:2191
fom_exec (fom) at fop/fom.c:747
```

m0_be_btree_cursor_*() is the only API currently that provides
btree lookup by not exact key (slant key) - that's mainly why
it is used at m0_balloc_load_extents().

Solution: introduce m0_be_btree_lookup_slant(key) function and
use it at m0_balloc_load_extents() instead of m0_btree_cursor_*().
m0_be_btree_lookup_slant() uses internal btree's lock and copies
the result (value and the exact key) into the provided buffers,
so there is no need for external locking.

This is the upgrade of old PR - https://github.com/Seagate/cortx-motr-old/pull/70 which was already reviewed and approved by @nikitadanilov and @huanghua78 .