### PR TITLE
EOS-14966: Fixed fom_desc::sender according to the addb2dump output

### DIFF
--- a/scripts/addb-py/chronometry/addb2db.py
+++ b/scripts/addb-py/chronometry/addb2db.py
@@ -104,7 +104,7 @@ class fom_desc(BaseModel):
     time       = IntegerField()
     pid        = IntegerField()
     service    = TextField()
-    sender     = IntegerField()
+    sender     = TextField()
     req_opcode = TextField()
     rep_opcode = TextField()
     local      = TextField()


### PR DESCRIPTION

 * Symptom seen before fix:
   OverflowError: Python int too large to convert to SQLite INTEGER:
                  db_consume_data(args.dumps)
                  File "addb2db.py", line 588, in db_consume_data
                  globals()[k].insert_many(batch).execute().

 * Sqlite integer fields are int64 and addb2dump produces uint64.