### PR TITLE
EOS-14977: Fixed motr sanity failure due to BELOG_SIZE

### DIFF
--- a/utils/m0provision
+++ b/utils/m0provision
@@ -92,10 +92,12 @@ do_test()
     die_if_failed $? "Script [cortx_srvc_sanity.sh] failed."
 
     /opt/seagate/cortx/motr/libexec/motr_cfg.sh -d MOTR_M0D_IOS_BESEG_SIZE /etc/sysconfig/motr
+    /opt/seagate/cortx/motr/libexec/motr_cfg.sh -d MOTR_M0D_BELOG_SIZE /etc/sysconfig/motr
     msg "Executing motr_sanity.sh"
     /opt/seagate/cortx/motr/sanity/motr_sanity.sh
     rc=$?
     /opt/seagate/cortx/motr/libexec/motr_cfg.sh -e MOTR_M0D_IOS_BESEG_SIZE /etc/sysconfig/motr
+    /opt/seagate/cortx/motr/libexec/motr_cfg.sh -e MOTR_M0D_BELOG_SIZE /etc/sysconfig/motr
     die_if_failed $rc "Script [motr_sanity.sh] failed."
 
     die $ERR_SUCCESS


### PR DESCRIPTION
During motr sanity it goes for be_log_resize(), where it further moves
ahead because config parameter MOTR_M0D_BELOG_SIZE is not disabled
During sanity test it is not expected to go for be_log_resize() hence
disabled MOTR_M0D_BELOG_SIZE before sanity run and enabled it back later.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>