### PR TITLE
Add support for optional sync of data object operations.

### DIFF
--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -604,6 +604,7 @@ static int net_buffer_acquire(struct m0_fom *);
 static int io_prepare(struct m0_fom *);
 static int io_launch(struct m0_fom *);
 static int io_finish(struct m0_fom *);
+static int io_sync(struct m0_fom *fom);
 static int zero_copy_initiate(struct m0_fom *);
 static int zero_copy_finish(struct m0_fom *);
 static int net_buffer_release(struct m0_fom *);
@@ -704,6 +705,10 @@ static const struct m0_io_fom_cob_rw_state_transition io_fom_write_st[] = {
 [M0_FOPH_IO_BUFFER_RELEASE] =
 { M0_FOPH_IO_BUFFER_RELEASE, &net_buffer_release,
   M0_FOPH_IO_FOM_BUFFER_ACQUIRE, 0, "network-buffer-release", },
+
+[M0_FOPH_IO_SYNC] =
+{ M0_FOPH_IO_SYNC, &io_sync, M0_FOPH_QUEUE_REPLY,  M0_FOPH_IO_SYNC, "io-sync" }
+
 };
 
 struct m0_sm_state_descr io_phases[] = {
@@ -755,6 +760,10 @@ struct m0_sm_state_descr io_phases[] = {
 		.sd_allowed   = M0_BITS(M0_FOPH_IO_FOM_BUFFER_ACQUIRE,
 					M0_FOPH_SUCCESS)
 	},
+	[M0_FOPH_IO_SYNC] = {
+		.sd_name      = "tx-sync",
+		.sd_allowed   = M0_BITS(M0_FOPH_IO_SYNC, M0_FOPH_QUEUE_REPLY)
+	},
 };
 
 struct m0_sm_trans_descr io_phases_trans[] = {
@@ -799,6 +808,9 @@ struct m0_sm_trans_descr io_phases_trans[] = {
 	{"zero-copy-wait-failed", M0_FOPH_IO_ZERO_COPY_WAIT, M0_FOPH_FAILURE},
 	{"network-buffer-released",
 	 M0_FOPH_IO_BUFFER_RELEASE, M0_FOPH_IO_FOM_BUFFER_ACQUIRE},
+	{"tx-wait", M0_FOPH_QUEUE_REPLY, M0_FOPH_IO_SYNC },
+	{"tx-wait-more", M0_FOPH_IO_SYNC, M0_FOPH_IO_SYNC },
+	{"tx-wait-done", M0_FOPH_IO_SYNC, M0_FOPH_QUEUE_REPLY },
 	{"all-done", M0_FOPH_IO_BUFFER_RELEASE, M0_FOPH_SUCCESS},
 };
 
@@ -1955,6 +1967,23 @@ static int io_finish(struct m0_fom *fom)
 	return M0_FSO_AGAIN;
 }
 
+/**
+ * If necessary, waits until the transaction for this fom becomes persistent.
+ */
+static int io_sync(struct m0_fom *fom)
+{
+	struct m0_io_fom_cob_rw *fobj = M0_AMB(fobj, fom, fcrw_gen);
+	struct m0_be_tx         *tx   = m0_fom_tx(fom);
+
+	if ((fobj->fcrw_flags & M0_IO_FLAG_SYNC) &&
+	    m0_be_tx_state(tx) < M0_BTS_LOGGED) {
+		M0_LOG(M0_DEBUG, "fom wait for tx to be logged");
+		m0_fom_wait_on(fom, &tx->t_sm.sm_chan, &fom->fo_cb);
+		return M0_FSO_WAIT;
+	} else
+		return M0_FSO_AGAIN;
+}
+
 /*
  * This function converts the on-wire m0_io_indexvec to in-mem m0_indexvec,
  * with index and count values appropriately block shifted.
@@ -2108,6 +2137,7 @@ static void stob_be_credit(struct m0_fom *fom)
 static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 {
 	int                                       rc;
+	int                                       phase = m0_fom_phase(fom);
 	struct m0_io_fom_cob_rw                  *fom_obj;
 	struct m0_io_fom_cob_rw_state_transition  st;
 	struct m0_fop_cob_rw                     *rwfop;
@@ -2123,11 +2153,11 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 
 	M0_ENTRY("fom %p, fop %p, item %p[%u] %s" FID_F, fom, fom->fo_fop,
 		 m0_fop_to_rpc_item(fom->fo_fop), m0_fop_opcode(fom->fo_fop),
-		 m0_fom_phase_name(fom, m0_fom_phase(fom)),
+		 m0_fom_phase_name(fom, phase),
 		 FID_P(&rwfop->crw_fid));
 
 	/* first handle generic phase */
-	if (m0_fom_phase(fom) == M0_FOPH_INIT) {
+	if (phase == M0_FOPH_INIT) {
 		rc = indexvec_wire2mem(fom) ?:
 			stob_io_create(fom);
 		if (rc != 0) {
@@ -2135,8 +2165,8 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 			return M0_RC(M0_FSO_AGAIN);
 		}
 	}
-	if (m0_fom_phase(fom) < M0_FOPH_NR && m0_is_write_fop(fom->fo_fop)) {
-		if (m0_fom_phase(fom) == M0_FOPH_TXN_OPEN) {
+	if (phase < M0_FOPH_NR && m0_is_write_fop(fom->fo_fop)) {
+		if (phase == M0_FOPH_TXN_OPEN) {
 			struct m0_be_tx_credit *accum;
 
 			accum = m0_fom_tx_credit(fom);
@@ -2152,24 +2182,30 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 				m0_cob_tx_credit(fom_cdom(fom),
 						 M0_COB_OP_DELETE, accum);
 			}
-		} else if (m0_fom_phase(fom) == M0_FOPH_AUTHORISATION) {
+		} else if (phase == M0_FOPH_AUTHORISATION) {
 			rc = m0_fom_tick_generic(fom);
 			if (m0_fom_phase(fom) == M0_FOPH_TXN_INIT)
 				m0_fom_phase_set(fom, M0_FOPH_IO_FOM_PREPARE);
 			return M0_RC(rc);
-		} else if (m0_fom_phase(fom) == M0_FOPH_TXN_WAIT) {
+		} else if (phase == M0_FOPH_TXN_WAIT) {
 			rc = m0_fom_tick_generic(fom);
 			if (m0_fom_phase(fom) == M0_FOPH_IO_FOM_PREPARE)
 				m0_fom_phase_set(fom, M0_FOPH_IO_STOB_INIT);
 			return M0_RC(rc);
+		} else if (phase == M0_FOPH_TXN_COMMIT) {
+			rc = m0_fom_tick_generic(fom);
+			M0_ASSERT(rc == M0_FSO_AGAIN);
+			M0_ASSERT(m0_fom_phase(fom) == M0_FOPH_QUEUE_REPLY);
+			if (m0_is_write_fop(fom->fo_fop))
+				m0_fom_phase_set(fom, M0_FOPH_IO_SYNC);
+			return M0_RC(rc);
 		}
 	}
-	if (m0_fom_phase(fom) < M0_FOPH_NR) {
+	if (phase < M0_FOPH_NR) {
 		M0_LOG(M0_DEBUG, "fom=%p, stob=%p, rc=%d", fom,
 		       fom_obj->fcrw_stob, m0_fom_rc(fom));
 
-		if (m0_fom_phase(fom) == M0_FOPH_FAILURE &&
-		    fom_obj->fcrw_stob != NULL &&
+		if (phase == M0_FOPH_FAILURE && fom_obj->fcrw_stob != NULL &&
 		    m0_fom_rc(fom) == -E2BIG) {
 			m0_storage_dev_stob_put(m0_cs_storage_devs_get(),
 						fom_obj->fcrw_stob);
@@ -2211,13 +2247,9 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 		m0_fom_phase_set(fom, M0_FOPH_TXN_INIT);
 		return M0_RC(M0_FSO_AGAIN);
 	}
-
 	m0_fom_phase_set(fom, rc == M0_FSO_AGAIN ?
 				st.fcrw_st_next_phase_again :
 				st.fcrw_st_next_phase_wait);
-	M0_ASSERT(m0_fom_phase(fom) > M0_FOPH_NR &&
-		  m0_fom_phase(fom) <= M0_FOPH_IO_BUFFER_RELEASE);
-
 	return M0_RC(rc);
 }
 

--- a/ioservice/io_foms.h
+++ b/ioservice/io_foms.h
@@ -247,6 +247,7 @@ enum m0_io_fom_cob_rw_phases {
 	M0_FOPH_IO_ZERO_COPY_INIT,
 	M0_FOPH_IO_ZERO_COPY_WAIT,
 	M0_FOPH_IO_BUFFER_RELEASE,
+	M0_FOPH_IO_SYNC
 };
 
 /**

--- a/ioservice/io_fops.c
+++ b/ioservice/io_fops.c
@@ -292,6 +292,8 @@ M0_INTERNAL int m0_ioservice_fop_init(void)
 
 	io_conf.scf_state[M0_FOPH_TXN_INIT].sd_allowed |=
 		M0_BITS(M0_FOPH_IO_FOM_PREPARE);
+	io_conf.scf_state[M0_FOPH_QUEUE_REPLY].sd_allowed |=
+		M0_BITS(M0_FOPH_IO_SYNC);
 
 	m0_sm_conf_init(&io_conf);
 #else

--- a/ioservice/io_fops.h
+++ b/ioservice/io_fops.h
@@ -358,6 +358,8 @@ struct m0_fop_cob_writev_rep {
 enum m0_io_flags {
 	M0_IO_FLAG_CROW   = (1 << 0), /**< Create cob on write if not present */
 	M0_IO_FLAG_NOHOLE = (1 << 1), /**< Return error if read see holes */
+	/** Wait until the transaction is persistent. */
+	M0_IO_FLAG_SYNC   = (1 << 2)
 };
 
 /**

--- a/ioservice/ut/bulkio_ut.c
+++ b/ioservice/ut/bulkio_ut.c
@@ -250,6 +250,7 @@ enum fom_state_transition_tests {
 	TEST07,
 	TEST10,
 	TEST11,
+	TEST12
 };
 
 static int                        i = 0;
@@ -685,6 +686,14 @@ static int check_write_fom_tick(struct m0_fom *fom)
 	                     m0_fom_phase(fom) == M0_FOPH_SUCCESS);
 
 	        fill_buffers_pool(colour);
+		next_write_test = TEST12;
+	} else if (next_write_test == TEST12) {
+		/* @todo XXX Add tests for M0_FOPH_IO_SYNC, M0_IO_FLAG_SYNC. */
+	        fom_phase_set(fom, M0_FOPH_IO_SYNC);
+	        rc = m0_io_fom_cob_rw_tick(fom);
+	        M0_UT_ASSERT(m0_fom_rc(fom) == 0 &&
+	                     rc == M0_FSO_AGAIN &&
+	                     m0_fom_phase(fom) == M0_FOPH_QUEUE_REPLY);
 	} else {
 	        M0_UT_ASSERT(0); /* this should not happen */
 	        rc = M0_FSO_WAIT; /* to avoid compiler warning */

--- a/motr/client.h
+++ b/motr/client.h
@@ -574,7 +574,12 @@ enum m0_op_obj_flags {
 	 * Read operation should not see any holes. If a hole is met during
 	 * read, return error instead.
 	 */
-	M0_OOF_NOHOLE = (1 << 0)
+	M0_OOF_NOHOLE = 1 << 0,
+	/**
+	 * Write, alloc and free operations wait for the transaction to become
+	 * persistent before returning.
+	 */
+	M0_OOF_SYNC   = 1 << 1
 } M0_XCA_ENUM;
 
 /**
@@ -888,7 +893,7 @@ struct m0_config {
 	/**
  	 * ADDB size
  	 */
-	m0_bcount_t mc_addb_size; 
+	m0_bcount_t mc_addb_size;
 };
 
 /** The identifier of the root of realm hierarchy. */
@@ -1372,7 +1377,7 @@ void m0_obj_idx_init(struct m0_idx       *idx,
  * @pre ergo(M0_IN(opcode, (M0_OC_ALLOC, M0_OC_FREE)),
  *           data == NULL && attr == NULL && mask == 0)
  * @pre ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE)))
- * @pre ergo(opcode != M0_OC_READ, flags == 0)
+ * @pre ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC)))
  *
  * @post ergo(*op != NULL, *op->op_code == opcode &&
  *            *op->op_sm.sm_state == M0_OS_INITIALISED)

--- a/motr/io.c
+++ b/motr/io.c
@@ -732,7 +732,7 @@ int m0_obj_op(struct m0_obj       *obj,
 	M0_PRE(obj != NULL);
 	M0_PRE(op != NULL);
 	M0_PRE(ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE))));
-	M0_PRE(ergo(opcode != M0_OC_READ, flags == 0));
+	M0_PRE(ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC))));
 
 	if (M0_FI_ENABLED("fail_op"))
 		return M0_ERR(-EINVAL);

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -929,6 +929,8 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 		rw_fop->crw_index = ti->ti_obj;
 		if (ioo->ioo_flags & M0_OOF_NOHOLE)
 			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
+		if (ioo->ioo_flags & M0_OOF_SYNC)
+			rw_fop->crw_flags |= M0_IO_FLAG_SYNC;
 		io_attr = m0_io_attr(ioo);
 		rw_fop->crw_lid = io_attr->oa_layout_id;
 


### PR DESCRIPTION
Add M0_OOF_SYNC flag to motr client object
operations (READ, ALLOC, FREE). When this
flag is set, the server waits until the
meta-data transaction becomes persistent
before replying to the client.

This flag translates to M0_IO_FLAG_SYNC flag at
ioservice fop.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>