### PR TITLE
motr dep: libedit and libedit-devel added in build dependency

### DIFF
--- a/scripts/provisioning/roles/motr-build/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-build/vars/RedHat.yml
@@ -36,6 +36,8 @@ motr_build_deps_pkgs:
   - libuuid-devel
   - libyaml
   - libyaml-devel
+  - libedit
+  - libedit-devel
   - make
   - perl
   - perl-File-Find-Rule


### PR DESCRIPTION
Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>