### PR TITLE
EOS-15052 increase timeout value for 47motr-tests-user-kernel

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -494,7 +494,7 @@ Tests:
     sandbox  : /var/motr/sandbox.47motr_client
     groupname: 02motr-single-node
     polltime : 30
-    timeout  : 1800
+    timeout  : 2400
 
   - id       : 48motr-raid0-io
     script   : motr_raid0_st.sh


### PR DESCRIPTION
Signed-off-by: Hua Huang <hua.huang@seagate.com>