### PR TITLE
EOS-14813: discard multiple log record sequentially in single ast

### DIFF
--- a/be/log_discard.c
+++ b/be/log_discard.c
@@ -69,7 +69,6 @@ struct m0_be_log_discard_item {
 	 * To run ldsc_discard callback outside the m0_be_log_discard lock.
 	 * XXX Temporary solution.
 	 */
-	struct m0_sm_ast                ldi_discard_ast;
 };
 
 
@@ -122,7 +121,6 @@ M0_INTERNAL int m0_be_log_discard_init(struct m0_be_log_discard     *ld,
 	ld->lds_need_sync = false;
 	ld->lds_sync_in_progress = false;
 	ld->lds_sync_deadline = M0_TIME_NEVER;
-	ld->lds_discard_left = 0;
 	ld->lds_discard_waiting = false;
 	m0_be_op_init(&ld->lds_sync_op);
 	m0_be_op_callback_set(&ld->lds_sync_op, &be_log_discard_sync_done_cb,
@@ -130,6 +128,7 @@ M0_INTERNAL int m0_be_log_discard_init(struct m0_be_log_discard     *ld,
 	ld->lds_flush_op = NULL;
 	m0_sm_timer_init(&ld->lds_sync_timer);
 	ld->lds_stopping = false;
+	ld->lds_discard_ast_posted = false;
 	m0_semaphore_init(&ld->lds_discard_wait_sem, 0);
 	be_log_discard_timer_start(ld);
 	return 0;
@@ -225,46 +224,22 @@ static void be_log_discard_check_sync(struct m0_be_log_discard *ld,
 	}
 }
 
-static void be_log_discard_item_discard_ast(struct m0_sm_group *grp,
-                                            struct m0_sm_ast   *ast)
+static void be_log_discard_item_discard(struct m0_be_log_discard      *ld,
+					struct m0_be_log_discard_item *ldi)
 {
-	struct m0_be_log_discard_item *ldi = ast->sa_datum;
-	struct m0_be_log_discard      *ld  = ldi->ldi_ld;
 
 	M0_ENTRY("ld=%p ldi=%p", ld, ldi);
 
 	ld->lds_cfg.ldsc_discard(ld, ldi);
-
-	be_log_discard_lock(ld);
 	ldi->ldi_state = LDI_DISCARDED;
+	be_log_discard_lock(ld);
 	m0_be_log_discard_item_put(ld, ldi);
-	M0_CNT_DEC(ld->lds_discard_left);
-	if (ld->lds_discard_waiting)
-		m0_semaphore_up(&ld->lds_discard_wait_sem);
 	be_log_discard_unlock(ld);
-}
-
-static void be_log_discard_item_discard(struct m0_be_log_discard      *ld,
-                                        struct m0_be_log_discard_item *ldi)
-{
-	M0_LOG(M0_DEBUG, "ld=%p ldi=%p", ld, ldi);
-
-	M0_PRE(be_log_discard_is_locked(ld));
-	M0_PRE(ldi->ldi_state == LDI_SYNCED);
-
-	M0_CNT_INC(ld->lds_discard_left);
-	ldi->ldi_discard_ast = (struct m0_sm_ast){
-		.sa_cb    = &be_log_discard_item_discard_ast,
-		.sa_datum = ldi,
-	};
-	/* get out of the m0_be_log_discard lock */
-	m0_sm_ast_post(m0_locality_here()->lo_grp, &ldi->ldi_discard_ast);
 }
 
 static void be_log_discard_item_trydiscard(struct m0_be_log_discard      *ld,
                                            struct m0_be_log_discard_item *ldi)
 {
-	M0_PRE(be_log_discard_is_locked(ld));
 	M0_PRE(M0_IN(ldi->ldi_state, (LDI_STARTING, LDI_FINISHED)));
 
 	if (ldi->ldi_state == LDI_FINISHED && ldi->ldi_synced)
@@ -273,30 +248,67 @@ static void be_log_discard_item_trydiscard(struct m0_be_log_discard      *ld,
 		be_log_discard_item_discard(ld, ldi);
 }
 
-static void be_log_discard_sync_done_cb(struct m0_be_op *op, void *param)
+static void be_log_discard_ast(struct m0_sm_group *grp,
+			       struct m0_sm_ast   *ast)
 {
-	struct m0_be_log_discard_item *ldi;
-	struct m0_be_log_discard      *ld = param;
+	struct m0_be_log_discard      *ld  = ast->sa_datum;
 
-	M0_LOG(M0_DEBUG, "ld=%p", ld);
+	struct m0_be_log_discard_item *ldi;
+	struct m0_be_log_discard_item *sync_item;
+
+	M0_ENTRY("ld=%p", ld);
 	be_log_discard_lock(ld);
 	M0_PRE(ld->lds_sync_item != NULL);
-	m0_be_op_reset(op);
-	m0_tl_for(ld_start, &ld->lds_start_q, ldi) {
-		M0_ASSERT_INFO(ldi->ldi_state == LDI_FINISHED,
-			       "ldi=%p state=%d", ldi, ldi->ldi_state);
-		ld_start_tlist_del(ldi);
-		ldi->ldi_synced = true;
-		be_log_discard_item_trydiscard(ld, ldi);
-		if (ldi == ld->lds_sync_item)
-			break;
-	} m0_tl_endfor;
+	be_log_discard_unlock(ld);
+
+	do {
+               be_log_discard_lock(ld);
+               sync_item = ld->lds_sync_item;
+               ldi = ld_start_tlist_pop(&ld->lds_start_q);
+               be_log_discard_unlock(ld);
+
+               M0_ASSERT(ldi != NULL); // it's not an endless loop
+               M0_ASSERT_INFO(ldi->ldi_state == LDI_FINISHED,
+                   "ldi=%p state=%d", ldi, ldi->ldi_state);
+               ldi->ldi_synced = true;
+               be_log_discard_item_trydiscard(ld, ldi);
+	} while (ldi != sync_item);
+
+	be_log_discard_lock(ld);
 	ld->lds_sync_item = NULL;
 	ld->lds_sync_in_progress = false;
 	if (ld_start_tlist_is_empty(&ld->lds_start_q))
 		ld->lds_sync_deadline = M0_TIME_NEVER;
 	be_log_discard_check_sync(ld, false);
+	ld->lds_discard_ast_posted = false;
+
+	if (ld->lds_discard_waiting)
+		m0_semaphore_up(&ld->lds_discard_wait_sem);
 	be_log_discard_unlock(ld);
+}
+
+static void be_log_discard_sync_done_cb(struct m0_be_op *op, void *param)
+{
+	struct m0_be_log_discard      *ld = param;
+
+	M0_LOG(M0_DEBUG, "ld=%p", ld);
+	m0_be_op_reset(op);
+
+	be_log_discard_lock(ld);
+	if (ld->lds_discard_ast_posted) {
+		be_log_discard_unlock(ld);
+		return;
+	}
+
+	ld->lds_discard_ast_posted = true;
+	be_log_discard_unlock(ld);
+
+	ld->lds_discard_ast = (struct m0_sm_ast){
+		.sa_cb    = &be_log_discard_ast,
+		.sa_datum = ld,
+	};
+	/* get out of the m0_be_log_discard lock */
+	m0_sm_ast_post(m0_locality_here()->lo_grp, &ld->lds_discard_ast);
 }
 
 static void be_log_discard_timer_cb(struct m0_sm_timer *timer);
@@ -375,17 +387,16 @@ M0_INTERNAL void m0_be_log_discard_flush(struct m0_be_log_discard *ld,
 
 static void be_log_discard_wait(struct m0_be_log_discard *ld)
 {
-	int left;
-	int i;
+	bool posted;
 
 	M0_PRE(!ld->lds_discard_waiting);
 
 	be_log_discard_lock(ld);
-	left = ld->lds_discard_left;
 	ld->lds_discard_waiting = true;
+	posted = ld->lds_discard_ast_posted;
 	be_log_discard_unlock(ld);
 
-	for (i = 0; i < left; ++i)
+	if (posted)
 		m0_semaphore_down(&ld->lds_discard_wait_sem);
 }
 

--- a/be/log_discard.h
+++ b/be/log_discard.h
@@ -115,8 +115,14 @@ struct m0_be_log_discard {
 	 * XXX Temporary solution.
 	 */
 	struct m0_semaphore                  lds_discard_wait_sem;
-	int                                  lds_discard_left;
 	bool                                 lds_discard_waiting;
+
+
+	/**
+	 * Add single ast to discard multiple ldi
+	 */
+	struct m0_sm_ast                     lds_discard_ast;
+	bool                                 lds_discard_ast_posted;
 };
 
 M0_INTERNAL int m0_be_log_discard_init(struct m0_be_log_discard     *ld,


### PR DESCRIPTION
Fix for EOS-14813 and EOS-9668 
Problem:
As per the current implementation, the discarded records are received via the AST-mechanism
in backwards order via the m0_be_group_format_discard() calls. If the lg_discarded position is moved by the records sizes , it is possible that lgr_last_discarded at m0_be_log_record_io_prepare() picks up some interim lg_discarded value between
the 1st and the last AST-calls of m0_be_group_format_discard() and write it down into the log. If it is the last log record just before the crash - the wrong discarded position will be taken during the recovery on m0d process restart resulting in a data corruption.
Solution:
Post a single ast after fdatasync() (if there is no ast running already) and discard each log record sequentially in a loop in that ast.
This will avoid the case where lgr_last_discarded can get updated with the interim lg_discarded value due to multiple ASTs being posted.
