### PR TITLE
EOS-15083 reset 'rc' after overwritten.

### DIFF
--- a/motr/m0d.c
+++ b/motr/m0d.c
@@ -230,7 +230,8 @@ start_m0d:
 		else if (rc == 0)
 			warnx("systemd notifications not allowed\n");
 		else
-			warnx("systemd READY notification successfull\n");
+			warnx("systemd READY notification successful\n");
+		rc = 0;
 #endif
 		result = cs_wait_signal();
 		if (gotsignal)

--- a/st/m0d-signal-test.sh
+++ b/st/m0d-signal-test.sh
@@ -49,6 +49,7 @@ test_for_signal()
     local sig=$1
     echo "------------------ Configuring Motr for $sig test ------------------"
     systemctl start motr-mkfs
+    local cursor=$(journalctl --show-cursor -n0 | grep -e '-- cursor:' | sed -e 's/^-- cursor: //')
     systemctl start motr
 
     echo 'Waiting for ios1 to become active'
@@ -56,7 +57,6 @@ test_for_signal()
         sleep 1
     done
 
-    local cursor=$(journalctl --show-cursor -n0 | grep -e '-- cursor:' | sed -e 's/^-- cursor: //')
     while ! journalctl -c "$cursor" -l -u motr-server@ios1 | grep -q 'Press CTRL+C to quit'; do
         sleep 1
     done


### PR DESCRIPTION
- This was introduced by:
   commit a1a5e630aa5105ccbbfdca36964a7b69a8f7c3d7
   EOS-13872 motr: don't start clients before motr IOS process starts functional (#146)

- Get the journalctl cursor before starting motr service.

Signed-off-by: Hua Huang <hua.huang@seagate.com>