### PR TITLE
Fix dependency error at example1.c

### DIFF
--- a/motr/examples/example1.c
+++ b/motr/examples/example1.c
@@ -36,7 +36,8 @@
  * Please change the configuration according to you development environment.
  *
  * How to run:
- * LD_LIBRARY_PATH=/work/cortx-motr/motr/.libs/                              \
+ * LD_LIBRARY_PATH=/work/cortx-motr/motr/.libs/                              
+ * export LD_LIBRARY_PATH
  * ./example1 172.16.154.179@tcp:12345:34:1 172.16.154.179@tcp:12345:33:1000 \
  *         "<0x7000000000000001:0>" "<0x7200000000000001:64>" 12345670
  */
@@ -45,6 +46,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include "motr/idx.h"
 
 static struct m0_client         *m0_instance = NULL;
 static struct m0_container       motr_container;


### PR DESCRIPTION
There are two updates:

1. `export LD_LIBRARY_PATH` is needed so that GCC can get the linked libraries. Otherwise, we will get this error:
`./example1: error while loading shared libraries: libmotr.so.1: cannot open shared object file: No such file or directory`

2. `#include "motr/idx.h"` is needed because this example uses `M0_IDX_DIX` which is located at `idx.h`. Otherwise, we will get this error:

```
example1.c: In function ‘main’:
example1.c:411:2: error: invalid use of undefined type ‘struct m0_idx_dix_config’
  motr_dix_conf.kc_create_meta = false;
  ^
example1.c:421:39: error: ‘M0_IDX_DIX’ undeclared (first use in this function)
  motr_conf.mc_idx_service_id        = M0_IDX_DIX;
                                       ^
example1.c:421:39: note: each undeclared identifier is reported only once for each function it appears in
```

Signed-off-by: Daniar Kurniawan <ddhhkk2@gmail.com>