### PR TITLE
EOS-15338 motr-free-space-monitor: changed IEM alert message format 

### DIFF
--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -197,14 +197,16 @@ if __name__ == '__main__':
                 cluster_usage_percentage >= iem_alert_high_thresold):
                 send_iem = True
 
+#           update idx as per current usage percent to get current next low from
+#           from threshold list.
+            idx = bisect.bisect_right(param_list, cluster_usage_percentage)
+            if idx >= list_len:
+                idx = list_len - 1
+            iem_alert_low_new = param_list[idx]
+
             if send_iem:
-                idx = bisect.bisect_right(param_list, int(iem_alert_low_thresold))
-                if idx >= list_len:
-                    idx = list_len - 1
-                iem_alert_low_new = param_list[idx]
-                if iem_alert_high_thresold > iem_alert_low_thresold:
-                    iem_alert_low_thresold = iem_alert_low_new
-                    print_iem(cluster_usage_percentage)
+                print_iem(cluster_usage_percentage)
+            iem_alert_low_thresold = iem_alert_low_new
             cluster_usage_prev = cluster_usage_percentage
         else:
             if cluster_usage_prev > iem_min_threshold:

--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -123,9 +123,16 @@ def print_iem(usage_percentage):
     evt_id = iem_event_id
     msg = f"Cluster size {usage_percentage}"
     msg_b = msg.encode('utf-8')
-    libmotr.m0_time_init()
-    libmotr.m0_iem(ctypes.c_char_p(file_parm_b), function_parm, line_num,
-                        sev_id, mod_id, evt_id, ctypes.c_char_p(msg_b))
+
+#   Current libmotr api "m0_iem()" is generalize for all IEM alerts from motr.
+#   Which is not allowing to provide free space monitor alert message as
+#   required format, hence added print log to provide alert in required format.
+#   Keeping exiting logic as well (commented) as it may required in LDR-R2
+
+    log.error(f"IEC: AS0020020002: Usable storage is {usage_percentage} % full");
+#    libmotr.m0_time_init()
+#    libmotr.m0_iem(ctypes.c_char_p(file_parm_b), function_parm, line_num,
+#                        sev_id, mod_id, evt_id, ctypes.c_char_p(msg_b))
 
 
 if __name__ == '__main__':
@@ -182,11 +189,11 @@ if __name__ == '__main__':
 
         cluster_usage_percentage = cluster_size[USAGE_PERCENTAGE]
         if cluster_usage_percentage > iem_min_threshold:
-            if (cluster_usage_prev < iem_alert_low_thresold and
-                cluster_usage_percentage > iem_alert_low_thresold):
+            if (cluster_usage_prev <= iem_alert_low_thresold and
+                cluster_usage_percentage >= iem_alert_low_thresold):
                 send_iem = True
-            if (cluster_usage_prev < iem_alert_high_thresold and
-                cluster_usage_percentage > iem_alert_high_thresold):
+            if (cluster_usage_prev <= iem_alert_high_thresold and
+                cluster_usage_percentage >= iem_alert_high_thresold):
                 send_iem = True
 
             if send_iem:

--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -156,7 +156,7 @@ if __name__ == '__main__':
     thr_min = min(param_list)
     thr_max = max(param_list)
     iem_alert_low_thresold = thr_min
-    iem_alert_high_thresold = min(100, thr_max + 1)
+    iem_alert_high_thresold = min(100, thr_max)
     iem_min_threshold = iem_alert_low_thresold
     list_len = len(param_list)
     os.makedirs(iem_work_dir, exist_ok=True)
@@ -190,11 +190,8 @@ if __name__ == '__main__':
 
         cluster_usage_percentage = cluster_size[USAGE_PERCENTAGE]
         if cluster_usage_percentage > iem_min_threshold:
-            if (cluster_usage_prev <= iem_alert_low_thresold and
+            if (cluster_usage_prev < iem_alert_low_thresold and
                 cluster_usage_percentage >= iem_alert_low_thresold):
-                send_iem = True
-            if (cluster_usage_prev <= iem_alert_high_thresold and
-                cluster_usage_percentage >= iem_alert_high_thresold):
                 send_iem = True
 
 #           update idx as per current usage percent to get current next low from
@@ -202,16 +199,15 @@ if __name__ == '__main__':
             idx = bisect.bisect_right(param_list, cluster_usage_percentage)
             if idx >= list_len:
                 idx = list_len - 1
-            iem_alert_low_new = param_list[idx]
+            iem_alert_low_thresold = param_list[idx]
 
             if send_iem:
                 print_iem(cluster_usage_percentage)
-            iem_alert_low_thresold = iem_alert_low_new
             cluster_usage_prev = cluster_usage_percentage
         else:
             if cluster_usage_prev > iem_min_threshold:
                 print_iem(cluster_usage_percentage)
                 cluster_usage_prev = 0
                 iem_alert_low_thresold = thr_min
-                iem_alert_high_thresold = thr_max
+                iem_alert_high_thresold = min(100, thr_max)
         time.sleep(wait_time)

--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -129,6 +129,7 @@ def print_iem(usage_percentage):
 #   required format, hence added print log to provide alert in required format.
 #   Keeping exiting logic as well (commented) as it may required in LDR-R2
 
+    usage_percentage = int(usage_percentage)
     log.error(f"IEC: AS0020020002: Usable storage is {usage_percentage} % full");
 #    libmotr.m0_time_init()
 #    libmotr.m0_iem(ctypes.c_char_p(file_parm_b), function_parm, line_num,


### PR DESCRIPTION
Current libmotr api "m0_iem()" is generalize for all IEM alerts from motr.
Which is not allowing to change format of free space monitor alert message as
required, hence added print log (instead of api) to provide alert in required format.
Keeping exiting logic as well (commented) as it may required in LDR-R2

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>