### PR TITLE
Revert-EOS-14788 (Do Not Merge)

### DIFF
--- a/ioservice/io_foms.h
+++ b/ioservice/io_foms.h
@@ -247,7 +247,6 @@ enum m0_io_fom_cob_rw_phases {
 	M0_FOPH_IO_ZERO_COPY_INIT,
 	M0_FOPH_IO_ZERO_COPY_WAIT,
 	M0_FOPH_IO_BUFFER_RELEASE,
-	M0_FOPH_IO_SYNC
 };
 
 /**

--- a/ioservice/io_fops.c
+++ b/ioservice/io_fops.c
@@ -292,8 +292,6 @@ M0_INTERNAL int m0_ioservice_fop_init(void)
 
 	io_conf.scf_state[M0_FOPH_TXN_INIT].sd_allowed |=
 		M0_BITS(M0_FOPH_IO_FOM_PREPARE);
-	io_conf.scf_state[M0_FOPH_QUEUE_REPLY].sd_allowed |=
-		M0_BITS(M0_FOPH_IO_SYNC);
 
 	m0_sm_conf_init(&io_conf);
 #else

--- a/ioservice/io_fops.h
+++ b/ioservice/io_fops.h
@@ -358,8 +358,6 @@ struct m0_fop_cob_writev_rep {
 enum m0_io_flags {
 	M0_IO_FLAG_CROW   = (1 << 0), /**< Create cob on write if not present */
 	M0_IO_FLAG_NOHOLE = (1 << 1), /**< Return error if read see holes */
-	/** Wait until the transaction is persistent. */
-	M0_IO_FLAG_SYNC   = (1 << 2)
 };
 
 /**

--- a/ioservice/ut/bulkio_ut.c
+++ b/ioservice/ut/bulkio_ut.c
@@ -250,7 +250,6 @@ enum fom_state_transition_tests {
 	TEST07,
 	TEST10,
 	TEST11,
-	TEST12
 };
 
 static int                        i = 0;
@@ -686,14 +685,6 @@ static int check_write_fom_tick(struct m0_fom *fom)
 	                     m0_fom_phase(fom) == M0_FOPH_SUCCESS);
 
 	        fill_buffers_pool(colour);
-		next_write_test = TEST12;
-	} else if (next_write_test == TEST12) {
-		/* @todo XXX Add tests for M0_FOPH_IO_SYNC, M0_IO_FLAG_SYNC. */
-	        fom_phase_set(fom, M0_FOPH_IO_SYNC);
-	        rc = m0_io_fom_cob_rw_tick(fom);
-	        M0_UT_ASSERT(m0_fom_rc(fom) == 0 &&
-	                     rc == M0_FSO_AGAIN &&
-	                     m0_fom_phase(fom) == M0_FOPH_QUEUE_REPLY);
 	} else {
 	        M0_UT_ASSERT(0); /* this should not happen */
 	        rc = M0_FSO_WAIT; /* to avoid compiler warning */

--- a/motr/client.h
+++ b/motr/client.h
@@ -574,12 +574,7 @@ enum m0_op_obj_flags {
 	 * Read operation should not see any holes. If a hole is met during
 	 * read, return error instead.
 	 */
-	M0_OOF_NOHOLE = 1 << 0,
-	/**
-	 * Write, alloc and free operations wait for the transaction to become
-	 * persistent before returning.
-	 */
-	M0_OOF_SYNC   = 1 << 1
+	M0_OOF_NOHOLE = (1 << 0)
 } M0_XCA_ENUM;
 
 /**
@@ -1377,7 +1372,7 @@ void m0_obj_idx_init(struct m0_idx       *idx,
  * @pre ergo(M0_IN(opcode, (M0_OC_ALLOC, M0_OC_FREE)),
  *           data == NULL && attr == NULL && mask == 0)
  * @pre ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE)))
- * @pre ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC)))
+ * @pre ergo(opcode != M0_OC_READ, flags == 0)
  *
  * @post ergo(*op != NULL, *op->op_code == opcode &&
  *            *op->op_sm.sm_state == M0_OS_INITIALISED)

--- a/motr/io.c
+++ b/motr/io.c
@@ -556,7 +556,6 @@ static int obj_io_init(struct m0_obj      *obj,
 	ioo->ioo_sns_state = SRS_UNINITIALIZED;
 	ioo->ioo_ext = *ext;
 	ioo->ioo_flags = flags;
-	ioo->ioo_flags |= M0_OOF_SYNC;
 	if (M0_IN(opcode, (M0_OC_READ, M0_OC_WRITE))) {
 		ioo->ioo_data = *data;
 		ioo->ioo_attr = *attr;
@@ -733,7 +732,7 @@ int m0_obj_op(struct m0_obj       *obj,
 	M0_PRE(obj != NULL);
 	M0_PRE(op != NULL);
 	M0_PRE(ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE))));
-	M0_PRE(ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC))));
+	M0_PRE(ergo(opcode != M0_OC_READ, flags == 0));
 
 	if (M0_FI_ENABLED("fail_op"))
 		return M0_ERR(-EINVAL);

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -929,8 +929,6 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 		rw_fop->crw_index = ti->ti_obj;
 		if (ioo->ioo_flags & M0_OOF_NOHOLE)
 			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
-		if (ioo->ioo_flags & M0_OOF_SYNC)
-			rw_fop->crw_flags |= M0_IO_FLAG_SYNC;
 		io_attr = m0_io_attr(ioo);
 		rw_fop->crw_lid = io_attr->oa_layout_id;
 


### PR DESCRIPTION
To figure out delay in EOs-15349,  we are reverting changes of 'EOS-14788 Enable sync for object operations' 
for creating custom build.