### PR TITLE
provisioning: update Lustre version to 2.12.6

### DIFF
--- a/scripts/provisioning/roles/lustre-client/tasks/main.yml
+++ b/scripts/provisioning/roles/lustre-client/tasks/main.yml
@@ -53,7 +53,7 @@
     - { version: 2.10.5, enabled: '{{ (redhat_release is version("7.5", "=")) | ternary("yes", "no") }}' }
     - { version: 2.10.8, enabled: '{{ (redhat_release is version("7.6", "=")) | ternary("yes", "no") }}' }
     - { version: 2.12.4, enabled: '{{ (redhat_release is version("7.7", "=")) | ternary("yes", "no") }}' }
-    - { version: 2.12.5, enabled: '{{ (redhat_release is version("7.8", ">=")) | ternary("yes", "no") }}' }
+    - { version: 2.12.5, enabled: '{{ (redhat_release is version("7.8", "=")) | ternary("yes", "no") }}' }
     - { version: 2.12.6, enabled: '{{ (redhat_release is version("7.9", ">=")) | ternary("yes", "no") }}' }
   when: ansible_os_family == 'RedHat'
   tags:

--- a/scripts/provisioning/roles/lustre-client/tasks/main.yml
+++ b/scripts/provisioning/roles/lustre-client/tasks/main.yml
@@ -54,6 +54,7 @@
     - { version: 2.10.8, enabled: '{{ (redhat_release is version("7.6", "=")) | ternary("yes", "no") }}' }
     - { version: 2.12.4, enabled: '{{ (redhat_release is version("7.7", "=")) | ternary("yes", "no") }}' }
     - { version: 2.12.5, enabled: '{{ (redhat_release is version("7.8", ">=")) | ternary("yes", "no") }}' }
+    - { version: 2.12.6, enabled: '{{ (redhat_release is version("7.9", ">=")) | ternary("yes", "no") }}' }
   when: ansible_os_family == 'RedHat'
   tags:
     - lustre


### PR DESCRIPTION
The current Lustre version we support (2.12.5) does not work on CentOS-7.9 (which is used by Vagrant now when provisioning the nodes), so the provisioning is broken at the moment (unless some older version of CentOS is specified explicitly via the M0_VM_BOX_VERSION parameter).

Solution: update our list of supported Lustre versions up to 2.12.6.