### PR TITLE
Linking to motr in prose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ Get to know
 
 - `Quick Start Guide </doc/Quick-Start-Guide.rst>`_
 
+- `Architectural Summary </doc/motr-in-prose.md>`_
+
 - `Source Structure </doc/source-structure.md>`_
 
 - `Coding Style </doc/coding-style.md>`_


### PR DESCRIPTION
Signed-off-by: John Bent <john.bent@seagate.com>

Adding link to motr in prose from top-level readme