### PR TITLE
EOS-15316 code coverage: removed compile time error with coverage flag

### DIFF
--- a/motr/io.c
+++ b/motr/io.c
@@ -93,7 +93,7 @@ ioo_to_poolmach(struct m0_op_io *ioo)
 static bool indexvec_segments_overlap(struct m0_indexvec *ivec)
 {
 	uint32_t seg;
-	bool     overlap;
+	bool     overlap = false;
 
 	for (seg = 0; seg < SEG_NR(ivec) - 1; ++seg) {
 		overlap = (INDEX(ivec, seg) + COUNT(ivec, seg)) >

--- a/pool/pool.c
+++ b/pool/pool.c
@@ -1671,7 +1671,7 @@ M0_INTERNAL int m0_pool_version_append(struct m0_pools_common  *pc,
 				       struct m0_conf_pver     *pver,
 				       struct m0_pool_version **pv)
 {
-	struct m0_conf_pool *cp;
+	struct m0_conf_pool *cp = NULL;
 	struct m0_pool      *p;
 	int                  rc;
 
@@ -1685,6 +1685,7 @@ M0_INTERNAL int m0_pool_version_append(struct m0_pools_common  *pc,
 		if (rc != 0)
 			return M0_ERR(rc);
 	}
+	M0_ASSERT(cp != NULL); 
 	p = pool_find(pc, &cp->pl_obj.co_id);
 	M0_ASSERT(p != NULL);
 

--- a/pool/pool_foms.c
+++ b/pool/pool_foms.c
@@ -125,8 +125,8 @@ static void poolmach_set_op(struct m0_fom *fom)
 
 static void poolmach_query_op(struct m0_fom *fom)
 {
-	uint32_t                 idx;
-	int                      rc = 0;
+	uint32_t                 idx = 0;
+	int                      rc  = 0;
 	int                      i;
 	int                      j;
 	struct m0_fop           *req_fop = fom->fo_fop;

--- a/pool/pool_machine.c
+++ b/pool/pool_machine.c
@@ -920,7 +920,7 @@ M0_INTERNAL void m0_poolmach_failvec_apply(struct m0_poolmach *pm,
 	struct m0_pooldev        *pd;
 	struct m0_pool           *pool;
 	uint32_t                  i;
-	uint32_t                  pd_idx;
+	uint32_t                  pd_idx = 0;
 	int                       rc;
 
 	M0_PRE(!pm->pm_state->pst_su_initialised);


### PR DESCRIPTION
Build failed with code coverage flag enabled:
sh autogen.sh; ./configure --enable-coverage; make

Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>