### PR TITLE
EOS-15686 be/tool/beck: fix bnode pre-validation check in beck tool.

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -2103,8 +2103,8 @@ static bool btree_node_pre_is_valid(const struct m0_be_bnode *node,
 {
 	M0_PRE(node != NULL);
 	return
-		(node->bt_num_active_key < ARRAY_SIZE(node->bt_kv_arr))    &&
-		(m0_fid_tget(&node->bt_backlink.bli_fid) == 'b')       	   &&
+		(node->bt_num_active_key <= ARRAY_SIZE(node->bt_kv_arr))   &&
+		(m0_fid_tget(&node->bt_backlink.bli_fid) == 'b')           &&
 		(node->bt_isleaf == (node->bt_level == 0))                 &&
 		m0_forall(i, node->bt_num_active_key,
 			  node->bt_kv_arr[i].btree_key != NULL &&


### PR DESCRIPTION
btree_node_pre_is_valid() has check (node->bt_num_active_key <
ARRAY_SIZE(node->bt_kv_arr)).
This check used to fail when node->bt_num_active_key = 255 i.e. when all KV
entries were full. This leads to treating KV entries as bad.
The end user result was some of the objects written before recovery were
missing, even when there was no error injection.

Signed-off-by: Mukund Kanekar <mukund.kanekar@seagate.com>