### PR TITLE
provisioning: fix interfaces at lnet.conf on vmware

### DIFF
--- a/scripts/provisioning/roles/lustre-client/tasks/main.yml
+++ b/scripts/provisioning/roles/lustre-client/tasks/main.yml
@@ -65,12 +65,25 @@
   tags:
     - lustre
 
-- name: write modprobe config for LNet module
+- name: write modprobe config for LNet module on vmware_desktop provider
   lineinfile:
     path:   /etc/modprobe.d/lnet.conf
     create: yes
-    # we want eth1 interface to be used by default by Motr, so specify it first
-    line:   'options lnet networks=tcp(eth1),tcp1(eth0) config_on_load=1'
+    regexp: '^options lnet networks='
+    # In VMware eth0 (NAT) is always the interface for Motr's LNet:
+    line:   'options lnet networks=tcp(eth0) config_on_load=1'
+  when: ansible_facts['facter_virtual'] == "vmware"
+  tags: lustre
+
+- name: write modprobe config for LNet module on other providers
+  lineinfile:
+    path:   /etc/modprobe.d/lnet.conf
+    create: yes
+    regexp: '^options lnet networks='
+    # eth1 (host-only) interface is used for LNet in this case.
+    # (Note: VirtualBox won't inter-connect the nodes on NAT interfaces.)
+    line:   'options lnet networks=tcp(eth1) config_on_load=1'
+  when: ansible_facts['facter_virtual'] != "vmware"
   tags: lustre
 
 - name: fix empty /etc/lnet.conf


### PR DESCRIPTION
Currently on vmware_desktop-provider-based nodes there is
only one network interface configured. But in lnet config
at /etc/modprobe.d/lnet.conf there would be two interfaces
added after provisioning and, as result, lnet would not
add any of them (`lctl list_nids` wouldn't show anything)
and Motr processes startup would fail.

Solution: check virtualisation provider when configuring
interfaces in lnet.conf at lustre-client/tasks/main.yml
and use eth0 (NAT) interface in case of VMware provider.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>