### PR TITLE
Vagrantfile: set vmware hw.version to 10

### DIFF
--- a/scripts/provisioning/Vagrantfile
+++ b/scripts/provisioning/Vagrantfile
@@ -620,6 +620,9 @@ def setup(node, cpu_nr, mem_mb, disk_nr = 0, disk_size = 1)
 
     v.vmx['numvcpus'] = cpu_nr
     v.vmx['memsize']  = mem_mb
+    # Default version 8 allows only 8 CPUs and 8GB RAM.
+    # Version 10 allows 16 CPUs and 64 GB RAM.
+    v.vmx['virtualhw.version'] = 10
 
     # re-use main VM disk as copy-on-write base image
     v.linked_clone = true
@@ -645,8 +648,8 @@ def setup(node, cpu_nr, mem_mb, disk_nr = 0, disk_size = 1)
     # disks
     vdiskmanager = 'C:\Program Files (x86)\VMware\VMware Workstation\vmware-vdiskmanager.exe'
     if RbConfig::CONFIG['host_os'] =~ /darwin/
-      # After some time when all developers upgrade their vmware plugin
-      # to vmware_desktop, vmware_fusion provider could be removed.
+      # After some time when all developers upgrade their vmware plugin to
+      # vmware_desktop, vmware_fusion provider code (above) could be removed.
       vdiskmanager = '/Applications/VMware Fusion.app/Contents/Library/vmware-vdiskmanager'
     end
     if PROVIDER == :vmware_desktop and File.exist?(vdiskmanager)


### PR DESCRIPTION
Currently, version 8 is used (set by default by Vagrant) which limits the virtual machines to 8 CPUs and 8 GB RAM.

Solution: set version 10 explicitly in Vagrantfile. Version 10 allows to create machines with 16 CPUs and 64 GB RAM.