### PR TITLE
EOS-13057 ha: wait time added in ham utility for listening mode

### DIFF
--- a/ha/ham-st
+++ b/ha/ham-st
@@ -122,7 +122,7 @@ wait_for $spawn_id client
 say "---------------"
 say "Test: both send"
 say "---------------"
-spawn -noecho bash -c "[hagen nvec_set] | sudo [m0 ha/m0ham] -lv \
+spawn -noecho bash -c "[hagen nvec_set] | sudo [m0 ha/m0ham] -lv -w 2\
       | [hagen -d SERVER]"
 set server $spawn_id
 expect "Listening at *.\r\n"

--- a/ha/ham.c
+++ b/ha/ham.c
@@ -677,7 +677,7 @@ int main(int argc, char **argv)
 		M0_ASSERT(m0_semaphore_value(&g_sem) == 0);
 	}
 	if (g_params.hp_mode == HM_LISTEN && g_params.hp_wait > 0) {
-		sleep(g_params.hp_wait);
+		m0_nanosleep(m0_time(g_params.hp_wait, 0), NULL);
 	}
 	ham_say("Finishing");
 	m0_ha_flush(&ha, hl);

--- a/ha/ham.c
+++ b/ha/ham.c
@@ -59,8 +59,9 @@
 #include <getopt.h>           /* getopt_long */
 #include <unistd.h>           /* isatty */
 
-#define HAM_SERVER_EP_DEFAULT "0@lo:12345:63:100"
-#define HAM_CLIENT_EP_DEFAULT "0@lo:12345:63:101"
+#define HAM_SERVER_EP_DEFAULT   "0@lo:12345:63:100"
+#define HAM_CLIENT_EP_DEFAULT   "0@lo:12345:63:101"
+#define HAM_SERVER_WAIT_DEFAULT 0
 
 enum ham_mode { HM_CONNECT, HM_LISTEN, HM_SELF_CHECK };
 
@@ -73,6 +74,7 @@ static struct ham_params {
 	const char   *hp_ep_local;
 	const char   *hp_ep_remote; /* connect mode only */
 	bool          hp_verbose;
+	unsigned int  hp_wait;      /* listen mode only */
 	const char   *hp_progname;
 } g_params;
 
@@ -473,6 +475,8 @@ static void ham_help(FILE *stream, char *progname)
 "  -l, --listen       Listen for incoming connections\n"
 "  -s, --source addr  Specify source address to use (doesn't affect -l);\n"
 "                     defaults to "HAM_CLIENT_EP_DEFAULT"\n"
+"  -w, --wait time    Wait in seconds before finishing listening mode\n"
+"                     Default is zero second\n"
 "  -v, --verbose      Explain what is being done\n",
 		/*
 		 * `--self-check' is intentionally left undocumented.
@@ -492,7 +496,6 @@ ham_args_parse(struct ham_params *params, int argc, char *const *argv)
 	/*
 	 * XXX FUTURE: We may want to add
 	 *   -k, --keep-open (Accept multiple connections)
-	 *   -w time, --wait time (Specify connect timeout)
 	 * options in the future; see ncat(1).
 	 */
 	const struct option opts[] = {
@@ -500,6 +503,7 @@ ham_args_parse(struct ham_params *params, int argc, char *const *argv)
 		{ "help",       no_argument, NULL, 'h' },
 		{ "listen",     no_argument, NULL, 'l' },
 		{ "source",     required_argument, NULL, 's' },
+		{ "wait",       required_argument, NULL, 'w' },
 		{ "verbose",    no_argument, NULL, 'v' },
 		{} /* terminator */
 	};
@@ -510,9 +514,10 @@ ham_args_parse(struct ham_params *params, int argc, char *const *argv)
 		.hp_ep_local  = NULL,
 		.hp_ep_remote = NULL,
 		.hp_verbose   = false,
+		.hp_wait      = HAM_SERVER_WAIT_DEFAULT,
 		.hp_progname  = basename(argv[0])
 	};
-	while ((c = getopt_long(argc, argv, "hls:v", opts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "hls:w:v", opts, NULL)) != -1) {
 		switch (c) {
 		case 'c':
 			params->hp_mode = HM_SELF_CHECK;
@@ -528,6 +533,9 @@ ham_args_parse(struct ham_params *params, int argc, char *const *argv)
 			break;
 		case 'v':
 			params->hp_verbose = true;
+			break;
+		case 'w':
+			params->hp_wait = atoi(optarg);
 			break;
 		default:
 			goto err;
@@ -667,6 +675,9 @@ int main(int argc, char **argv)
 		ham_say("Awaiting reply");
 		m0_semaphore_down(&g_sem);
 		M0_ASSERT(m0_semaphore_value(&g_sem) == 0);
+	}
+	if (g_params.hp_mode == HM_LISTEN && g_params.hp_wait > 0) {
+		sleep(g_params.hp_wait);
 	}
 	ham_say("Finishing");
 	m0_ha_flush(&ha, hl);


### PR DESCRIPTION
- 06ham st got stuck while test "Both Send" because,
  many times server process exit before client process
  complete connection.
- wait time option added for listening mode. So, process
  will wait before finilize server connection.

Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>