### PR TITLE
Vagrantfile: fix lustre-client provisioning

### DIFF
--- a/scripts/provisioning/roles/lustre-client/tasks/main.yml
+++ b/scripts/provisioning/roles/lustre-client/tasks/main.yml
@@ -72,7 +72,7 @@
     regexp: '^options lnet networks='
     # In VMware eth0 (NAT) is always the interface for Motr's LNet:
     line:   'options lnet networks=tcp(eth0) config_on_load=1'
-  when: ansible_facts['facter_virtual'] == "vmware"
+  when: ansible_virtualization_type == "VMware"
   tags: lustre
 
 - name: write modprobe config for LNet module on other providers
@@ -83,7 +83,7 @@
     # eth1 (host-only) interface is used for LNet in this case.
     # (Note: VirtualBox won't inter-connect the nodes on NAT interfaces.)
     line:   'options lnet networks=tcp(eth1) config_on_load=1'
-  when: ansible_facts['facter_virtual'] != "vmware"
+  when: ansible_virtualization_type != "VMware"
   tags: lustre
 
 - name: fix empty /etc/lnet.conf


### PR DESCRIPTION
The regression was introduced at commit b0d129e77 when
we started checking for vmware when configuring lnet.conf.
The problem is that we check for the 'facter_virtual' but
facter is not installed by the time when the lustre-client
ansible task if performed. facter utility is installed
later during motr-runtime task.

Solution: check for 'ansible_virtualization_type' variable
instead of 'facter_virtual'. 'ansible_virtualization_type'
is internal to ansible and is independent of facter.