### PR TITLE
EOS-16191 Libfabric: Use libfabric source code to build libfabric library for compiling motr code with libfabric transport

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,7 @@ AC_ARG_VAR([CXXXML],  [gccxml/castxml command])
 AH_TEMPLATE([MOTR_IDX_STORE_CASS],    [Use Cassandra as KVS backend.])
 AH_TEMPLATE([IDX_CASS_DRV_V22],       [Cassandra driver version >= 2.2.])
 AH_TEMPLATE([ENABLE_LUSTRE],          [Enable LNet network stack from Lustre.])
-AH_TEMPLATE([ENABLE_LIBFAB],          [Enable Libfabric network stack ])
+AH_TEMPLATE([ENABLE_LIBFAB],          [Enable Libfabric network stack.])
 AH_TEMPLATE([ENABLE_CASTXML],         [Use CastXML instead of GCC-XML])
 AH_TEMPLATE([ENABLE_DIST_MODE],       [Enable distribution mode (only for package building).])
 AH_TEMPLATE([ENABLE_DEV_MODE],        [Enable developer mode.])
@@ -457,7 +457,6 @@ AC_SUBST([BUILD_KERNEL])
 # Skip all checks in distribution mode
 AS_IF([test x$enable_dist_mode = xno],[
 
-
 #
 # Checking Lustre sources ------------------------------------------------- {{{1
 #
@@ -591,7 +590,6 @@ Red Hat based systems])
 #
 # Checking required libraries --------------------------------------------- {{{1
 #
-
 
 # sqrt() requires m library
 MOTR_SEARCH_LIBS([sqrt], [c m], [MATH_LIBS],
@@ -775,6 +773,12 @@ AS_IF([test x$with_lustre != xno],[
 # Checking libfabric library----------------------------------------------- {{{1
 #
 
+AC_ARG_ENABLE([libfab],
+        [AS_HELP_STRING([--enable-libfab],
+                        [Use libfabric transport])],
+        [],[enable_libfab=no]
+)
+
 AC_ARG_WITH([libfab],
         [AS_HELP_STRING([--with-libfab=path],
                         [set path to user installed libfabric headers and library])],
@@ -782,26 +786,27 @@ AC_ARG_WITH([libfab],
         [LIBFABRIC=""]
 )
 
-AC_DEFINE([ENABLE_LIBFAB])
-
-AS_IF([test x$with_libfab != xno && ! test -z "$with_libfab"],
+AS_IF([! test -z "$with_libfab"],
       [
         LIB_FAB_INCLUDES="-I$LIBFABRIC/include"
         LIBFAB_LIBS="-L$LIBFABRIC/lib -lfabric"
         M0_CPPFLAGS="$M0_CPPFLAGS $LIB_FAB_INCLUDES"
-      ],[
+      ],
+)
+AS_IF([test x$enable_libfab = xyes],
+      [
 	MOTR_SEARCH_LIBS([fi_fabric], [fabric], [LIBFAB_LIBS],
-                  [fi_fabric cannot be found! Try to install libfabric-devel package]
+                  [fi_fabric cannot be found! Try to install libfabric  package]
           )
 	AC_CHECK_HEADERS([rdma/fabric.h], [],
-		AC_MSG_ERROR([rdma/fabric.h is not found. Try to install libfabric-devel package])
+		AC_MSG_ERROR([rdma/fabric.h is not found. Try to install libfabric package])
           )
       ]
 )
 
 AC_SUBST([LIBFAB_LIBS])
 AM_CONDITIONAL([ENABLE_LIBFAB],
-               [test x$with_libfab != xno && ! test -z "$LIBFAB_LIBS"])
+               [test "x$enable_libfab" = xyes || ! test -z "$with_libfab"])
 
 #
 # Checking Lustre --------------------------------------------------------- {{{1

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -91,7 +91,6 @@ BuildRequires:  perl-autodie
 BuildRequires:  systemd-devel
 BuildRequires:  python-devel
 BuildRequires:  libedit-devel
-BuildRequires:  libfabric-devel
 %if %{with cassandra}
 BuildRequires:  libcassandra
 BuildRequires:  libuv
@@ -119,7 +118,6 @@ Requires:       facter
 Requires:       rubygem-net-ssh
 Requires:       python36-ply
 Requires:       libedit
-Requires:       libfabric
 Requires(pre):  shadow-utils
 Requires(post): findutils
 

--- a/motr/init.c
+++ b/motr/init.c
@@ -188,8 +188,10 @@ struct init_fini_call subsystem[] = {
 	/* addb2-net must be after rpc, because it initialises a fop type. */
 	{ &m0_addb2_net_module_init, &m0_addb2_net_module_fini, "addb2-net" },
 #ifndef __KERNEL__
-	{ &m0_net_sock_mod_init, &m0_net_sock_mod_fini, "net/sock" },
+#ifdef ENABLE_LIBFAB
 	{ &m0_net_libfab_init,   &m0_net_libfab_fini,   "net/libfab" },
+#endif /* ENABLE_LIBFAB */
+	{ &m0_net_sock_mod_init, &m0_net_sock_mod_fini, "net/sock" },
 #endif
 	{ &m0_mem_xprt_init,    &m0_mem_xprt_fini,    "bulk/mem" },
 	{ &m0_net_lnet_init,    &m0_net_lnet_fini,    "net/lnet" },

--- a/scripts/provisioning/roles/motr-build/tasks/main.yml
+++ b/scripts/provisioning/roles/motr-build/tasks/main.yml
@@ -231,7 +231,7 @@
   block:
     - name: download and install libfabric
       unarchive:
-        src: https://github.com/ofiwg/libfabric/releases/download/v1.11.0/libfabric-1.11.0.tar.bz2
+        src: https://github.com/ofiwg/libfabric/releases/download/v1.11.2/libfabric-1.11.2.tar.bz2
         dest: /usr/src/
         owner: root
         group: root

--- a/scripts/provisioning/roles/motr-build/tasks/main.yml
+++ b/scripts/provisioning/roles/motr-build/tasks/main.yml
@@ -227,12 +227,30 @@
     - lustre-devel
     - lustre
 
-- name: install libfab
+- name: install libfabric
   block:
-    - name: install libfabric
-      yum:
-        name: libfabric-devel
-        state: latest
+    - name: download and install libfabric
+      unarchive:
+        src: https://github.com/ofiwg/libfabric/releases/download/v1.11.0/libfabric-1.11.0.tar.bz2
+        dest: /usr/src/
+        owner: root
+        group: root
+        remote_src: yes
+
+    - name: check Libfabric src dir
+      shell: ls -1rd /usr/src/libfabric-* | head -n 1
+      register: libfabric_src_dir
+      changed_when: false
+
+    - name: build libfabric sources
+      command: '{{ item }}'
+      args:
+        chdir: '{{ libfabric_src_dir.stdout }}'
+        creates: Module.symvers
+      with_items:
+        - ./configure
+        - make -j4
+        - make install
   when: ansible_os_family == 'RedHat'
   tags:
     - libfab


### PR DESCRIPTION
Motr code can be compiled with libfabric using option --enable-libfab to use default version downloaded, compiled and installed using ./scripts/install-build-deps and custom libfabric build  can be used using option --with-libfab=path.
if these options (--enable-libfab, --with-libfab) are not provided then motr code will be compiled without libfabric transport  

Signed-off-by: Jaydeep Mohite <jaydeep.mohite@seagate.com>