### PR TITLE
stripe size alignment based balloc

### DIFF
--- a/balloc/balloc.c
+++ b/balloc/balloc.c
@@ -2418,12 +2418,14 @@ repeat:
 			// m0_balloc_debug_dump_group("searching group ...",
 			//			 grp);
 
-			rc = m0_balloc_trylock_group(grp);
-			if (rc != 0) {
-				M0_LOG(M0_DEBUG, "grp=%d is busy", (int)group);
-				/* This group is under processing by others. */
+
+			/* quick check to skip empty groups */
+			if (is_free_space_unavailable(grp, bac->bac_flags)) {
+				M0_LOG(M0_DEBUG, "grp=%d is empty", (int)group);
 				continue;
 			}
+
+			m0_balloc_lock_group(grp);
 
 			/* quick check to skip empty groups */
 			if (is_free_space_unavailable(grp, bac->bac_flags)) {

--- a/balloc/balloc.h
+++ b/balloc/balloc.h
@@ -134,6 +134,8 @@ struct m0_balloc_zone_param {
 	m0_bcount_t                     bzp_freeblocks;
 	m0_bcount_t                     bzp_fragments;
 	m0_bcount_t                     bzp_maxchunk;
+	struct m0_ext                   bzp_maxchunk_ext;
+	struct m0_ext                   bzp_curchunk_ext;
 	struct m0_list                  bzp_extents;
 };
 
@@ -206,7 +208,8 @@ enum m0_balloc_super_block_state {
 };
 
 enum m0_balloc_super_block_version {
-	M0_BALLOC_SB_VERSION = 1ULL,
+	M0_BALLOC_SB_VERSION     = 1ULL,
+	M0_BALLOC_SB_STRIPE_SIZE = 4 * 1024 * 1024,
 };
 
 enum {


### PR DESCRIPTION
Experiment to do balloc allocation based on stripe size
alignment can give performance improvement.
When allocation done from all groups for write and some of
allocation deleted from groups which will create holes in stripe
(disk/controller level), further writing on such stripe will cost
for reading old disk data and recalculating parity, to avoid
recalculating parity we must choose allocation from empty stripe
by aligning logical address to stripe size boundaries.
