### PR TITLE
process balloc request in FIFO order for a group

### DIFF
--- a/balloc/balloc.h
+++ b/balloc/balloc.h
@@ -161,6 +161,14 @@ struct m0_balloc_group_info {
 	struct m0_lext              *bgi_extents;
 	/** per-group lock */
 	struct m0_be_mutex           bgi_mutex;
+
+	/** balloc allocation context list head */
+	struct m0_list               bgi_bac_head;
+	struct m0_mutex              bgi_bac_mutex;
+
+	/** To sleep and wakeup on bac queue */
+	struct m0_mutex              bgi_chan_mutex;
+	struct m0_chan               bgi_chan;
 };
 
 enum m0_balloc_group_info_state {

--- a/balloc/balloc.h
+++ b/balloc/balloc.h
@@ -134,6 +134,8 @@ struct m0_balloc_zone_param {
 	m0_bcount_t                     bzp_freeblocks;
 	m0_bcount_t                     bzp_fragments;
 	m0_bcount_t                     bzp_maxchunk;
+	struct m0_ext                   bzp_maxchunk_ext;
+	struct m0_ext                   bzp_curchunk_ext;
 	struct m0_list                  bzp_extents;
 };
 
@@ -206,7 +208,8 @@ enum m0_balloc_super_block_state {
 };
 
 enum m0_balloc_super_block_version {
-	M0_BALLOC_SB_VERSION = 1ULL,
+	M0_BALLOC_SB_VERSION     = 1ULL,
+	M0_BALLOC_SB_STRIPE_SIZE = 4 * 1024 * 1024,
 };
 
 enum {


### PR DESCRIPTION
group try lock failed if already acquired by other thread
in this case wait until lock get released by adding request bac
at the end of  group specific bac list.
This changes will make sure request are processed in order of request.
This change made on top of RAID alignment changes.


