### PR TITLE
EOS-16241: Increase parallelization in accessing EMAP btrees

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -2779,7 +2779,7 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
                                   m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].
 							   sad_adata,
 						    &prefix, 0, &it),
-			           bo_u.u_emap.e_rc);
+				  bo_u.u_emap.e_rc);
 		if (rc == 0)
 			m0_be_emap_close(&it);
 		else {
@@ -2790,7 +2790,7 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 		                                      tx, &op,
 						      &prefix,
 						      AET_HOLE),
-                               bo_u.u_emap.e_rc);
+				bo_u.u_emap.e_rc);
 		}
 		m0_mutex_unlock(&beck_builder.b_emaplock[id]);
 	}

--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -2777,9 +2777,9 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 		m0_mutex_lock(&beck_builder.b_emaplock[id]);
 		rc = M0_BE_OP_SYNC_RET_WITH(&it.ec_op,
                                   m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].
-							   sad_adata,
-						    &prefix, 0, &it),
-				  bo_u.u_emap.e_rc);
+							     sad_adata,
+						      &prefix, 0, &it),
+				    bo_u.u_emap.e_rc);
 		if (rc == 0)
 			m0_be_emap_close(&it);
 		else {

--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -1257,8 +1257,8 @@ static struct m0_stob_ad_domain *emap_dom_find(const struct action *act,
 	for (i = 0; i < act->a_builder->b_ad_dom_count; i++) {
 		adom = act->a_builder->b_ad_domain[i];
 		if (m0_fid_eq(emap_fid,
-	            &adom->sad_adata_ht[ht_idx].sad_adata.em_mapping.
-                          bb_backlink.bli_fid)) {
+			      &adom->sad_adata_ht[ht_idx].sad_adata.em_mapping.
+			             bb_backlink.bli_fid)) {
 			break;
 		}
 	}
@@ -1365,7 +1365,7 @@ static int emap_entry_lookup(struct m0_stob_ad_domain  *adom,
 	M0_LOG(M0_DEBUG, U128X_F, U128_P(&prefix));
 	rc = M0_BE_OP_SYNC_RET_WITH( &it->ec_op,
 	                m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata,
-                                         &prefix, offset, it),
+					  &prefix, offset, it),
 				  bo_u.u_emap.e_rc);
 	return rc == -ESRCH ? -ENOENT : rc;
 }
@@ -1406,7 +1406,7 @@ static int emap_prep(struct action *act, struct m0_be_tx_credit *credit)
 			m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata,
 					  M0_BEO_INSERT, 1, credit);
 		m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata,
-                                 M0_BEO_PASTE, BALLOC_FRAGS_MAX + 1, credit);
+				  M0_BEO_PASTE, BALLOC_FRAGS_MAX + 1, credit);
 	}
 	m0_mutex_unlock(&beck_builder.b_emaplock[id]);
 	return 0;
@@ -1458,8 +1458,8 @@ static void emap_act(struct action *act, struct m0_be_tx *tx)
 
 		rc = rc ? M0_BE_OP_SYNC_RET(op,
 			    m0_be_emap_obj_insert(&adom->sad_adata_ht[ht_idx].
-                                                        sad_adata, tx, &op,
-                                                 &emap_key->ek_prefix,
+							 sad_adata, tx, &op,
+						  &emap_key->ek_prefix,
 						  AET_HOLE),
 			    bo_u.u_emap.e_rc) : 0;
 
@@ -2772,21 +2772,21 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 
 		emap_dom_find(&ca->coa_act,
 			      &adom->sad_adata_ht[ht_idx].sad_adata.em_mapping.
-                                    bb_backlink.bli_fid,
-                             &id);
+				     bb_backlink.bli_fid,
+			      &id);
 		m0_mutex_lock(&beck_builder.b_emaplock[id]);
 		rc = M0_BE_OP_SYNC_RET_WITH(&it.ec_op,
                                   m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].
-                                                           sad_adata,
-						     &prefix, 0, &it),
+							   sad_adata,
+						    &prefix, 0, &it),
 			           bo_u.u_emap.e_rc);
 		if (rc == 0)
 			m0_be_emap_close(&it);
 		else {
 			rc = M0_BE_OP_SYNC_RET(op,
 	                        m0_be_emap_obj_insert(&adom->
-                                                           sad_adata_ht[ht_idx].
-                                                           sad_adata,
+							   sad_adata_ht[ht_idx].
+							   sad_adata,
 		                                      tx, &op,
 						      &prefix,
 						      AET_HOLE),

--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -1250,11 +1250,14 @@ static struct m0_stob_ad_domain *emap_dom_find(const struct action *act,
 {
 	struct m0_stob_ad_domain *adom = NULL;
 	int			  i;
+	uint8_t			  ht_idx;
+
+	ht_idx = m0_stob_get_hash(emap_fid);
 
 	for (i = 0; i < act->a_builder->b_ad_dom_count; i++) {
 		adom = act->a_builder->b_ad_domain[i];
 		if (m0_fid_eq(emap_fid,
-	            &adom->sad_adata.em_mapping.bb_backlink.bli_fid)) {
+	            &adom->sad_adata_ht[ht_idx].sad_adata.em_mapping.bb_backlink.bli_fid)) {
 			break;
 		}
 	}
@@ -1352,10 +1355,15 @@ static int emap_entry_lookup(struct m0_stob_ad_domain  *adom,
 			     struct m0_be_emap_cursor  *it)
 {
 	int                       rc;
+	struct m0_fid             fid;
+	uint8_t                   ht_idx;
 
+	fid.f_container = prefix.u_hi;
+	fid.f_key = prefix.u_lo;
+	ht_idx = m0_stob_get_hash(&fid);
 	M0_LOG(M0_DEBUG, U128X_F, U128_P(&prefix));
 	rc = M0_BE_OP_SYNC_RET_WITH( &it->ec_op,
-				  m0_be_emap_lookup(&adom->sad_adata,
+				  m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata,
 						    &prefix, offset, it),
 				  bo_u.u_emap.e_rc);
 	return rc == -ESRCH ? -ENOENT : rc;
@@ -1370,6 +1378,8 @@ static int emap_prep(struct action *act, struct m0_be_tx_credit *credit)
 	int 			  rc;
 	struct m0_be_emap_cursor  it = {};
 	int                       id;
+	struct m0_fid             fid;
+	uint8_t                   ht_idx;
 
 	adom = emap_dom_find(act, &emap_ac->emap_fid, &id);
 	if (adom == NULL || id < 0 || id >= AO_NR - AO_EMAP_FIRST) {
@@ -1384,13 +1394,17 @@ static int emap_prep(struct action *act, struct m0_be_tx_credit *credit)
 		adom->sad_ballroom->ab_ops->bo_alloc_credit(adom->sad_ballroom,
 							    1, credit);
 		emap_key = emap_ac->emap_key.b_addr;
+		fid.f_container = emap_key->ek_prefix.u_hi;
+		fid.f_key = emap_key->ek_prefix.u_lo;
+		ht_idx = m0_stob_get_hash(&fid);
+
 		rc = emap_entry_lookup(adom, emap_key->ek_prefix, 0, &it);
 		if (rc == 0)
 			m0_be_emap_close(&it);
 		else
-			m0_be_emap_credit(&adom->sad_adata,
+			m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata,
 					  M0_BEO_INSERT, 1, credit);
-		m0_be_emap_credit(&adom->sad_adata, M0_BEO_PASTE,
+		m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata, M0_BEO_PASTE,
 				  BALLOC_FRAGS_MAX + 1, credit);
 	}
 	m0_mutex_unlock(&beck_builder.b_emaplock[id]);
@@ -1408,6 +1422,8 @@ static void emap_act(struct action *act, struct m0_be_tx *tx)
 	struct m0_be_emap_cursor  it = {};
 	struct m0_ext             in_ext;
 	int                       id;
+	struct m0_fid             fid;
+	uint8_t			  ht_idx;
 
 	adom = emap_dom_find(act, &emap_ac->emap_fid, &id);
 	emap_val = emap_ac->emap_val.b_addr;
@@ -1435,8 +1451,12 @@ static void emap_act(struct action *act, struct m0_be_tx *tx)
 
 		rc = emap_entry_lookup(adom, emap_key->ek_prefix, 0, &it);
 		/* No emap entry found for current stob, insert hole */
+		fid.f_container = emap_key->ek_prefix.u_hi;
+		fid.f_key = emap_key->ek_prefix.u_lo;
+		ht_idx = m0_stob_get_hash(&fid);
+
 		rc = rc ? M0_BE_OP_SYNC_RET(op,
-				m0_be_emap_obj_insert(&adom->sad_adata,
+				m0_be_emap_obj_insert(&adom->sad_adata_ht[ht_idx].sad_adata,
 						      tx, &op,
 						      &emap_key->ek_prefix,
 						      AET_HOLE),
@@ -2723,6 +2743,8 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 	struct m0_be_emap_cursor  it = {};
 	struct m0_uint128         prefix;
 	int			  id;
+	struct m0_fid 		  fid;
+	uint8_t			  ht_idx;
 
 	m0_mutex_lock(&beck_builder.b_coblock);
 
@@ -2742,12 +2764,17 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 		adom = stob_ad_domain2ad(sdom);
 		prefix = M0_UINT128(stob_id.si_fid.f_container,
 				    stob_id.si_fid.f_key);
+
+		fid.f_container = stob_id.si_fid.f_container;
+		fid.f_key = stob_id.si_fid.f_key;
+		ht_idx = m0_stob_get_hash(&fid);
+
 		emap_dom_find(&ca->coa_act,
-			      &adom->sad_adata.em_mapping.bb_backlink.bli_fid,
+			      &adom->sad_adata_ht[ht_idx].sad_adata.em_mapping.bb_backlink.bli_fid,
 			      &id);
 		m0_mutex_lock(&beck_builder.b_emaplock[id]);
 		rc = M0_BE_OP_SYNC_RET_WITH(&it.ec_op,
-					    m0_be_emap_lookup(&adom->sad_adata,
+					    m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata,
 							      &prefix, 0, &it),
 					    bo_u.u_emap.e_rc);
 		if (rc == 0)
@@ -2755,7 +2782,7 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 		else {
 			rc = M0_BE_OP_SYNC_RET(op,
 					       m0_be_emap_obj_insert(&adom->
-								     sad_adata,
+								     sad_adata_ht[ht_idx].sad_adata,
 								     tx, &op,
 								     &prefix,
 								     AET_HOLE),

--- a/be/tool/main.c
+++ b/be/tool/main.c
@@ -114,22 +114,24 @@ void track_ad_btrees(struct stob_ad_0type_rec *rec, bool print_btree)
 				struct m0_balloc, cb_ballroom);
 
 	if (print_btree) {
-                for (i = 0; i < EMAP_HT_SIZE; i++) {
-		        M0_LOG(M0_ALWAYS, "em_mapping %d",i);
-		        btree_dbg_print(&rec->sa0_ad_domain->sad_adata_ht[i].sad_adata.em_mapping);
-                }
-		        M0_LOG(M0_ALWAYS, "grp_exts");
-		        btree_dbg_print(&m0balloc->cb_db_group_extents);
-                        M0_LOG(M0_ALWAYS, "grp_dsc");
-                        btree_dbg_print(&m0balloc->cb_db_group_desc);
+		for (i = 0; i < EMAP_HT_SIZE; i++) {
+			M0_LOG(M0_ALWAYS, "em_mapping %d",i);
+			btree_dbg_print(&rec->sa0_ad_domain->sad_adata_ht[i].
+                                             sad_adata.em_mapping);
+		}
+		M0_LOG(M0_ALWAYS, "grp_exts");
+		btree_dbg_print(&m0balloc->cb_db_group_extents);
+		M0_LOG(M0_ALWAYS, "grp_dsc");
+		btree_dbg_print(&m0balloc->cb_db_group_desc);
 	} else {
-                for (i = 0; i < EMAP_HT_SIZE; i++) {
-		M0_LOG(M0_ALWAYS,"M0_BE:AD em_mapping = %p"
-				 "cb_db_group_extents btree= %p "
-				 "cb_db_group_desc btree= %p",
-				 &rec->sa0_ad_domain->sad_adata_ht[i].sad_adata.em_mapping,
-				 &m0balloc->cb_db_group_extents,
-				 &m0balloc->cb_db_group_desc);
+		for (i = 0; i < EMAP_HT_SIZE; i++) {
+			M0_LOG(M0_ALWAYS,"M0_BE:AD em_mapping = %p"
+				"cb_db_group_extents btree= %p "
+				"cb_db_group_desc btree= %p",
+				&rec->sa0_ad_domain->sad_adata_ht[i].sad_adata.
+                                     em_mapping,
+				&m0balloc->cb_db_group_extents,
+				&m0balloc->cb_db_group_desc);
                 }
         }
 
@@ -254,7 +256,6 @@ int main(int argc, char *argv[])
 	char                    *path;
 	int                      rc;
 
-	// m0_node_uuid_string_set(NULL);
 	if (argc > 1 && m0_streq(argv[1], "be_recovery_run")) {
 		path = argc > 2 ? argv[2] : NULL;
 		be_recovery_run(path);

--- a/be/tool/main.c
+++ b/be/tool/main.c
@@ -108,24 +108,30 @@ void track_cob_btrees(struct m0_cob_domain *cdom, bool print_btree)
 void track_ad_btrees(struct stob_ad_0type_rec *rec, bool print_btree)
 {
 	struct m0_balloc         *m0balloc;
+        int                       i;
 
 	m0balloc = container_of(rec->sa0_ad_domain->sad_ballroom,
 				struct m0_balloc, cb_ballroom);
 
 	if (print_btree) {
-		M0_LOG(M0_ALWAYS, "em_mapping");
-		btree_dbg_print(&rec->sa0_ad_domain->sad_adata.em_mapping);
-		M0_LOG(M0_ALWAYS, "grp_exts");
-		btree_dbg_print(&m0balloc->cb_db_group_extents);
-		M0_LOG(M0_ALWAYS, "grp_dsc");
-		btree_dbg_print(&m0balloc->cb_db_group_desc);
-	} else
+                for (i = 0; i < EMAP_HT_SIZE; i++) {
+		        M0_LOG(M0_ALWAYS, "em_mapping %d",i);
+		        btree_dbg_print(&rec->sa0_ad_domain->sad_adata_ht[i].sad_adata.em_mapping);
+                }
+		        M0_LOG(M0_ALWAYS, "grp_exts");
+		        btree_dbg_print(&m0balloc->cb_db_group_extents);
+                        M0_LOG(M0_ALWAYS, "grp_dsc");
+                        btree_dbg_print(&m0balloc->cb_db_group_desc);
+	} else {
+                for (i = 0; i < EMAP_HT_SIZE; i++) {
 		M0_LOG(M0_ALWAYS,"M0_BE:AD em_mapping = %p"
 				 "cb_db_group_extents btree= %p "
 				 "cb_db_group_desc btree= %p",
-				 &rec->sa0_ad_domain->sad_adata.em_mapping,
+				 &rec->sa0_ad_domain->sad_adata_ht[i].sad_adata.em_mapping,
 				 &m0balloc->cb_db_group_extents,
 				 &m0balloc->cb_db_group_desc);
+                }
+        }
 
 }
 static void scan_btree(struct m0_be_domain *dom, bool print_btree)
@@ -248,6 +254,7 @@ int main(int argc, char *argv[])
 	char                    *path;
 	int                      rc;
 
+	// m0_node_uuid_string_set(NULL);
 	if (argc > 1 && m0_streq(argv[1], "be_recovery_run")) {
 		path = argc > 2 ? argv[2] : NULL;
 		be_recovery_run(path);

--- a/be/tool/main.c
+++ b/be/tool/main.c
@@ -117,7 +117,7 @@ void track_ad_btrees(struct stob_ad_0type_rec *rec, bool print_btree)
 		for (i = 0; i < EMAP_HT_SIZE; i++) {
 			M0_LOG(M0_ALWAYS, "em_mapping %d",i);
 			btree_dbg_print(&rec->sa0_ad_domain->sad_adata_ht[i].
-                                             sad_adata.em_mapping);
+                                              sad_adata.em_mapping);
 		}
 		M0_LOG(M0_ALWAYS, "grp_exts");
 		btree_dbg_print(&m0balloc->cb_db_group_extents);
@@ -129,7 +129,7 @@ void track_ad_btrees(struct stob_ad_0type_rec *rec, bool print_btree)
 				"cb_db_group_extents btree= %p "
 				"cb_db_group_desc btree= %p",
 				&rec->sa0_ad_domain->sad_adata_ht[i].sad_adata.
-                                     em_mapping,
+                                      em_mapping,
 				&m0balloc->cb_db_group_extents,
 				&m0balloc->cb_db_group_desc);
                 }

--- a/be/tool/main.c
+++ b/be/tool/main.c
@@ -108,7 +108,7 @@ void track_cob_btrees(struct m0_cob_domain *cdom, bool print_btree)
 void track_ad_btrees(struct stob_ad_0type_rec *rec, bool print_btree)
 {
 	struct m0_balloc         *m0balloc;
-        int                       i;
+	int 			  i;
 
 	m0balloc = container_of(rec->sa0_ad_domain->sad_ballroom,
 				struct m0_balloc, cb_ballroom);
@@ -117,7 +117,7 @@ void track_ad_btrees(struct stob_ad_0type_rec *rec, bool print_btree)
 		for (i = 0; i < EMAP_HT_SIZE; i++) {
 			M0_LOG(M0_ALWAYS, "em_mapping %d",i);
 			btree_dbg_print(&rec->sa0_ad_domain->sad_adata_ht[i].
-                                              sad_adata.em_mapping);
+					      sad_adata.em_mapping);
 		}
 		M0_LOG(M0_ALWAYS, "grp_exts");
 		btree_dbg_print(&m0balloc->cb_db_group_extents);
@@ -129,7 +129,7 @@ void track_ad_btrees(struct stob_ad_0type_rec *rec, bool print_btree)
 				"cb_db_group_extents btree= %p "
 				"cb_db_group_desc btree= %p",
 				&rec->sa0_ad_domain->sad_adata_ht[i].sad_adata.
-                                      em_mapping,
+				      em_mapping,
 				&m0balloc->cb_db_group_extents,
 				&m0balloc->cb_db_group_desc);
                 }

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -720,8 +720,8 @@ static int stob_ad_create(struct m0_stob *stob,
 	return M0_BE_OP_SYNC_RET(op,
 			    m0_be_emap_obj_insert(&adom->sad_adata_ht[ht_idx].
 							 sad_adata,
-						   &dtx->tx_betx, &op,
-						   &prefix, AET_HOLE),
+						  &dtx->tx_betx, &op,
+						  &prefix, AET_HOLE),
 			    bo_u.u_emap.e_rc);
 }
 

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -386,7 +386,7 @@ static int stob_ad_domain_init(struct m0_stob_type *type,
 	struct m0_ad_balloc       *ballroom;
 	bool                       balloc_inited;
 	int                        rc = 0;
-	int			   i = 0;
+	int			   i;
 	adom = stob_ad_domain_locate(location_data);
 	if (adom == NULL)
 		return M0_RC(-ENOENT);
@@ -410,9 +410,9 @@ static int stob_ad_domain_init(struct m0_stob_type *type,
 	dom->sd_private = adom;
 	dom->sd_ops     = &stob_ad_domain_ops;
 
-	for (i = 0; i < EMAP_HT_SIZE; i++) {
+	for (i = 0; i < EMAP_HT_SIZE; i++)
 	        m0_be_emap_init(&adom->sad_adata_ht[i].sad_adata, seg);
-	}
+
 	ballroom = adom->sad_ballroom;
 	m0_balloc_init(b2m0(ballroom));
 	rc = ballroom->ab_ops->bo_init(ballroom, seg,
@@ -432,9 +432,9 @@ static int stob_ad_domain_init(struct m0_stob_type *type,
 		if (balloc_inited)
 			ballroom->ab_ops->bo_fini(ballroom);
 
-		for (i = 0; i < EMAP_HT_SIZE; i++) {
+		for (i = 0; i < EMAP_HT_SIZE; i++)
 			m0_be_emap_fini(&adom->sad_adata_ht[i].sad_adata);
-		}
+
 		m0_free(dom);
 	} else {
 		m0_stob_ad_domain_bob_init(adom);
@@ -459,9 +459,9 @@ static void stob_ad_domain_fini(struct m0_stob_domain *dom)
 	int			  i;
 
 	ballroom->ab_ops->bo_fini(ballroom);
-	for (i = 0; i < EMAP_HT_SIZE; i++) {
+	for (i = 0; i < EMAP_HT_SIZE; i++)
 		m0_be_emap_fini(&adom->sad_adata_ht[i].sad_adata);
-	}
+
 	m0_stob_put(adom->sad_bstore);
 	m0_stob_ad_domain_bob_fini(adom);
 	m0_free(dom);
@@ -622,13 +622,15 @@ static int stob_ad_domain_destroy(struct m0_stob_type *type,
 		for (i = 0; i < EMAP_HT_SIZE; i++) {
 			emap = &adom->sad_adata_ht[i].sad_adata;
 			m0_be_emap_init(emap, seg);
-			rc = M0_BE_OP_SYNC_RET(op, m0_be_emap_destroy(emap, &tx, &op),
-						bo_u.u_emap.e_rc);
-			rc = rc ?: m0_be_0type_del(&m0_stob_ad_0type, seg->bs_domain,
-						&tx, location_data);
+			rc = M0_BE_OP_SYNC_RET(op,
+                                              m0_be_emap_destroy(emap, &tx, &op),
+					       bo_u.u_emap.e_rc);
+			rc = rc ?: m0_be_0type_del(&m0_stob_ad_0type,
+                                                  seg->bs_domain,
+	                                           &tx, location_data);
 		}
 		if (rc == 0)
-				M0_BE_FREE_PTR_SYNC(adom, seg, &tx);
+		        M0_BE_FREE_PTR_SYNC(adom, seg, &tx);
 		m0_be_tx_close_sync(&tx);
 	}
 	m0_be_tx_fini(&tx);
@@ -680,7 +682,8 @@ static int stob_ad_init(struct m0_stob *stob,
 	stob->so_ops = &stob_ad_ops;
 	rc = M0_BE_OP_SYNC_RET_WITH(
 		&it.ec_op,
-		m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata, &prefix, 0, &it),
+		m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata, &prefix,
+                                 0, &it),
 		bo_u.u_emap.e_rc);
 	if (rc == 0) {
 		m0_be_emap_close(&it);
@@ -696,7 +699,8 @@ static void stob_ad_create_credit(struct m0_stob_domain *dom,
 				  struct m0_be_tx_credit *accum)
 {
 	struct m0_stob_ad_domain *adom = stob_ad_domain2ad(dom);
-	m0_be_emap_credit(&adom->sad_adata_ht[0].sad_adata, M0_BEO_INSERT, 1, accum);
+	m0_be_emap_credit(&adom->sad_adata_ht[0].sad_adata, M0_BEO_INSERT, 1,
+                         accum);
 }
 
 static int stob_ad_create(struct m0_stob *stob,
@@ -714,10 +718,11 @@ static int stob_ad_create(struct m0_stob *stob,
 	ht_idx = m0_stob_get_hash(stob_fid);
 	M0_LOG(M0_DEBUG, U128X_F, U128_P(&prefix));
 	return M0_BE_OP_SYNC_RET(op,
-				 m0_be_emap_obj_insert(&adom->sad_adata_ht[ht_idx].sad_adata,
-						       &dtx->tx_betx, &op,
-						       &prefix, AET_HOLE),
-				 bo_u.u_emap.e_rc);
+                            m0_be_emap_obj_insert(&adom->sad_adata_ht[ht_idx].
+                                                         sad_adata,
+						   &dtx->tx_betx, &op,
+						   &prefix, AET_HOLE),
+                            bo_u.u_emap.e_rc);
 }
 
 /**
@@ -785,7 +790,8 @@ static int stob_ad_punch_credit(struct m0_stob *stob,
 		M0_LOG(M0_DEBUG, "stob:%p todo:"EXT_F ", existing ext:"EXT_F,
 				stob, EXT_P(&todo), EXT_P(&seg->ee_ext));
 		M0_SET0(&cred);
-		m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata, M0_BEO_PASTE, 1, &cred);
+		m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata,
+                                 M0_BEO_PASTE, 1, &cred);
 		ballroom->ab_ops->bo_free_credit(ballroom, 3, &cred);
 		if (m0_be_should_break(eng, accum, &cred))
 			break;
@@ -897,7 +903,8 @@ static void stob_ad_destroy_credit(struct m0_stob *stob,
 
 	ht_idx = m0_stob_get_hash(fid);
 	adom = stob_ad_domain2ad(m0_stob_dom_get(stob));
-	m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata, M0_BEO_DELETE, 1, accum);
+	m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata, M0_BEO_DELETE,
+                         1, accum);
 }
 
 static int stob_ad_destroy(struct m0_stob *stob, struct m0_dtx *tx)
@@ -912,10 +919,11 @@ static int stob_ad_destroy(struct m0_stob *stob, struct m0_dtx *tx)
 	prefix = M0_UINT128(fid->f_container, fid->f_key);
 	ht_idx = m0_stob_get_hash(fid);
 	rc = M0_BE_OP_SYNC_RET(op,
-			       m0_be_emap_obj_delete(&adom->sad_adata_ht[ht_idx].sad_adata,
-						     &tx->tx_betx, &op,
-						     &prefix),
-			       bo_u.u_emap.e_rc);
+			   m0_be_emap_obj_delete(&adom->sad_adata_ht[ht_idx].
+                                                       sad_adata,
+						 &tx->tx_betx, &op,
+						 &prefix),
+			   bo_u.u_emap.e_rc);
 
 	return M0_RC(rc);
 }
@@ -1105,7 +1113,8 @@ M0_INTERNAL int stob_ad_cursor(struct m0_stob_ad_domain *adom,
 	M0_SET0(&it->ec_op);
 	rc = M0_BE_OP_SYNC_RET_WITH(
 		&it->ec_op,
-		m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata, &prefix, offset, it),
+		m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata,
+                                 &prefix, offset, it),
 		bo_u.u_emap.e_rc);
 	return M0_RC(rc);
 }
@@ -1166,7 +1175,8 @@ static void stob_ad_write_credit(const struct m0_stob_domain *dom,
 	 * emap credit (BETREE_DELETE epecially). Adding one more extra credit
 	 * of 'emap paste' (that is frags + 1) to verify this idea.
 	 */
-	m0_be_emap_credit(&adom->sad_adata_ht[0].sad_adata, M0_BEO_PASTE, frags + 1, accum);
+	m0_be_emap_credit(&adom->sad_adata_ht[0].sad_adata, M0_BEO_PASTE, 
+                         frags + 1, accum);
 
 	if (adom->sad_overwrite && ballroom->ab_ops->bo_free_credit != NULL) {
 		/* for each emap_paste() seg_free() could be called 3 times */

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -411,7 +411,7 @@ static int stob_ad_domain_init(struct m0_stob_type *type,
 	dom->sd_ops     = &stob_ad_domain_ops;
 
 	for (i = 0; i < EMAP_HT_SIZE; i++)
-	        m0_be_emap_init(&adom->sad_adata_ht[i].sad_adata, seg);
+		m0_be_emap_init(&adom->sad_adata_ht[i].sad_adata, seg);
 
 	ballroom = adom->sad_ballroom;
 	m0_balloc_init(b2m0(ballroom));
@@ -623,14 +623,14 @@ static int stob_ad_domain_destroy(struct m0_stob_type *type,
 			emap = &adom->sad_adata_ht[i].sad_adata;
 			m0_be_emap_init(emap, seg);
 			rc = M0_BE_OP_SYNC_RET(op,
-                                              m0_be_emap_destroy(emap, &tx, &op),
+					       m0_be_emap_destroy(emap, &tx, &op),
 					       bo_u.u_emap.e_rc);
 			rc = rc ?: m0_be_0type_del(&m0_stob_ad_0type,
-                                                  seg->bs_domain,
-	                                           &tx, location_data);
+						   seg->bs_domain,
+						   &tx, location_data);
 		}
 		if (rc == 0)
-		        M0_BE_FREE_PTR_SYNC(adom, seg, &tx);
+			M0_BE_FREE_PTR_SYNC(adom, seg, &tx);
 		m0_be_tx_close_sync(&tx);
 	}
 	m0_be_tx_fini(&tx);
@@ -683,7 +683,7 @@ static int stob_ad_init(struct m0_stob *stob,
 	rc = M0_BE_OP_SYNC_RET_WITH(
 		&it.ec_op,
 		m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata, &prefix,
-                                 0, &it),
+				  0, &it),
 		bo_u.u_emap.e_rc);
 	if (rc == 0) {
 		m0_be_emap_close(&it);
@@ -700,7 +700,7 @@ static void stob_ad_create_credit(struct m0_stob_domain *dom,
 {
 	struct m0_stob_ad_domain *adom = stob_ad_domain2ad(dom);
 	m0_be_emap_credit(&adom->sad_adata_ht[0].sad_adata, M0_BEO_INSERT, 1,
-                         accum);
+			  accum);
 }
 
 static int stob_ad_create(struct m0_stob *stob,
@@ -718,11 +718,11 @@ static int stob_ad_create(struct m0_stob *stob,
 	ht_idx = m0_stob_get_hash(stob_fid);
 	M0_LOG(M0_DEBUG, U128X_F, U128_P(&prefix));
 	return M0_BE_OP_SYNC_RET(op,
-                            m0_be_emap_obj_insert(&adom->sad_adata_ht[ht_idx].
-                                                         sad_adata,
+			    m0_be_emap_obj_insert(&adom->sad_adata_ht[ht_idx].
+							 sad_adata,
 						   &dtx->tx_betx, &op,
 						   &prefix, AET_HOLE),
-                            bo_u.u_emap.e_rc);
+			    bo_u.u_emap.e_rc);
 }
 
 /**
@@ -791,7 +791,7 @@ static int stob_ad_punch_credit(struct m0_stob *stob,
 				stob, EXT_P(&todo), EXT_P(&seg->ee_ext));
 		M0_SET0(&cred);
 		m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata,
-                                 M0_BEO_PASTE, 1, &cred);
+				  M0_BEO_PASTE, 1, &cred);
 		ballroom->ab_ops->bo_free_credit(ballroom, 3, &cred);
 		if (m0_be_should_break(eng, accum, &cred))
 			break;
@@ -904,7 +904,7 @@ static void stob_ad_destroy_credit(struct m0_stob *stob,
 	ht_idx = m0_stob_get_hash(fid);
 	adom = stob_ad_domain2ad(m0_stob_dom_get(stob));
 	m0_be_emap_credit(&adom->sad_adata_ht[ht_idx].sad_adata, M0_BEO_DELETE,
-                         1, accum);
+			  1, accum);
 }
 
 static int stob_ad_destroy(struct m0_stob *stob, struct m0_dtx *tx)
@@ -920,7 +920,7 @@ static int stob_ad_destroy(struct m0_stob *stob, struct m0_dtx *tx)
 	ht_idx = m0_stob_get_hash(fid);
 	rc = M0_BE_OP_SYNC_RET(op,
 			   m0_be_emap_obj_delete(&adom->sad_adata_ht[ht_idx].
-                                                       sad_adata,
+							sad_adata,
 						 &tx->tx_betx, &op,
 						 &prefix),
 			   bo_u.u_emap.e_rc);
@@ -1114,7 +1114,7 @@ M0_INTERNAL int stob_ad_cursor(struct m0_stob_ad_domain *adom,
 	rc = M0_BE_OP_SYNC_RET_WITH(
 		&it->ec_op,
 		m0_be_emap_lookup(&adom->sad_adata_ht[ht_idx].sad_adata,
-                                 &prefix, offset, it),
+				  &prefix, offset, it),
 		bo_u.u_emap.e_rc);
 	return M0_RC(rc);
 }
@@ -1176,7 +1176,7 @@ static void stob_ad_write_credit(const struct m0_stob_domain *dom,
 	 * of 'emap paste' (that is frags + 1) to verify this idea.
 	 */
 	m0_be_emap_credit(&adom->sad_adata_ht[0].sad_adata, M0_BEO_PASTE, 
-                         frags + 1, accum);
+			  frags + 1, accum);
 
 	if (adom->sad_overwrite && ballroom->ab_ops->bo_free_credit != NULL) {
 		/* for each emap_paste() seg_free() could be called 3 times */

--- a/stob/ad.h
+++ b/stob/ad.h
@@ -110,7 +110,7 @@ enum { AD_PATHLEN = 4096 };
 
 /** Defines hash table size for struct m0_be_emap. This size should be pow of 2.
  */
-enum { EMAP_HT_SIZE = 256 };
+enum { EMAP_HT_SIZE = 128 };
 
 struct m0_perf_ht {
         struct m0_be_emap       sad_adata;

--- a/stob/ad.h
+++ b/stob/ad.h
@@ -107,6 +107,13 @@ struct m0_ad_balloc_ops {
 };
 
 enum { AD_PATHLEN = 4096 };
+// Defines hash table size for struct m0_be_emap. This size should be pow of 2,
+// and maximum allowed size is 65536.
+#define EMAP_HT_SIZE 256
+
+struct m0_perf_ht {
+	struct m0_be_emap       sad_adata;
+} M0_XCA_RECORD M0_XCA_DOMAIN(be);
 
 struct m0_stob_ad_domain {
 	struct m0_format_header sad_header;
@@ -126,7 +133,7 @@ struct m0_stob_ad_domain {
 	 * m0_be_emap has it's own volatile-only fields, so it can't be placed
 	 * before the m0_format_footer, where only persistent fields allowed
 	 */
-	struct m0_be_emap       sad_adata;
+	struct m0_perf_ht 	sad_adata_ht[EMAP_HT_SIZE];
 	/*
 	 * volatile-only fields
 	 */
@@ -223,6 +230,10 @@ M0_INTERNAL int stob_ad_cursor(struct m0_stob_ad_domain *adom,
 			       struct m0_stob *obj,
 			       uint64_t offset,
 			       struct m0_be_emap_cursor *it);
+
+// Calculates uint16_t hash number for given m0_fid which
+// is in between 0 to EMAP_HT_SIZE
+M0_INTERNAL uint16_t m0_stob_get_hash(const struct m0_fid *fid);
 
 /**
  * Sets the flags associated with the balloc zones (spare/non-spare).

--- a/stob/ad.h
+++ b/stob/ad.h
@@ -107,12 +107,13 @@ struct m0_ad_balloc_ops {
 };
 
 enum { AD_PATHLEN = 4096 };
-// Defines hash table size for struct m0_be_emap. This size should be pow of 2,
-// and maximum allowed size is 65536.
-#define EMAP_HT_SIZE 256
+
+/** Defines hash table size for struct m0_be_emap. This size should be pow of 2.
+ */
+enum { EMAP_HT_SIZE = 256 };
 
 struct m0_perf_ht {
-	struct m0_be_emap       sad_adata;
+        struct m0_be_emap       sad_adata;
 } M0_XCA_RECORD M0_XCA_DOMAIN(be);
 
 struct m0_stob_ad_domain {
@@ -231,8 +232,9 @@ M0_INTERNAL int stob_ad_cursor(struct m0_stob_ad_domain *adom,
 			       uint64_t offset,
 			       struct m0_be_emap_cursor *it);
 
-// Calculates uint16_t hash number for given m0_fid which
-// is in between 0 to EMAP_HT_SIZE
+/** Calculates uint16_t hash number for given m0_fid which is in between 
+ * 0 to EMAP_HT_SIZE
+ */
 M0_INTERNAL uint16_t m0_stob_get_hash(const struct m0_fid *fid);
 
 /**


### PR DESCRIPTION
Changes:
Added an array (currently 256 entries) of m0_be_emap in
struct m0_stob_ad_domain which is used as hash table where each entry will
point to one emap btree.
The #define EMAP_HT_SIZE is used to define the size of hash table which is
power of 2 and limited to 65536.
Used m0_fid_hash() to get the hash on the ek_prefix from struct m0_be_emap_key.
Then did mod operation (currently %256) on the returned hash to use that as array index.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>