### PR TITLE
EOS-16485: support zero-spare configuration in DIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,7 @@ AH_TEMPLATE([ENABLE_DATA_INTEGRITY],  [Enable data integrity.])
 AH_TEMPLATE([ENABLE_FREE_POISON],     [Poison freed memory for debugging.])
 AH_TEMPLATE([ENABLE_DETAILED_BACKTRACE],[Enable detailed backtraces on crash using gdb.])
 AH_TEMPLATE([M0_NDEBUG],              [Disable M0_ASSERT.])
+AH_TEMPLATE([DTM0],                   [Enable DTM0 mode.])
 AH_TEMPLATE([M0_BE_SEGMENT_SIZE],     [BE segment size in MiB.])
 AH_TEMPLATE([M0_TRACE_KBUF_SIZE],     [Kernel space trace buffer size in MiB.])
 AH_TEMPLATE([M0_TRACE_UBUF_SIZE],     [User space trace buffer size in MiB.])
@@ -313,6 +314,14 @@ AC_ARG_ENABLE([m0_asserts],
 )
 AS_IF([test x$enable_m0_asserts = xno],
       AC_DEFINE([M0_NDEBUG]))
+
+# dtm0 {{{3
+AC_ARG_ENABLE([dtm0],
+        AS_HELP_STRING([--enable-dtm0],[enable DTM0 mode]),
+        [], [enable_dtm0=no]
+)
+AS_IF([test x$enable_dtm0 = xyes],
+      AC_DEFINE([DTM0]))
 
 # expensive-checks {{{3
 AC_ARG_ENABLE([expensive_checks],

--- a/dix/ut/client_ut.c
+++ b/dix/ut/client_ut.c
@@ -1465,6 +1465,9 @@ static void dix_create_crow(void)
 
 static void dix_create_dgmode(void)
 {
+#ifdef DTM0
+	return;
+#endif
 	struct m0_dix indices[COUNT_INDEX];
 	uint32_t      indices_nr = ARRAY_SIZE(indices);
 	int           i;
@@ -1562,6 +1565,9 @@ static void dix_delete_crow(void)
 
 static void dix_delete_dgmode(void)
 {
+#ifdef DTM0
+	return;
+#endif
 	struct m0_dix indices[COUNT_INDEX];
 	uint32_t      indices_nr = ARRAY_SIZE(indices);
 	int           i;
@@ -1803,6 +1809,9 @@ static void dix_put_crow(void)
 
 static void dix_put_dgmode(void)
 {
+#ifdef DTM0
+	return;
+#endif
 	struct m0_dix      index;
 	struct m0_bufvec   keys;
 	struct m0_bufvec   vals;
@@ -1995,6 +2004,9 @@ static void dix_dgmode_disks_unprep(enum ut_pg_unit        unit1,
 
 static void dix_get_dgmode(void)
 {
+#ifdef DTM0
+	return;
+#endif
 	struct m0_dix         index;
 	struct m0_bufvec      keys;
 	struct m0_bufvec      vals;
@@ -2217,6 +2229,9 @@ static void dix_next_crow(void)
 
 static void dix_next_dgmode(void)
 {
+#ifdef DTM0
+	return;
+#endif
 	struct m0_dix      index;
 	struct m0_bufvec   keys;
 	struct m0_bufvec   start_key;
@@ -2324,6 +2339,9 @@ static void dix_records_restore(struct m0_dix *index, struct m0_bufvec *keys,
 
 static void dix_del_dgmode(void)
 {
+#ifdef DTM0
+	return;
+#endif
 	struct m0_dix      index;
 	struct m0_bufvec   keys;
 	struct m0_bufvec   vals;


### PR DESCRIPTION
Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>