### PR TITLE
go/mio: fix multi-threads i/o on composite objects

### DIFF
--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -73,6 +73,12 @@ package mio
 //
 //         return rc;
 // }
+//
+// uint64_t m0_obj_layout_id(uint64_t lid)
+// {
+//         return M0_OBJ_LAYOUT_ID(lid);
+// }
+//
 import "C"
 
 import (
@@ -93,7 +99,7 @@ type Mio struct {
     objID   C.struct_m0_uint128
     obj    *C.struct_m0_obj
     objSz   uint64
-    objLid  uint
+    objLid  C.ulong
     objPool C.struct_m0_fid
     off     int64
 }
@@ -224,7 +230,7 @@ func (mio *Mio) open(sz uint64) error {
     mio.objPool = pv.pv_pool.po_id
 
     mio.objSz = sz
-    mio.objLid = uint(mio.obj.ob_attr.oa_layout_id)
+    mio.objLid = C.m0_obj_layout_id(mio.obj.ob_attr.oa_layout_id)
     mio.off = 0
 
     return nil
@@ -371,7 +377,7 @@ func (mio *Mio) getOptimalBlockSz(bufSz int) (bsz, gsz int) {
                   " (%v + 2 * %v == %v), check pool parity configuration",
                   pa.pa_P, pa.pa_N, pa.pa_K, pa.pa_N + 2 * pa.pa_K)
     }
-    usz := int(C.m0_obj_layout_id_to_unit_size(C.ulong(mio.objLid)))
+    usz := int(C.m0_obj_layout_id_to_unit_size(mio.objLid))
     gsz = usz * int(pa.pa_N) /* group size in data units only */
     /* should be max 2-times pool-width deep, otherwise we may get -E2BIG */
     maxBs := int(C.uint(usz) * 2 * pa.pa_P * pa.pa_N / (pa.pa_N + 2 * pa.pa_K))


### PR DESCRIPTION
Currently, m0_obj_op() is not re-entrant for the composite objects (because it checks and allocates `obj->ob_layout`).

Solution: call m0_obj_op() from the main thread only.

The patch allows to run multi-threads i/o on the composite objects:

```
19:47 tkachuk1@datawarp-01:mcp$ ./mcp -prof 0x7000000000000001:0x4e9 -hax 172.18.1.33@o2ib:12345:1:1 -ep 172.18.1.33@o2ib:12345:4:1 -proc 0x7200000000000001:0x376 -v -threads 8 /tmp/1GB 0x1122113:0x11221002
2021/01/20 19:49:24 mio.go:490: W: off=0 len=33554432 bs=4194304 gs=2097152 speed=82 (Mbytes/sec)
2021/01/20 19:49:25 mio.go:490: W: off=33554432 len=33554432 bs=4194304 gs=2097152 speed=88 (Mbytes/sec)
2021/01/20 19:49:25 mio.go:490: W: off=67108864 len=33554432 bs=4194304 gs=2097152 speed=88 (Mbytes/sec)
2021/01/20 19:49:26 mio.go:490: W: off=100663296 len=33554432 bs=4194304 gs=2097152 speed=89 (Mbytes/sec)
2021/01/20 19:49:26 mio.go:490: W: off=134217728 len=33554432 bs=4194304 gs=2097152 speed=86 (Mbytes/sec)
...
```

Without patch it fails:

```
12:52 tkachuk1@datawarp-01:mcp$ ./mcp -prof 0x7000000000000001:0x4e9 -hax 172.18.1.33@o2ib:12345:1:1 -ep 172.18.1.33@o2ib:12345:4:1 -proc 0x7200000000000001:0x376 -v -threads 2 /tmp/1GB 0x1122113:0x11221002
motr[38730]:  9040  FATAL  [lib/assert.c:50:m0_panic]  panic: (valid_subobj_cnt != 0) at composite_io_divide() (motr/composite_layout.c:738)  [git: sage-base-1.0-170-g89f7737] 
Motr panic: (valid_subobj_cnt != 0) at composite_io_divide() motr/composite_layout.c:738 (errno: 22) (last failed: none) [git: sage-base-1.0-170-g89f7737] pid: 38730  
/lib64/libmotr.so.1(m0_arch_backtrace+0x2f)[0x7f947c453c9f]
/lib64/libmotr.so.1(m0_arch_panic+0xf3)[0x7f947c453e83]
/lib64/libmotr.so.1(+0x3353a4)[0x7f947c4443a4]
/lib64/libmotr.so.1(+0x382bf0)[0x7f947c491bf0]
/lib64/libmotr.so.1(m0_obj_op+0x2f9)[0x7f947c481729]
```

Kudos to @siningwuseagate who helped with root-causing it.