### PR TITLE
go/README: update mio -> go/mio

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,21 +1,21 @@
-# Go bindings for Motr - mio
+# Go bindings for Motr - go/mio
 
-`mio` Go package implements Reader/Writer interface over Motr client I/O API.
+`go/mio` Go package implements Reader/Writer interface over Motr client I/O API.
 This allows writing Motr client applications quickly and efficiently in the Go language.
 
-`mio` automatically determines the optimal unit (stripe) size for the newly created object
+`go/mio` automatically determines the optimal unit (stripe) size for the newly created object
 (based on the object size provided by user in the mio.Create(obj, sz) call), as well as
 the optimal block size for Motr I/O based on the cluster configuration. So users don't have
 to bother about tuning these Motr-specific parameters for each specific object to reach
 maximum I/O performance on it and yet don't waste space (in case of a small objects).
 
-`mio` allows to read/write the blocks to Motr in parallel threads (see `-threads` option)
+`go/mio` allows to read/write the blocks to Motr in parallel threads (see `-threads` option)
 provided there is enough buffer size to accomodate several of such blocks in one
 Read()/Write() request. (For example, see the source code of `mcp` utility and its `-bsz`
 option.)
 
 `mcp` (Motr cp) utility is a client application example written in pure Go which uses
-`mio` package and has only 97 lines of code (as of 30 Oct 2020):
+`go/mio` package and has only 97 lines of code (as of 30 Oct 2020):
 
 ```Text
 Usage: mcp [options] src dst


### PR DESCRIPTION
Update update `mio` to `go/mio` to avoid clashes with another mio package for Motr (another client API) developed by Sining Wu (@siningwuseagate) for Maestro project.