### PR TITLE
EOS-16866: [DTM0] Introduce tx_desc.

### DIFF
--- a/dtm0/Kbuild.sub
+++ b/dtm0/Kbuild.sub
@@ -1,4 +1,6 @@
 m0tr_objects += \
                   dtm0/fop_xc.o \
                   dtm0/clk_src.o \
-                  dtm0/clk_src_xc.o
+                  dtm0/clk_src_xc.o \
+                  dtm0/tx_desc.o \
+                  dtm0/tx_desc_xc.o

--- a/dtm0/Makefile.sub
+++ b/dtm0/Makefile.sub
@@ -5,15 +5,20 @@ motr_libmotr_la_SOURCES += \
                         dtm0/service.c \
                         dtm0/service.h \
                         dtm0/clk_src.c \
-                        dtm0/clk_src.h
+                        dtm0/clk_src.h \
+                        dtm0/tx_desc.c \
+                        dtm0/tx_desc.h
+
 
 nodist_motr_libmotr_la_SOURCES += \
                                   dtm0/fop_xc.c \
-                                  dtm0/clk_src_xc.c
+                                  dtm0/clk_src_xc.c \
+                                  dtm0/tx_desc_xc.c
 
 
 XC_FILES += \
             dtm0/fop_xc.h \
-            dtm0/clk_src_xc.h
+            dtm0/clk_src_xc.h \
+            dtm0/tx_desc_xc.h
 
 CONFXC_FILES += dtm0/conf.xc

--- a/dtm0/clk_src.h
+++ b/dtm0/clk_src.h
@@ -93,6 +93,7 @@ enum m0_dtm0_cs_types {
 
 /** A data type that represents a timestamp (see CS.TS).*/
 struct m0_dtm0_ts {
+	/* TODO: Think about adding enum cs_types here */
 	m0_time_t dts_phys;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 

--- a/dtm0/tx_desc.c
+++ b/dtm0/tx_desc.c
@@ -1,0 +1,121 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+
+
+/**
+ * @addtogroup dtm
+ *
+ * @{
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
+#include "dtm0/tx_desc.h"
+#include "lib/assert.h" /* M0_PRE */
+#include "lib/memory.h" /* M0_ALLOC */
+#include "lib/errno.h"  /* ENOMEM */
+#include "lib/trace.h"  /* M0_ERR */
+
+M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td)
+{
+	/* Assumption: a valid tx_desc should have
+	 *   pre-allocated array of participants AND
+	 *   the states should be inside the range [0, nr) AND
+	 *   if all PAs are moved past INIT state then
+	 *     the descriptor should have a valid ID.
+	 */
+
+	return _0C(td->dtd_pg.dtpg_pa != NULL) &&
+		_0C(m0_forall(i, td->dtd_pg.dtpg_nr,
+			      td->dtd_pg.dtpg_pa[i].pa_state >= 0 &&
+			      td->dtd_pg.dtpg_pa[i].pa_state < M0_DTPS_NR)) &&
+		_0C(ergo(m0_forall(i, td->dtd_pg.dtpg_nr,
+			      td->dtd_pg.dtpg_pa[i].pa_state > M0_DTPS_INIT),
+			 m0_dtm0_tid__invariant(&td->dtd_id)));
+}
+
+M0_INTERNAL bool m0_dtm0_tid__invariant(const struct m0_dtm0_tid *tid)
+{
+	return _0C(m0_dtm0_ts__invariant(&tid->dti_ts)) &&
+		   _0C(m0_fid_is_set(&tid->dti_fid)) &&
+		   _0C(m0_fid_is_valid(&tid->dti_fid));
+}
+
+/* Writes a deep copy of "src" into "dst". */
+M0_INTERNAL int m0_dtm0_tx_desc_copy(const struct m0_dtm0_tx_desc *src,
+				     struct m0_dtm0_tx_desc       *dst)
+{
+	int      rc;
+
+	M0_PRE(m0_dtm0_tx_desc__invariant(src));
+
+	rc = m0_dtm0_tx_desc_init(dst, src->dtd_pg.dtpg_nr);
+	if (rc != 0)
+		return rc;
+
+	dst->dtd_id = src->dtd_id;
+	memcpy(dst->dtd_pg.dtpg_pa, src->dtd_pg.dtpg_pa,
+	       sizeof(src->dtd_pg.dtpg_pa[0]) * src->dtd_pg.dtpg_nr);
+
+	M0_POST(m0_dtm0_tx_desc__invariant(dst));
+	return 0;
+}
+
+M0_INTERNAL int m0_dtm0_tx_desc_init(struct m0_dtm0_tx_desc *td,
+				     uint32_t nr_pa)
+{
+	M0_ALLOC_ARR(td->dtd_pg.dtpg_pa, nr_pa);
+	if (td->dtd_pg.dtpg_pa == NULL)
+		return M0_ERR(-ENOMEM);
+	M0_POST(m0_dtm0_tx_desc__invariant(td));
+	return 0;
+}
+
+M0_INTERNAL void m0_dtm0_tx_desc_fini(struct m0_dtm0_tx_desc *td)
+{
+	m0_free(td->dtd_pg.dtpg_pa);
+	M0_SET0(td);
+}
+
+M0_INTERNAL int m0_dtm0_tid_cmp(struct m0_dtm0_clk_src   *cs,
+				const struct m0_dtm0_tid *left,
+				const struct m0_dtm0_tid *right)
+{
+	return m0_dtm0_ts_cmp(cs, &left->dti_ts, &right->dti_ts) ?:
+		m0_fid_cmp(&left->dti_fid, &right->dti_fid);
+}
+
+#undef M0_TRACE_SUBSYSTEM
+
+/** @} end of dtm group */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/tx_desc.h
+++ b/dtm0/tx_desc.h
@@ -1,0 +1,152 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2012-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+
+#pragma once
+
+#ifndef __MOTR_DTM0_TX_DESC_H__
+#define __MOTR_DTM0_TX_DESC_H__
+
+/* Transaction descriptor
+ * ----------------------
+ *
+ *   Transaction descriptor is a on-wire/on-disk used to attach the following
+ * information to RPC messages and log records:
+ *     * unique TX id;
+ *     * list of participants and their states;
+ *
+ * Use-cases
+ * ---------
+ *
+ * 1. Tx descriptor as a part of a log record:
+ * @verbatim
+ *	struct log_record {
+ *		tx_descr td;
+ *		request  req;
+ *		tlink    vlog_linkage;
+ *	};
+ *
+ *	...
+ *	log_record *rec = alloc();
+ *	tx_desc_copy((fop.data as kvs_op).td, rec.td);
+ *	rec->req = fop.data.copy();
+ *	log_add(rec);
+ *	...
+ *
+ * @endverbatim
+ *
+ * 2. Tx descriptor as a part of a data/metadata message:
+ * @verbatim
+ *	struct kvs_op {
+ *		tx_descr td;
+ *		kv_pairs kv;
+ *	};
+ *
+ *	...
+ *	kvs_op op;
+ *	nr_devices = layout.nr_devices();
+ *	tx_desc_init(&op->td, nr_devices);
+ *	...
+ *
+ * @endverbatim
+ *
+ * 3. Tx descriptor as a part of a notice:
+ * @verbatim
+ *	struct persistent_notice_op {
+ *		tx_descr td;
+ *	};
+ *
+ *	...
+ *	log_record = fom.log_record;
+ *	persistent_notice_op item;
+ *	tx_desc_copy(&item->td, log_record->td);
+ *	post_item(persistent);
+ *	....
+ *
+ * @endverbatim
+ */
+
+#include "fid/fid.h" /* m0_fid */
+#include "fid/fid_xc.h"
+#include "dtm0/clk_src.h" /* ts and cs */
+#include "dtm0/clk_src_xc.h"
+#include "xcode/xcode.h" /* XCA */
+
+struct m0_dtm0_tid {
+	struct m0_dtm0_ts dti_ts;
+	struct m0_fid     dti_fid;
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc|be);
+
+enum m0_dtm0_tx_pa_state {
+	M0_DTPS_INIT,
+	M0_DTPS_INPROGRESS,
+	M0_DTPS_EXECUTED,
+	M0_DTPS_PERSISTENT,
+	M0_DTPS_NR,
+} M0_XCA_ENUM M0_XCA_DOMAIN(rpc|be);
+
+struct m0_dtm0_tx_pa {
+	struct m0_fid pa_fid;
+	uint32_t      pa_state M0_XCA_FENUM(m0_dtm0_tx_pa_state);
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc|be);
+
+/** A list of participants (and their states) of a transaction. */
+struct m0_dtm0_tx_pa_group {
+	uint32_t              dtpg_nr;
+	struct m0_dtm0_tx_pa *dtpg_pa;
+} M0_XCA_SEQUENCE M0_XCA_DOMAIN(rpc|be);
+
+struct m0_dtm0_tx_desc {
+	struct m0_dtm0_tid          dtd_id;
+	struct m0_dtm0_tx_pa_group  dtd_pg;
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc|be);
+
+/** Writes a deep copy of "src" into "dst". */
+M0_INTERNAL int m0_dtm0_tx_desc_copy(const struct m0_dtm0_tx_desc *src,
+				     struct m0_dtm0_tx_desc       *dst);
+
+/** Creates a new tx descriptor with the given number of participants. */
+M0_INTERNAL int m0_dtm0_tx_desc_init(struct m0_dtm0_tx_desc *td,
+				     uint32_t                nr_pa);
+
+M0_INTERNAL void m0_dtm0_tx_desc_fini(struct m0_dtm0_tx_desc *td);
+
+M0_INTERNAL int m0_dtm0_tid_cmp(struct m0_dtm0_clk_src   *cs,
+				const struct m0_dtm0_tid *left,
+				const struct m0_dtm0_tid *right);
+
+M0_INTERNAL bool m0_dtm0_tid__invariant(const struct m0_dtm0_tid *tid);
+M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td);
+
+#endif /* __MOTR_DTM0_TX_DESC_H__ */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */


### PR DESCRIPTION
Transaction descriptor is an on-wire/on-disk
structure used to propagate DTM0-related
information accoss the network (rpc) and to preserve
it across reboots (be).
The tx_desc module defines the corresponding
data types and associated functions.