### PR TITLE
EOS-16459: [DTM0] Updated log header to cleanup common structure

### DIFF
--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -23,6 +23,16 @@
 #ifndef __MOTR_BE_DTM0_LOG_H__
 #define __MOTR_BE_DTM0_LOG_H__
 
+#include "be/list.h"		/* m0_be_list */
+#include "dtm0/tx_desc.h"	/* m0_dtm0_tx_desc */
+#include "fid/fid.h"		/* m0_fid */
+#include "lib/buf.h"		/* m0_buf */
+
+/* import */
+struct m0_be_tx;
+struct m0_be_tx_credit;
+struct m0_dtm0_clk_src;
+
 /**
  *  @page dtm0 log implementation
  *
@@ -58,27 +68,26 @@
  *  each individual participant and payload.
  *
  *  When a distributed transaction(dtx) is executed by participant, participant
- *  modify its state in group of state as M0_DTML_STATE_EXECUTED and will
- *  add/modify DTM0 log record, for rest of the participant it will keep the
- *  state as it is in distributed transaction(dtx).
+ *  modify its state in group of state as M0_DTPS_EXECUTED and will add/modify
+ *  DTM0 log record, for rest of the participant it will keep the state as it is
+ *  in distributed transaction(dtx).
  *
  *  When a distributed transaction(dtx) become persistent on participant,
- *  participant will modify its state in group of state as
- *  M0_DTML_STATE_PERSISTENT and will modify DTM0 log record, for rest of the
- *  participant it will keep the state as it is in DTM0 log record.
+ *  participant will modify its state in group of state as M0_DTPS_PERSISTENT
+ *  and will modify DTM0 log record, for rest of the participant it will keep
+ *  the state as it is in DTM0 log record.
  *
  *  Originator also maintains the same distributed transaction(dtx) record in
  *  volatile memory. Originator is expecting to get replies from participant
- *  when distributed transaction(dtx) on participant is M0_DTML_STATE_EXECUTED
- *  or M0_DTML_STATE_PERSISTENT. On originator the state of the distributed
- *  transaction(dtx) can be M0_DTML_STATE_INPROGRESS to M0_DTML_STATE_PERSISTENT
- *  for each participant.
+ *  when distributed transaction(dtx) on participant is M0_DTPS_EXECUTED or
+ *  M0_DTPS_PERSISTENT. On originator the state of the distributed transaction
+ *  (dtx) can be M0_DTPS_INPROGRESS to M0_DTPS_PERSISTENT for each participant.
  *
  *  During recovery operation of any of the participant, rest of the participant
  *  and originator will iterate over the logged journal and extract the state
  *  of each transation for participant under recovery from logged information
  *  and will send redo request for those distributed transaction(dtx) which  are
- *  not M0_DTML_STATE_PERSISTENT on participant being recovered.
+ *  not M0_DTPS_PERSISTENT on participant being recovered.
  *
  *  Upon receiving redo request participant under recovery will log the state
  *  of same distributed transaction(dtx) of remote participant in persistent
@@ -91,49 +100,57 @@
  *
  * 2. When distributed transaction(dtx) successfully executed on participant,
  *    DTM0 log record will be added by participant to persistent store and where
- *    participant state in group of state will be M0_DTML_STATE_EXECUTED and for
+ *    participant state in group of state will be M0_DTPS_EXECUTED and for
  *    rest of the participant state will be logged as it is.
- * {
- *    struct m0_be_tx_credit     cred;
- *    struct m0_be_dtm0_log     *log;
- *    struct m0_be_tx           *tx;
- *    struct m0_dtm0_txr        *txr;
- *    struct m0_be_seg          *seg;
  *
- *    m0_be_dtm0_log_credit(M0_DTML_EXECUTED, tx, seg, &cred);
- *    m0_be_tx_open(tx, cred);
+ * @verbatime
+ *    {
+ *       struct m0_be_tx_credit  cred;
+ *       struct m0_be_dtm0_log  *log;
+ *       struct m0_be_tx        *tx;
+ *       struct m0_dtm0_clk_src *cs;
+ *       struct m0_dtm0_tx_desc *txd;
+ *       struct m0_buf          *pyld;
+ *       struct m0_be_seg       *seg;
  *
- *    ...
- *    m0_be_dtm0_log_update(log, tx, txr);
- *    tx_close(tx);
- * }
+ *       m0_be_dtm0_log_credit(M0_DTML_EXECUTED, tx, seg, &cred);
+ *       m0_be_tx_open(tx, cred);
+ *
+ *       ...
+ *       m0_be_dtm0_log_update(log, tx, cs, txd, pyld);
+ *       tx_close(tx);
+ *    }
+ * @endverbatim
  *
  * 3. When distributed transaction(dtx) become persistent on particular
  *    participant, the state of the distributed transaction(dtx) for this
- *    participant will be updated as M0_DTML_STATE_PERSISTENT.
+ *    participant will be updated as M0_DTPS_PERSISTENT.
  *
- * {
- *    struct m0_be_tx_credit     cred;
- *    struct m0_be_dtm0_log     *log;
- *    struct m0_be_tx           *tx;
- *    struct m0_dtm0_txr        *txr;
- *    struct m0_be_seg          *seg;
+ * @verbatime
+ *    {
+ *       struct m0_be_tx_credit  cred;
+ *       struct m0_be_dtm0_log  *log;
+ *       struct m0_be_tx        *tx;
+ *       struct m0_dtm0_clk_src *cs;
+ *       struct m0_dtm0_tx_desc *txd;
+ *       struct m0_buf          *pyld;
+ *       struct m0_be_seg       *seg;
  *
- *    m0_be_dtm0_log_credit(M0_DTML_PERSISTENT, tx, seg, &cred);
- *    m0_be_tx_open(tx, cred);
+ *       m0_be_dtm0_log_credit(M0_DTPS_PERSISTENT, tx, seg, &cred);
+ *       m0_be_tx_open(tx, cred);
  *
- *    ...
- *    m0_be_dtm0_log_update(log, tx, txr);
- *    tx_close(tx);
- * }
+ *       ...
+ *       m0_be_dtm0_log_update(log, tx, cs, txd, pyld);
+ *       tx_close(tx);
+ *    }
+ * @endverbatim
  *
  * 4. When distributed transaction(dtx) become persistent on remote participant,
  *    the participant sends the persistent notice to rest of the participants
  *    and originator stating that distributed transaction(dtx) is persistent on
  *    its store. Upon receiving persistent notice each of the participants and
  *    originator will update the state of distributed transaction(dtx) for
- *    remote participant as M0_DTML_STATE_PERSISTENT
- *    in DTM0 log record.
+ *    remote participant as M0_DTPS_PERSISTENT in DTM0 log record.
  *
  *    There is one special case where a process got a persistent notice from
  *    another process but the corresponding request and reply were not
@@ -142,31 +159,28 @@
  *    should be ready to encounter such a log entry, and treat it differently
  *    whenever it is required.
  *
- * {
- *    struct m0_be_tx_credit     cred;
- *    struct m0_be_dtm0_log     *log;
- *    struct m0_be_tx           *tx;
- *    struct m0_dtm0_txr        *txr;
- *    struct m0_be_seg          *seg;
+ * @verbatim
+ *    {
+ *       struct m0_be_tx_credit  cred;
+ *       struct m0_be_dtm0_log  *log;
+ *       struct m0_be_tx        *tx;
+ *       struct m0_dtm0_clk_src *cs;
+ *       struct m0_dtm0_tx_desc *txd;
+ *       struct m0_buf          *pyld;
+ *       struct m0_be_seg       *seg;
  *
- *    m0_be_dtm0_log_credit(M0_DTML_PERSISTENT, tx, seg, &cred);
- *    m0_be_tx_prep(tx, &cred);
- *    m0_be_tx_open(tx);
+ *       m0_be_dtm0_log_credit(M0_DTML_PERSISTENT, tx, seg, &cred);
+ *       m0_be_tx_prep(tx, &cred);
+ *       m0_be_tx_open(tx);
  *
- *    ...
- *    m0_be_dtm0_log_update(log, tx, txr);
- *    tx_close(tx);
- * }
+ *       ...
+ *       m0_be_dtm0_log_update(log, tx, cs, txd, pyld);
+ *       tx_close(tx);
+ *    }
+ * @endverbatim
  *
  *
  */
-
-/* Participant state */
-enum m0_dtm0_log_pa_state {
-	M0_DTML_STATE_INPROGRESS,
-	M0_DTML_STATE_EXECUTED,
-	M0_DTML_STATE_PERSISTENT,
-};
 
 enum m0_be_dtm0_log_credit_op {
 	M0_DTML_CREATE,
@@ -176,39 +190,23 @@ enum m0_be_dtm0_log_credit_op {
 	M0_DTML_REDO
 };
 
-/* Unique identifier for request */
-struct m0_dtm0_dtx_id {
-	struct m0_fid di_fid;
-	uint64_t      di_ts;
-};
-
-struct m0_dtm0_log_pa {
-	struct m0_fid             pfid;
-	enum m0_dtm0_log_pa_state pstate;
-};
-
-/* TODO: define in a separate header. */
-struct m0_dtm0_txr {
-	struct m0_dtm0_dtx_id  dt_tid;
-	struct m0_dtm0_log_pa *dt_participants;
-	uint16_t               dt_participants_nr;
-	struct m0_buf          dt_txr_payload;
-};
-
 struct m0_dtm0_log_record {
-	struct m0_dtm0_txr     dlr_txr;
+	struct m0_dtm0_tx_desc dlr_txd;
 	struct m0_be_list_link dlr_link; /* link into m0_be_dtm0_log::list */
 	struct m0_list_link    dlr_tlink;
+	struct m0_buf          dlr_pyld;
 };
 
 struct m0_be_dtm0_log {
-	struct m0_mutex    dl_lock;  /* volatile structure */
-	struct m0_be_list *dl_list;  /* persistent structure */
-	struct m0_list    *dl_vlist; /* Volatile list */
+	struct m0_mutex         dl_lock;  /* volatile structure */
+	struct m0_dtm0_clk_src *dl_cs,
+	struct m0_be_list      *dl_list;  /* persistent structure */
+	struct m0_list         *dl_vlist; /* Volatile list */
 };
 
 // init/fini (for volatile fields)
-M0_INTERNAL void m0_be_dtm0_log_init(struct m0_be_dtm0_log *log);
+M0_INTERNAL void m0_be_dtm0_log_init(struct m0_be_dtm0_log *log,
+                                     struct m0_dtm0_clk_src *cs);
 M0_INTERNAL void m0_be_dtm0_log_fini(struct m0_be_dtm0_log *log);
 
 // credit interface
@@ -217,7 +215,7 @@ M0_INTERNAL void m0_be_dtm0_log_credit(enum m0_be_dtm0_log_credit_op op,
                                        struct m0_be_seg             *seg,
                                        struct m0_be_tx_credit       *accum);
 // create/destroy
-M0_INTERNAL void m0_be_dtm0_log_create(struct m0_be_tx i      *tx,
+M0_INTERNAL void m0_be_dtm0_log_create(struct m0_be_tx        *tx,
                                        struct m0_be_seg       *seg,
                                        struct m0_be_dtm0_log **out);
 
@@ -225,18 +223,12 @@ M0_INTERNAL void m0_be_dtm0_log_destroy(struct m0_be_dtm0_log **log,
                                         struct m0_be_tx        *tx);
 
 // operational interfaces
-M0_INTERNAL void m0_be_dtm0_log_update(struct m0_be_dtm0_log *log,
-                                       struct m0_be_tx       *tx,
-                                       struct m0_dtm0_txr    *txr);
+M0_INTERNAL void m0_be_dtm0_log_update(struct m0_be_dtm0_log  *log,
+                                       struct m0_be_tx        *tx,
+                                       struct m0_dtm0_tx_desc *txd,
+                                       struct m0_buf          *pyld);
 
-M0_INTERNAL int m0_be_dtm0_log_find(struct m0_be_dtm0_log       *log,
-                                    const struct m0_dtm0_dtx_id *id,
-                                    struct m0_dtm0_log_record   *out);
-/*
- *       0  -- if left == right
- *      -1  -- if left <  right
- *       1  -- if left >  right
- */
-M0_INTERNAL int m0_dtm0_dtx_id_cmp(struct m0_dtm0_dtx_id *left,
-                                   struct m0_dtm0_dtx_id *right);
+M0_INTERNAL int m0_be_dtm0_log_find(struct m0_be_dtm0_log        *log,
+                                    const struct m0_dtm0_tid     *id,
+                                    struct m0_dtm0_log_record   **out);
 #endif /* __MOTR_BE_DTM0_LOG_H__ */


### PR DESCRIPTION
With https://github.com/Seagate/cortx-motr/pull/365, common tx descriptor structure has been moved to tx_desc.h and hence removed from dtm0_log.h file and cleanup whatever was required.