### PR TITLE
provisioning/README: add single-node example

### DIFF
--- a/scripts/provisioning/build-prep-1node.sh
+++ b/scripts/provisioning/build-prep-1node.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Clone, build and prepare to start a single-node cluster.
+
+set -eu -o pipefail
+
+[[ -d cortx-motr ]] ||
+    git clone --recurse https://github.com/Seagate/cortx-motr.git &&
+        ln -s cortx-motr motr
+cd motr
+echo 'Building and installing Motr...'
+./autogen.sh && ./configure --disable-expensive-checks && make -j4 &&
+    ./scripts/install-motr-service
+cd -
+
+[[ -d cortx-hare ]] ||
+    git clone --recurse https://github.com/Seagate/cortx-hare.git &&
+        ln -s cortx-hare hare
+cd hare
+echo 'Building and installing Hare...'
+make && make devinstall
+cd -
+
+echo 'Creating block devices...'
+mkdir -p /var/motr
+for i in {0..9}; do
+    dd if=/dev/zero of=/var/motr/disk$i.img bs=1M seek=9999 count=1
+    losetup /dev/loop$i /var/motr/disk$i.img
+done
+
+echo 'Preparing CDF (Cluster Description File)...'
+[[ -f singlenode.yaml ]] || cp hare/cfgen/examples/singlenode.yaml ./
+sed 's/localhost/cmu/' -i singlenode.yaml
+sed 's/data_iface: eth./data_iface: eth0/' -i singlenode.yaml
+
+echo
+echo 'Now you are ready to start the singlenode Motr cluster!'
+echo 'To start run: hctl bootstrap --mkfs singlenode.yaml'
+echo 'To check:     hctl status'
+echo 'To shutdown:  hctl shutdown'


### PR DESCRIPTION
Add an example about starting a single-node Motr cluster.

-----
[View rendered scripts/provisioning/README.md](https://github.com/Seagate/cortx-motr/blob/andriytk-patch-1/scripts/provisioning/README.md)