### PR TITLE
provisioner: multinode motr provisioner support added

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -193,6 +193,8 @@ Troubleshooting
         
 Tested by:
 
+- Jan 27, 2021: Patrick Hession (patrick.hession@seagate.com) in CentOS 7.8.2003 on a Windows laptop running VMWare Workstation Pro 16
+
 - Jan 20, 2021: Mayur Gupta (mayur.gupta@seagate.com) on a Windows laptop running VMware Workstation Pro 16.
 
 - Dec 1, 2020: Huang Hua (hua.huang@seagate.com) in CentOS 7.7.1908

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -58,13 +58,13 @@ def execute_command(self, cmd, timeout_secs = TIMEOUT_SECS, verbose = False):
         raise MotrError(ps.returncode, f"\"{cmd}\" command execution failed")
     return stdout, ps.returncode
 
-def check_type(var, type, msg):
-    if not isinstance(var, type):
-        raise MotrError(errno.EINVAL, f"Invalid {msg} type. Expected: {type}")
+def check_type(var, vtype, msg):
+    if not isinstance(var, vtype):
+        raise MotrError(errno.EINVAL, f"Invalid {msg} type. Expected: {vtype}")
 
 
 def get_current_node(self):
-    """get current node name using machine-id"""
+    """get current node name using machine-id."""
     cmd = "cat /etc/machine-id"
     machine_id = execute_command(self, cmd)
     machine_id = machine_id[0].split('\n')[0]
@@ -136,7 +136,7 @@ def motr_config(self):
         execute_command(self, MOTR_CONFIG_SCRIPT, verbose = True)
 
 def configure_net(self):
-    """Wrapper function to detect lnet/libfabric transport"""
+    """Wrapper function to detect lnet/libfabric transport."""
     try:
         transport_type = Conf.get(self._index,
             f'cluster>{self._server_id}')['network']['data']['transport_type']
@@ -277,7 +277,6 @@ def create_lvm(self, index, metadata_dev):
     try:
         cmd = f"vgs {vg_name}"
         op = execute_command(self, cmd)
-        ret = op[1]
     except MotrError:
         pass
     else:
@@ -303,7 +302,7 @@ def create_lvm(self, index, metadata_dev):
     cmd = f"vgchange --addtag {node_name} {vg_name}"
     execute_command(self, cmd)
 
-    sys.stdout.write(f"Scanning volume group\n")
+    sys.stdout.write("Scanning volume group\n")
     cmd = "vgscan --cache"
     execute_command(self, cmd)
 
@@ -319,7 +318,7 @@ def create_lvm(self, index, metadata_dev):
 
 
 def config_lvm(self):
-    "create volume group and lvm for swap and metadata"
+    """create volume group and lvm for swap and metadata."""
     try:
         metadata_devices = Conf.get(self._index,
                 f'cluster>{self._server_id}')['storage']['metadata_devices']
@@ -333,7 +332,7 @@ def config_lvm(self):
 
 
 def get_lnet_xface() -> str:
-    """get lnet interface"""
+    """get lnet interface."""
     lnet_xface = None
     try:
         with open(LNET_CONF_FILE, 'r') as f:
@@ -356,7 +355,7 @@ def get_lnet_xface() -> str:
     return lnet_xface
 
 def check_pkgs(self, pkgs):
-    """check rpm packages"""
+    """check rpm packages."""
     for pkg in pkgs:
         ret = 1
         cmd = f"rpm -q {pkg}"
@@ -373,7 +372,7 @@ def check_pkgs(self, pkgs):
             raise MotrError(errno.ENOENT, f"Missing rpm: {pkg}")
 
 def get_nids(self, nodes):
-    """get lnet nids of all available nodes in cluster"""
+    """get lnet nids of all available nodes in cluster."""
     nids = []
 
     for node in nodes.values():
@@ -385,7 +384,7 @@ def get_nids(self, nodes):
         check_type(hostname, str, "hostname")
 
         if self._server_id == node:
-            cmd = f"lctl list_nids"
+            cmd = "lctl list_nids"
         else:
             cmd = (f"ssh  -o \"StrictHostKeyChecking=no\" {hostname}"
                     " lctl list_nids")
@@ -395,7 +394,7 @@ def get_nids(self, nodes):
     return nids
 
 def lnet_ping(self):
-    """lctl ping on all available nodes in cluster"""
+    """lctl ping on all available nodes in cluster."""
     try:
         nodes = Conf.get(self._index, 'cluster>server_nodes')
     except:
@@ -405,8 +404,8 @@ def lnet_ping(self):
 
     nids = get_nids(self, nodes)
 
-    sys.stdout.write(f"lnet pinging on all nodes in cluster\n")
-    sys.stdout.write(f"motr_setup init MUST be performed on all nodes before "
+    sys.stdout.write("lnet pinging on all nodes in cluster\n")
+    sys.stdout.write("motr_setup init MUST be performed on all nodes before "
                       "executing this\n")
     for nid in nids:
        cmd = f"lctl ping {nid}"

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -260,6 +260,7 @@ def create_lvm(self, index, metadata_dev):
         6. create swap from lvm
     '''
 
+    metadata_dev = f"{metadata_dev}2"
     index = index + 1
     node_name = self._server_id
     vg_name = f"vg_{node_name}_md{index}"

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -328,7 +328,8 @@ def config_lvm(self):
                 f'cluster>{self._server_id}')['storage']['metadata_devices']
     except:
         raise MotrError(errno.EINVAL, "metadata_devices not found\n")
-
+    check_type(metadata_devices, list, "metadata_devices")
+    
     sys.stdout.write(f"\nlvm metadata_devices: {metadata_devices}\n\n")
 
     for device in metadata_devices:

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -96,7 +96,7 @@ def restart_services(self, services):
 
 def validate_file(file):
     if not os.path.exists(file):
-        raise MotrError(errno.ENOENT, "{} not exist".format(file))
+        raise MotrError(errno.ENOENT, f"{file} not exist")
 
 def is_hw_node(self):
     try:

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -64,7 +64,7 @@ def check_type(var, vtype, msg):
 
 
 def get_current_node(self):
-    """get current node name using machine-id."""
+    """Get current node name using machine-id."""
     cmd = "cat /etc/machine-id"
     machine_id = execute_command(self, cmd)
     machine_id = machine_id[0].split('\n')[0]
@@ -162,6 +162,10 @@ def configure_lnet(self):
         iface = iface[0]
     except:
         raise MotrError(errno.EINVAL, "private_interfaces[0] not found\n")
+
+    sys.stdout.write(f"Validate private_interfaces[0]: {iface}\n")
+    cmd = f"ip addr show {iface}"
+    execute_command(self, cmd)
 
     try:
         iface_type = Conf.get(self._index,
@@ -276,7 +280,7 @@ def create_lvm(self, index, metadata_dev):
 
     try:
         cmd = f"vgs {vg_name}"
-        op = execute_command(self, cmd)
+        execute_command(self, cmd)
     except MotrError:
         pass
     else:
@@ -285,10 +289,10 @@ def create_lvm(self, index, metadata_dev):
         del_swap_fstab_by_vg_name(self, vg_name)
 
         cmd = f"vgchange -an {vg_name}"
-        op = execute_command(self, cmd)
+        execute_command(self, cmd)
 
         cmd = f"vgremove {vg_name} -ff"
-        op = execute_command(self, cmd)
+        execute_command(self, cmd)
 
     sys.stdout.write(f"Creating physical volume from {metadata_dev}\n")
     cmd = f"pvcreate {metadata_dev} --yes"
@@ -318,7 +322,7 @@ def create_lvm(self, index, metadata_dev):
 
 
 def config_lvm(self):
-    """create volume group and lvm for swap and metadata."""
+    """Create volume group and lvm for swap and metadata."""
     try:
         metadata_devices = Conf.get(self._index,
                 f'cluster>{self._server_id}')['storage']['metadata_devices']
@@ -332,7 +336,7 @@ def config_lvm(self):
 
 
 def get_lnet_xface() -> str:
-    """get lnet interface."""
+    """Get lnet interface."""
     lnet_xface = None
     try:
         with open(LNET_CONF_FILE, 'r') as f:
@@ -355,7 +359,7 @@ def get_lnet_xface() -> str:
     return lnet_xface
 
 def check_pkgs(self, pkgs):
-    """check rpm packages."""
+    """Check rpm packages."""
     for pkg in pkgs:
         ret = 1
         cmd = f"rpm -q {pkg}"
@@ -372,7 +376,7 @@ def check_pkgs(self, pkgs):
             raise MotrError(errno.ENOENT, f"Missing rpm: {pkg}")
 
 def get_nids(self, nodes):
-    """get lnet nids of all available nodes in cluster."""
+    """Get lnet nids of all available nodes in cluster."""
     nids = []
 
     for node in nodes.values():
@@ -394,7 +398,7 @@ def get_nids(self, nodes):
     return nids
 
 def lnet_ping(self):
-    """lctl ping on all available nodes in cluster."""
+    """Lnet lctl ping on all available nodes in cluster."""
     try:
         nodes = Conf.get(self._index, 'cluster>server_nodes')
     except:

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -93,6 +93,7 @@ class PostInstallCmd(Cmd):
     def process(self):
         sys.stdout.write(f"Processing {self.name} {self.url} {self._args}\n")
         validate_motr_rpm(self)
+        sys.stdout.write("SUCCESS\n")
 
 class ConfigCmd(Cmd):
     """Config Setup Cmd"""
@@ -104,6 +105,7 @@ class ConfigCmd(Cmd):
     def process(self):
         sys.stdout.write(f"Processing {self.name} {self.url} {self._args}\n")
         motr_config(self)
+        sys.stdout.write("SUCCESS\n")
 
 class InitCmd(Cmd):
     """Init Setup Cmd"""
@@ -116,6 +118,7 @@ class InitCmd(Cmd):
         sys.stdout.write(f"Processing {self.name} {self.url} {self._args}\n")
         config_lvm(self)
         configure_net(self)
+        sys.stdout.write("SUCCESS\n")
 
 class TestCmd(Cmd):
     """Test Setup Cmd"""
@@ -127,6 +130,7 @@ class TestCmd(Cmd):
     def process(self):
         sys.stdout.write(f"Processing {self.name} {self.url} {self._args}\n")
         test_lnet(self)
+        sys.stdout.write("SUCCESS\n")
 
 class ResetCmd(Cmd):
     """Reset Setup Cmd"""

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -190,7 +190,7 @@ def main(argv: dict):
 
     except Exception as e:
         sys.stderr.write(f"\n{str(e)}\n\n")
-        sys.stderr.write( f"{traceback.format_exc()}\n")
+        sys.stderr.write(f"{traceback.format_exc()}\n")
         Cmd.usage(argv[0])
         return errno.EINVAL
 

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -35,7 +35,9 @@ class Cmd:
         self._url = args.config
         Conf.load(self._index, self._url)
         self._args = args.args
+        self._debug = args.debug
         self._server_id = get_current_node(self)
+        sys.stdout.write(f"Node name: {self._server_id}\n")
 
     @property
     def args(self) -> str:
@@ -50,11 +52,11 @@ class Cmd:
         """Print usage instructions"""
 
         sys.stderr.write(
-            f"usage: {prog} [-h] <cmd> <url> <args>\n"
+            f"usage: {prog} [-h] <cmd> --config <url> <args>\n"
             f"where:\n"
-            f"cmd   post_install, config, init, test, reset, cleanup, upgarde,"
-            f" backup, restore\n"
-            f"--config url  Config URL\n")
+            f"cmd           post_install, config, init, test, reset, cleanup,"
+            f" upgarde, backup, restore\n"
+            f"url           Config URL\n")
 
     @staticmethod
     def get_command(desc: str, argv: dict):
@@ -73,9 +75,11 @@ class Cmd:
     def add_args(parser: str, cls: str, name: str):
         """Add Command args for parsing."""
 
-        parser1 = parser.add_parser(cls.name, help='setup %s' % name)
+        parser1 = parser.add_parser(cls.name, help=f'setup {name}')
         parser1.add_argument('--config', type=str, help="Config URL")
         parser1.add_argument('args', nargs='*', default=[], help='args')
+        parser1.add_argument('--debug', '-d', help='enable debug print',
+                         action="store_true")
         parser1.set_defaults(command=cls)
 
 
@@ -181,8 +185,8 @@ def main(argv: dict):
         command.process()
 
     except Exception as e:
-        sys.stderr.write("error: %s\n\n" % str(e))
-        sys.stderr.write("%s\n" % traceback.format_exc())
+        sys.stderr.write(f"\n{str(e)}\n\n")
+        sys.stderr.write( f"{traceback.format_exc()}\n")
         Cmd.usage(argv[0])
         return errno.EINVAL
 

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -463,12 +463,13 @@ else
     if [ $# == 0 ]; then
         PCMD=$(ps -o args= $PPID)
         dbg "PCMD [$PCMD]"
-        if [[ "$PCMD" == *"m0provision config" ]]; then
-            do_m0provision_action
-        else
-            err "The m0provision may only call this script without any args."
-            err "PCMD [$PCMD]"
-        fi
+        do_m0provision_action
+        #if [[ "$PCMD" == *"m0provision config" ]]; then
+        #    do_m0provision_action
+        #else
+        #    err "The m0provision may only call this script without any args."
+        #    err "PCMD [$PCMD]"
+        #fi
     fi
 fi
 

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_cfg.sh
@@ -247,27 +247,27 @@ do_m0provision_action()
         fi
     fi 
    
-    SALT_OPT=$(salt-call --local grains.get virtual)
-    platform=$(get_platform)
-    echo "Server type is $platform"
-
-    ANY_ERR=$(echo $SALT_OPT | grep -i ERROR | wc -l)
-    if [ "$ANY_ERR" != "0" ]; then
-        msg "Salt command failed or not available."
-        msg "[$SALT_OPT]"
-        #die $ERR_CFG_SALT_FAILED
-    fi
-
-    CLUSTER_TYPE=$(echo $SALT_OPT | grep physical | wc -l)
-    echo $CLUSTER_TYPE
-    if [[ "$CLUSTER_TYPE" != "1" ]] && [[ $platform != "physical" ]]; then
-        msg "CLUSTER_TYPE is [$CLUSTER_TYPE]. Config operation is not allowed."
-        msg "Only physical clusters will be configured here. "
-        msg "[$SALT_OPT]"
-        die $ERR_NOT_IMPLEMENTED
-    fi
-
-    dbg "[$SALT_OPT]"
+    #SALT_OPT=$(salt-call --local grains.get virtual)
+    #platform=$(get_platform)
+    #echo "Server type is $platform"
+    #
+    #ANY_ERR=$(echo $SALT_OPT | grep -i ERROR | wc -l)
+    #if [ "$ANY_ERR" != "0" ]; then
+    #    msg "Salt command failed or not available."
+    #    msg "[$SALT_OPT]"
+    #    #die $ERR_CFG_SALT_FAILED
+    #fi
+    #
+    #CLUSTER_TYPE=$(echo $SALT_OPT | grep physical | wc -l)
+    #echo $CLUSTER_TYPE
+    #if [[ "$CLUSTER_TYPE" != "1" ]] && [[ $platform != "physical" ]]; then
+    #    msg "CLUSTER_TYPE is [$CLUSTER_TYPE]. Config operation is not allowed."
+    #    msg "Only physical clusters will be configured here. "
+    #    msg "[$SALT_OPT]"
+    #    die $ERR_NOT_IMPLEMENTED
+    #fi
+    #
+    #dbg "[$SALT_OPT]"
 
     while IFS= read -r CFG_LINE
     do


### PR DESCRIPTION
- EOS-16363
- lnet sanity test added for multinode cluster
- lvm creation improved, so not fail if volume group exist
- general error handling of motr_setup commands
- motr_cfg.sh fixed to run without m0provision and salt
- always return 0 on success
- failure will retun with error code and traceback

Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>
