### PR TITLE
EOS-16937: ADDB stob doesn't contain IO path records

### DIFF
--- a/addb2/global.c
+++ b/addb2/global.c
@@ -78,7 +78,7 @@ M0_INTERNAL int m0_addb2_global_init(void)
 
 	result = m0_addb2_sys_init((struct m0_addb2_sys **)&SYS(),
 				   &(struct m0_addb2_config) {
-					       .co_queue_max = 1024 * 1024,
+					       .co_queue_max = 4 * 1024 * 1024,
 					       .co_pool_min  = 1024,
 					       .co_pool_max  = 1024 * 1024
 				   });

--- a/fop/fom.c
+++ b/fop/fom.c
@@ -1199,7 +1199,8 @@ M0_INTERNAL int m0_fom_domain_init(struct m0_fom_domain **out)
 
 	result = m0_addb2_sys_init(&dom->fd_addb2_sys,
 				   &(struct m0_addb2_config) {
-					   .co_queue_max = 1024 * 1024,
+					   .co_queue_max = (cpu_nr + 1 ) / 2 *
+						   1024 * 1024,
 					   .co_pool_min  = cpu_nr,
 					   .co_pool_max  = cpu_nr
 				   });


### PR DESCRIPTION
Problem: It's been found that ADDB stob doesn't contain
IO path records on a node with 96 CPU cores. ADDB2 queue overflow
message was observed during debugging.

Solution: Global ADDB2 system's queue size has been increased.
FOM ADDB2 system's queue size has been scaled up to the number
of CPU cores.