### PR TITLE
[DTM0] Add dtm0 service connections

### DIFF
--- a/dix/req.c
+++ b/dix/req.c
@@ -1368,7 +1368,9 @@ static void dix__rop(struct m0_dix_req *req, const struct m0_bufvec *keys,
 	M0_PRE(keys_nr != 0);
 #else
 	/* We support only one record per request in DTM0. */
-	M0_PRE(keys_nr == 1);
+	M0_PRE(ergo(M0_IN(req->dr_type, (DIX_CREATE, DIX_DELETE,
+					 DIX_PUT, DIX_DEL)),
+		    keys_nr == 1));
 #endif
 	M0_ALLOC_PTR(rop);
 	if (rop == NULL) {

--- a/dtm0/Makefile.sub
+++ b/dtm0/Makefile.sub
@@ -7,8 +7,9 @@ motr_libmotr_la_SOURCES += \
                         dtm0/clk_src.c \
                         dtm0/clk_src.h \
                         dtm0/tx_desc.c \
-                        dtm0/tx_desc.h
-
+                        dtm0/tx_desc.h \
+                        dtm0/helper.c \
+                        dtm0/helper.h
 
 nodist_motr_libmotr_la_SOURCES += \
                                   dtm0/fop_xc.c \

--- a/dtm0/conf.cg
+++ b/dtm0/conf.cg
@@ -40,9 +40,9 @@
 (process-5 cores=[3] mem_limit_as=0 mem_limit_rss=0 mem_limit_stack=0
     mem_limit_memlock=0 endpoint="0@lo:12345:34:1"
     services=[service-9, service-10, service-20, service-21, service-22,
-              service-23, service-24, service-25, service-26, service-28])
+              service-23, service-24, service-25, service-28])
 (process-6 cores=[3] mem_limit_as=0 mem_limit_rss=0 mem_limit_stack=0
-    mem_limit_memlock=0 endpoint="0@lo:12345:34:1" services=[])
+    mem_limit_memlock=0 endpoint="0@lo:12345:34:2" services=[service-26])
 (service-9 type=@M0_CST_IOS endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[sdev-15, sdev-71, sdev-72, sdev-73, sdev-74])
 (service-10 type=@M0_CST_MDS endpoints=["0@lo:12345:34:1"] params=[]
@@ -55,8 +55,7 @@
     sdevs=[])
 (service-25 type=@M0_CST_SNS_REB endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[])
-(service-26 type=@M0_CST_DS1 endpoints=["0@lo:12345:34:1"] params=[]
-    sdevs=[sdev-96, sdev-97])
+(service-26 type=@M0_CST_DTM0 endpoints=["0@lo:12345:34:2"] params=[] sdevs=[])
 (service-28 type=@M0_CST_DTM0 endpoints=["0@lo:12345:34:1"] params=[] sdevs=[])
 (sdev-13 dev_idx=3 iface=4 media=1 bsize=4096 size=1073741824 last_state=3
     flags=4 filename="/dev/sdev0")
@@ -72,10 +71,6 @@
     flags=4 filename="/dev/sdev5")
 (sdev-74 dev_idx=4 iface=7 media=2 bsize=8192 size=1073741824 last_state=2
     flags=4 filename="/dev/sdev6")
-(sdev-96 dev_idx=1 iface=4 media=1 bsize=4096 size=0 last_state=3 flags=4
-    filename="/var/motr/m0ut/ut-sandbox/d1")
-(sdev-97 dev_idx=2 iface=4 media=1 bsize=4096 size=0 last_state=3 flags=4
-    filename="/var/motr/m0ut/ut-sandbox/d2")
 
 (node-48 memsize=16000 nr_cpu=2 last_state=3 flags=2 processes=[process-49])
 (process-49 cores=[3] mem_limit_as=0 mem_limit_rss=0 mem_limit_stack=0

--- a/dtm0/helper.c
+++ b/dtm0/helper.c
@@ -1,0 +1,64 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2011-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM0
+#include "lib/trace.h"
+#include "lib/assert.h"
+#include "reqh/reqh_service.h"
+#include "reqh/reqh.h"               /* m0_reqh */
+
+M0_INTERNAL struct m0_reqh_service *
+m0_dtm__client_service_start(struct m0_reqh *reqh, struct m0_fid *cli_srv_fid)
+{
+       struct m0_reqh_service_type *svct;
+       struct m0_reqh_service      *reqh_svc;
+       int rc;
+
+       svct = m0_reqh_service_type_find("M0_CST_DTM0");
+       M0_ASSERT(svct != NULL);
+
+       rc = m0_reqh_service_allocate(&reqh_svc, svct, NULL);
+       M0_ASSERT(rc == 0);
+
+       m0_reqh_service_init(reqh_svc, reqh, cli_srv_fid);
+
+       rc = m0_reqh_service_start(reqh_svc);
+       M0_ASSERT(rc == 0);
+
+       return reqh_svc;
+}
+
+M0_INTERNAL void m0_dtm__client_service_stop(struct m0_reqh_service *svc)
+{
+       m0_reqh_service_prepare_to_stop(svc);
+       m0_reqh_idle_wait_for(svc->rs_reqh, svc);
+       m0_reqh_service_stop(svc);
+       m0_reqh_service_fini(svc);
+}
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */

--- a/dtm0/helper.h
+++ b/dtm0/helper.h
@@ -22,25 +22,26 @@
 
 #pragma once
 
-#ifndef __MOTR_DTM0_SERVICE_H__
-#define __MOTR_DTM0_SERVICE_H__
+#ifndef __MOTR_DTM0_HELPER_H__
+#define __MOTR_DTM0_HELPER_H__
 
-#include "reqh/reqh_service.h"
+struct m0_reqh_service;
+struct m0_reqh;
+struct m0_fid;
 
-extern struct m0_reqh_service_type dtm0_service_type;
+M0_INTERNAL struct m0_reqh_service *
+m0_dtm__client_service_start(struct m0_reqh *reqh, struct m0_fid *cli_srv_fid);
+M0_INTERNAL void m0_dtm__client_service_stop(struct m0_reqh_service *svc);
 
-int m0_dtm0_stype_init(void);
-void m0_dtm0_stype_fini(void);
+/* __MOTR_DTM0_HELPER_H__ */
+#endif
 
-
-M0_INTERNAL int m0_dtm0_service_process_connect(struct m0_reqh_service *s,
-						struct m0_fid *remote_srv,
-						const char    *remote_ep);
-M0_INTERNAL int m0_dtm0_service_process_disconnect(struct m0_reqh_service *s,
-						   struct m0_fid *remote_srv);
-M0_INTERNAL struct m0_rpc_session *
-m0_dtm0_service_process_session_get(struct m0_reqh_service *s,
-				    struct m0_fid *remote_srv);
-
-
-#endif /* __MOTR_DTM0_SERVICE_H__ */
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */

--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -19,12 +19,17 @@
  *
  */
 
-
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM0
+#include "lib/trace.h"
+#include "lib/string.h"
 #include "lib/errno.h"
 #include "lib/memory.h"
-
 #include "reqh/reqh_service.h"
+#include "reqh/reqh.h"               /* m0_reqh */
+#include "rpc/rpc_machine.h"         /* m0_rpc_machine */
 #include "dtm0/fop.h"
+#include "lib/tlist.h"
+
 
 static int dtm0_service_start(struct m0_reqh_service *service);
 static void dtm0_service_stop(struct m0_reqh_service *service);
@@ -49,11 +54,132 @@ struct m0_reqh_service_type dtm0_service_type = {
 	.rst_level = M0_RS_LEVEL_LATE,
 };
 
-static int _dtm0_alloc(struct m0_reqh_service **service,
-		     const struct m0_reqh_service_type *stype,
-		     const struct m0_reqh_service_ops *ops)
+
+/**
+ * System process which dtm0 subscribes for state updates
+ */
+struct dtm0_process {
+	struct m0_tlink     dop_link;
+	uint64_t            dop_magic;
+
+	/**
+	 * Listens for an event on process conf object's HA channel.
+	 * Updates dtm0_process status in the clink callback on HA notification.
+	 */
+	struct m0_clink     dop_ha_link;
+	/**
+	 * Link connected to remote process
+	 */
+	struct m0_rpc_link  dop_rlink;
+	/**
+	 * Remote process fid
+	 */
+	struct m0_fid       dop_rfid;
+	/**
+	 * Remote process endpoint
+	 */
+	const char         *dop_rep;
+};
+
+M0_TL_DESCR_DEFINE(dopr, "dtm0_process", static, struct dtm0_process, dop_link,
+		   dop_magic, 0x8888888888888888, 0x7777777777777777);
+M0_TL_DEFINE(dopr, static, struct dtm0_process);
+
+/**
+ * DTM0 service structure
+ */
+struct m0_dtm0_service {
+       struct m0_reqh_service dos_generic;
+       struct m0_tl           dos_processes;
+};
+
+static void dtm0_service__init(struct m0_dtm0_service *s)
 {
-	struct m0_reqh_service *s;
+       dopr_tlist_init(&s->dos_processes);
+}
+
+static void dtm0_service__fini(struct m0_dtm0_service *s)
+{
+       dopr_tlist_fini(&s->dos_processes);
+}
+
+M0_INTERNAL int m0_dtm0_service_process_connect(struct m0_reqh_service *s,
+						struct m0_fid *remote_srv,
+						const char    *remote_ep)
+{
+	struct m0_dtm0_service *service =
+		container_of(s, struct m0_dtm0_service, dos_generic);
+	struct dtm0_process *process;
+	struct m0_rpc_machine *mach =
+		m0_reqh_rpc_mach_tlist_head(&s->rs_reqh->rh_rpc_machines);
+	int rc;
+
+
+	M0_ALLOC_PTR(process);
+	M0_ASSERT(process != NULL);
+
+	rc = m0_rpc_link_init(&process->dop_rlink, mach, remote_srv,
+			      remote_ep, 10);
+	M0_ASSERT(rc == 0);
+	rc = m0_rpc_link_connect_sync(&process->dop_rlink, M0_TIME_NEVER);
+	M0_ASSERT(rc == 0);
+
+	process->dop_rfid = *remote_srv;
+	process->dop_rep  = m0_strdup(remote_ep);
+
+	dopr_tlink_init(process);
+	dopr_tlist_add(&service->dos_processes, process);
+
+	return M0_RC(0);
+}
+
+M0_INTERNAL int m0_dtm0_service_process_disconnect(struct m0_reqh_service *s,
+						   struct m0_fid *remote_srv)
+{
+	int rc;
+	struct m0_dtm0_service *service =
+		container_of(s, struct m0_dtm0_service, dos_generic);
+	struct dtm0_process *process = NULL;
+
+	m0_tl_for(dopr, &service->dos_processes, process) {
+		if (m0_fid_eq(&process->dop_rfid, remote_srv))
+			break;
+	} m0_tl_endfor;
+
+	if (process == NULL)
+		return -ENOENT;
+
+	rc = m0_rpc_link_disconnect_sync(&process->dop_rlink, M0_TIME_NEVER);
+	M0_ASSERT(rc == 0);
+	m0_rpc_link_fini(&process->dop_rlink);
+
+	dopr_tlist_remove(process);
+	dopr_tlink_fini(process);
+
+	return M0_RC(0);
+}
+
+M0_INTERNAL struct m0_rpc_session *
+m0_dtm0_service_process_session_get(struct m0_reqh_service *s,
+				    struct m0_fid *remote_srv)
+{
+	struct m0_dtm0_service *service =
+		container_of(s, struct m0_dtm0_service, dos_generic);
+	struct dtm0_process *process = NULL;
+
+	m0_tl_for(dopr, &service->dos_processes, process) {
+		if (m0_fid_eq(&process->dop_rfid, remote_srv))
+			break;
+	} m0_tl_endfor;
+
+	return process == NULL ? NULL : &process->dop_rlink.rlk_sess;
+}
+
+static int dtm0_service__alloc(struct m0_reqh_service **service,
+			       const struct m0_reqh_service_type *stype,
+			       const struct m0_reqh_service_ops *ops)
+{
+	struct m0_dtm0_service *s;
 
 	M0_PRE(stype != NULL && service != NULL && ops != NULL);
 
@@ -61,17 +187,18 @@ static int _dtm0_alloc(struct m0_reqh_service **service,
 	if (s == NULL)
 		return -ENOMEM;
 
-	s->rs_type = stype;
-	s->rs_ops = ops;
-	*service = s;
+	s->dos_generic.rs_type = stype;
+	s->dos_generic.rs_ops  = ops;
+	*service = &s->dos_generic;
+	dtm0_service__init(s);
 
 	return 0;
 }
 
 static int dtm0_service_allocate(struct m0_reqh_service **service,
-				const struct m0_reqh_service_type *stype)
+				 const struct m0_reqh_service_type *stype)
 {
-	return _dtm0_alloc(service, stype, &dtm0_service_ops);
+	return dtm0_service__alloc(service, stype, &dtm0_service_ops);
 }
 
 static int dtm0_service_start(struct m0_reqh_service *service)
@@ -90,6 +217,9 @@ static void dtm0_service_stop(struct m0_reqh_service *service)
 static void dtm0_service_fini(struct m0_reqh_service *service)
 {
 	M0_PRE(service != NULL);
+	dtm0_service__fini(container_of(service,
+					struct m0_dtm0_service,
+					dos_generic));
         m0_free(service);
 }
 

--- a/fop/fom_generic.c
+++ b/fop/fom_generic.c
@@ -96,9 +96,12 @@ int32_t m0_rpc_item_generic_reply_rc(const struct m0_rpc_item *reply)
 }
 M0_EXPORTED(m0_rpc_item_generic_reply_rc);
 
+#include "reqh/reqh_service.h"
 static bool fom_is_update(const struct m0_fom *fom)
 {
-	return m0_rpc_item_is_update(m0_fop_to_rpc_item(fom->fo_fop));
+	/* XXX: make dtm0 service happy on client side */
+	return fom->fo_service->rs_service_fid.f_key != 0x1a &&
+		m0_rpc_item_is_update(m0_fop_to_rpc_item(fom->fo_fop));
 }
 
 /**

--- a/lib/trace.h
+++ b/lib/trace.h
@@ -261,7 +261,8 @@ M0_INTERNAL int m0_trace_set_level(const char *level);
   M0_TRACE_SUBSYS(STOB,      42) \
   M0_TRACE_SUBSYS(XCODE,     43) \
   M0_TRACE_SUBSYS(FDMI,      44) \
-  M0_TRACE_SUBSYS(ISCS,      45)
+  M0_TRACE_SUBSYS(ISCS,      45) \
+  M0_TRACE_SUBSYS(DTM0,      46)
 
 #define M0_TRACE_SUBSYS(name, value) M0_TRACE_SUBSYS_ ## name = (1UL << value),
 /** The subsystem bitmask definitions */

--- a/motr/ut/dix_conf.cg
+++ b/motr/ut/dix_conf.cg
@@ -9,10 +9,10 @@
 (process-5 cores=[3] mem_limit_as=0 mem_limit_rss=0 mem_limit_stack=0
     mem_limit_memlock=0 endpoint="0@lo:12345:34:1"
     services=[service-9, service-10, service-20, service-21,
-              service-22, service-23, service-24, service-25, service-26,
-              service-11])
+              service-22, service-23, service-24, service-25, service-126,
+              service-11, service-28])
 (process-6 cores=[3] mem_limit_as=0 mem_limit_rss=0 mem_limit_stack=0
-    mem_limit_memlock=0 endpoint="0@lo:12345:34:1" services=[])
+    mem_limit_memlock=0 endpoint="0@lo:12345:34:1" services=[service-26])
 (service-9 type=@M0_CST_IOS endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[sdev-15, sdev-71, sdev-72, sdev-73, sdev-74])
 (service-10 type=@M0_CST_MDS endpoints=["0@lo:12345:34:1"] params=[]
@@ -25,7 +25,12 @@
     sdevs=[])
 (service-25 type=@M0_CST_SNS_REB endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[])
-(service-26 type=@M0_CST_DIX_REP endpoints=["0@lo:12345:34:1"] params=[]
+
+(service-26 type=@M0_CST_DTM0 endpoints=["0@lo:12345:34:1"] params=[] sdevs=[])
+(service-28 type=@M0_CST_DTM0 endpoints=["0@lo:12345:34:1"] params=[] sdevs=[])
+
+
+(service-126 type=@M0_CST_DIX_REP endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[sdev-96, sdev-97])
 (service-11 type=@M0_CST_CAS endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[sdev-100, sdev-101, sdev-102])
@@ -82,10 +87,10 @@
 (node-48 memsize=16000 nr_cpu=2 last_state=3 flags=2 processes=[process-49])
 (process-49 cores=[3] mem_limit_as=0 mem_limit_rss=0 mem_limit_stack=0
     mem_limit_memlock=0 endpoint="0@lo:12345:34:1"
-    services=[service-27, service-28])
+    services=[service-27, service-128])
 (service-27 type=@M0_CST_IOS endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[sdev-51, sdev-83, sdev-84, sdev-85, sdev-86])
-(service-28 type=@M0_CST_DIX_REP endpoints=["0@lo:12345:34:1"] params=[]
+(service-128 type=@M0_CST_DIX_REP endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[])
 (sdev-51 dev_idx=6 iface=4 media=1 bsize=4096 size=1073741824 last_state=3
     flags=4 filename="/dev/sdev0")

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -782,15 +782,68 @@ struct m0_client* st_get_instance()
 	return ut_m0c;
 }
 
+#include "dtm0/helper.h"
+#include "dtm0/service.h"
+
+#define M0_FID(c_, k_)  { .f_container = c_, .f_key = k_ }
+static void st_one_dtm0_op_idx_create(void)
+{
+	struct m0_container realm;
+	struct m0_idx       idx;
+	struct m0_fid       ifid;
+	struct m0_op       *op = NULL;
+	int                 rc;
+
+	general_ifid_fill(&ifid, true);
+	m0_container_init(&realm, NULL, &M0_UBER_REALM, ut_m0c);
+	m0_idx_init(&idx, &realm.co_realm, (struct m0_uint128 *)&ifid);
+
+	/* Create index. */
+	rc = m0_entity_create(NULL, &idx.in_entity, &op);
+	M0_UT_ASSERT(rc == 0);
+	m0_op_launch(&op, 1);
+	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
+	M0_UT_ASSERT(rc == 0);
+	m0_op_fini(op);
+	m0_free0(&op);
+
+	m0_idx_fini(&idx);
+}
+
+static void st_one_dtm0_op(void)
+{
+	static struct m0_fid     cli_srv_fid  = M0_FID(0x7300000000000001, 0x1a);
+	static struct m0_fid     srv_dtm0_fid = M0_FID(0x7300000000000001, 0x1c);
+	static const char       *cl_ep_addr   = "0@lo:12345:34:1";
+	struct m0_reqh_service  *cli_srv;
+	struct m0_reqh_service  *srv_srv;
+	struct m0_reqh          *srv_reqh = &dix_ut_sctx.rsx_motr_ctx.cc_reqh_ctx.rc_reqh;
+	int rc;
+
+	cli_srv = m0_dtm__client_service_start(&ut_m0c->m0c_reqh, &cli_srv_fid);
+	M0_UT_ASSERT(cli_srv != NULL);
+	srv_srv = m0_reqh_service_lookup(srv_reqh, &srv_dtm0_fid);
+	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr);
+	M0_UT_ASSERT(rc == 0);
+
+	/* XXX: put logic here */
+	st_one_dtm0_op_idx_create();
+
+	rc = m0_dtm0_service_process_disconnect(srv_srv, &cli_srv_fid);
+	M0_UT_ASSERT(rc == 0);
+	m0_dtm__client_service_stop(cli_srv);
+}
+
 struct m0_ut_suite ut_suite_mt_idx_dix = {
 	.ts_name   = "idx-dix-mt",
 	.ts_owners = "Anatoliy",
 	.ts_init   = ut_suite_mt_idx_dix_init,
 	.ts_fini   = ut_suite_mt_idx_dix_fini,
 	.ts_tests  = {
-		{ "fom", st_mt,    "Anatoliy" },
-		{ "lsf", st_lsfid, "Anatoliy" },
-		{ "lsfc", st_lsfid_cancel, "Vikram" },
+		{ "fom",  st_mt,           "Anatoliy" },
+		{ "lsf",  st_lsfid,        "Anatoliy" },
+		{ "lsfc", st_lsfid_cancel, "Vikram"   },
+		{ "dtm0", st_one_dtm0_op,  "Anatoliy" },
 		{ NULL, NULL }
 	}
 };


### PR DESCRIPTION
[DTM0]: Add dtm0 connections.
The patch updates the ping-pong test
(it turns it into "ping-pong-pong-poing" test).
Also, it introduces a test template for m0client
operations and connects dtm0 services together.

