### PR TITLE
EOS-17070 ISA-L: Integrate ISAL encode APIs and check performance.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,7 +185,7 @@ motr_libmotr_la_CPPFLAGS  = -DM0_TARGET='libmotr' $(AM_CPPFLAGS)
 motr_libmotr_la_LDFLAGS   = -version-info @LT_VERSION@ -pthread $(AM_LDFLAGS)
 motr_libmotr_la_LIBADD    = @MATH_LIBS@ @PTHREAD_LIBS@ @AIO_LIBS@ @RT_LIBS@ \
                             @YAML_LIBS@ @PROFILER_LIBS@ @UUID_LIBS@ @GALOIS_LIBS@ \
-                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@
+                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@ @ISAL_LIBS@
 
 # install directory for public libmotr headers
 motr_includedir             = $(includedir)/motr
@@ -941,7 +941,7 @@ motr_cron_SCRIPTS = \
     scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
     scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
 EXTRA_DIST += $(motr_cron_SCRIPTS)
-    
+
 motr_confdir = $(motrdir)/conf
 motr_conf_DATA = scripts/install$(motr_confdir)/motr.conf \
                  scripts/install$(motr_confdir)/setup.yaml

--- a/configure.ac
+++ b/configure.ac
@@ -629,6 +629,11 @@ MOTR_SEARCH_LIBS([uuid_generate], [uuid c], [UUID_LIBS],
 	[uuid_generate cannot be found! Try to install libuuid and libuuid-devel.])
 AC_SUBST([UUID_LIBS])
 
+# check for isa library
+MOTR_SEARCH_LIBS([ec_encode_data], [c isal], [ISAL_LIBS],
+        [ec_encode_data cannot be found! Try to install Intel ISA library package.]
+)
+AC_SUBST([ISAL_LIBS])
 
 #
 # Checking for required header files
@@ -639,6 +644,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h malloc.h memory.h netdb.h \
                   sys/socket.h sys/time.h unistd.h])
 
 AC_CHECK_HEADERS([pthread.h], [], [AC_MSG_ERROR([pthread.h cannot be found!])])
+AC_CHECK_HEADERS([isa-l.h],   [], [AC_MSG_ERROR([isa-l.h cannot be found!])])
 
 
 AC_HEADER_STDBOOL
@@ -1026,6 +1032,7 @@ echo "PROFILER_LIBS  :  \"$PROFILER_LIBS\""
 echo "GALOIS_LIBS    :  \"$GALOIS_LIBS\""
 echo "YAML_LIBS      :  \"$YAML_LIBS\""
 echo "UUID_LIBS      :  \"$UUID_LIBS\""
+echo "ISAL_LIBS      :  \"$ISAL_LIBS\""
 echo ""
 echo "Gcc            :  \"$BUILD_GCC\""
 AS_IF([test x$with_lustre != xno],[

--- a/lib/ub.c
+++ b/lib/ub.c
@@ -164,7 +164,7 @@ static void results_print(uint32_t round)
 				kib = bytes / 1024;
 				bw_kibps = bw(bytes, bench->ub_total_etime) /1024;
 				kbs_per_op = bench->ub_block_size * bench->ub_blocks_per_op;
-				iops = (bw_kibps / kbs_per_op) * 1024;
+				iops = (bw_kibps *1024) / kbs_per_op;
 			}
 
 			printf("\t%12.12s: [%7i] %6.2f %6.2f %6.2f %5.2f%%"

--- a/scripts/m0
+++ b/scripts/m0
@@ -132,6 +132,11 @@ cmd_run_kut() {
     $SUDO "$M0_SRC_DIR/ut/m0kut" "$@"
 }
 
+cmd_run_ub() {
+    rundir_init
+    $SUDO "$M0_SRC_DIR/utils/m0run" m0ub -- "$@"
+}
+
 cmd_run_st() {
     local pattern
     local f
@@ -213,6 +218,9 @@ Commands:
 
     run-kut              Run kernel unit tests.
 
+    run-ub [OPTION]...   Run user-space unit benchmarking.
+                         OPTIONs are passed to 'ut/m0ub'.
+
     run-st [-l] [PATTERN]...
                          Run system tests or list ('-l') their names.
                          Optional arguments specify which tests to run:
@@ -256,7 +264,7 @@ OPTS=
 while [ $# -gt 0 ]; do
     case $1 in
         make|clean|rebuild|run-ut|run-kut|run-st|run-all|dist-check| \
-            check-everything|configure|help)
+            run-ub|check-everything|configure|help)
             [ -z "$CMD" ] || _exec $CMD $OPTS
             CMD=cmd_${1//-/_}
             OPTS=;;

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -311,18 +311,14 @@ M0_INTERNAL int m0_parity_math_init(struct m0_parity_math *math,
 
 	M0_SET0(math);
 
-	math->pmi_data_count	      = data_count;
-	math->pmi_parity_count	      = parity_count;
+	math->pmi_data_count	= data_count;
+	math->pmi_parity_count	= parity_count;
 
-        if (parity_count == 1) {
+	if (parity_count == 1) {
 		math->pmi_parity_algo = M0_PARITY_CAL_ALGO_XOR;
 		return 0;
 	} else {
 		math->pmi_parity_algo = M0_PARITY_CAL_ALGO_REED_SOLOMON;
-		/*
-                 * init galois, only first call makes initialisation,
-		 * no de-initialisation needed.
-		 */
 
 		ret = vandmat_init(&math->pmi_vandmat, data_count,
 				   parity_count);

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -412,13 +412,13 @@ M0_INTERNAL int m0_parity_math_init(struct m0_parity_math *math,
 			goto handle_error;
 		}
 
-		M0_ALLOC_ARR(math->data_frags, (data_count * sizeof(uint8_t*)));
+		M0_ALLOC_ARR(math->data_frags, data_count);
 		if (math->data_frags == NULL) {
 			ret = M0_ERR(-ENOMEM);
 			goto handle_error;
 		}
 
-		M0_ALLOC_ARR(math->parity_frags, (parity_count * sizeof(uint8_t*)));
+		M0_ALLOC_ARR(math->parity_frags, parity_count);
 		if (math->parity_frags == NULL) {
 			ret = M0_ERR(-ENOMEM);
 			goto handle_error;
@@ -539,6 +539,8 @@ static void isal_diff(struct m0_parity_math *math,
 	ec_encode_data_update(block_size, math->pmi_data_count,
 			      math->pmi_parity_count, index, math->g_tbls,
 			      diff_data, math->parity_frags);
+
+	m0_free(diff_data);
 }
 #else
 static void reed_solomon_diff(struct m0_parity_math *math,
@@ -892,10 +894,10 @@ static void isal_recover(struct m0_parity_math *math,
 	M0_ALLOC_ARR(err_list, fail_count);
 	M0_ASSERT(err_list != NULL);
 
-	M0_ALLOC_ARR(data_in, (math->pmi_data_count * sizeof(uint8_t *)));
+	M0_ALLOC_ARR(data_in, math->pmi_data_count);
 	M0_ASSERT(data_in != NULL);
 
-	M0_ALLOC_ARR(data_out, (fail_count * sizeof(uint8_t *)));
+	M0_ALLOC_ARR(data_out, fail_count);
 	M0_ASSERT(data_out != NULL);
 
 #if DEBUG

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -37,12 +37,6 @@
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_SNS
 #include "lib/trace.h"
 
-#if DEBUG
-#ifndef __KERNEL__
-#include <stdio.h>
-#endif /* __KERNEL__ */
-#endif /* DEBUG */
-
 #define ir_invalid_col_t UINT8_MAX
 
 /* Forward declarations */
@@ -885,7 +879,7 @@ static void isal_recover(struct m0_parity_math *math,
 	fail_count = fails_count(fail, unit_count);
 
 #if DEBUG
-	printf("\n fail_count: %d", fail_count);
+	m0_console_printf("\n fail_count: %d", fail_count);
 #endif
 
 	M0_ASSERT(fail_count > 0);
@@ -901,7 +895,7 @@ static void isal_recover(struct m0_parity_math *math,
 	M0_ASSERT(data_out != NULL);
 
 #if DEBUG
-	printf("\n err_list: ");
+	m0_console_printf("\n err_list: ");
 #endif
 	for (i = 0, j = 0, r = 0; i < unit_count; i++) {
 		if (fail[i]) {
@@ -913,7 +907,7 @@ static void isal_recover(struct m0_parity_math *math,
 				data_out[j] = math->parity_frags[i - math->pmi_data_count];
 
 #if DEBUG
-			printf(" %d", i);
+			m0_console_printf(" %d", i);
 #endif
 			j++;
 		} else {
@@ -942,18 +936,18 @@ static void isal_recover(struct m0_parity_math *math,
 	M0_ASSERT(decode_matrix != NULL);
 
 #if DEBUG
-	printf("\n data_frags:");
+	m0_console_printf("\n data_frags:");
 	for (i = 0; i < math->pmi_data_count; i++) {
 		if (i%8 == 0)
-			printf("\n");
-		printf("    %p", math->data_frags[i]);
+			m0_console_printf("\n");
+		m0_console_printf("    %p", math->data_frags[i]);
 	}
 
-	printf("\n parity_frags:");
+	m0_console_printf("\n parity_frags:");
 	for (i = 0; i < math->pmi_parity_count; i++) {
 		if (i%8 == 0)
-			printf("\n");
-		printf("    %p", math->parity_frags[i]);
+			m0_console_printf("\n");
+		m0_console_printf("    %p", math->parity_frags[i]);
 
 	}
 #endif
@@ -969,19 +963,19 @@ static void isal_recover(struct m0_parity_math *math,
 	}
 
 #if DEBUG
-	printf("\n Get Data In and Data Out:");
-	printf("\n Data In:");
+	m0_console_printf("\n Get Data In and Data Out:");
+	m0_console_printf("\n Data In:");
 	for (i = 0; i < math->pmi_data_count; i++) {
 		if (i%8 == 0)
-			printf("\n");
-		printf("    %p", data_in[i]);
+			m0_console_printf("\n");
+		m0_console_printf("    %p", data_in[i]);
 	}
 
-	printf("\n Data Out:");
+	m0_console_printf("\n Data Out:");
 	for (i = 0; i < fail_count; i++) {
 		if (i%8 == 0)
-			printf("\n");
-		printf("    %p", data_out[i]);
+			m0_console_printf("\n");
+		m0_console_printf("    %p", data_out[i]);
 	}
 #endif
 

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -507,7 +507,7 @@ static void isal_diff(struct m0_parity_math *math,
 		      uint32_t               index)
 {
 	uint8_t *diff_data = NULL;
-	uint32_t block_size = new[index].b_nob;
+	uint32_t block_size;
 	uint32_t ei;
 	uint32_t pi;
 
@@ -516,6 +516,9 @@ static void isal_diff(struct m0_parity_math *math,
 	M0_PRE(new    != NULL);
 	M0_PRE(parity != NULL);
 	M0_PRE(index  <  math->pmi_data_count);
+
+	block_size = new[index].b_nob;
+
 	M0_PRE(old[index].b_nob == block_size);
 	M0_PRE(m0_forall(i, math->pmi_parity_count,
 		         block_size == parity[i].b_nob));

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -119,7 +119,7 @@ struct m0_parity_math {
 	struct m0_matvec	     pmi_sys_res;
 	struct m0_linsys	     pmi_sys;
 	/* Data recovery matrix that's inverse of pmi_sys_mat. */
-	struct m0_matrix             pmi_recov_mat;
+	struct m0_matrix	     pmi_recov_mat;
 };
 
 /* Holds information essential for incremental recovery. */

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -49,6 +49,7 @@
 enum m0_parity_cal_algo {
         M0_PARITY_CAL_ALGO_XOR,
         M0_PARITY_CAL_ALGO_REED_SOLOMON,
+	M0_PARITY_CAL_ALGO_ISA,
 	M0_PARITY_CAL_ALGO_NR
 };
 
@@ -119,7 +120,14 @@ struct m0_parity_math {
 	struct m0_matvec	     pmi_sys_res;
 	struct m0_linsys	     pmi_sys;
 	/* Data recovery matrix that's inverse of pmi_sys_mat. */
-	struct m0_matrix	     pmi_recov_mat;
+	struct m0_matrix             pmi_recov_mat;
+
+#ifndef __KERNEL__
+	uint8_t                     *encode_matrix;
+	uint8_t                     *g_tbls;
+	uint8_t                    **data_frags;
+	uint8_t                    **parity_frags;
+#endif
 };
 
 /* Holds information essential for incremental recovery. */

--- a/sns/parity_ops.c
+++ b/sns/parity_ops.c
@@ -29,13 +29,17 @@
 
 M0_INTERNAL void m0_parity_fini(void)
 {
+#ifdef __KERNEL__
 	galois_calc_tables_release();
+#endif /* __KERNEL__ */
 }
 
 M0_INTERNAL int m0_parity_init(void)
 {
+#ifdef __KERNEL__
 	int ret = galois_create_mult_tables(M0_PARITY_GALOIS_W);
 	M0_ASSERT(ret == 0);
+#endif /* __KERNEL__ */
 	return 0;
 }
 

--- a/sns/parity_ops.h
+++ b/sns/parity_ops.h
@@ -25,11 +25,25 @@
 #ifndef __MOTR_SNS_PARITY_OPS_H__
 #define __MOTR_SNS_PARITY_OPS_H__
 
+#ifndef __KERNEL__
+#include <isa-l/erasure_code.h>
+#else
 #include "galois/galois.h"
+#endif /* __KERNEL__ */
 #include "lib/assert.h"
 
 #define M0_PARITY_ZERO (0)
+
+#ifdef __KERNEL__
 #define M0_PARITY_GALOIS_W (8)
+#endif
+
+#ifndef __KERNEL__
+#define M0_PARITY_W (8)
+#else
+#define M0_PARITY_W M0_PARITY_GALOIS_W
+#endif /* __KERNEL__ */
+
 typedef int m0_parity_elem_t;
 
 M0_INTERNAL int m0_parity_init(void);
@@ -50,14 +64,22 @@ static inline m0_parity_elem_t m0_parity_sub(m0_parity_elem_t x, m0_parity_elem_
 
 static inline m0_parity_elem_t m0_parity_mul(m0_parity_elem_t x, m0_parity_elem_t y)
 {
+#ifndef __KERNEL__
+	return gf_mul(x, y);
+#else
 	/* return galois_single_multiply(x, y, M0_PARITY_GALOIS_W); */
 	return galois_multtable_multiply(x, y, M0_PARITY_GALOIS_W);
+#endif /* __KERNEL__ */
 }
 
 static inline m0_parity_elem_t m0_parity_div(m0_parity_elem_t x, m0_parity_elem_t y)
 {
+#ifndef __KERNEL__
+	return gf_mul(x, gf_inv(y));
+#else
 	/* return galois_single_divide(x, y, M0_PARITY_GALOIS_W); */
 	return galois_multtable_divide(x, y, M0_PARITY_GALOIS_W);
+#endif /* __KERNEL__ */
 }
 
 static inline m0_parity_elem_t m0_parity_lt(m0_parity_elem_t x, m0_parity_elem_t y)

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -1434,7 +1434,34 @@ static void ub_large_32768(int iter)
 	parity_math_tb();
 }
 
-enum { UB_ITER = 1 };
+static void ub_small_4_2_4K(int iter)
+{
+	UNIT_BUFF_SIZE = 4096;
+	duc = 4;
+	puc = 2;
+	fuc = duc+puc;
+	parity_math_tb();
+}
+
+static void ub_small_4_2_256K(int iter)
+{
+	UNIT_BUFF_SIZE = 262144;
+	duc = 4;
+	puc = 2;
+	fuc = duc+puc;
+	parity_math_tb();
+}
+
+static void ub_small_4_2_1M(int iter)
+{
+	UNIT_BUFF_SIZE = 1048576;
+	duc = 4;
+	puc = 2;
+	fuc = duc+puc;
+	parity_math_tb();
+}
+
+enum { UB_ITER = 100 };
 
 struct m0_ub_set m0_parity_math_ub = {
         .us_name = "parity-math-ub",
@@ -1443,39 +1470,75 @@ struct m0_ub_set m0_parity_math_ub = {
         .us_run  = {
                 { .ub_name  = "s 10/05/ 4K",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_small_4096 },
+                  .ub_round = ub_small_4096,
+                  .ub_block_size = 4096,
+                  .ub_blocks_per_op = 15 },
 
                 { .ub_name  = "m 20/06/ 4K",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_medium_4096 },
+                  .ub_round = ub_medium_4096,
+                  .ub_block_size = 4096,
+                  .ub_blocks_per_op = 26 },
 
                 { .ub_name  = "l 30/12/ 4K",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_large_4096 },
+                  .ub_round = ub_large_4096,
+                  .ub_block_size = 4096,
+                  .ub_blocks_per_op = 42 },
 
                 { .ub_name  = "s 10/05/32K",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_small_32768 },
+                  .ub_round = ub_small_32768,
+                  .ub_block_size = 32768,
+                  .ub_blocks_per_op = 15 },
 
                 { .ub_name  = "m 20/06/32K",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_medium_32768 },
+                  .ub_round = ub_medium_32768,
+                  .ub_block_size = 32768,
+                  .ub_blocks_per_op = 26 },
 
                 { .ub_name  = "l 30/12/32K",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_large_32768 },
+                  .ub_round = ub_large_32768,
+                  .ub_block_size = 32768,
+                  .ub_blocks_per_op = 42 },
 
                 { .ub_name  = "s  03/02/ 1M",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_small_1048576 },
+                  .ub_round = ub_small_1048576,
+                  .ub_block_size = 1048576,
+                  .ub_blocks_per_op = 5 },
 
                 { .ub_name  = "m 06/03/ 1M",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_medium_1048576 },
+                  .ub_round = ub_medium_1048576,
+                  .ub_block_size = 1048576,
+                  .ub_blocks_per_op = 9 },
 
                 { .ub_name  = "l 08/04/ 1M",
                   .ub_iter  = UB_ITER,
-                  .ub_round = ub_large_1048576 },
+                  .ub_round = ub_large_1048576,
+                  .ub_block_size = 1048576,
+                  .ub_blocks_per_op = 12 },
+
+                { .ub_name  = "s 04/02/4K",
+                  .ub_iter  = UB_ITER,
+                  .ub_round = ub_small_4_2_4K,
+                  .ub_block_size = 4096,
+                  .ub_blocks_per_op = 6 },
+
+                { .ub_name  = "m 04/02/256K",
+                  .ub_iter  = UB_ITER,
+                  .ub_round = ub_small_4_2_256K,
+                  .ub_block_size = 262144,
+                  .ub_blocks_per_op = 6 },
+
+                { .ub_name  = "l 04/02/1M",
+                  .ub_iter  = UB_ITER,
+                  .ub_round = ub_small_4_2_1M,
+                  .ub_block_size = 1048576,
+                  .ub_blocks_per_op = 6 },
 
 		{ .ub_name = NULL}
 	}

--- a/ut/m0ub.c
+++ b/ut/m0ub.c
@@ -105,7 +105,7 @@ static void ub_add(const struct ub_args *args)
 	m0_ub_set_add(&m0_time_ub);
 	m0_ub_set_add(&m0_thread_ub);
 //	m0_ub_set_add(&m0_rpc_ub);
-//XXX_BE_DB	m0_ub_set_add(&m0_parity_math_ub);
+	m0_ub_set_add(&m0_parity_math_ub);
 	m0_ub_set_add(&m0_memory_ub);
 	m0_ub_set_add(&m0_list_ub);
 	m0_ub_set_add(&m0_fom_ub);


### PR DESCRIPTION
EOS-17070 ISA-L: Integrate ISAL encode APIs and check performance.

- Added option 'run-ub' to m0 script to run unit benchmarking.
- Used Intel ISA arithmetic APIs in m0_parity_mul() and m0_parity_div() functions.
- Intel ISA APIs are accessed in user space only.
- Galois APIs are called only in kernel space for now.
- Integrated ISA encoding APIs
- Implemented isal_encode() and isal_recover() functions.
- Updated ub tests for parity_math.
- Increased number of iterations for parity_math ub tests to 100.
- Added function for differential parity calculation using Intel ISA API.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>