### PR TITLE
EOS-16459: [DTM0] Implement DTM0 local non-persistent log structure for originators

### DIFF
--- a/be/Makefile.sub
+++ b/be/Makefile.sub
@@ -39,7 +39,8 @@ nobase_motr_include_HEADERS += \
 			       be/tx_internal.h     \
                                be/tx_regmap.h       \
                                be/tx_service.h	    \
-			       be/ut/helper.h
+			       be/ut/helper.h       \
+			       be/dtm0_log.h
 
 motr_libmotr_la_SOURCES += be/alloc.c           \
                            be/active_record.c   \
@@ -74,7 +75,8 @@ motr_libmotr_la_SOURCES += be/alloc.c           \
 			   be/tx_group_format.c \
 			   be/tx_regmap.c       \
 			   be/tx_service.c      \
-                           be/ut/helper.c
+			   be/ut/helper.c       \
+			   be/dtm0_log.c
 
 nodist_motr_libmotr_la_SOURCES  +=                 \
 			   be/addb2_xc.c           \

--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -1,0 +1,321 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
+#include "be/dtm0_log.h"
+#include "be/list.h"
+#include "lib/assert.h" /* M0_PRE */
+#include "lib/errno.h"  /* ENOENT */
+#include "lib/memory.h" /* M0_ALLOC */
+#include "lib/trace.h"
+
+enum {
+	M0_BE_DTM_LREC_MAGIX = 0xdeaddeaddeaddead,
+	M0_BE_DTM_LOG_MAGIX  = 0xbadbadbadbadbadb
+};
+
+M0_TL_DESCR_DEFINE(lrec, "DTM0 Log", static, struct m0_dtm0_log_rec,
+                   dlr_tlink, dlr_magic, M0_BE_DTM_LREC_MAGIX,
+                   M0_BE_DTM_LOG_MAGIX);
+
+M0_TL_DEFINE(lrec, static, struct m0_dtm0_log_rec);
+
+static bool m0_be_dtm0_log__invariant(const struct m0_be_dtm0_log *log)
+{
+	return _0C(log != NULL) &&
+	       _0C(log->dl_cs != NULL) &&
+	       _0C(lrec_tlist_invariant(log->dl_tlist));
+}
+
+static bool m0_dtm0_log_rec__invariant(const struct m0_dtm0_log_rec *rec)
+{
+	return _0C(rec != NULL) &&
+	       _0C(m0_dtm0_tx_desc__invariant(&rec->dlr_txd)) &&
+	       _0C(m0_tlink_invariant(&lrec_tl, rec));
+}
+
+M0_INTERNAL int m0_be_dtm0_log_init(struct m0_be_dtm0_log **out,
+                                    struct m0_dtm0_clk_src *cs,
+                                    bool                    isvstore)
+{
+	struct m0_be_dtm0_log *log;
+
+	M0_PRE(out != NULL);
+	M0_PRE(cs != NULL);
+
+	if (isvstore) {
+		M0_ALLOC_PTR(log);
+		if (log == NULL)
+			return M0_ERR(-ENOMEM);
+
+		M0_SET0(log);
+		M0_ALLOC_PTR(log->dl_tlist);
+		if (log->dl_tlist == NULL) {
+			m0_free(log);
+			return M0_ERR(-ENOMEM);
+		}
+		lrec_tlist_init(log->dl_tlist);
+		*out = log;
+	} else {
+		log = *out;
+	}
+
+	m0_mutex_init(&log->dl_lock);
+	log->dl_cs = cs;
+	return 0;
+}
+
+M0_INTERNAL void m0_be_dtm0_log_fini(struct m0_be_dtm0_log **log,
+                                     bool                    isvstore)
+{
+	struct m0_be_dtm0_log *plog = *log;
+
+	M0_PRE(m0_be_dtm0_log__invariant(plog));
+	m0_mutex_fini(&plog->dl_lock);
+	lrec_tlist_fini(plog->dl_tlist);
+	plog->dl_cs = NULL;
+
+	if (isvstore) {
+		m0_free(plog->dl_tlist);
+		m0_free(plog);
+		*log = NULL;
+	}
+}
+
+M0_INTERNAL void m0_be_dtm0_log_credit(enum m0_be_dtm0_log_credit_op op,
+                                       struct m0_be_tx              *tx,
+                                       struct m0_be_seg             *seg,
+                                       struct m0_be_tx_credit       *accum)
+{
+	/*TODO:Complete implementation during persistent list implementation */
+	switch (op) {
+	case M0_DTML_CREATE:
+	case M0_DTML_SENT:
+	case M0_DTML_EXECUTED:
+	case M0_DTML_PERSISTENT:
+	case M0_DTML_REDO:
+	default:
+		M0_IMPOSSIBLE("");
+	}
+}
+
+M0_INTERNAL int m0_be_dtm0_log_create(struct m0_be_tx        *tx,
+                                      struct m0_be_seg       *seg,
+                                      struct m0_be_dtm0_log **out)
+{
+	//struct m0_be_dtm0_log *log;
+
+#if 0
+	M0_PRE(tx);
+	M0_PRE(seg);
+	M0_PRE(m0_be_tx__invariant(tx));
+
+	M0_BE_ALLOC_PTR_SYNC(log, seg, tx);
+	M0_ASSERT(log);
+	M0_BE_ALLOC_PTR_SYNC(log->dl_list, seg, tx);
+	M0_ASSERT(log->dl_list);
+
+	dtm0_log_be_list_create(log->dl_list, tx);
+#endif
+	return 0;
+}
+
+M0_INTERNAL void m0_be_dtm0_log_destroy(struct m0_be_tx        *tx,
+                                        struct m0_be_dtm0_log **log)
+{
+#if 0
+	struct m0_be_dtm0_log *plog = *log;
+
+	M0_PRE(plog != NULL);
+	m0_free(plog->dl_tlist);
+	m0_free(plog);
+	*log = NULL;
+#endif
+}
+
+M0_INTERNAL
+struct m0_dtm0_log_rec *m0_be_dtm0_log_find(struct m0_be_dtm0_log    *log,
+                                            const struct m0_dtm0_tid *id)
+{
+	M0_PRE(m0_be_dtm0_log__invariant(log));
+	M0_PRE(m0_dtm0_tid__invariant(id));
+	M0_PRE(m0_mutex_is_locked(&log->dl_lock));
+
+	return m0_tl_find(lrec, rec, log->dl_tlist,
+                          m0_dtm0_tid_cmp(log->dl_cs, &rec->dlr_txd.dtd_id,
+                                          id) == M0_DTS_EQ);
+}
+
+static int m0_be_dtm0_log_rec_init(struct m0_dtm0_log_rec **rec,
+                                   struct m0_be_tx         *tx,
+                                   struct m0_dtm0_tx_desc  *txd,
+                                   struct m0_buf           *pyld)
+{
+	int                     rc;
+	struct m0_dtm0_log_rec *lrec;
+
+	M0_ALLOC_PTR(lrec);
+	if (lrec == NULL)
+		return M0_ERR(-ENOMEM);
+
+	rc = m0_dtm0_tx_desc_copy(txd, &lrec->dlr_txd);
+	if (rc != 0) {
+		m0_free(lrec);
+		return rc;
+	}
+
+	rc = m0_buf_copy(&lrec->dlr_pyld, pyld);
+	if (rc != 0) {
+		m0_dtm0_tx_desc_fini(&lrec->dlr_txd);
+		m0_free(lrec);
+		return rc;
+	}
+
+	*rec = lrec;
+	return 0;
+}
+
+static void m0_be_dtm0_log_rec_fini(struct m0_dtm0_log_rec **rec,
+                                    struct m0_be_tx        *tx)
+{
+	struct m0_dtm0_log_rec *lrec = *rec;
+
+	m0_buf_free(&lrec->dlr_pyld);
+	m0_dtm0_tx_desc_fini(&lrec->dlr_txd);
+	m0_free(lrec);
+	*rec = NULL;
+}
+
+static int m0_be_dtm0_log__insert(struct m0_be_dtm0_log  *log,
+                                  struct m0_be_tx        *tx,
+                                  struct m0_dtm0_tx_desc *txd,
+                                  struct m0_buf          *pyld)
+{
+	int                     rc;
+	struct m0_dtm0_log_rec *rec;
+
+	rc = m0_be_dtm0_log_rec_init(&rec, tx, txd, pyld);
+	if (rc !=  0)
+		return rc;
+
+	lrec_tlink_init_at_tail(rec, log->dl_tlist);
+	return rc;
+}
+
+
+static int m0_be_dtm0_log__set(struct m0_be_dtm0_log  *log,
+                               struct m0_be_tx        *tx,
+                               struct m0_dtm0_tx_desc *txd,
+                               struct m0_buf          *pyld,
+                               struct m0_dtm0_log_rec *rec)
+{
+	int                     rc;
+	int                     pa_id;
+	struct m0_dtm0_tx_desc *ltxd     = &rec->dlr_txd;
+	struct m0_buf          *lpyld    = &rec->dlr_pyld;
+	struct m0_dtm0_tx_pa   *ldtpg_pa = ltxd->dtd_pg.dtpg_pa;
+	struct m0_dtm0_tx_pa   *dtpg_pa  = txd->dtd_pg.dtpg_pa;
+	uint32_t                num_pa   = ltxd->dtd_pg.dtpg_nr;
+
+	M0_PRE(m0_dtm0_log_rec__invariant(rec));
+
+	/* Attach payload to log if it is not attached */
+	if (!m0_dtm0_txr_rec_is_set(lpyld) && m0_dtm0_txr_rec_is_set(pyld)) {
+		rc = m0_buf_copy(lpyld, pyld);
+		if (rc != 0)
+			return rc;
+	}
+
+	for (pa_id = 0; pa_id < num_pa; ++pa_id) {
+		m0_dtm0_update_pa_state(&ldtpg_pa[pa_id].pa_state,
+                                        &dtpg_pa[pa_id].pa_state);
+	}
+
+	return rc;
+}
+
+M0_INTERNAL int m0_be_dtm0_log_update(struct m0_be_dtm0_log  *log,
+                                      struct m0_be_tx        *tx,
+                                      struct m0_dtm0_tx_desc *txd,
+                                      struct m0_buf          *pyld)
+{
+	struct m0_dtm0_log_rec *rec;
+
+	M0_PRE(pyld != NULL);
+	M0_PRE(m0_be_dtm0_log__invariant(log));
+	M0_PRE(m0_dtm0_tx_desc__invariant(txd));
+	M0_PRE(m0_mutex_is_locked(&log->dl_lock));
+
+	return (rec = m0_be_dtm0_log_find(log, &txd->dtd_id)) ?
+                m0_be_dtm0_log__set(log, tx, txd, pyld, rec) :
+                m0_be_dtm0_log__insert(log, tx, txd, pyld);
+}
+
+M0_INTERNAL int m0_be_dtm0_log_prune(struct m0_be_dtm0_log    *log,
+                                     struct m0_be_tx          *tx,
+                                     const struct m0_dtm0_tid *id)
+{
+	/* This assignment is meaningful as it covers the empty log case */
+	int                     rc = M0_DTS_LT;
+	struct m0_dtm0_log_rec *rec;
+	struct m0_dtm0_log_rec *currec;
+
+	M0_PRE(m0_be_dtm0_log__invariant(log));
+	M0_PRE(m0_dtm0_tid__invariant(id));
+	M0_PRE(m0_mutex_is_locked(&log->dl_lock));
+
+	m0_tl_for (lrec, log->dl_tlist, rec) {
+		if (!m0_dtm0_is_rec_is_stable(&rec->dlr_txd.dtd_pg))
+			return M0_ERR(-EPROTO);
+
+		rc = m0_dtm0_tid_cmp(log->dl_cs, &rec->dlr_txd.dtd_id, id);
+		if (rc != M0_DTS_LT)
+			break;
+	} m0_tl_endfor;
+
+	if (rc != M0_DTS_EQ)
+		return -ENOENT;
+
+	while ((currec = lrec_tlist_pop(log->dl_tlist)) != rec) {
+		M0_ASSERT(m0_dtm0_log_rec__invariant(currec));
+		m0_be_dtm0_log_rec_fini(&currec, tx);
+	}
+
+	m0_be_dtm0_log_rec_fini(&currec, tx);
+	return rc;
+}
+
+#undef M0_TRACE_SUBSYSTEM
+
+/** @} end of dtm group */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/be/ut/Makefile.sub
+++ b/be/ut/Makefile.sub
@@ -26,4 +26,5 @@ ut_libmotr_ut_la_SOURCES += be/ut/alloc.c           \
                             be/ut/tx.c              \
                             be/ut/tx_bulk.c         \
                             be/ut/tx_group_format.c \
-                            be/ut/tx_regmap.c
+                            be/ut/tx_regmap.c       \
+                            be/ut/dtm0_log_ut.c

--- a/be/ut/dtm0_log_ut.c
+++ b/be/ut/dtm0_log_ut.c
@@ -1,0 +1,298 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
+#include "be/dtm0_log.h"
+#include "be/list.h"
+#include "dtm0/clk_src.h"
+#include "lib/errno.h"
+#include "lib/misc.h"		/* m0_forall */
+#include "ut/ut.h"		/* M0_UT_ASSERT */
+
+#define UT_DTM0_LOG_MAX_PA            3
+#define UT_DTM0_LOG_MAX_LOG_REC      10
+#define UT_DTM0_LOG_BUF_SIZE        256
+
+void ut_dl_set_pa_state(struct m0_dtm0_tx_pa *pa, uint32_t state)
+{
+	pa->pa_state = state;
+}
+
+void ut_dl_init_pa(struct m0_dtm0_tx_pa *pa, int rand)
+{
+	m0_fid_set(&pa->pa_fid, rand + 1, rand + 1);
+	ut_dl_set_pa_state(pa, M0_DTPS_INPROGRESS);
+}
+
+bool ut_dl_verify_pa(struct m0_dtm0_tx_pa *pa, int rand)
+{
+	struct m0_fid temp_fid;
+	m0_fid_set(&temp_fid, rand + 1, rand + 1);
+
+	return (m0_fid_cmp(&pa->pa_fid, &temp_fid) == 0) &&
+               pa->pa_state >= 0                         &&
+               pa->pa_state < M0_DTPS_NR;
+}
+
+void ut_dl_init_tid(struct m0_dtm0_tid *tid, int rand)
+{
+	m0_fid_set(&tid->dti_fid, rand + 1, rand + 1);
+	tid->dti_ts.dts_phys = rand + 1;
+}
+
+bool ut_dl_verify_tid(struct m0_dtm0_tid *tid, int rand)
+{
+	struct m0_fid temp_fid;
+	m0_fid_set(&temp_fid, rand + 1, rand + 1);
+
+	return (m0_fid_cmp(&tid->dti_fid, &temp_fid) == 0) &&
+               (tid->dti_ts.dts_phys == rand + 1);
+}
+
+int ut_dl_init_txd(struct m0_dtm0_tx_desc *txd, int rand)
+{
+	int i;
+	int rc;
+
+	rc = m0_dtm0_tx_desc_init(txd, UT_DTM0_LOG_MAX_PA);
+	if (rc != 0)
+		return rc;
+
+	ut_dl_init_tid(&txd->dtd_id, rand);
+
+	for (i = 0; i < txd->dtd_pg.dtpg_nr; ++i) {
+		ut_dl_init_pa(&txd->dtd_pg.dtpg_pa[i], rand);
+	}
+
+	return rc;
+}
+
+void ut_dl_fini_txd(struct m0_dtm0_tx_desc *txd)
+{
+	m0_dtm0_tx_desc_fini(txd);
+}
+
+bool ut_dl_verify_txd(struct m0_dtm0_tx_desc *txd, int rand)
+{
+	return ut_dl_verify_tid(&txd->dtd_id, rand)        &&
+               (txd->dtd_pg.dtpg_nr == UT_DTM0_LOG_MAX_PA) &&
+	       m0_forall(i, txd->dtd_pg.dtpg_nr,
+                         ut_dl_verify_pa(&txd->dtd_pg.dtpg_pa[i], rand));
+}
+
+int ut_dl_init_buf(struct m0_buf *buf, int rand)
+{
+	int rc;
+	rc = m0_buf_alloc(buf, UT_DTM0_LOG_BUF_SIZE);
+	if (rc != 0)
+		return rc;
+	memset(buf->b_addr, rand + 1, UT_DTM0_LOG_BUF_SIZE);
+	return rc;
+}
+
+void ut_dl_fini_buf(struct m0_buf *buf)
+{
+	m0_buf_free(buf);
+}
+
+bool ut_dl_verify_buf(struct m0_buf *buf, int rand)
+{
+	bool          rc       = true;
+	struct m0_buf temp_buf = {};
+
+	if (buf->b_nob) {
+		ut_dl_init_buf(&temp_buf, rand);
+		rc = m0_buf_eq(&temp_buf, buf);
+		m0_buf_free(&temp_buf);
+	} else {
+		rc = (m0_buf_is_set(buf) == 0);
+	}
+
+	return rc;
+}
+
+int ut_dl_init(struct m0_dtm0_tx_desc *txd, struct m0_buf *buf, int rand)
+{
+	int rc;
+
+	rc = ut_dl_init_txd(txd, rand);
+	if (rc != 0)
+		return rc;
+
+	rc = ut_dl_init_buf(buf, rand);
+	if (rc != 0)
+		m0_dtm0_tx_desc_fini(txd);
+
+	return rc;
+}
+
+void ut_dl_fini(struct m0_dtm0_tx_desc *txd, struct m0_buf *buf)
+{
+	ut_dl_fini_txd(txd);
+	ut_dl_fini_buf(buf);
+}
+
+bool ut_dl_verify_log_rec(struct m0_dtm0_log_rec *rec, int rand)
+{
+	return ut_dl_verify_buf(&rec->dlr_pyld, rand) &&
+               ut_dl_verify_txd(&rec->dlr_txd, rand);
+}
+
+
+void test_volatile_dtm0_log(void)
+{
+	int                     i;
+	int                     rc;
+	struct m0_dtm0_clk_src  cs;
+	struct m0_dtm0_tx_desc  txd[UT_DTM0_LOG_MAX_LOG_REC];
+	struct m0_buf           buf[UT_DTM0_LOG_MAX_LOG_REC] = {};
+	struct m0_buf           empty_buf                    = {};
+	struct m0_dtm0_log_rec *rec[UT_DTM0_LOG_MAX_LOG_REC] = {};
+	struct m0_be_dtm0_log  *log                          = NULL;
+
+	rc = m0_dtm0_clk_src_init(&cs, M0_DTM0_CS_PHYS);
+	M0_UT_ASSERT(rc == 0);
+
+	rc = m0_be_dtm0_log_init(&log, &cs, true);
+	M0_UT_ASSERT(rc == 0);
+
+	for (i = 0; i < UT_DTM0_LOG_MAX_LOG_REC; ++i) {
+		rc = ut_dl_init(&txd[i], &buf[i], i);
+		M0_UT_ASSERT(rc == 0);
+	}
+
+	/* pa[0].st = EX pa[1].st = IP pa[2].st = IP, pyld = valid */
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[0], M0_DTPS_EXECUTED);
+	m0_mutex_lock(&log->dl_lock);
+	rc = m0_be_dtm0_log_update(log, NULL, &txd[0], &buf[0]);
+	M0_UT_ASSERT(rc == 0);
+	rec[0] = m0_be_dtm0_log_find(log, &txd[0].dtd_id);
+	M0_UT_ASSERT(rec[0] != NULL);
+	rc = ut_dl_verify_log_rec(rec[0], 0);
+	M0_UT_ASSERT(rc != 0);
+
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[1], M0_DTPS_PERSISTENT);
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[2], M0_DTPS_PERSISTENT);
+	rc = m0_be_dtm0_log_update(log, NULL, &txd[0], &buf[0]);
+	M0_UT_ASSERT(rc == 0);
+	rec[0] = m0_be_dtm0_log_find(log, &txd[0].dtd_id);
+	M0_UT_ASSERT(rec[0] != NULL);
+	rc = ut_dl_verify_log_rec(rec[0], 0);
+	M0_UT_ASSERT(rc != 0);
+
+	rc = m0_be_dtm0_log_prune(log, NULL, &txd[0].dtd_id);
+	M0_UT_ASSERT(rc == -EPROTO);
+
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[0], M0_DTPS_PERSISTENT);
+	rc = m0_be_dtm0_log_update(log, NULL, &txd[0], &buf[0]);
+	M0_UT_ASSERT(rc == 0);
+
+	rc = m0_be_dtm0_log_prune(log, NULL, &txd[0].dtd_id);
+	M0_UT_ASSERT(rc == 0);
+
+	rec[0] = m0_be_dtm0_log_find(log, &txd[0].dtd_id);
+	M0_UT_ASSERT(rec[0] == NULL);
+
+	rc = m0_be_dtm0_log_prune(log, NULL, &txd[0].dtd_id);
+	M0_UT_ASSERT(rc == -ENOENT);
+
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[0], M0_DTPS_INPROGRESS);
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[1], M0_DTPS_INPROGRESS);
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[2], M0_DTPS_PERSISTENT);
+	rc = m0_be_dtm0_log_update(log, NULL, &txd[0], &empty_buf);
+	M0_UT_ASSERT(rc == 0);
+	rec[0] = m0_be_dtm0_log_find(log, &txd[0].dtd_id);
+	M0_UT_ASSERT(rec[0] != NULL);
+	rc = ut_dl_verify_log_rec(rec[0], 0);
+	M0_UT_ASSERT(rc != 0);
+
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[0], M0_DTPS_PERSISTENT);
+	ut_dl_set_pa_state(&txd[0].dtd_pg.dtpg_pa[1], M0_DTPS_PERSISTENT);
+	rc = m0_be_dtm0_log_update(log, NULL, &txd[0], &buf[0]);
+	M0_UT_ASSERT(rc == 0);
+	rec[0] = m0_be_dtm0_log_find(log, &txd[0].dtd_id);
+	M0_UT_ASSERT(rec[0] != NULL);
+	rc = ut_dl_verify_log_rec(rec[0], 0);
+	M0_UT_ASSERT(rc != 0);
+	rc = m0_be_dtm0_log_prune(log, NULL, &txd[0].dtd_id);
+	M0_UT_ASSERT(rc == 0);
+	rec[0] = NULL;
+
+	for (i = 0; i < UT_DTM0_LOG_MAX_LOG_REC; ++i) {
+		ut_dl_set_pa_state(&txd[i].dtd_pg.dtpg_pa[0],
+                                   M0_DTPS_PERSISTENT);
+		ut_dl_set_pa_state(&txd[i].dtd_pg.dtpg_pa[1],
+                                   M0_DTPS_PERSISTENT);
+		ut_dl_set_pa_state(&txd[i].dtd_pg.dtpg_pa[2],
+                                   M0_DTPS_PERSISTENT);
+		rc = m0_be_dtm0_log_update(log, NULL, &txd[i], &buf[i]);
+		M0_UT_ASSERT(rc == 0);
+		rec[i] = m0_be_dtm0_log_find(log, &txd[i].dtd_id);
+		M0_UT_ASSERT(rec[i] != NULL);
+		rc = ut_dl_verify_log_rec(rec[i], i);
+		M0_UT_ASSERT(rc != 0);
+		rec[i] = NULL;
+	}
+
+	rec[5] = m0_be_dtm0_log_find(log, &txd[5].dtd_id);
+	M0_UT_ASSERT(rec[5] != NULL);
+	rc = ut_dl_verify_log_rec(rec[5], 5);
+	M0_UT_ASSERT(rc != 0);
+	rec[5] = NULL;
+
+	rc = m0_be_dtm0_log_prune(log, NULL, &txd[9].dtd_id);
+	M0_UT_ASSERT(rc == 0);
+	rec[9] = m0_be_dtm0_log_find(log, &txd[9].dtd_id);
+	M0_UT_ASSERT(rec[9] == NULL);
+
+	/* Finalization */
+	for (i = 0; i < UT_DTM0_LOG_MAX_LOG_REC; ++i) {
+		ut_dl_fini(&txd[i], &buf[i]);
+	}
+
+	m0_mutex_unlock(&log->dl_lock);
+	m0_be_dtm0_log_fini(&log, true);
+	m0_dtm0_clk_src_fini(&cs);
+}
+
+struct m0_ut_suite dtm0_log_ut = {
+	.ts_name   = "dtm0-log-ut",
+	.ts_init   = NULL,
+	.ts_fini   = NULL,
+	.ts_tests  = {
+		{ "dtm0-log-list", test_volatile_dtm0_log},
+		{ NULL, NULL }
+	}
+};
+
+#undef M0_TRACE_SUBSYSTEM
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/tx_desc.c
+++ b/dtm0/tx_desc.c
@@ -85,6 +85,7 @@ M0_INTERNAL int m0_dtm0_tx_desc_init(struct m0_dtm0_tx_desc *td,
 	M0_ALLOC_ARR(td->dtd_pg.dtpg_pa, nr_pa);
 	if (td->dtd_pg.dtpg_pa == NULL)
 		return M0_ERR(-ENOMEM);
+	td->dtd_pg.dtpg_nr = nr_pa;
 	M0_POST(m0_dtm0_tx_desc__invariant(td));
 	return 0;
 }
@@ -101,6 +102,24 @@ M0_INTERNAL int m0_dtm0_tid_cmp(struct m0_dtm0_clk_src   *cs,
 {
 	return m0_dtm0_ts_cmp(cs, &left->dti_ts, &right->dti_ts) ?:
 		m0_fid_cmp(&left->dti_fid, &right->dti_fid);
+}
+
+M0_INTERNAL int m0_dtm0_txr_rec_is_set(struct m0_buf *pyld)
+{
+	return m0_buf_is_set(pyld);
+}
+
+M0_INTERNAL void m0_dtm0_update_pa_state(enum m0_dtm0_tx_pa_state *dst,
+                                         enum m0_dtm0_tx_pa_state *src)
+{
+	if (*dst < *src)
+		*dst = *src;
+}
+
+M0_INTERNAL bool m0_dtm0_is_rec_is_stable(struct m0_dtm0_tx_pa_group *pg)
+{
+	return m0_forall(i, pg->dtpg_nr,
+                         pg->dtpg_pa[i].pa_state == M0_DTPS_PERSISTENT);
 }
 
 #undef M0_TRACE_SUBSYSTEM

--- a/dtm0/tx_desc.h
+++ b/dtm0/tx_desc.h
@@ -136,6 +136,10 @@ M0_INTERNAL int m0_dtm0_tid_cmp(struct m0_dtm0_clk_src   *cs,
 M0_INTERNAL bool m0_dtm0_tid__invariant(const struct m0_dtm0_tid *tid);
 M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td);
 
+M0_INTERNAL int m0_dtm0_txr_rec_is_set(struct m0_buf *pyld);
+M0_INTERNAL void m0_dtm0_update_pa_state(enum m0_dtm0_tx_pa_state *dst,
+                                         enum m0_dtm0_tx_pa_state *src);
+M0_INTERNAL bool m0_dtm0_is_rec_is_stable(struct m0_dtm0_tx_pa_group *pg);
 #endif /* __MOTR_DTM0_TX_DESC_H__ */
 
 /*

--- a/ut/m0ut.c
+++ b/ut/m0ut.c
@@ -101,6 +101,7 @@ extern struct m0_ut_suite dtm_nucleus_ut;
 extern struct m0_ut_suite dtm_transmit_ut;
 extern struct m0_ut_suite dtm0_ut;
 extern struct m0_ut_suite dtm0_clk_src_ut;
+extern struct m0_ut_suite dtm0_log_ut;
 extern struct m0_ut_suite emap_ut;
 extern struct m0_ut_suite failure_domains_tree_ut;
 extern struct m0_ut_suite failure_domains_ut;
@@ -231,6 +232,7 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &dtm_dtx_ut, true);
 	m0_ut_add(m, &dtm0_ut, true);
 	m0_ut_add(m, &dtm0_clk_src_ut, true);
+	m0_ut_add(m, &dtm0_log_ut, true);
 	m0_ut_add(m, &failure_domains_tree_ut, true);
 	m0_ut_add(m, &failure_domains_ut, true);
 	m0_ut_add(m, &fis_ut, true);


### PR DESCRIPTION
## Change Summary
Implemented following APIs and supporting APIs needed for that as well as UT to ensure implementation is working as expected.
Also have added modification to DLD as per discussion and changes done in this PR.

1. m0_be_dtm0_log_init
2. m0_be_dtm0_log_fini
3. m0_be_dtm0_log_create
4. m0_be_dtm0_log_destroy
5. m0_be_dtm0_log_find
6. m0_be_dtm0_log_update
7. m0_be_dtm0_log_prune

## UT O/P
$ sudo ./utils/m0run   -- "m0ut -t dtm0-log-ut"
dtm0-log-ut
  dtm0-log-list                                   0.00 sec    4 KiB
  [ time: 0.00 sec, mem: 4 KiB, leaked: 0 B ]

Time: 0.00 sec, Mem: 4 KiB, Leaked: 0 B, Asserts: 11
Unit tests status: SUCCESS
utime 0.229253 stime 0.077094 maxrss 55640 nvcsw 1388 nivcsw 13
minflt 13468 majflt 2 inblock 0 oublock 65544
rchar 95429 wchar 1083 syscr 202 syscw 42
read_bytes 0 write_bytes 33558528 cancelled_write_bytes 0
