### PR TITLE
m0crate: fix operations logging

### DIFF
--- a/motr/m0crate/crate_io.c
+++ b/motr/m0crate/crate_io.c
@@ -504,7 +504,8 @@ int cr_op_namei(struct m0_workload_io  *cwi, struct m0_task_io *cti,
 
 	cr_log(CLL_TRACE, TIME_F" t%02d: %s objects...\n",
 	       TIME_P(m0_time_now()), cti->cti_task_idx,
-	       op_code == CR_CREATE ? "Creating" : "Deleting");
+	       op_code == CR_CREATE ? "Creating" :
+	       op_code == CR_OPEN ? "Opening" : "Deleting");
 	m0_semaphore_init(&cti->cti_max_ops_sem, cwi->cwi_max_nr_ops);
 	stime = m0_time_now();
 
@@ -565,7 +566,8 @@ int cr_op_namei(struct m0_workload_io  *cwi, struct m0_task_io *cti,
 			m0_obj_fini(&cti->cti_objs[i]);
 	cr_log(CLL_TRACE, TIME_F" t%02d: %s done.\n",
 	       TIME_P(m0_time_now()), cti->cti_task_idx,
-	       op_code == CR_CREATE ? "Creation" : "Deletion");
+	       op_code == CR_CREATE ? "Creation" :
+	       op_code == CR_OPEN ? "Open" : "Deletion");
 
 	return rc;
 }


### PR DESCRIPTION
Currently, it shows "Deleting" instead of "Opening" in the log:

```
  trace: [1612444701:441610295] t01: Creating objects...
  trace: [1612444705:817830062] t01: Creation done.
  trace: [1612444705:817873262] t01: Deleting objects... !!! <- here
  trace: [1612444706:726894586] t01: Deletion done.      !!!
  trace: [1612444706:726942709] t01: Writing objects...
  trace: [1612444712:624709872] t01: Write done.
  trace: [1612444712:624737930] t01: Deleting objects...
  trace: [1612444715:353146688] t01: Deletion done.
```

Solution: fix the logging at cr_op_namei().