### PR TITLE
EOS-16866: [DTM0] DIX with DTX.

### DIFF
--- a/cas/cas.h
+++ b/cas/cas.h
@@ -39,6 +39,8 @@
 #include "fop/fom_generic_xc.h" /* m0_fop_mod_rep */
 #include "dix/layout.h"
 #include "dix/layout_xc.h"
+#include "dtm0/tx_desc.h"	/* tx_desc */
+#include "dtm0/tx_desc_xc.h"	/* xc for tx_desc */
 
 /**
  * @page cas-fspec The catalogue service (CAS)
@@ -283,7 +285,7 @@ enum m0_cas_type {
  */
 struct m0_cas_op {
 	/** Index to make operation in. */
-	struct m0_cas_id   cg_id;
+	struct m0_cas_id       cg_id;
 
 	/**
 	 * Array of input records.
@@ -293,14 +295,19 @@ struct m0_cas_op {
 	 *
 	 * Array should be non-empty.
 	 */
-	struct m0_cas_recv cg_rec;
+	struct m0_cas_recv     cg_rec;
 
 	/**
 	 * CAS operation flags.
 	 *
 	 * It's a bitmask of flags from m0_cas_op_flags enumeration.
 	 */
-	uint32_t           cg_flags;
+	uint32_t               cg_flags;
+
+	/**
+	 * Transaction descriptor associated with CAS operation.
+	 */
+	struct m0_dtm0_tx_desc cg_txd;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 /**

--- a/cas/client.c
+++ b/cas/client.c
@@ -39,7 +39,7 @@
 #include "cas/client.h"
 #include "lib/finject.h"
 #include "cas/cas_addb2.h"
-
+#include "dtm0/dtx.h"   /* struct m0_dtm0_dtx */
 /**
  * @addtogroup cas-client
  * @{
@@ -1659,9 +1659,11 @@ M0_INTERNAL int m0_cas_put(struct m0_cas_req      *req,
 		~(COF_CREATE | COF_OVERWRITE | COF_CROW | COF_SYNC_WAIT)) == 0);
 	M0_PRE(m0_cas_id_invariant(index));
 
-	(void)dtx;
 	rc = cas_req_prep(req, index, keys, values, keys->ov_vec.v_nr, flags,
 			  &op);
+	if (rc != 0)
+		return M0_ERR(rc);
+	rc = m0_dtx0_copy_txd(dtx, &op->cg_txd);
 	if (rc != 0)
 		return M0_ERR(rc);
 	rc = creq_fop_create_and_prepare(req, &cas_put_fopt, op, &next_state);
@@ -1823,9 +1825,11 @@ M0_INTERNAL int m0_cas_del(struct m0_cas_req *req,
 	M0_PRE(m0_cas_id_invariant(index));
 	M0_PRE(M0_IN(flags, (0, COF_DEL_LOCK, COF_SYNC_WAIT)));
 
-	(void)dtx;
 	rc = cas_req_prep(req, index, keys, NULL, keys->ov_vec.v_nr, flags,
 			  &op);
+	if (rc != 0)
+		return M0_ERR(rc);
+	rc = m0_dtx0_copy_txd(dtx, &op->cg_txd);
 	if (rc != 0)
 		return M0_ERR(rc);
 	rc = creq_fop_create_and_prepare(req, &cas_del_fopt, op, &next_state);

--- a/cas/service.c
+++ b/cas/service.c
@@ -1116,6 +1116,15 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	is_index_drop = op_is_index_drop(opc, ct);
 	M0_PRE(ctidx != NULL);
 	M0_PRE(cas_fom_invariant(fom));
+#if defined(DTM0)
+	M0_PRE(ergo(!M0_IS0(&op->cg_txd),
+		    m0_dtm0_tx_desc__invariant(&op->cg_txd)));
+	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT) {
+		M0_LOG(DEBUG, "Got CAS with txid: " FID_F ", " M0_DTM0_TS_FMT,
+		       FID_P(&op->cg_txd.dtd_id.dti_fid),
+		       M0_DTM0_TS_P(&op->cg_txd.dtd_id.dti_ts));
+	}
+#endif
 	switch (phase) {
 	case M0_FOPH_INIT ... M0_FOPH_NR - 1:
 

--- a/dix/client.c
+++ b/dix/client.c
@@ -139,6 +139,7 @@ M0_INTERNAL int m0_dix_cli_init(struct m0_dix_cli       *cli,
 	cli->dx_ldom = ldom;
 	cli->dx_pver = m0_pool_version_find(pc, pver);
 	cli->dx_sync_rec_update = NULL;
+	cli->dx_dtms = NULL;
 	m0_dix_ldesc_init(&cli->dx_root,
 			  &(struct m0_ext) { .e_start = 0,
 			                     .e_end = IMASK_INF },
@@ -271,6 +272,7 @@ M0_INTERNAL void m0_dix_cli_fini(struct m0_dix_cli *cli)
 	m0_dix_ldesc_fini(&cli->dx_layout);
 	m0_dix_ldesc_fini(&cli->dx_ldescr);
 	m0_sm_fini(&cli->dx_sm);
+	cli->dx_dtms = NULL;
 }
 
 M0_INTERNAL void m0_dix_cli_fini_lock(struct m0_dix_cli *cli)

--- a/dix/client.h
+++ b/dix/client.h
@@ -167,6 +167,7 @@ struct m0_be_tx_remid;
 struct m0_dix_req;
 struct m0_pool_version;
 struct m0_fid;
+struct m0_dtm0_service;
 
 enum m0_dix_cli_state {
         DIXCLI_INVALID,
@@ -191,6 +192,7 @@ struct m0_dix_cli {
 	struct m0_dix_ldesc      dx_root;
 	struct m0_dix_ldesc      dx_layout;
 	struct m0_dix_ldesc      dx_ldescr;
+	struct m0_dtm0_service   *dx_dtms;
 
 	/**
 	 * The callback function is triggerred to update FSYNC records

--- a/dtm/dtm.h
+++ b/dtm/dtm.h
@@ -503,6 +503,7 @@
 
 /* import */
 struct m0_dtm_history_type;
+struct m0_dtm0_dtx;
 
 /* export */
 struct m0_dtm;
@@ -558,6 +559,8 @@ struct m0_dtx {
 	struct m0_be_tx        tx_betx;
 	struct m0_be_tx_credit tx_betx_cred;
 	struct m0_fol_rec      tx_fol_rec;
+	/* It is the real dtx here (at least on the originator side). */
+	struct m0_dtm0_dtx    *tx_dtx;
 };
 
 M0_INTERNAL void m0_dtx_init(struct m0_dtx *tx,

--- a/dtm0/Kbuild.sub
+++ b/dtm0/Kbuild.sub
@@ -5,4 +5,5 @@ m0tr_objects += \
                   dtm0/tx_desc.o \
                   dtm0/tx_desc_xc.o \
                   dtm0/service.o \
-                  dtm0/fop.o
+                  dtm0/fop.o \
+                  dtm0/dtx.o

--- a/dtm0/Makefile.sub
+++ b/dtm0/Makefile.sub
@@ -9,7 +9,9 @@ motr_libmotr_la_SOURCES += \
                         dtm0/tx_desc.c \
                         dtm0/tx_desc.h \
                         dtm0/helper.c \
-                        dtm0/helper.h
+                        dtm0/helper.h \
+                        dtm0/dtx.c \
+                        dtm0/dtx.h
 
 nodist_motr_libmotr_la_SOURCES += \
                                   dtm0/fop_xc.c \

--- a/dtm0/dtx.c
+++ b/dtm0/dtx.c
@@ -1,0 +1,287 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+
+
+/**
+ * @addtogroup dtm
+ *
+ * @{
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
+#include "dtm0/dtx.h"
+#include "lib/assert.h" /* M0_PRE */
+#include "lib/memory.h" /* M0_ALLOC */
+#include "lib/errno.h"  /* ENOMEM */
+#include "lib/trace.h"  /* M0_ERR */
+#include "dtm0/service.h" /* m0_dtm0_service */
+#include "reqh/reqh.h" /* reqh2confc */
+#include "conf/helpers.h" /* proc2srv */
+
+static struct m0_sm_state_descr dtx_states[] = {
+	[M0_DDS_INIT] = {
+		.sd_flags     = M0_SDF_INITIAL | M0_SDF_FINAL,
+		.sd_name      = "init",
+		.sd_allowed   = M0_BITS(M0_DDS_INPROGRESS),
+	},
+	[M0_DDS_INPROGRESS] = {
+		.sd_name      = "inprogress",
+		.sd_allowed   = M0_BITS(M0_DDS_EXECUTED, M0_DDS_FAILED),
+	},
+	[M0_DDS_EXECUTED] = {
+		.sd_name      = "executed",
+		.sd_allowed   = M0_BITS(M0_DDS_PERSISTENT),
+	},
+	[M0_DDS_PERSISTENT] = {
+		.sd_name      = "persistent",
+		.sd_allowed   = M0_BITS(M0_DDS_STABLE),
+	},
+	[M0_DDS_STABLE] = {
+		.sd_name      = "stable",
+		.sd_allowed   = M0_BITS(M0_DDS_DONE),
+	},
+	[M0_DDS_DONE] = {
+		.sd_name      = "done",
+		.sd_flags     = M0_SDF_TERMINAL,
+	},
+	[M0_DDS_FAILED] = {
+		.sd_name      = "failed",
+		.sd_flags     = M0_SDF_TERMINAL | M0_SDF_FAILURE
+	}
+};
+
+static struct m0_sm_trans_descr dtx_trans[] = {
+	{ "populated",  M0_DDS_INIT,       M0_DDS_INPROGRESS },
+	{ "executed",   M0_DDS_INPROGRESS, M0_DDS_EXECUTED   },
+	{ "exec-fail",  M0_DDS_INPROGRESS, M0_DDS_FAILED     },
+	{ "persistent", M0_DDS_EXECUTED,   M0_DDS_PERSISTENT },
+	{ "stable",     M0_DDS_PERSISTENT, M0_DDS_STABLE     },
+	{ "prune",      M0_DDS_STABLE,     M0_DDS_DONE       }
+};
+
+static struct m0_sm_conf dtx_sm_conf = {
+	.scf_name      = "dtm0dtx",
+	.scf_nr_states = ARRAY_SIZE(dtx_states),
+	.scf_state     = dtx_states,
+	.scf_trans_nr  = ARRAY_SIZE(dtx_trans),
+	.scf_trans     = dtx_trans,
+};
+
+M0_INTERNAL void m0_dtm0_dtx_domain_init(void)
+{
+	if (!m0_sm_conf_is_initialized(&dtx_sm_conf))
+		m0_sm_conf_init(&dtx_sm_conf);
+}
+
+M0_INTERNAL void m0_dtm0_dtx_domain_fini(void)
+{
+	if (m0_sm_conf_is_initialized(&dtx_sm_conf))
+		m0_sm_conf_fini(&dtx_sm_conf);
+}
+
+static struct m0_dtm0_dtx *m0_dtm0_dtx_alloc(struct m0_dtm0_service *svc,
+					     struct m0_sm_group     *group)
+{
+	struct m0_dtm0_dtx *dtx;
+
+	M0_PRE(svc != NULL);
+	M0_PRE(group != NULL);
+
+	M0_ALLOC_PTR(dtx);
+	if (dtx != NULL) {
+		dtx->dd_dtms = svc;
+		dtx->dd_ancient_dtx.tx_dtx = dtx;
+		m0_sm_init(&dtx->dd_sm, &dtx_sm_conf, M0_DDS_INIT, group);
+	}
+	return dtx;
+}
+
+static void m0_dtm0_dtx_free(struct m0_dtm0_dtx *dtx)
+{
+	M0_PRE(dtx != NULL);
+	m0_sm_fini(&dtx->dd_sm);
+	m0_dtm0_tx_desc_fini(&dtx->dd_txd);
+	m0_free(dtx);
+}
+
+static int m0_dtm0_dtx_prepare(struct m0_dtm0_dtx *dtx)
+{
+	int               rc;
+
+	M0_PRE(dtx != NULL);
+	rc = m0_dtm0_clk_src_now(&dtx->dd_dtms->dos_clk_src,
+				 &dtx->dd_txd.dtd_id.dti_ts);
+	if (rc != 0)
+		return M0_RC(rc);
+
+	dtx->dd_txd.dtd_id.dti_fid = dtx->dd_dtms->dos_generic.rs_service_fid;
+	M0_POST(m0_dtm0_tid__invariant(&dtx->dd_txd.dtd_id));
+	return 0;
+}
+
+static int m0_dtm0_dtx_open(struct m0_dtm0_dtx  *dtx,
+			    uint32_t             nr)
+{
+	M0_PRE(dtx != NULL);
+	return m0_dtm0_tx_desc_init(&dtx->dd_txd, nr);
+}
+
+static int m0_dtm0_dtx_assign(struct m0_dtm0_dtx  *dtx,
+			      uint32_t             pa_idx,
+			      const struct m0_fid *pa_fid)
+{
+	struct m0_dtm0_tx_pa   *pa;
+	struct m0_reqh         *reqh;
+	struct m0_conf_cache   *cache;
+	struct m0_conf_obj     *obj;
+	struct m0_conf_process *proc;
+	struct m0_fid           rdtms_fid;
+	int                     rc;
+
+	M0_PRE(dtx != NULL);
+	M0_PRE(pa_idx < dtx->dd_txd.dtd_pg.dtpg_nr);
+	M0_PRE(m0_fid_is_valid(pa_fid));
+
+	/* TODO: Should we release any conf objects in the end? */
+
+	reqh = dtx->dd_dtms->dos_generic.rs_reqh;
+	cache = &m0_reqh2confc(reqh)->cc_cache;
+
+	obj = m0_conf_cache_lookup(cache, pa_fid);
+	M0_ASSERT_INFO(obj != NULL, "User service is not in the conf cache?");
+
+	obj = m0_conf_obj_grandparent(obj);
+	M0_ASSERT_INFO(obj != NULL, "Process the service belongs to "
+		       "is not a part of the conf cache?");
+
+	proc = M0_CONF_CAST(obj, m0_conf_process);
+	M0_ASSERT_INFO(proc != NULL, "The grandparent is not a process?");
+
+	rc = m0_conf_process2service_get(&reqh->rh_rconfc.rc_confc,
+					 &proc->pc_obj.co_id, M0_CST_DTM0,
+					 &rdtms_fid);
+
+	M0_ASSERT_INFO(rc == 0, "Cannot find remote DTM service on the remote "
+		       "process that runs this user service?");
+
+	pa = &dtx->dd_txd.dtd_pg.dtpg_pa[pa_idx];
+	M0_PRE(M0_IS0(pa));
+
+	pa->pa_fid = rdtms_fid;
+	M0_ASSERT(pa->pa_state == M0_DTPS_INIT);
+	pa->pa_state = M0_DTPS_INPROGRESS;
+
+	M0_LOG(DEBUG, "pa: " FID_F " (User) => " FID_F " (DTM) ",
+	       FID_P(pa_fid), FID_P(&rdtms_fid));
+
+	/* TODO: All these M0_ASSERTs will be converted into IFs eventually
+	 * if we want to gracefully fail instead of m0_panic'ing in the case
+	 * where the config is not correct.
+	 */
+	return M0_RC(0);
+}
+
+static int m0_dtm0_dtx_close(struct m0_dtm0_dtx *dtx)
+{
+	M0_PRE(dtx != NULL);
+	M0_PRE(m0_sm_group_is_locked(dtx->dd_sm.sm_grp));
+
+	m0_sm_state_set(&dtx->dd_sm, M0_DDS_INPROGRESS);
+
+	/* TODO: add a log entry */
+
+	return 0;
+}
+
+M0_INTERNAL struct m0_dtx* m0_dtx0_alloc(struct m0_dtm0_service *svc,
+					 struct m0_sm_group     *group)
+{
+	struct m0_dtm0_dtx *dtx;
+
+	dtx = m0_dtm0_dtx_alloc(svc, group);
+	if (dtx == NULL)
+		return NULL;
+
+	return &dtx->dd_ancient_dtx;
+}
+
+M0_INTERNAL void m0_dtx0_free(struct m0_dtx *dtx)
+{
+	M0_PRE(dtx != NULL);
+	m0_dtm0_dtx_free(dtx->tx_dtx);
+}
+
+M0_INTERNAL int m0_dtx0_prepare(struct m0_dtx *dtx)
+{
+	M0_PRE(dtx != NULL);
+	return m0_dtm0_dtx_prepare(dtx->tx_dtx);
+}
+
+M0_INTERNAL int m0_dtx0_open(struct m0_dtx  *dtx, uint32_t nr)
+{
+	M0_PRE(dtx != NULL);
+	return m0_dtm0_dtx_open(dtx->tx_dtx, nr);
+}
+
+M0_INTERNAL int m0_dtx0_assign(struct m0_dtx       *dtx,
+			       uint32_t             pa_idx,
+			       const struct m0_fid *pa_fid)
+{
+	M0_PRE(dtx != NULL);
+	return m0_dtm0_dtx_assign(dtx->tx_dtx, pa_idx, pa_fid);
+}
+
+M0_INTERNAL int m0_dtx0_close(struct m0_dtx *dtx)
+{
+	M0_PRE(dtx != NULL);
+	return m0_dtm0_dtx_close(dtx->tx_dtx);
+}
+
+M0_INTERNAL int m0_dtx0_copy_txd(const struct m0_dtx    *dtx,
+				 struct m0_dtm0_tx_desc *dst)
+{
+	if (dtx == NULL) {
+		/* No DTX => no txr */
+		M0_SET0(dst);
+		return 0;
+	}
+
+	return m0_dtm0_tx_desc_copy(&dtx->tx_dtx->dd_txd, dst);
+}
+
+
+#undef M0_TRACE_SUBSYSTEM
+
+/** @} end of dtm group */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/dtx.h
+++ b/dtm0/dtx.h
@@ -1,0 +1,107 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2012-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+
+#pragma once
+
+#ifndef __MOTR_DTM0_DTX_H__
+#define __MOTR_DTM0_DTX_H__
+
+#include "dtm0/tx_desc.h" /* m0_dtm0_tx_desc */
+#include "sm/sm.h"        /* m0_sm */
+#include "dtm/dtm.h"      /* m0_dtx */
+
+enum m0_dtm0_dtx_state {
+	/** An empty dtx. */
+	M0_DDS_INIT,
+	/* dtx has a valid tx record. */
+	M0_DDS_INPROGRESS,
+	/* dtx got one reply. */
+	M0_DDS_EXECUTED,
+	/* dtx got one PERSISTENT notice. */
+	M0_DDS_PERSISTENT,
+	/* dtx Got enough PERSISTENT notices. */
+	M0_DDS_STABLE,
+	/* dtx can be released when this state reached. */
+	M0_DDS_DONE,
+	/* dtx can fail. */
+	M0_DDS_FAILED,
+	M0_DDS_NR,
+};
+
+struct m0_dtm0_dtx {
+	/** An imprint of the ancient version of dtx.
+	 * This DTX was created at the begining of the time, and it was
+	 * propogated all over the codebase. Since it is really hard to
+	 * remove it, we instead venerate it by providing the very first
+	 * place in this new dtm0 structure. It helps to have a simple
+	 * typecast (without branded object) and no extra allocations for
+	 * this ancient but not really useful at this momemnt structure.
+	 */
+	struct m0_dtx           dd_ancient_dtx;
+	/* see m0_dtm0_dtx_state */
+	struct m0_sm            dd_sm;
+	struct m0_dtm0_tx_desc  dd_txd;
+	struct m0_dtm0_service *dd_dtms;
+};
+
+M0_INTERNAL void m0_dtm0_dtx_domain_init(void);
+M0_INTERNAL void m0_dtm0_dtx_domain_fini(void);
+
+/* The API below extends the existing m0_dtx API. Since it operates
+ * on m0_dtx structure in the "DTM0"-way, the naming convention here is
+ * a bit different (m0_dtx + dtm0 => m0_dtx0).
+ */
+
+M0_INTERNAL struct m0_dtx* m0_dtx0_alloc(struct m0_dtm0_service *svc,
+					 struct m0_sm_group     *group);
+M0_INTERNAL void m0_dtx0_free(struct m0_dtx *dtx);
+
+/* Assigns TID to the transaction. */
+M0_INTERNAL int m0_dtx0_prepare(struct m0_dtx *dtx);
+
+M0_INTERNAL int m0_dtx0_open(struct m0_dtx  *dtx, uint32_t nr);
+M0_INTERNAL int m0_dtx0_assign(struct m0_dtx       *dtx,
+			       uint32_t             pa_idx,
+			       const struct m0_fid *pa_fid);
+M0_INTERNAL int m0_dtx0_close(struct m0_dtx *dtx);
+
+/* Puts a copy of dtx's transaction descriptor into "dst".
+ * User is responsible for m0_dtm0_tx_desc_fini()lasing 'dst'.
+ * If dtx is NULL then dst will be filled with the empty tx_desc.
+ */
+M0_INTERNAL int m0_dtx0_copy_txd(const struct m0_dtx    *dtx,
+				 struct m0_dtm0_tx_desc *dst);
+
+#endif /* __MOTR_DTM0_DTX_H__ */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -91,14 +91,14 @@ static void dtm0_rpc_item_reply_cb(struct m0_rpc_item *item)
 	}
 }
 
-void m0_dtm0_fop_fini(void)
+M0_INTERNAL void m0_dtm0_fop_fini(void)
 {
 	m0_fop_type_fini(&dtm0_req_fop_fopt);
 	m0_fop_type_fini(&dtm0_rep_fop_fopt);
 	m0_xc_dtm0_fop_fini();
 }
 
-int m0_dtm0_fop_init(void)
+M0_INTERNAL int m0_dtm0_fop_init(void)
 {
 	static int init_once = 0;
 	if (init_once++ > 0)

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -34,8 +34,8 @@ extern struct m0_fop_type dtm0_rep_fop_fopt;
 extern const struct m0_rpc_item_ops dtm0_req_fop_rpc_item_ops;
 
 
-int m0_dtm0_fop_init(void);
-void m0_dtm0_fop_fini(void);
+M0_INTERNAL int m0_dtm0_fop_init(void);
+M0_INTERNAL void m0_dtm0_fop_fini(void);
 
 struct dtm0_req_fop {
 	uint64_t csr_value;

--- a/dtm0/service.h
+++ b/dtm0/service.h
@@ -26,6 +26,24 @@
 #define __MOTR_DTM0_SERVICE_H__
 
 #include "reqh/reqh_service.h"
+#include "dtm0/clk_src.h"
+
+enum m0_dtm0_service_origin {
+	DTM0_UNKNOWN = 0,
+	DTM0_ON_VOLATILE,
+	DTM0_ON_PERSISTENT,
+};
+
+/**
+ * DTM0 service structure
+ */
+struct m0_dtm0_service {
+	struct m0_reqh_service       dos_generic;
+	struct m0_tl                 dos_processes;
+	enum m0_dtm0_service_origin  dos_origin;
+	uint64_t                     dos_magix;
+	struct m0_dtm0_clk_src       dos_clk_src;
+};
 
 extern struct m0_reqh_service_type dtm0_service_type;
 
@@ -45,4 +63,6 @@ m0_dtm0_service_process_session_get(struct m0_reqh_service *s,
 M0_INTERNAL bool m0_dtm0_is_a_volatile_dtm(struct m0_reqh_service *service);
 M0_INTERNAL bool m0_dtm0_is_a_persistent_dtm(struct m0_reqh_service *service);
 
+M0_INTERNAL struct m0_dtm0_service *
+m0_dtm0_service_find(const struct m0_reqh *reqh);
 #endif /* __MOTR_DTM0_SERVICE_H__ */

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -37,6 +37,7 @@
 #include "rm/rm_service.h"            /* m0_rms_type */
 #include "net/lnet/lnet_core_types.h" /* M0_NET_LNET_NIDSTR_SIZE */
 #include "net/lnet/lnet.h"            /* m0_net_lnet_xprt */
+#include "dtm0/service.h"              /* m0_dtm0_service_find */
 
 #include "motr/io.h"                /* io_sm_conf */
 #include "motr/client.h"
@@ -1603,6 +1604,8 @@ int m0_client_init(struct m0_client **m0c_p,
 
 	/* Init the hash-table for RM contexts */
 	rm_ctx_htable_init(&m0c->m0c_rm_ctxs, M0_RM_HBUCKET_NR);
+
+	m0c->m0c_dtms = m0_dtm0_service_find(&m0c->m0c_reqh);
 
 	if (conf->mc_is_addb_init) {
 		char buf[64];

--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -63,6 +63,8 @@
 #include "fop/fop.h"
 
 struct m0_idx_service_ctx;
+struct m0_dtm0_service;
+struct m0_dtx;
 
 #ifdef CLIENT_FOR_M0T1FS
 /**
@@ -225,6 +227,9 @@ struct m0_op_idx {
 	struct dix_req     *oi_dix_req;
 	/** To know dix req in completion callback */
 	bool                oi_in_completion;
+
+	/** Distributed transaction associated with the operation */
+	struct m0_dtx      *oi_dtx;
 };
 
 /**
@@ -581,6 +586,8 @@ struct m0_client {
 #endif
 
 	struct m0_htable                        m0c_rm_ctxs;
+
+	struct m0_dtm0_service                 *m0c_dtms;
 };
 
 /** CPUs semaphore - to control CPUs usage by parity calcs. */

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -785,18 +785,30 @@ struct m0_client* st_get_instance()
 #include "dtm0/helper.h"
 #include "dtm0/service.h"
 
-#define M0_FID(c_, k_)  { .f_container = c_, .f_key = k_ }
-static void st_one_dtm0_op_idx_create(void)
+static void st_put_one(void)
 {
 	struct m0_container realm;
 	struct m0_idx       idx;
 	struct m0_fid       ifid;
 	struct m0_op       *op = NULL;
 	int                 rc;
+	struct m0_bufvec    keys;
+	struct m0_bufvec    vals;
+	int                 rcs[1];
+	m0_bcount_t         len = 1;
+	char               *key;
+	char               *val;
+	int                 flags = 0;
+
+	key = m0_strdup("ItIsAKey");
+	val = m0_strdup("ItIsAValue");
+
+	keys = M0_BUFVEC_INIT_BUF((void **) &key, &len);
+	vals = M0_BUFVEC_INIT_BUF((void **) &val, &len);
 
 	general_ifid_fill(&ifid, true);
 	m0_container_init(&realm, NULL, &M0_UBER_REALM, ut_m0c);
-	m0_idx_init(&idx, &realm.co_realm, (struct m0_uint128 *)&ifid);
+	m0_idx_init(&idx, &realm.co_realm, (struct m0_uint128 *) &ifid);
 
 	/* Create index. */
 	rc = m0_entity_create(NULL, &idx.in_entity, &op);
@@ -805,29 +817,47 @@ static void st_one_dtm0_op_idx_create(void)
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_fini(op);
-	m0_free0(&op);
+	m0_op_free(op);
+	op = NULL;
+
+	/* PUT one kv pair */
+	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs, flags, &op);
+	M0_UT_ASSERT(rc == 0);
+	m0_op_launch(&op, 1);
+	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(op->op_rc == 0);
+	m0_op_fini(op);
+	m0_op_free(op);
+	op = NULL;
 
 	m0_idx_fini(&idx);
+	m0_free(key);
+	m0_free(val);
 }
 
 static void st_one_dtm0_op(void)
 {
-	static struct m0_fid     cli_srv_fid  = M0_FID(0x7300000000000001, 0x1a);
-	static struct m0_fid     srv_dtm0_fid = M0_FID(0x7300000000000001, 0x1c);
+	static struct m0_fid     cli_srv_fid  = M0_FID_INIT(0x7300000000000001,
+							    0x1a);
+	static struct m0_fid     srv_dtm0_fid = M0_FID_INIT(0x7300000000000001,
+							    0x1c);
 	static const char       *cl_ep_addr   = "0@lo:12345:34:1";
 	struct m0_reqh_service  *cli_srv;
 	struct m0_reqh_service  *srv_srv;
-	struct m0_reqh          *srv_reqh = &dix_ut_sctx.rsx_motr_ctx.cc_reqh_ctx.rc_reqh;
-	int rc;
+	struct m0_reqh          *srv_reqh;
+	int                      rc;
 
+	srv_reqh = &dix_ut_sctx.rsx_motr_ctx.cc_reqh_ctx.rc_reqh;
 	cli_srv = m0_dtm__client_service_start(&ut_m0c->m0c_reqh, &cli_srv_fid);
 	M0_UT_ASSERT(cli_srv != NULL);
 	srv_srv = m0_reqh_service_lookup(srv_reqh, &srv_dtm0_fid);
 	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr);
 	M0_UT_ASSERT(rc == 0);
+	ut_m0c->m0c_dtms = m0_dtm0_service_find(srv_reqh);
+	M0_UT_ASSERT(ut_m0c->m0c_dtms != NULL);
 
-	/* XXX: put logic here */
-	st_one_dtm0_op_idx_create();
+	st_put_one();
 
 	rc = m0_dtm0_service_process_disconnect(srv_srv, &cli_srv_fid);
 	M0_UT_ASSERT(rc == 0);


### PR DESCRIPTION
The patch introduces DTX into DIX and
the related modules (motr client, dix/cas
requests and so on).
The patch has an update version of the UT
where m0 client sends a kv pair. When
DTM0 is enabled (--enable-dtm0), DTX module
sets the TX record. The transaction id of this
record is printed on the receiver side.

Signed-off-by: Ivan Alekhin <ivan.alekhin@seagate.com>