### PR TITLE
EOS-16179:[DTM0]

### DIFF
--- a/cas/client.c
+++ b/cas/client.c
@@ -176,6 +176,7 @@ static int creq_op_alloc(uint64_t           recs_nr,
 	} else {
 		op->cg_rec.cr_nr = recs_nr;
 		op->cg_rec.cr_rec = rec;
+		m0_dtm0_tx_desc_init_none(&op->cg_txd);
 		*out = op;
 	}
 	return M0_RC(0);

--- a/cas/service.c
+++ b/cas/service.c
@@ -20,6 +20,10 @@
  */
 
 
+#include "be/op.h"
+#include "be/tx_credit.h"
+#include "dtm0/fop.h"
+#include "dtm0/fop_xc.h"
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_CAS
 
 #include "lib/trace.h"
@@ -277,7 +281,7 @@
  * - HLD of the catalogue service :
  * For documentation links, please refer to this file :
  * doc/motr-design-doc-list.rst
- * 
+ *
  * @{
  */
 
@@ -1335,6 +1339,24 @@ static int cas_fom_tick(struct m0_fom *fom0)
 			m0_ctg_op_init(&fom->cf_ctg_op, fom0,
 				       cas_op(fom0)->cg_flags);
 		}
+
+		/* If cas request has a txr payload, this a dtm0 operation.
+		 * We need to calculate credits for creating a dtm0 log record.
+		 *
+		 */
+		if (!m0_dtm0_tx_desc_is_none(&cas_op(fom0)->cg_txd)) {
+			/*
+			struct m0_be_tx_credit dtm0logrec_cred;
+
+			m0_be_dtm0_log_credit(M0_DTML_EXECUTED,
+					      tx,
+					      cas_op(fom0)->cg_txd,
+					      m0_fom_reqh(fom0)->rh_beseg,
+					      &dtm0logrec_cred);
+			m0_be_tx_credit_add(&fom0->fo_tx.tx_betx_cred, &dtm0logrec_cred);
+					      */
+		}
+
 		m0_fom_phase_set(fom0, M0_FOPH_TXN_OPEN);
 		/*
 		 * @todo waiting for transaction open with btree (which can be

--- a/dtm0/dtm0.h
+++ b/dtm0/dtm0.h
@@ -1,0 +1,110 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+#pragma once
+
+#ifndef __MOTR_DTM0_DTM0_H__
+#define __MOTR_DTM0_DTM0_H__
+
+/**
+ * @page dtm0s-fspec The dtm0 service (DTM0S)
+ *
+ * DTM0 will reuse existing cas service and cas fops/foms to deliver dtx related
+ * information.
+ *
+ * Cas fop will aggregate additional data related to dtx, txr {list of
+ * participants, versions, ...}. It creates a tx descriptor containing this
+ * information and embeds it in cas_op as a dtm0 transaction payload.
+ *
+ * The interface of the service for a user is a format of request/reply FOPs.
+ * DTM0 service registers following FOP types during initialisation:
+ * - @ref dtm0_req_fop_fopt
+ * - @ref dtm0_rep_fop_fopt
+ *
+ * DTM supports three kinds of FOP/FOM operations.
+ * - EXECUTED FOP/FOM: when a cas fop is being executed, cas service will check
+ *   for the existence of the dtm transaction information. If it is present, cas
+ *   will log the tx descriptor locally on each of the dtm participants.  dtm0
+ *   log will be updated inside cas fom (ad property of tx). The txr will be
+ *   executed just before tx_close phase of the fom inside fom_fol_rec_add().
+ * - REDO FOP/FOM: When a participant service restarts after a transient failure
+ *   the other existing participants sends REDO requests to the recovering
+ *   participant.
+ * - PERSISTENT FOP/FOM: When the transaction get logged, DTM sends a PERSISTENT
+ *   FOP to the other participants and to the originator indicating that the
+ *   change caused by the Cas operation has become permanent.
+ *
+ * @subsection dtm0-state State Specification
+ *
+ * @verbatim
+ *
+ *			    |
+ *			    V
+ *			FOPH_INIT
+ *			    |
+ *			    V
+ *		    [generic phases]
+ *			    |
+ *			    V
+ *			 TXN_INIT
+ * 			    |
+ *			    V
+ *			 TXN_OPEN
+ *			    |
+ *			    V
+ *		    UPDATE DTM0 LOG
+ *			    |
+ *			    V
+ *			 TXN_CLOSE
+ *			    |
+ *			    V
+ *			FOPH_FINI
+ *
+ * @verbatim
+ *
+ * Each dtm0_req_fop also carries a dtm_msg type which tells what kind of message it
+ * is carrying.  A dtms0_op containing a request must specify a message type of
+ * either DMT_EXECUTE,indicating that this request contains an operation to
+ * be executed, a m0_dtms0_op containing a reply operation should contain either
+ * a DMT_EXECUTED or a DMT_PERSISTENT message.
+ */
+
+/**
+ * @{
+ */
+
+#endif /* __MOTR_DTM0_DTM0_H__ */
+
+/*
+ * }@
+ */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -127,20 +127,6 @@ M0_INTERNAL int m0_dtm0_fop_init(void)
 	return 0;
 }
 
-static bool dtm0_service_started(struct m0_fop  *fop,
-				struct m0_reqh *reqh)
-{
-	struct m0_reqh_service            *svc;
-	const struct m0_reqh_service_type *stype;
-
-	stype = fop->f_type->ft_fom_type.ft_rstype;
-	M0_ASSERT(stype != NULL);
-
-	svc = m0_reqh_service_find(stype, reqh);
-	M0_ASSERT(svc != NULL);
-
-	return m0_reqh_service_state_get(svc) == M0_RST_STARTED;
-}
 /*
   Allocates a fop.
  */
@@ -177,9 +163,6 @@ static int dtm0_fom_create(struct m0_fop *fop,
 	struct m0_fom     *fom0;
 	struct m0_fop     *repfop;
 	struct dtm0_rep_fop *reply;
-
-	if (!dtm0_service_started(fop, reqh))
-		return M0_ERR(-EAGAIN);
 
 	M0_ALLOC_PTR(fom);
 

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -20,17 +20,21 @@
  */
 
 
+#include "dtm0/tx_desc.h"
+#include "dtm0/tx_desc_xc.h"
 #include "lib/errno.h"
 #include "lib/assert.h"
 #include "lib/memory.h"
 #include "lib/chan.h"
 #include "lib/finject.h"
 #include "lib/time.h"
+#include "lib/trace.h"
 #include "lib/misc.h"           /* M0_IN() */
 #include "fop/fop.h"
 #include "fop/fom.h"
 #include "fop/fom_generic.h"
 
+/* #include "lib/user_space/misc.h" */
 #include "rpc/rpc.h"
 #include "rpc/rpclib.h"
 #include "fop/fop_item_type.h"
@@ -56,12 +60,12 @@ struct m0_fop_type dtm0_rep_fop_fopt;
   Fom specific routines for corresponding fops.
  */
 static int dtm0_fom_tick(struct m0_fom *fom);
-static int dtm0_req_fop_fom_create(struct m0_fop *fop, struct m0_fom **out,
-				   struct m0_reqh *reqh);
+static int dtm0_fom_create(struct m0_fop *fop, struct m0_fom **out,
+			       struct m0_reqh *reqh);
 static void dtm0_fom_fini(struct m0_fom *fom);
 static size_t dtm0_fom_locality(const struct m0_fom *fom);
 
-static const struct m0_fom_ops dtm0_req_fop_fom_ops = {
+static const struct m0_fom_ops dtm0_req_fom_ops = {
 	.fo_fini = dtm0_fom_fini,
 	.fo_tick = dtm0_fom_tick,
 	.fo_home_locality = dtm0_fom_locality
@@ -73,8 +77,8 @@ enum dtm0_phases {
 	DTM0_REQ_WHATEVER = M0_FOPH_NR + 1,
 };
 
-static const struct m0_fom_type_ops dtm0_req_fop_fom_type_ops = {
-        .fto_create = dtm0_req_fop_fom_create,
+static const struct m0_fom_type_ops dtm0_req_fom_type_ops = {
+        .fto_create = dtm0_fom_create,
 };
 
 static void dtm0_rpc_item_reply_cb(struct m0_rpc_item *item)
@@ -110,7 +114,7 @@ M0_INTERNAL int m0_dtm0_fop_init(void)
 			 .opcode    = M0_DTM0_REQ_OPCODE,
 			 .xt        = dtm0_req_fop_xc,
 			 .rpc_flags = M0_RPC_MUTABO_REQ,
-			 .fom_ops   = &dtm0_req_fop_fom_type_ops,
+			 .fom_ops   = &dtm0_req_fom_type_ops,
 			 .sm        = &m0_generic_conf,
 			 .svc_type  = &dtm0_service_type);
 	M0_FOP_TYPE_INIT(&dtm0_rep_fop_fopt,
@@ -118,38 +122,83 @@ M0_INTERNAL int m0_dtm0_fop_init(void)
 			 .opcode    = M0_DTM0_REP_OPCODE,
 			 .xt        = dtm0_rep_fop_xc,
 			 .rpc_flags = M0_RPC_ITEM_TYPE_REPLY,
-			 .fom_ops   = &dtm0_req_fop_fom_type_ops);
+			 .fom_ops   = &dtm0_req_fom_type_ops);
 	return 0;
 }
 
-/*
-  Allocates and initialises a fom.
- */
-static int dtm0_req_fop_fom_create(struct m0_fop *fop,
-				   struct m0_fom **out, struct m0_reqh *reqh)
+static bool dtm0_service_started(struct m0_fop  *fop,
+				struct m0_reqh *reqh)
 {
-        struct m0_fom           *fom;
-	struct m0_fop           *rfop;
+	struct m0_reqh_service            *svc;
+	const struct m0_reqh_service_type *stype;
 
-	M0_PRE(fop != NULL);
-        M0_PRE(out != NULL);
-	M0_PRE(M0_IN(m0_fop_opcode(fop), (M0_DTM0_REQ_OPCODE)));
+	stype = fop->f_type->ft_fom_type.ft_rstype;
+	M0_ASSERT(stype != NULL);
 
-        M0_ALLOC_PTR(fom);
-        if (fom == NULL)
-                return -ENOMEM;
+	svc = m0_reqh_service_find(stype, reqh);
+	M0_ASSERT(svc != NULL);
 
-	rfop = m0_fop_reply_alloc(fop, &dtm0_rep_fop_fopt);
+	return m0_reqh_service_state_get(svc) == M0_RST_STARTED;
+}
+/*
+  Allocates a fop.
+ */
 
-	if (rfop == NULL) {
+int m0_dtm0_fop_create(struct m0_rpc_session	 *session,
+		       enum m0_dtm0s_msg	  opmsg,
+		       struct m0_dtm0_tx_desc	 *txr,
+		       struct m0_fop		**out)
+{
+	struct dtm0_req_fop  *op;
+	struct m0_fop	     *fop;
+	int                rc = 0;
+
+	*out = NULL;
+
+	fop = m0_fop_alloc_at(session, &dtm0_req_fop_fopt);
+	if (fop == NULL)
+		return M0_ERR(-ENOMEM);
+	op = m0_fop_data(fop);
+	op->dtr_msg = opmsg;
+	op->dtr_txr = *txr;
+	*out = fop;
+	return rc;
+}
+M0_EXPORTED(m0_dtm0_fop_create);
+
+/*
+  Allocates a fom.
+ */
+static int dtm0_fom_create(struct m0_fop *fop,
+			  struct m0_fom **out, struct m0_reqh *reqh)
+{
+	struct dtm0_fom    *fom;
+	struct m0_fom     *fom0;
+	struct m0_fop     *repfop;
+	struct dtm0_rep_fop *reply;
+
+	if (!dtm0_service_started(fop, reqh))
+		return M0_ERR(-EAGAIN);
+
+	M0_ALLOC_PTR(fom);
+
+	repfop = m0_fop_reply_alloc(fop, &dtm0_rep_fop_fopt);
+	if (fom != NULL && repfop != NULL) {
+		*out = fom0 = &fom->dtf_fom;
+		/** TODO: calculate credits for the operation.
+		 */
+
+		reply = m0_fop_data(repfop);
+		reply->dr_txr = (struct m0_dtm0_tx_desc) {};
+		reply->dr_rc = 0;
+		m0_fom_init(fom0, &fop->f_type->ft_fom_type,
+			    &dtm0_req_fom_ops, fop, repfop, reqh);
+		return M0_RC(0);
+	} else {
+		m0_free(repfop);
 		m0_free(fom);
-		return -ENOMEM;
+		return M0_ERR(-ENOMEM);
 	}
-	m0_fom_init(fom, &fop->f_type->ft_fom_type,
-		    &dtm0_req_fop_fom_ops, fop, rfop, reqh);
-
-        *out = fom;
-        return 0;
 }
 
 static void dtm0_fom_fini(struct m0_fom *fom)
@@ -168,19 +217,29 @@ static size_t dtm0_fom_locality(const struct m0_fom *fom)
 }
 
 #define M0_FID(c_, k_)  { .f_container = c_, .f_key = k_ }
-static void dtm0_pong_back(struct m0_rpc_session *session)
+static void dtm0_pong_back(struct m0_fid *fid, struct m0_rpc_session *session)
 {
         struct m0_fop         *fop;
 	struct dtm0_req_fop   *req;
 	struct m0_rpc_item    *item;
 	int                    rc;
 
+	struct m0_dtm0_tx_desc txr;
+
+	struct m0_dtm0_clk_src dcs;
+	struct m0_dtm0_ts      now;
+	/* struct m0_fid fid = M0_FID(0x7300000000000001, 0x1a); */
+
 	M0_PRE(session != NULL);
+
+	m0_dtm0_clk_src_init(&dcs, M0_DTM0_CS_PHYS);
+	rc = m0_dtm0_clk_src_now(&dcs, &now);
+
+	txr.dtd_id = (struct m0_dtm0_tid) { .dti_ts = now, .dti_fid = *fid};
 
 	fop = m0_fop_alloc_at(session, &dtm0_req_fop_fopt);
 	req = m0_fop_data(fop);
-	req->csr_value = 555;
-
+	req->dtr_txr = txr;
 	item              = &fop->f_item;
 	item->ri_ops      = &dtm0_req_fop_rpc_item_ops;
 	item->ri_session  = session;
@@ -203,18 +262,21 @@ static int dtm0_fom_tick(struct m0_fom *fom)
 	} else {
 		req = m0_fop_data(fom->fo_fop);
 		rep = m0_fop_data(fom->fo_rep_fop);
-		rep->csr_rc = req->csr_value;
+
+		//m0_buf_copy(&rep->dr_txr->dt_txr_payload, &req->dto_txr->dt_txr_payload);
+		rep->dr_txr = req->dtr_txr;
+		rep->dr_rc = 0;
 		m0_fom_phase_set(fom, M0_FOPH_SUCCESS);
 		rc = M0_FSO_AGAIN;
 		if (m0_dtm0_is_a_persistent_dtm(fom->fo_service)) {
 			struct m0_fid fid = M0_FID(0x7300000000000001, 0x1a);
-			dtm0_pong_back(
+			dtm0_pong_back(&fid,
 				m0_dtm0_service_process_session_get(
 					fom->fo_service, &fid));
 		}
 	}
 
-	return rc;
+	return M0_RC(rc);
 }
 
 /*

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -22,11 +22,27 @@
 
 #pragma once
 
-#ifndef __MOTR_DTM0_FOP_FOMS_H__
-#define __MOTR_DTM0_FOP_FOMS_H__
+#ifndef __MOTR_DTM0_FOP_H__
+#define __MOTR_DTM0_FOP_H__
 
+#include "fop/fop.h"
+#include "fop/fom_generic.h"
+#include "fop/fom_long_lock.h"
+#include "be/op.h"
+#include "be/btree.h"
+#include "be/btree_xc.h"
+#include "be/tx_credit.h"
+/* #include "dtm0/fop_xc.h" */
+#include "lib/buf.h"
+#include "lib/buf_xc.h"
 #include "lib/types.h"
+#include "rpc/at.h"
 #include "xcode/xcode_attr.h"
+#include "format/format.h"
+#include "be/dtm0_log.h"
+#include "dtm0/tx_desc.h"
+#include "dtm0/tx_desc_xc.h"
+
 
 extern struct m0_fop_type dtm0_req_fop_fopt;
 extern struct m0_fop_type dtm0_rep_fop_fopt;
@@ -37,15 +53,33 @@ extern const struct m0_rpc_item_ops dtm0_req_fop_rpc_item_ops;
 M0_INTERNAL int m0_dtm0_fop_init(void);
 M0_INTERNAL void m0_dtm0_fop_fini(void);
 
+enum m0_dtm0s_msg {
+	DMT_EXECUTE,
+	DMT_EXECUTED,
+	DTM_PERSISTENT,
+	DMT_REDO
+} M0_XCA_ENUM;
+
 struct dtm0_req_fop {
-	uint64_t csr_value;
+	uint32_t		dtr_msg M0_XCA_FENUM(
+	m0_dtm0s_msg);
+	struct m0_dtm0_tx_desc dtr_txr;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 struct dtm0_rep_fop {
-	int32_t csr_rc;
+	/** Status code of dtm operation. */
+	int32_t			dr_rc;
+	/** operation results. */
+	struct m0_dtm0_tx_desc	dr_txr;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
-/* __MOTR_DTM0_FOP_FOMS_H__ */
+/** Structure that describes dtm0 FOM. */
+struct dtm0_fom {
+	/** Caller FOM. */
+	struct m0_fom		     dtf_fom;
+};
+
+/* __MOTR_DTM0_FOP_H__ */
 #endif
 
 /*

--- a/dtm0/tx_desc.c
+++ b/dtm0/tx_desc.c
@@ -27,12 +27,24 @@
  * @{
  */
 
+#include "dtm0/clk_src.h"
+#include "lib/misc.h"
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
 #include "dtm0/tx_desc.h"
 #include "lib/assert.h" /* M0_PRE */
 #include "lib/memory.h" /* M0_ALLOC */
 #include "lib/errno.h"  /* ENOMEM */
 #include "lib/trace.h"  /* M0_ERR */
+
+M0_INTERNAL void m0_dtm0_tx_desc_init_none(struct m0_dtm0_tx_desc *td)
+{
+	M0_SET0(td);
+}
+
+M0_INTERNAL bool m0_dtm0_tx_desc_is_none(const struct m0_dtm0_tx_desc *td)
+{
+	return M0_IS0(td);
+}
 
 M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td)
 {

--- a/dtm0/tx_desc.h
+++ b/dtm0/tx_desc.h
@@ -133,6 +133,9 @@ M0_INTERNAL int m0_dtm0_tid_cmp(struct m0_dtm0_clk_src   *cs,
 				const struct m0_dtm0_tid *left,
 				const struct m0_dtm0_tid *right);
 
+M0_INTERNAL void m0_dtm0_tx_desc_init_none(struct m0_dtm0_tx_desc *td);
+M0_INTERNAL bool m0_dtm0_tx_desc_is_none(const struct m0_dtm0_tx_desc *td);
+
 M0_INTERNAL bool m0_dtm0_tid__invariant(const struct m0_dtm0_tid *tid);
 M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td);
 

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -99,8 +99,7 @@ static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
 
 	M0_ASSERT(m0_dtm0_ts__invariant(&reply_data.dti_ts));
 
-	M0_UT_ASSERT(m0_fid_cmp(&g_process_fid, &reply_data.dti_fid) == 0);
-	M0_UT_ASSERT(m0_dtm0_ts_cmp(&dcs, &now, &reply_data.dti_ts) == M0_DTS_EQ);
+	M0_UT_ASSERT(m0_dtm0_tid_cmp(&dcs, &txr.dtd_id, &reply_data) == M0_DTS_EQ);
 
 	m0_fop_put_lock(fop);
 }

--- a/ut/m0ut.c
+++ b/ut/m0ut.c
@@ -194,6 +194,14 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &buffer_pool_ut, true);
 	m0_ut_add(m, &bulkio_client_ut, true);
 	m0_ut_add(m, &bulkio_server_ut, true);
+
+	/*
+	 * ALARM/WARN/XXX: `dtm0_ut' added before mt_idx_dix, due to
+	 * finalisation order of internal structures inside dtm0_ut!
+	 * NEEDS to be addressed! (by Anatoliy)
+	 */
+	m0_ut_add(m, &dtm0_ut, true);
+
 	m0_ut_add(m, &capa_ut, true);
 	m0_ut_add(m, &cas_client_ut, true);
 	m0_ut_add(m, &cas_service_ut, true);
@@ -230,7 +238,6 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &dtm_nucleus_ut, true);
 	m0_ut_add(m, &dtm_transmit_ut, true);
 	m0_ut_add(m, &dtm_dtx_ut, true);
-	m0_ut_add(m, &dtm0_ut, true);
 	m0_ut_add(m, &dtm0_clk_src_ut, true);
 	m0_ut_add(m, &dtm0_log_ut, true);
 	m0_ut_add(m, &failure_domains_tree_ut, true);


### PR DESCRIPTION
Added dtm0 fop request, reply structures, operation and message types,
markers in code where dtm0 operation related credit calculation should
be performed and dtm0 log routines should be called for the basic case
of executing a dtm0 request.
Also added DLD for dtm0 service.

Signed-off-by: Mehul Manharlal Joshi <mehul.joshi@seagate.com>