### PR TITLE
EOS-17153: data recovery orchastration failed with motr-kernel service is not starting on remote node

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -432,7 +432,7 @@ replay_logs_and_get_gen_id_of_seg0() {
             run_cmd_on_remote_node "systemctl start motr-kernel.service"; exit_code=$?;
             [[ $exit_code == 0 ]] && break; (( cnt+=1 ));
         done
-        if ! run_cmd_on_remote_node "[[ `systemctl is-active motr-kernel.service` == 'active' ]]";then
+        if ! run_cmd_on_remote_node "[[ \`systemctl is-active motr-kernel.service\` == 'active' ]]";then
             die "motr-kernel service is not starting on remote node, cannot proceed recovery further."
         fi
     fi
@@ -803,7 +803,7 @@ run_becktool() {
             run_cmd_on_remote_node "systemctl start motr-kernel.service"; exit_code=$?;
             [[ $exit_code == 0 ]] && break; (( cnt+=1 ));
         done
-        if ! run_cmd_on_remote_node "[[ `systemctl is-active motr-kernel.service` == 'active' ]]";then
+        if ! run_cmd_on_remote_node "[[ \`systemctl is-active motr-kernel.service\` == 'active' ]]";then
         die "motr-kernel service is not starting on remote node, cannot proceed recovery further."
         fi
     fi

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -422,6 +422,7 @@ replay_logs_and_get_gen_id_of_seg0() {
             systemctl start motr-kernel.service; exit_code=$?;
             [[ $exit_code == 0 ]] && break; (( cnt+=1 ));
         done
+        sleep 10
         [[ `systemctl is-active motr-kernel.service` == "active" ]] || \
         die "motr-kernel service is not starting on local node, cannot proceed recovery further."
     fi
@@ -432,6 +433,7 @@ replay_logs_and_get_gen_id_of_seg0() {
             run_cmd_on_remote_node "systemctl start motr-kernel.service"; exit_code=$?;
             [[ $exit_code == 0 ]] && break; (( cnt+=1 ));
         done
+        sleep 10
         if ! run_cmd_on_remote_node "[[ \`systemctl is-active motr-kernel.service\` == 'active' ]]";then
             die "motr-kernel service is not starting on remote node, cannot proceed recovery further."
         fi
@@ -794,6 +796,7 @@ run_becktool() {
         systemctl start motr-kernel.service; exit_code=$?;
         [[ $exit_code == 0 ]] && break; (( cnt+=1 ));
     done
+    sleep 10
     [[ `systemctl is-active motr-kernel.service` == "active" ]] || \
     die "motr-kernel service is not starting on local node, cannot proceed recovery further."
 
@@ -803,6 +806,7 @@ run_becktool() {
             run_cmd_on_remote_node "systemctl start motr-kernel.service"; exit_code=$?;
             [[ $exit_code == 0 ]] && break; (( cnt+=1 ));
         done
+        sleep 10
         if ! run_cmd_on_remote_node "[[ \`systemctl is-active motr-kernel.service\` == 'active' ]]";then
         die "motr-kernel service is not starting on remote node, cannot proceed recovery further."
         fi


### PR DESCRIPTION
Issue:
While checking status of motr-kernel service on remote node,
the command for checking status were executing on local node shell.

Fix:
Used escape "\\" char while passing command to remote node to ignore the
special meaning for symbol "`".

Signed-off-by: Kanchan Chaudhari kanchan.chaudhari@seagate.com