### PR TITLE
EOS-17417: [DTM0] Propagate E state for DTX.

### DIFF
--- a/be/Kbuild.sub
+++ b/be/Kbuild.sub
@@ -19,4 +19,5 @@ m0tr_objects += \
                   be/seg_dict.o \
                   be/linux_kernel/stubs.o \
                   be/tx_xc.o \
-                  be/tx_credit.o
+                  be/tx_credit.o \
+                  be/dtm0_log.o

--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -27,6 +27,7 @@
 #include "dtm0/tx_desc.h"	/* m0_dtm0_tx_desc */
 #include "fid/fid.h"		/* m0_fid */
 #include "lib/buf.h"		/* m0_buf */
+#include "dtm0/dtx.h"           /* struct m0_dtm0_dtx */
 
 /* import */
 struct m0_be_tx;
@@ -191,6 +192,7 @@ enum m0_be_dtm0_log_credit_op {
 };
 
 struct m0_dtm0_log_rec {
+	struct m0_dtm0_dtx     dlr_dtx;
 	struct m0_dtm0_tx_desc dlr_txd;
 	struct m0_be_list_link dlr_link; /* link into m0_be_dtm0_log::list */
 	uint64_t               dlr_magic;
@@ -239,6 +241,15 @@ struct m0_dtm0_log_rec *m0_be_dtm0_log_find(struct m0_be_dtm0_log    *log,
 M0_INTERNAL int m0_be_dtm0_log_prune(struct m0_be_dtm0_log    *log,
                                      struct m0_be_tx          *tx,
                                      const struct m0_dtm0_tid *id);
+
+/** Removes all records from the volatile log. */
+M0_INTERNAL void m0_be_dtm0_log_clear(struct m0_be_dtm0_log *log);
+
+M0_INTERNAL int m0_be_dtm0_log_insert_volatile(struct m0_be_dtm0_log *log,
+					       struct m0_dtm0_log_rec *rec);
+
+M0_INTERNAL void m0_be_dtm0_log_update_volatile(struct m0_be_dtm0_log *log,
+						struct m0_dtm0_log_rec *rec);
 #endif /* __MOTR_BE_DTM0_LOG_H__ */
 
 /*

--- a/dix/req.c
+++ b/dix/req.c
@@ -1659,6 +1659,36 @@ static void dix_rop_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	}
 }
 
+static void dix_rop_one_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
+{
+	struct m0_dix_cas_rop *crop = ast->sa_datum;
+	struct m0_dix_req     *dreq = crop->crp_parent;
+	struct m0_dix_cas_rop *cas_rop;
+	struct m0_dix_rop_ctx *rop;
+	int                    idx  = 0;
+
+	M0_PRE(!dreq->dr_is_meta);
+	M0_PRE(M0_IN(dreq->dr_type, (DIX_PUT, DIX_DEL)));
+
+	rop = crop->crp_parent->dr_rop;
+	dix_cas_rop_rc_update(crop, 0);
+
+	/* TODO: enumerating cas rops or keeping a list of opaque
+	 * contexts inside DTX will help us avoid such loops. */
+	m0_tl_for(cas_rop, &rop->dg_cas_reqs, cas_rop) {
+		if (cas_rop == crop) {
+			m0_dtx0_executed(dreq->dr_dtx, idx);
+			break;
+		}
+		idx++;
+	} m0_tl_endfor;
+
+	if (rop->dg_completed_nr == rop->dg_cas_reqs_nr) {
+		ast->sa_datum = dreq;
+		dix_rop_completed(grp, ast);
+	}
+}
+
 static bool dix_cas_rop_clink_cb(struct m0_clink *cl)
 {
 	struct m0_dix_cas_rop  *crop = container_of(cl, struct m0_dix_cas_rop,
@@ -1686,11 +1716,22 @@ static bool dix_cas_rop_clink_cb(struct m0_clink *cl)
 		rop = crop->crp_parent->dr_rop;
 		rop->dg_completed_nr++;
 		M0_PRE(rop->dg_completed_nr <= rop->dg_cas_reqs_nr);
-		if (rop->dg_completed_nr == rop->dg_cas_reqs_nr) {
-			rop->dg_ast.sa_cb = dix_rop_completed;
-			rop->dg_ast.sa_datum = dreq;
+
+		if (dreq->dr_dtx != NULL) {
+			rop->dg_ast.sa_cb = dix_rop_one_completed;
+			rop->dg_ast.sa_datum = crop;
+			M0_ASSERT(dix_req_smgrp(dreq) ==
+				  dreq->dr_dtx->tx_dtx->dd_sm.sm_grp);
 			m0_sm_ast_post(dix_req_smgrp(dreq), &rop->dg_ast);
+		} else {
+			if (rop->dg_completed_nr == rop->dg_cas_reqs_nr) {
+				rop->dg_ast.sa_cb = dix_rop_completed;
+				rop->dg_ast.sa_datum = dreq;
+				m0_sm_ast_post(dix_req_smgrp(dreq),
+					       &rop->dg_ast);
+			}
 		}
+
 	}
 	return true;
 }
@@ -2192,7 +2233,6 @@ static int dix_cas_rops_alloc(struct m0_dix_req *req)
 	if (dtx) {
 		M0_ASSERT(!req->dr_is_meta);
 		M0_ASSERT(M0_IN(req->dr_type, (DIX_PUT, DIX_DEL)));
-
 		rc = m0_dtx0_open(dtx, cas_rop_tlist_length(&rop->dg_cas_reqs));
 		if (rc != 0)
 			goto end;

--- a/dtm0/dtx.h
+++ b/dtm0/dtx.h
@@ -49,12 +49,12 @@ enum m0_dtm0_dtx_state {
 
 struct m0_dtm0_dtx {
 	/** An imprint of the ancient version of dtx.
-	 * This DTX was created at the begining of the time, and it was
-	 * propogated all over the codebase. Since it is really hard to
+	 * This DTX was created at the beginning of the time, and it was
+	 * propagated all over the codebase. Since it is really hard to
 	 * remove it, we instead venerate it by providing the very first
 	 * place in this new dtm0 structure. It helps to have a simple
 	 * typecast (without branded object) and no extra allocations for
-	 * this ancient but not really useful at this momemnt structure.
+	 * this ancient but not really useful at this moment structure.
 	 */
 	struct m0_dtx           dd_ancient_dtx;
 	/* see m0_dtm0_dtx_state */
@@ -63,6 +63,14 @@ struct m0_dtm0_dtx {
 	struct m0_dtm0_service *dd_dtms;
 	uint32_t                dd_nr_executed;
 	struct m0_sm_ast        dd_exec_all_ast;
+
+	/* XXX: The implementation is very simple and it relies on the idea
+	 * of fully replicated requests. Therefore, all FOP submitted
+	 * as a part of this DTX should to be identical (at least
+	 * from the REDO mechanism standpoint). So that we do not use
+	 * any lists here. But we will have to some time later.
+	 */
+	const struct m0_fop    *dd_fop;
 };
 
 M0_INTERNAL void m0_dtm0_dtx_domain_init(void);
@@ -77,19 +85,26 @@ M0_INTERNAL struct m0_dtx* m0_dtx0_alloc(struct m0_dtm0_service *svc,
 					 struct m0_sm_group     *group);
 M0_INTERNAL void m0_dtx0_free(struct m0_dtx *dtx);
 
-/* Assigns TID to the transaction. */
+/** Assignsa a TID to the transaction. */
 M0_INTERNAL int m0_dtx0_prepare(struct m0_dtx *dtx);
 
 M0_INTERNAL int m0_dtx0_open(struct m0_dtx  *dtx, uint32_t nr);
-M0_INTERNAL int m0_dtx0_assign(struct m0_dtx       *dtx,
-			       uint32_t             pa_idx,
-			       const struct m0_fid *pa_fid);
+
+/** Fills in the FID of the given participant. */
+M0_INTERNAL int m0_dtx0_assign_fid(struct m0_dtx       *dtx,
+				   uint32_t             pa_idx,
+				   const struct m0_fid *pa_fid);
+
+/** Fills in the FOP associated with the given participant. */
+M0_INTERNAL void m0_dtx0_assign_fop(struct m0_dtx       *dtx,
+				    uint32_t             pa_idx,
+				    const struct m0_fop *pa_fop);
 M0_INTERNAL int m0_dtx0_close(struct m0_dtx *dtx);
 
 M0_INTERNAL void m0_dtx0_executed(struct m0_dtx *dtx, uint32_t pa_idx);
 
-/* Puts a copy of dtx's transaction descriptor into "dst".
- * User is responsible for m0_dtm0_tx_desc_fini()lasing 'dst'.
+/** Puts a copy of dtx's transaction descriptor into "dst".
+ * User is responsible for m0_dtm0_tx_desc_fini()lasing of 'dst'.
  * If dtx is NULL then dst will be filled with the empty tx_desc.
  */
 M0_INTERNAL int m0_dtx0_copy_txd(const struct m0_dtx    *dtx,

--- a/dtm0/dtx.h
+++ b/dtm0/dtx.h
@@ -36,9 +36,9 @@ enum m0_dtm0_dtx_state {
 	M0_DDS_INPROGRESS,
 	/* dtx got one reply. */
 	M0_DDS_EXECUTED,
-	/* dtx got one PERSISTENT notice. */
-	M0_DDS_PERSISTENT,
-	/* dtx Got enough PERSISTENT notices. */
+	/* dtx got all replies. */
+	M0_DDS_EXECUTED_ALL,
+	/* dtx got enough PERSISTENT notices. */
 	M0_DDS_STABLE,
 	/* dtx can be released when this state reached. */
 	M0_DDS_DONE,
@@ -61,6 +61,8 @@ struct m0_dtm0_dtx {
 	struct m0_sm            dd_sm;
 	struct m0_dtm0_tx_desc  dd_txd;
 	struct m0_dtm0_service *dd_dtms;
+	uint32_t                dd_nr_executed;
+	struct m0_sm_ast        dd_exec_all_ast;
 };
 
 M0_INTERNAL void m0_dtm0_dtx_domain_init(void);
@@ -84,12 +86,16 @@ M0_INTERNAL int m0_dtx0_assign(struct m0_dtx       *dtx,
 			       const struct m0_fid *pa_fid);
 M0_INTERNAL int m0_dtx0_close(struct m0_dtx *dtx);
 
+M0_INTERNAL void m0_dtx0_executed(struct m0_dtx *dtx, uint32_t pa_idx);
+
 /* Puts a copy of dtx's transaction descriptor into "dst".
  * User is responsible for m0_dtm0_tx_desc_fini()lasing 'dst'.
  * If dtx is NULL then dst will be filled with the empty tx_desc.
  */
 M0_INTERNAL int m0_dtx0_copy_txd(const struct m0_dtx    *dtx,
 				 struct m0_dtm0_tx_desc *dst);
+
+M0_INTERNAL enum m0_dtm0_dtx_state m0_dtx0_sm_state(const struct m0_dtx *dtx);
 
 #endif /* __MOTR_DTM0_DTX_H__ */
 

--- a/dtm0/service.h
+++ b/dtm0/service.h
@@ -28,6 +28,8 @@
 #include "reqh/reqh_service.h"
 #include "dtm0/clk_src.h"
 
+struct m0_be_dtm0_log;
+
 enum m0_dtm0_service_origin {
 	DTM0_UNKNOWN = 0,
 	DTM0_ON_VOLATILE,
@@ -43,6 +45,7 @@ struct m0_dtm0_service {
 	enum m0_dtm0_service_origin  dos_origin;
 	uint64_t                     dos_magix;
 	struct m0_dtm0_clk_src       dos_clk_src;
+	struct m0_be_dtm0_log       *dos_log;
 };
 
 extern struct m0_reqh_service_type dtm0_service_type;

--- a/dtm0/tx_desc.h
+++ b/dtm0/tx_desc.h
@@ -139,10 +139,32 @@ M0_INTERNAL bool m0_dtm0_tx_desc_is_none(const struct m0_dtm0_tx_desc *td);
 M0_INTERNAL bool m0_dtm0_tid__invariant(const struct m0_dtm0_tid *tid);
 M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td);
 
-M0_INTERNAL int m0_dtm0_txr_rec_is_set(struct m0_buf *pyld);
-M0_INTERNAL void m0_dtm0_update_pa_state(enum m0_dtm0_tx_pa_state *dst,
-                                         enum m0_dtm0_tx_pa_state *src);
-M0_INTERNAL bool m0_dtm0_is_rec_is_stable(struct m0_dtm0_tx_pa_group *pg);
+/** Returns "true" iif the state of each participant equals to the given
+ * "state" value.
+ */
+M0_INTERNAL bool m0_dtm0_tx_desc_state_eq(const struct m0_dtm0_tx_desc *txd,
+					  enum m0_dtm0_tx_pa_state      state);
+
+/** Applies an update onto the given target value.
+ * The state of the participants of the target modifed as per the following
+ * statement:
+ * @verbatim
+ *	target = max_state(target, update);
+ * @endverbatim
+ */
+M0_INTERNAL void m0_dtm0_tx_desc_apply(struct m0_dtm0_tx_desc *tgt,
+				       const struct m0_dtm0_tx_desc *upd);
+
+/* TODO: move them to a dtm0 internal header? */
+
+#define dtds_forall(__txd, __exp)                                    \
+	m0_forall(i, (__txd)->dtd_pg.dtpg_nr,                        \
+			 (__txd)->dtd_pg.dtpg_pa[i].pa_state __exp)
+
+#define dtds_exists(__txd, __exp) !dtds_forall(__txd, __exp)
+
+
+
 #endif /* __MOTR_DTM0_TX_DESC_H__ */
 
 /*

--- a/motr/idx.h
+++ b/motr/idx.h
@@ -207,6 +207,10 @@ M0_BOB_DECLARE(M0_INTERNAL, m0_op_idx);
 M0_INTERNAL bool m0__idx_op_invariant(struct m0_op_idx *oi);
 M0_INTERNAL void idx_op_ast_complete(struct m0_sm_group *grp,
 				     struct m0_sm_ast *ast);
+M0_INTERNAL void idx_op_ast_executed(struct m0_sm_group *grp,
+				     struct m0_sm_ast *ast);
+M0_INTERNAL void idx_op_ast_stable(struct m0_sm_group *grp,
+				   struct m0_sm_ast *ast);
 M0_INTERNAL void idx_op_ast_fail(struct m0_sm_group *grp,
 				 struct m0_sm_ast *ast);
 

--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -38,6 +38,7 @@
 #include "dix/req.h"
 #include "dix/client.h"
 #include "motr/addb.h"
+#include "dtm0/dtx.h"
 
 /**
  * @addtogroup index-dix
@@ -89,6 +90,7 @@ struct dix_req {
 };
 
 static bool dixreq_clink_cb(struct m0_clink *cl);
+static bool dixreq_clink_dtx_cb(struct m0_clink *cl);
 static bool dix_meta_req_clink_cb(struct m0_clink *cl);
 static void dix_req_immed_failure(struct dix_req *req, int rc);
 static void dixreq_completed_post(struct dix_req *req, int rc);
@@ -610,7 +612,9 @@ static int dix_req_create(struct m0_op_idx  *oi,
 					oi->oi_sm_grp);
 			to_dix_map(&oi->oi_oc.oc_op, &req->idr_dreq);
 			req->idr_dreq.dr_dtx = oi->oi_dtx;
-			m0_clink_init(&req->idr_clink, dixreq_clink_cb);
+			m0_clink_init(&req->idr_clink,
+				      oi->oi_dtx != NULL ?
+				      dixreq_clink_dtx_cb : dixreq_clink_cb);
 
 			/* Store oi for dix callbacks to update SYNC records. */
 			if (M0_IN(oi->oi_oc.oc_op.op_code,
@@ -656,6 +660,10 @@ static void dixreq_completed_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	oi->oi_ar.ar_ast.sa_cb = (rc == 0) ? idx_op_ast_complete :
 					     idx_op_ast_fail;
 	oi->oi_in_completion = true;
+	/* XXX: it looks like there is no need to set up an ast for that.
+	 * The groups are the same. We can just call the callback right here:
+	 *   oi->oi_ar.ar_ast.sa_cb(oi->oi_sm_grp, &oi->oi_ar.ar_ast)
+	 */
 	m0_sm_ast_post(oi->oi_sm_grp, &oi->oi_ar.ar_ast);
 	dix_req_destroy(req);
 	M0_LEAVE();
@@ -771,6 +779,123 @@ static bool dix_meta_req_clink_cb(struct m0_clink *cl)
 			dix_list_reply_copy(mreq, oi->oi_rcs, oi->oi_keys) :
 			m0_dix_layout_rep_get(mreq, 0, NULL);
 	dixreq_completed_post(dix_req, rc);
+	return false;
+}
+
+static void dixreq_stable_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
+{
+	struct dix_req          *req = ast->sa_datum;
+	struct m0_op_idx        *oi = req->idr_oi;
+	int                      rc = oi->oi_ar.ar_rc;
+
+	M0_ENTRY();
+	oi->oi_ar.ar_ast.sa_cb = (rc == 0) ? idx_op_ast_stable : NULL;
+	/* XXX: It is safe to reuse the ast object used by executed()
+	 * and completed() callbacks as long as a dtx state change does not
+	 * happen twice in the same dixreq ast callback. The change
+	 * is done under the group lock, therefore this ast callback
+	 * (the function you are looking at) will be executed when the
+	 * group lock is released. A new ast cannot be queued before this
+	 * ast is completed. Therefore, if there is another function
+	 * where the state is beign changed from Executed to Stable then
+	 * this "another" function can be called only after that.
+	 * Inversion of calls (Stable first, then Executed) should not
+	 * be possible if the stability detector is implemented in the right
+	 * way (nothing is stable until all CAS requests are executed and
+	 * got persistent).
+	 */
+	/* XXX: The callback is executed directly since the group
+	 * lock is the same. See the XXX comment in ::dixreq_completed_ast.
+	 */
+	idx_op_ast_stable(oi->oi_sm_grp, &oi->oi_ar.ar_ast);
+	dix_req_destroy(req);
+	M0_LEAVE();
+}
+
+static void dixreq_stable_post(struct dix_req *req, int rc)
+{
+	struct m0_op_idx *oi = req->idr_oi;
+
+	M0_ENTRY();
+	oi->oi_ar.ar_rc = rc;
+	req->idr_ast.sa_cb = dixreq_stable_ast;
+	req->idr_ast.sa_datum = req;
+	m0_sm_ast_post(oi->oi_sm_grp, &req->idr_ast);
+	M0_LEAVE();
+}
+
+static void dixreq_executed_post(struct dix_req *req, int rc)
+{
+	struct m0_op_idx *oi = req->idr_oi;
+
+	M0_ENTRY();
+
+	M0_ASSERT_INFO(rc == 0, "TODO: Failures are not handled here.");
+	oi->oi_ar.ar_rc = rc;
+
+	/* XXX: DTX cannot be canceled (as per the current design),
+	 * so that once we got a reply, we prohibit any kind of cancelation.
+	 * The originator should m0_panic itself in case if something needs
+	 * to be canceled. It will be re-started and continue its execution.
+	 */
+	oi->oi_in_completion = true;
+	oi->oi_ar.ar_ast.sa_cb = idx_op_ast_executed;
+	m0_sm_ast_post(oi->oi_sm_grp, &oi->oi_ar.ar_ast);
+	M0_LEAVE();
+}
+
+static bool dixreq_clink_dtx_cb(struct m0_clink *cl)
+{
+	struct dix_req          *dix_req = M0_AMB(dix_req, cl, idr_clink);
+	struct m0_op_idx        *oi = dix_req->idr_oi;
+	struct m0_sm            *req_sm = M0_AMB(req_sm, cl->cl_chan, sm_chan);
+	struct m0_dix_req       *dreq = &dix_req->idr_dreq;
+	struct m0_dtx           *dtx = oi->oi_dtx;
+	enum m0_dtm0_dtx_state   state;
+	int                      i;
+
+	M0_PRE(M0_IN(oi->oi_oc.oc_op.op_code, (M0_IC_PUT, M0_IC_DEL)));
+	M0_PRE(dtx != NULL);
+
+	state = m0_dtx0_sm_state(dtx);
+
+	if (!M0_IN(state, (M0_DDS_EXECUTED, M0_DDS_STABLE, M0_DDS_FAILED)))
+		return false;
+
+	switch (state) {
+	case M0_DDS_EXECUTED:
+		/* TODO: we have a single kv pair; probably, it does not have
+		 * to be a loop.
+		 */
+		for (i = 0; i < m0_dix_req_nr(dreq); i++) {
+			oi->oi_rcs[i] = dreq->dr_items[i].dxi_rc;
+		}
+		/* XXX: We cannot use m0_dix_generic_rc here because the
+		 * precondition fails in this case. At this point error
+		 * handling is not covered here, and probably the error
+		 * code needs to be first propogated from DIX to DTX and
+		 * then it needs to be passed here as dtx.dd_sm.sm_rc.
+		 */
+		dixreq_executed_post(dix_req, dreq->dr_sm.sm_rc);
+		break;
+	case M0_DDS_STABLE:
+		M0_ASSERT_INFO(m0_dix_generic_rc(dreq) == 0,
+			       "TODO: DIX failures are not supported.");
+
+		M0_ASSERT_INFO(m0_forall(idx, m0_dix_req_nr(dreq),
+					 m0_dix_item_rc(dreq, idx) == 0),
+			       "TODO: failed executions of individual items "
+			       "are not supported yet.");
+
+		dixreq_stable_post(dix_req, m0_dix_generic_rc(dreq));
+		m0_clink_del(cl);
+		break;
+	case M0_DDS_FAILED:
+		M0_IMPOSSIBLE("DTX failures are not supported so far.");
+	default:
+		M0_IMPOSSIBLE("Only Executed and Stable are allowed so far.");
+	}
+
 	return false;
 }
 
@@ -935,7 +1060,9 @@ static void dix_dreq_prepare(struct dix_req   *req,
 			     struct m0_op_idx *oi)
 {
 	dix_build(oi, dix);
-	m0_clink_add(&req->idr_dreq.dr_sm.sm_chan, &req->idr_clink);
+	m0_clink_add(oi->oi_dtx != NULL ?
+		     &oi->oi_dtx->tx_dtx->dd_sm.sm_chan :
+		     &req->idr_dreq.dr_sm.sm_chan, &req->idr_clink);
 }
 
 static void dix_put_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)

--- a/motr/ut/idx.c
+++ b/motr/ut/idx.c
@@ -167,7 +167,7 @@ static void ut_idx_op_complete(void)
 
 	m0_fi_enable_once("m0_op_stable", "skip_ongoing_io_ref");
 	m0_sm_group_lock(&oi_grp);
-	idx_op_complete(oi);
+	idx_op_set_complete_state(oi, M0_BITS(M0_OS_EXECUTED, M0_OS_STABLE));
 	m0_sm_group_unlock(&oi_grp);
 
 	M0_UT_ASSERT(ent.en_sm.sm_state == M0_ES_OPEN);

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -824,9 +824,14 @@ static void st_put_one(void)
 	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs, flags, &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
-	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
+	rc = m0_op_wait(op, M0_BITS(M0_OS_EXECUTED), WAIT_TIMEOUT);
+	M0_LOG(DEBUG, "Got executed");
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(op->op_rc == 0);
+	M0_UT_ASSERT(rcs[0] == 0);
+	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
+	M0_LOG(DEBUG, "Got stable");
+	M0_UT_ASSERT(rc == 0);
 	m0_op_fini(op);
 	m0_op_free(op);
 	op = NULL;

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -824,6 +824,7 @@ static void st_put_one(void)
 	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs, flags, &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
+#if defined(DTM0)
 	rc = m0_op_wait(op, M0_BITS(M0_OS_EXECUTED), WAIT_TIMEOUT);
 	M0_LOG(DEBUG, "Got executed");
 	M0_UT_ASSERT(rc == 0);
@@ -832,6 +833,18 @@ static void st_put_one(void)
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
 	M0_LOG(DEBUG, "Got stable");
 	M0_UT_ASSERT(rc == 0);
+#else
+	/* When DTM0 is disabled, waiting on EXECUTED in a separate
+	 * op_wait call causes ESRCH (see ::m0_sm_timedwait).
+	 * Since EXECUTED -> STABLE transition happens without an external
+	 * event, waiting on EXECUTED in a separate call has no much sense
+	 * in non-DTM0 environment.
+	 */
+	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(op->op_rc == 0);
+	M0_UT_ASSERT(rcs[0] == 0);
+#endif
 	m0_op_fini(op);
 	m0_op_free(op);
 	op = NULL;
@@ -859,7 +872,7 @@ static void st_one_dtm0_op(void)
 	srv_srv = m0_reqh_service_lookup(srv_reqh, &srv_dtm0_fid);
 	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr);
 	M0_UT_ASSERT(rc == 0);
-	ut_m0c->m0c_dtms = m0_dtm0_service_find(srv_reqh);
+	ut_m0c->m0c_dtms = m0_dtm0_service_find(&ut_m0c->m0c_reqh);
 	M0_UT_ASSERT(ut_m0c->m0c_dtms != NULL);
 
 	st_put_one();


### PR DESCRIPTION
The patch extends m0c and dix code to propagate
the Executed ("E" in the title) state from CAS request
to DTX, and it separtes the "completed" machinery (asts, callbacks)
into separate "executed" and "stable" on the m0c side.

Note1: the patch has a few TODO/XXX comments for the reviewers.
Some of them may need to be resolved before considering
this patch for merging.
Note2: the patch was tested with "--enable-dtm0" only.
It needs to be verified with "--disable-dtm0".