### PR TITLE
provisioner: added minimal json file for motr mini provisioner deploy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -949,7 +949,8 @@ motr_conf_DATA = scripts/install$(motr_confdir)/motr.conf \
 EXTRA_DIST += $(motr_conf_DATA)
 
 motr_examplesdir = $(motr_confdir)/examples
-motr_examples_DATA = scripts/install$(motr_examplesdir)/provisioner_cluster.json
+motr_examples_DATA = scripts/install$(motr_examplesdir)/provisioner_cluster.json \
+                     scripts/install$(motr_examplesdir)/motr_cluster.json
 
 EXTRA_DIST += $(motr_examples_DATA)
 

--- a/scripts/install/opt/seagate/cortx/motr/conf/examples/motr_cluster.json
+++ b/scripts/install/opt/seagate/cortx/motr/conf/examples/motr_cluster.json
@@ -1,0 +1,90 @@
+{
+  "cluster": {
+    "server_nodes": {
+      "0a31807456be14965f31b49314f5664e": "srvnode-1",
+      "0a31807456be14965f31b49314f5664f": "srvnode-2",
+      "0a31807456be14965f31b49314f56640": "srvnode-3"
+    },
+    "srvnode-1": {
+      "machine_id": "0a31807456be14965f31b49314f5664e",
+      "hostname": "ssc-vm-2004.colo.seagate.com",
+      "node_type": "VM",
+      "network": {
+        "data": {
+          "public_interfaces": [
+            "eth1",
+            "eth2"
+          ],
+          "private_interfaces": [
+            "eth3",
+            "eth4"
+          ],
+          "interface_type": "tcp",
+          "transport_type": "lnet"
+        }
+      },
+      "storage": {
+        "metadata_devices": [
+          "/dev/sdb"
+        ],
+        "data_devices": [
+          "/dev/sdc"
+        ]
+      }
+    },
+    "srvnode-2": {
+      "machine_id": "0a31807456be14965f31b49314f5664f",
+      "hostname": "ssc-vm-2005.colo.seagate.com",
+      "node_type": "VM",
+      "network": {
+        "data": {
+          "public_interfaces": [
+            "eth1",
+            "eth2"
+          ],
+          "private_interfaces": [
+            "eth3",
+            "eth4"
+          ],
+          "interface_type": "tcp",
+          "transport_type": "lnet"
+        }
+      },
+      "storage": {
+        "metadata_devices": [
+          "/dev/sdb"
+        ],
+        "data_devices": [
+          "/dev/sdc"
+        ]
+      }
+    },
+    "srvnode-3": {
+      "machine_id": "0a31807456be14965f31b49314f56640",
+      "hostname": "ssc-vm-2006.colo.seagate.com",
+      "node_type": "VM",
+      "network": {
+        "data": {
+          "public_interfaces": [
+            "eth1",
+            "eth2"
+          ],
+          "private_interfaces": [
+            "eth3",
+            "eth4"
+          ],
+          "interface_type": "tcp",
+          "transport_type": "lnet"
+        }
+      },
+      "storage": {
+        "metadata_devices": [
+          "/dev/sdb"
+        ],
+        "data_devices": [
+          "/dev/sdc"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
- added motr_cluster.json confstore key-value file for motr single/three node mini provisioner deployment
- this file includes only keys required for motr deployment

Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>