### PR TITLE
go/mio: add -Wl,-rpath option for libmotr.so

### DIFF
--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -41,7 +41,7 @@ package mio
 // #cgo CFLAGS: -I../../.. -I../../../extra-libs/galois/include
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #cgo CFLAGS: -Wno-attributes
-// #cgo LDFLAGS: -L../../../motr/.libs -lmotr
+// #cgo LDFLAGS: -L../../../motr/.libs -Wl,-rpath=../../../motr/.libs -lmotr
 // #include <stdlib.h>
 // #include "lib/types.h"
 // #include "lib/trace.h"


### PR DESCRIPTION
This will allow the dynamic linker to find libmotr.so
in runtime also. No need to set LD_LIBRARY_PATH now.