### PR TITLE
EOS-18284: add license header to motr_data_recovery.sh file

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -1,4 +1,23 @@
 #!/usr/bin/env bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
 # set -x
 SCRIPT_START_TIME="$(date +"%s")"
 PROG=${0##*/}

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_data_recovery.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2020-2021 Seagate Technology LLC and/or its Affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added license header to motr_data_recovery.sh file.

Signed-off-by: Kanchan Chaudhari kanchan.chaudhari@seagate.com