### PR TITLE
[Do Not Merge ] : Stable branch PR validation Testing

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -3,22 +3,18 @@ Quick Start Guide
 =================
 This guide provides information to get Motr component ready.
 
-************
-Prerequisite
-************
+*************
+Prerequisites
+*************
 The prerequisite that is necessary to install the Motr component is mentioned below.
 
-- Kernel Version - 3.10.0-1062.el7
-
-  - To know the version being used, type the following:
-
-    - **uname -r**
-
-  - Different kernel versions that come from Centos7.7 or RHEL7.7 are supported.
+- CentOS-7 for x86_64 platform (ARM64 platform support work is in progress).
 
 - **Ansible** is needed. 
 
-  - Please refer to `Install EPEP repo <https://github.com/Seagate/cortx/blob/main/doc/LocalVMSetup.md#4-you-may-need-to-add-epel-repo>`_.
+  - Install EPEL repo:
+  
+    **$ sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm**
 
 **********
 Procedure


### PR DESCRIPTION
Drop mentioning the explicit kernel version and CentOS version and mentioning
that different kernel versions are supported at the same time - it's very confusing.
Just mention CentOS-7 version for x86_64 platform and ARM64 platform porting
working in progress.

Fix typo in mentioning EPEL repo and put the exact command about how to install it
instead of pointing to the document which is about to be deleted.


Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>