### PR TITLE
EOS-17584 dtm0: implement initial version of all2all connections

### DIFF
--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -33,6 +33,15 @@
 #include "lib/tlist.h"               /* tlist API */
 #include "be/dtm0_log.h"             /* DTM0 log API */
 
+#include "conf/confc.h"   /* m0_confc */
+#include "conf/diter.h"   /* m0_conf_diter */
+#include "conf/obj_ops.h" /* M0_CONF_DIRNEXT */
+#include "conf/helpers.h" /* m0_confc_root_open, m0_conf_process2service_get */
+#include "reqh/reqh.h"    /* m0_reqh2confc */
+
+static int dtm0_service__ha_subscribe(struct m0_reqh_service *service);
+static int dtm0_service__ha_unsubscribe(struct m0_reqh_service *service);
+
 static struct m0_dtm0_service *to_dtm(struct m0_reqh_service *service);
 static int dtm0_service_start(struct m0_reqh_service *service);
 static void dtm0_service_stop(struct m0_reqh_service *service);
@@ -62,26 +71,39 @@ struct m0_reqh_service_type dtm0_service_type = {
  * System process which dtm0 subscribes for state updates
  */
 struct dtm0_process {
-	struct m0_tlink     dop_link;
-	uint64_t            dop_magic;
+	struct m0_tlink         dop_link;
+	uint64_t                dop_magic;
 
 	/**
 	 * Listens for an event on process conf object's HA channel.
 	 * Updates dtm0_process status in the clink callback on HA notification.
 	 */
-	struct m0_clink     dop_ha_link;
+	struct m0_clink         dop_ha_link;
 	/**
 	 * Link connected to remote process
 	 */
-	struct m0_rpc_link  dop_rlink;
+	struct m0_rpc_link      dop_rlink;
 	/**
 	 * Remote process fid
 	 */
-	struct m0_fid       dop_rfid;
+	struct m0_fid           dop_rproc_fid;
+	/**
+	 * Remote service fid
+	 */
+	struct m0_fid           dop_rserv_fid;
 	/**
 	 * Remote process endpoint
 	 */
-	const char         *dop_rep;
+	const char             *dop_rep;
+	/**
+	 * Current dtm0 service dtm0 process to.
+	 */
+	struct m0_reqh_service *dop_dtm0_service;
+	/**
+	 * Connect ast
+	 */
+	struct m0_sm_ast        dop_service_connect_ast;
+	struct m0_clink         dop_service_connect_clink;
 };
 
 M0_TL_DESCR_DEFINE(dopr, "dtm0_process", static, struct dtm0_process, dop_link,
@@ -126,31 +148,59 @@ static void dtm0_service__fini(struct m0_dtm0_service *s)
 	m0_dtm0_service_bob_fini(s);
 }
 
+static struct dtm0_process *dtm0_service_process__lookup(struct m0_reqh_service *reqh_dtm0_svc,
+							 struct m0_fid *remote_dtm0)
+{
+	struct m0_dtm0_service *dtm0 =
+		container_of(reqh_dtm0_svc, struct m0_dtm0_service, dos_generic);
+	struct dtm0_process *process = NULL;
+
+	m0_tl_for(dopr, &dtm0->dos_processes, process) {
+		if (m0_fid_eq(&process->dop_rserv_fid, remote_dtm0))
+			break;
+	} m0_tl_endfor;
+
+	return process;
+}
+
+
 M0_INTERNAL int m0_dtm0_service_process_connect(struct m0_reqh_service *s,
 						struct m0_fid *remote_srv,
-						const char    *remote_ep)
+						const char    *remote_ep,
+						bool async)
 {
-	struct m0_dtm0_service *service = to_dtm(s);
 	struct dtm0_process *process;
 	struct m0_rpc_machine *mach =
 		m0_reqh_rpc_mach_tlist_head(&s->rs_reqh->rh_rpc_machines);
 	int rc;
 
 
-	M0_ALLOC_PTR(process);
-	M0_ASSERT(process != NULL);
+	process = dtm0_service_process__lookup(s, remote_srv);
+	if (process == NULL)
+		return M0_RC(-ENOENT);
 
 	rc = m0_rpc_link_init(&process->dop_rlink, mach, remote_srv,
 			      remote_ep, 10);
 	M0_ASSERT(rc == 0);
-	rc = m0_rpc_link_connect_sync(&process->dop_rlink, M0_TIME_NEVER);
-	M0_ASSERT(rc == 0);
 
-	process->dop_rfid = *remote_srv;
-	process->dop_rep  = m0_strdup(remote_ep);
+	M0_LOG(M0_DEBUG,
+	       " async=%d"
+	       " dtm0="FID_F
+	       " remote_srv="FID_F,
+	       !!((int)async),
+	       FID_P(&s->rs_service_fid),
+	       FID_P(remote_srv));
+	M0_LOG(M0_DEBUG, "rep=%s", remote_ep);
 
-	dopr_tlink_init(process);
-	dopr_tlist_add(&service->dos_processes, process);
+	if (!async) {
+		rc = m0_rpc_link_connect_sync(&process->dop_rlink,
+					      M0_TIME_NEVER);
+		M0_ASSERT(rc == 0);
+	} else {
+		m0_rpc_link_connect_async(&process->dop_rlink,
+					  M0_TIME_NEVER,
+					  &process->dop_service_connect_clink);
+	}
 
 	return M0_RC(0);
 }
@@ -159,23 +209,27 @@ M0_INTERNAL int m0_dtm0_service_process_disconnect(struct m0_reqh_service *s,
 						   struct m0_fid *remote_srv)
 {
 	int rc;
-	struct m0_dtm0_service *service = to_dtm(s);
 	struct dtm0_process *process = NULL;
 
-	m0_tl_for(dopr, &service->dos_processes, process) {
-		if (m0_fid_eq(&process->dop_rfid, remote_srv))
-			break;
-	} m0_tl_endfor;
+	M0_LOG(M0_DEBUG,
+	       " dtm0=%p"
+	       " remote_srv="FID_F,
+	       s,
+	       FID_P(remote_srv));
+
+	process = dtm0_service_process__lookup(s, remote_srv);
 
 	if (process == NULL)
 		return -ENOENT;
 
-	rc = m0_rpc_link_disconnect_sync(&process->dop_rlink, M0_TIME_NEVER);
-	M0_ASSERT(rc == 0);
-	m0_rpc_link_fini(&process->dop_rlink);
+	rc = m0_rpc_link_disconnect_sync(&process->dop_rlink,
+					 m0_time_from_now(5, 0));
 
-	dopr_tlist_remove(process);
-	dopr_tlink_fini(process);
+	M0_ASSERT(rc == 0 || rc == -ETIMEDOUT);
+	if (rc == -ETIMEDOUT)
+		M0_LOG(M0_WARN, "Disconnect timeout");
+
+	m0_rpc_link_fini(&process->dop_rlink);
 
 	return M0_RC(0);
 }
@@ -184,13 +238,8 @@ M0_INTERNAL struct m0_rpc_session *
 m0_dtm0_service_process_session_get(struct m0_reqh_service *s,
 				    struct m0_fid *remote_srv)
 {
-	struct m0_dtm0_service *service = to_dtm(s);
-	struct dtm0_process *process = NULL;
-
-	m0_tl_for(dopr, &service->dos_processes, process) {
-		if (m0_fid_eq(&process->dop_rfid, remote_srv))
-			break;
-	} m0_tl_endfor;
+	struct dtm0_process *process =
+		dtm0_service_process__lookup(s, remote_srv);
 
 	return process == NULL ? NULL : &process->dop_rlink.rlk_sess;
 }
@@ -266,7 +315,8 @@ out:
 static int dtm0_service_start(struct m0_reqh_service *service)
 {
         M0_PRE(service != NULL);
-        return dtm_service__origin_fill(service) ?: m0_dtm0_fop_init();
+        return dtm_service__origin_fill(service) ?: m0_dtm0_fop_init()
+		?: dtm0_service__ha_subscribe(service);
 }
 
 static void dtm0_service_stop(struct m0_reqh_service *service)
@@ -275,6 +325,8 @@ static void dtm0_service_stop(struct m0_reqh_service *service)
 
         M0_PRE(service != NULL);
 	dtm0 = to_dtm(service);
+
+	dtm0_service__ha_unsubscribe(service);
 
 	m0_dtm0_fop_fini();
 	/* It is safe to remove any remaining entries from the log
@@ -324,6 +376,222 @@ m0_dtm0_service_find(const struct m0_reqh *reqh)
 
 	return rh_srv == NULL ? NULL : to_dtm(rh_srv);
 }
+
+/* --------------------------------- EVENTS --------------------------------- */
+
+struct m0_semaphore g_test_wait;
+static int ready_to_process_ha_msgs = 0;
+
+static bool service_connect_clink(struct m0_clink *link)
+{
+	M0_ENTRY();
+	M0_LOG(M0_DEBUG, "Connected");
+	m0_semaphore_up(&g_test_wait);
+	M0_LEAVE();
+	return true;
+}
+
+static void service_connect_ast(struct m0_sm_group *grp,
+				struct m0_sm_ast   *ast)
+{
+	struct dtm0_process *process = ast->sa_datum;
+	int rc;
+
+	M0_ENTRY();
+	m0_clink_init(&process->dop_service_connect_clink, service_connect_clink);
+	process->dop_service_connect_clink.cl_is_oneshot = true;
+	rc = m0_dtm0_service_process_connect(process->dop_dtm0_service,
+					     &process->dop_rserv_fid,
+					     process->dop_rep,
+					     true);
+	M0_ASSERT(rc == 0);
+	M0_LEAVE();
+}
+
+static bool process_clink_cb(struct m0_clink *clink)
+{
+	struct dtm0_process *process    = M0_AMB(process, clink, dop_ha_link);
+	struct m0_conf_obj *process_obj = container_of(clink->cl_chan,
+						       struct m0_conf_obj,
+						       co_ha_chan);
+	struct m0_reqh_service *dtm0 = process->dop_dtm0_service;
+	struct m0_reqh         *reqh = dtm0->rs_reqh;
+	struct m0_fid          *current_proc_fid = &reqh->rh_fid;
+	struct m0_fid          *evented_proc_fid = &process_obj->co_id;
+	enum m0_ha_obj_state    evented_proc_state = process_obj->co_ha_state;
+
+	M0_ENTRY();
+	M0_PRE(m0_conf_obj_type(process_obj) == &M0_CONF_PROCESS_TYPE);
+	M0_PRE(m0_fid_eq(evented_proc_fid, &process->dop_rproc_fid));
+	M0_PRE(!m0_fid_eq(evented_proc_fid, &M0_FID0));
+	M0_PRE(!m0_fid_eq(evented_proc_fid, current_proc_fid));
+
+	/**
+	 * A weird logic to make a workaround for current HA
+	 * implementation: skip processing of all HA messages
+	 * until TRANSIENT is received. TRANSIENT is just a
+	 * trigger for handling HA messages in this case.
+	 */
+	if (evented_proc_state != M0_NC_TRANSIENT &&
+	    !ready_to_process_ha_msgs) {
+		M0_LOG(M0_DEBUG, "Is not ready to process HA messages");
+		goto out;
+	}
+
+	/* (M0_IN(obj->co_ha_state, (M0_NC_ONLINE, M0_NC_FAILED, M0_NC_TRANSIENT))) */
+	M0_LOG(M0_DEBUG,
+	       " evented_proc_state=%d"
+	       " evented_proc_fid="FID_F
+	       " dop_rserv_fid="FID_F
+	       " dop_rproc_fid="FID_F
+	       " curr_proc_fid="FID_F,
+	       evented_proc_state,
+	       FID_P(evented_proc_fid),
+	       FID_P(&process->dop_rserv_fid),
+	       FID_P(&process->dop_rproc_fid),
+	       FID_P(current_proc_fid));
+	M0_LOG(M0_DEBUG, "dtm0=%p dop_rep=%s", dtm0, process->dop_rep);
+
+	switch (evented_proc_state) {
+	case M0_NC_ONLINE:
+		process->dop_service_connect_ast = (struct m0_sm_ast){
+			.sa_cb    = &service_connect_ast,
+			.sa_datum = process,
+		};
+		m0_sm_ast_post(m0_locality_here()->lo_grp,
+			       &process->dop_service_connect_ast);
+		break;
+	case M0_NC_TRANSIENT:
+		ready_to_process_ha_msgs = 1;
+		M0_LOG(M0_DEBUG, "TRANSIENT received, now is "
+		       "ready to process HA messages");
+		break;
+	default:
+		M0_LOG(M0_DEBUG, "Ignored received proc state %d",
+		       evented_proc_state);
+		break;
+	}
+out:
+	M0_LEAVE();
+
+	return false;
+}
+
+static void dtm0_process__ha_state_subscribe(struct dtm0_process *process,
+					     struct m0_conf_obj  *obj)
+{
+	M0_ENTRY();
+	m0_clink_init(&process->dop_ha_link, process_clink_cb);
+	m0_clink_add_lock(&obj->co_ha_chan, &process->dop_ha_link);
+	M0_LEAVE();
+}
+
+static void dtm0_process__ha_state_unsubscribe(struct dtm0_process *process)
+{
+	M0_ENTRY();
+	m0_clink_del_lock(&process->dop_ha_link);
+	m0_clink_fini(&process->dop_ha_link);
+	M0_LEAVE();
+}
+
+static bool conf_obj_is_process(const struct m0_conf_obj *obj)
+{
+	return m0_conf_obj_type(obj) == &M0_CONF_PROCESS_TYPE;
+}
+
+static int dtm0_service__ha_subscribe(struct m0_reqh_service *service)
+{
+	struct m0_confc        *confc = m0_reqh2confc(service->rs_reqh);
+	struct m0_conf_root    *root;
+	struct m0_conf_diter    it;
+	struct m0_conf_obj     *obj;
+	struct m0_conf_process *process;
+	struct dtm0_process    *dtm0_process;
+	struct m0_dtm0_service *s;
+	struct m0_fid           rproc_fid;
+	struct m0_fid           rserv_fid;
+	struct m0_fid          *current_proc_fid = &service->rs_reqh->rh_fid;
+
+	int rc;
+
+	M0_ENTRY();
+
+	M0_PRE(service != NULL);
+	s = container_of(service, struct m0_dtm0_service, dos_generic);
+
+	/** UT workaround */
+	if (!m0_confc_is_inited(confc)) {
+		M0_LOG(M0_WARN, "confc is not initiated!");
+		return M0_RC(0);
+	}
+
+	rc = m0_confc_root_open(confc, &root);
+	if (rc != 0)
+		return M0_ERR(rc);
+
+	rc = m0_conf_diter_init(&it, confc,
+				&root->rt_obj,
+				M0_CONF_ROOT_NODES_FID,
+				M0_CONF_NODE_PROCESSES_FID);
+	if (rc != 0) {
+		m0_confc_close(&root->rt_obj);
+		return M0_ERR(rc);
+	}
+
+	while ((rc = m0_conf_diter_next_sync(&it, conf_obj_is_process)) > 0) {
+		obj = m0_conf_diter_result(&it);
+		process = M0_CONF_CAST(obj, m0_conf_process);
+		rproc_fid = process->pc_obj.co_id;
+		rc = m0_conf_process2service_get(confc, &rproc_fid,
+						 M0_CST_DTM0, &rserv_fid);
+		if (rc == 0) {
+			if (m0_fid_eq(&rproc_fid, current_proc_fid))
+				/* skip current process */
+				continue;
+			M0_ALLOC_PTR(dtm0_process);
+			M0_ASSERT(dtm0_process != NULL); /* XXX */
+			dtm0_process__ha_state_subscribe(dtm0_process, obj);
+			dopr_tlink_init(dtm0_process);
+			dopr_tlist_add(&s->dos_processes, dtm0_process);
+			dtm0_process->dop_rproc_fid = rproc_fid;
+			dtm0_process->dop_rserv_fid = rserv_fid;
+			dtm0_process->dop_rep =
+				m0_strdup(process->pc_endpoint);
+			dtm0_process->dop_dtm0_service = service;
+		}
+	}
+
+	m0_conf_diter_fini(&it);
+	m0_confc_close(&root->rt_obj);
+
+	return M0_RC(0);
+}
+
+static int dtm0_service__ha_unsubscribe(struct m0_reqh_service *reqh_service)
+{
+	struct dtm0_process *process;
+	struct m0_dtm0_service *service;
+	/* int rc; */
+
+	M0_PRE(reqh_service != NULL);
+	service = container_of(reqh_service, struct m0_dtm0_service, dos_generic);
+
+	M0_ENTRY();
+
+	while ((process = dopr_tlist_pop(&service->dos_processes)) != NULL) {
+		/* if (process->dop_rserv_fid.f_key == 0x1a) { */
+		/* 	       rc = m0_dtm0_service_process_disconnect(reqh_service, */
+		/* 						       &process->dop_rserv_fid); */
+		/* 	       M0_ASSERT(rc == 0 || rc == -ENOENT); */
+		/* } */
+		dtm0_process__ha_state_unsubscribe(process);
+		dopr_tlink_fini(process);
+		m0_free(process);
+	}
+
+	return M0_RC(0);
+}
+
 
 /*
  *  Local variables:

--- a/dtm0/service.h
+++ b/dtm0/service.h
@@ -69,4 +69,7 @@ M0_INTERNAL bool m0_dtm0_is_a_persistent_dtm(struct m0_reqh_service *service);
 
 M0_INTERNAL struct m0_dtm0_service *
 m0_dtm0_service_find(const struct m0_reqh *reqh);
+
+M0_INTERNAL bool m0_dtm0_in_ut(void);
+
 #endif /* __MOTR_DTM0_SERVICE_H__ */

--- a/dtm0/service.h
+++ b/dtm0/service.h
@@ -56,7 +56,8 @@ M0_INTERNAL void m0_dtm0_stype_fini(void);
 
 M0_INTERNAL int m0_dtm0_service_process_connect(struct m0_reqh_service *s,
 						struct m0_fid *remote_srv,
-						const char    *remote_ep);
+						const char    *remote_ep,
+						bool async);
 M0_INTERNAL int m0_dtm0_service_process_disconnect(struct m0_reqh_service *s,
 						   struct m0_fid *remote_srv);
 M0_INTERNAL struct m0_rpc_session *

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -72,7 +72,7 @@ static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
 	struct dtm0_req_fop   *req;
 
 	struct m0_dtm0_tx_desc txr = {};
-	struct m0_dtm0_tid      reply_data;
+	struct m0_dtm0_tid     reply_data;
 
 	struct m0_dtm0_clk_src dcs;
 	struct m0_dtm0_ts      now;
@@ -105,7 +105,7 @@ static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
 }
 
 static void dtm0_ut_client_init(struct cl_ctx *cctx, const char *cl_ep_addr,
-			      const char *srv_ep_addr, struct m0_net_xprt *xprt)
+				const char *srv_ep_addr, struct m0_net_xprt *xprt)
 {
 	int                       rc;
 	struct m0_rpc_client_ctx *cl_ctx;
@@ -138,6 +138,7 @@ static void dtm0_ut_client_fini(struct cl_ctx *cctx)
 	m0_net_domain_fini(&cctx->cl_ndom);
 }
 
+extern struct m0_semaphore g_test_wait;
 static void dtm0_ut_service(void)
 {
 	int rc;
@@ -150,8 +151,11 @@ static void dtm0_ut_service(void)
 		.rsx_log_file_name = DTM0_UT_LOG,
 	};
 	struct m0_reqh_service  *cli_srv;
+	/* m0_time_t rem; */
 	struct m0_reqh_service  *srv_srv;
 	struct m0_reqh          *srv_reqh = &sctx.rsx_motr_ctx.cc_reqh_ctx.rc_reqh;
+
+	m0_semaphore_init(&g_test_wait, 0);
 
 	rc = m0_rpc_server_start(&sctx);
 	M0_UT_ASSERT(rc == 0);
@@ -160,16 +164,21 @@ static void dtm0_ut_service(void)
 	cli_srv = m0_dtm__client_service_start(&cctx.cl_ctx.rcx_reqh, &cli_srv_fid);
 	M0_UT_ASSERT(cli_srv != NULL);
 	srv_srv = m0_reqh_service_lookup(srv_reqh, &srv_dtm0_fid);
-	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr);
-	M0_UT_ASSERT(rc == 0);
+	/* rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr, false); */
+	/* M0_UT_ASSERT(rc == 0); */
+
+	m0_semaphore_down(&g_test_wait);
 
 	dtm0_ut_send_fops(&cctx.cl_ctx.rcx_session);
 
-	rc = m0_dtm0_service_process_disconnect(srv_srv, &cli_srv_fid);
-	M0_UT_ASSERT(rc == 0);
+	/* rc = m0_dtm0_service_process_disconnect(srv_srv, &cli_srv_fid); */
+	/* M0_UT_ASSERT(rc == 0); */
+	(void)srv_srv;
+	m0_rpc_server_stop(&sctx);
+
 	m0_dtm__client_service_stop(cli_srv);
 	dtm0_ut_client_fini(&cctx);
-	m0_rpc_server_stop(&sctx);
+	/* m0_rpc_server_stop(&sctx); */
 }
 
 struct m0_ut_suite dtm0_ut = {

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -19,7 +19,6 @@
  *
  */
 
-
 #include "dtm0/clk_src.h"
 #include "dtm0/fop.h"
 #include "dtm0/helper.h"
@@ -155,6 +154,8 @@ static void dtm0_ut_service(void)
 	struct m0_reqh_service  *srv_srv;
 	struct m0_reqh          *srv_reqh = &sctx.rsx_motr_ctx.cc_reqh_ctx.rc_reqh;
 
+	m0_fi_enable("m0_dtm0_in_ut", "ut");
+
 	m0_semaphore_init(&g_test_wait, 0);
 
 	rc = m0_rpc_server_start(&sctx);
@@ -179,6 +180,7 @@ static void dtm0_ut_service(void)
 	m0_dtm__client_service_stop(cli_srv);
 	dtm0_ut_client_fini(&cctx);
 	/* m0_rpc_server_stop(&sctx); */
+	m0_fi_disable("m0_dtm0_in_ut", "ut");
 }
 
 struct m0_ut_suite dtm0_ut = {

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -870,7 +870,7 @@ static void st_one_dtm0_op(void)
 	cli_srv = m0_dtm__client_service_start(&ut_m0c->m0c_reqh, &cli_srv_fid);
 	M0_UT_ASSERT(cli_srv != NULL);
 	srv_srv = m0_reqh_service_lookup(srv_reqh, &srv_dtm0_fid);
-	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr);
+	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr, false);
 	M0_UT_ASSERT(rc == 0);
 	ut_m0c->m0c_dtms = m0_dtm0_service_find(&ut_m0c->m0c_reqh);
 	M0_UT_ASSERT(ut_m0c->m0c_dtms != NULL);

--- a/pool/pool.c
+++ b/pool/pool.c
@@ -880,13 +880,14 @@ static int __service_ctx_create(struct m0_pools_common *pc,
 	return M0_RC(rc);
 }
 
-static bool is_local_rms(const struct m0_conf_service *svc)
+static bool is_local_svc(const struct m0_conf_service *svc,
+			 enum m0_conf_service_type stype)
 {
 	const struct m0_conf_process *proc;
 	struct m0_rpc_machine        *mach;
 	const char                   *local_ep;
 
-	if (svc->cs_type != M0_CST_RMS)
+	if (svc->cs_type != stype)
 		return false;
 	proc = M0_CONF_CAST(m0_conf_obj_grandparent(&svc->cs_obj),
 			    m0_conf_process);
@@ -972,7 +973,8 @@ static int service_ctxs_create(struct m0_pools_common *pc,
 		 *
 		 * FI services need no service context either.
 		 */
-		if ((!rm_is_set && is_local_rms(svc)) ||
+		if ((!rm_is_set && is_local_svc(svc, M0_CST_RMS)) ||
+		    is_local_svc(svc, M0_CST_DTM0) ||
 		    !M0_IN(svc->cs_type, (M0_CST_CONFD, M0_CST_RMS, M0_CST_HA,
 					  M0_CST_FIS))) {
 			rc = __service_ctx_create(pc, svc, service_connect);


### PR DESCRIPTION
A new event-based connections mechanism is introduced.
Each node subscribes on state changes of process objects
with DTM0 service in confd to establish the connection
to DTM0 service when remote process becomes ONLINE.

NOTE: currently there is a logic to make a workaround
for current HA implementation: skip processing of all
HA messages until TRANSIENT is received. TRANSIENT is
just a trigger for handling HA messages in this case.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>