### PR TITLE
EOS-17630: [DTM0] Handle P notice on the client.

### DIFF
--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -19,12 +19,11 @@
  *
  */
 
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM0
+#include "be/dtm0_log.h"
+#include "be/alloc.h"
 #include "dtm0/clk_src.h"
 #include "lib/buf.h"
-#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
-#include "be/alloc.h"
-
-#include "be/dtm0_log.h"
 #include "be/list.h"
 #include "be/op.h"
 #include "be/tx.h"
@@ -34,6 +33,7 @@
 #include "lib/errno.h"  /* ENOENT */
 #include "lib/memory.h" /* M0_ALLOC */
 #include "lib/trace.h"
+#include "dtm0/fop.h"  /* dtm0_req_fop */
 
 enum {
 	M0_BE_DTM_LREC_MAGIX = 0xdeaddeaddeaddead,
@@ -122,7 +122,7 @@ M0_INTERNAL void dtm0_be_alloc_tx_desc_credit(struct m0_dtm0_tx_desc *txd,
 					      struct m0_be_tx_credit *accum)
 {
 	M0_BE_ALLOC_CREDIT_PTR(txd, seg, accum);
-	M0_BE_ALLOC_CREDIT_ARR(txd->dtd_pg.dtpg_pa, txd->dtd_pg.dtpg_nr, seg, accum);
+	M0_BE_ALLOC_CREDIT_ARR(txd->dtd_ps.dtp_pa, txd->dtd_ps.dtp_nr, seg, accum);
 }
 
 M0_INTERNAL void dtm0_be_alloc_log_rec_credit(struct m0_dtm0_tx_desc *txd,
@@ -148,8 +148,8 @@ M0_INTERNAL void dtm0_be_set_log_rec_credit(struct m0_dtm0_tx_desc *txd,
 	M0_BE_ALLOC_CREDIT_BUF(pyld, seg, accum);
 	m0_be_tx_credit_add(accum, &M0_BE_TX_CREDIT_TYPE(*pyld));
 	m0_be_tx_credit_add(accum, &M0_BE_TX_CREDIT_TYPE(*txd));
-	m0_be_tx_credit_add(accum, &M0_BE_TX_CREDIT(txd->dtd_pg.dtpg_nr, sizeof(struct m0_dtm0_tx_pa *)));
-	m0_be_tx_credit_add(accum, &M0_BE_TX_CREDIT(txd->dtd_pg.dtpg_nr, sizeof(struct m0_dtm0_tx_pa)));
+	m0_be_tx_credit_add(accum, &M0_BE_TX_CREDIT(txd->dtd_ps.dtp_nr, sizeof(struct m0_dtm0_tx_pa *)));
+	m0_be_tx_credit_add(accum, &M0_BE_TX_CREDIT(txd->dtd_ps.dtp_nr, sizeof(struct m0_dtm0_tx_pa)));
 	m0_be_tx_credit_add(accum, &M0_BE_TX_CREDIT_TYPE(*rec));
 }
 
@@ -158,7 +158,7 @@ M0_INTERNAL void dtm0_be_del_log_rec_credit(struct m0_be_seg       *seg,
 					    struct m0_be_tx_credit *accum)
 {
 	lrec_be_list_credit(M0_BLO_TLINK_DESTROY, 1, accum);
-	M0_BE_FREE_CREDIT_ARR(rec->dlr_txd.dtd_pg.dtpg_pa, rec->dlr_txd.dtd_pg.dtpg_nr, seg, accum);
+	M0_BE_FREE_CREDIT_ARR(rec->dlr_txd.dtd_ps.dtp_pa, rec->dlr_txd.dtd_ps.dtp_nr, seg, accum);
 	M0_BE_FREE_CREDIT_PTR(rec->dlr_pyld.b_addr, seg, accum);
 	M0_BE_FREE_CREDIT_PTR(rec, seg, accum);
 }
@@ -311,12 +311,12 @@ static int m0_be_dtm0_plog_rec_init(struct m0_dtm0_log_rec **dl_rec,
 	M0_ASSERT(rec != NULL);
 
 	rec->dlr_txd.dtd_id = txd->dtd_id;
-	rec->dlr_txd.dtd_pg.dtpg_nr = txd->dtd_pg.dtpg_nr;
-	M0_BE_ALLOC_ARR_SYNC(rec->dlr_txd.dtd_pg.dtpg_pa, txd->dtd_pg.dtpg_nr, seg, tx);
-	M0_ASSERT(rec->dlr_txd.dtd_pg.dtpg_pa != NULL);
+	rec->dlr_txd.dtd_ps.dtp_nr = txd->dtd_ps.dtp_nr;
+	M0_BE_ALLOC_ARR_SYNC(rec->dlr_txd.dtd_ps.dtp_pa, txd->dtd_ps.dtp_nr, seg, tx);
+	M0_ASSERT(rec->dlr_txd.dtd_ps.dtp_pa != NULL);
 
-	memcpy(rec->dlr_txd.dtd_pg.dtpg_pa, txd->dtd_pg.dtpg_pa,
-		sizeof(rec->dlr_txd.dtd_pg.dtpg_pa[0]) * rec->dlr_txd.dtd_pg.dtpg_nr);
+	memcpy(rec->dlr_txd.dtd_ps.dtp_pa, txd->dtd_ps.dtp_pa,
+		sizeof(rec->dlr_txd.dtd_ps.dtp_pa[0]) * rec->dlr_txd.dtd_ps.dtp_nr);
 
 	if (pyld->b_nob > 0) {
 		rec->dlr_pyld.b_nob = pyld->b_nob;
@@ -329,7 +329,7 @@ static int m0_be_dtm0_plog_rec_init(struct m0_dtm0_log_rec **dl_rec,
 		rec->dlr_pyld.b_nob = 0;
 	}
 
-	M0_BE_TX_CAPTURE_ARR(seg, tx, rec->dlr_txd.dtd_pg.dtpg_pa, rec->dlr_txd.dtd_pg.dtpg_nr);
+	M0_BE_TX_CAPTURE_ARR(seg, tx, rec->dlr_txd.dtd_ps.dtp_pa, rec->dlr_txd.dtd_ps.dtp_nr);
 	M0_BE_TX_CAPTURE_PTR(seg, tx, rec);
 
 	*dl_rec = rec;
@@ -355,7 +355,7 @@ static void m0_be_dtm0_plog_rec_fini(struct m0_dtm0_log_rec **dl_lrec,
 	struct m0_be_seg       *seg = log->seg;
 	struct m0_dtm0_log_rec *rec = *dl_lrec;
 
-	M0_BE_FREE_PTR_SYNC(rec->dlr_txd.dtd_pg.dtpg_pa, seg, tx);
+	M0_BE_FREE_PTR_SYNC(rec->dlr_txd.dtd_ps.dtp_pa, seg, tx);
 	M0_BE_FREE_PTR_SYNC(rec->dlr_pyld.b_addr, seg, tx);
 	M0_BE_FREE_PTR_SYNC(rec, seg, tx);
 }
@@ -413,8 +413,8 @@ static int m0_be_dtm0_log__set(struct m0_be_dtm0_log	    *log,
 	m0_dtm0_tx_desc_apply(&rec->dlr_txd, txd);
 	M0_POST(m0_dtm0_log_rec__invariant(rec));
 	if (dl_is_plog) {
-		M0_BE_TX_CAPTURE_ARR(seg, tx, rec->dlr_txd.dtd_pg.dtpg_pa,
-					      rec->dlr_txd.dtd_pg.dtpg_nr);
+		M0_BE_TX_CAPTURE_ARR(seg, tx, rec->dlr_txd.dtd_ps.dtp_pa,
+					      rec->dlr_txd.dtd_ps.dtp_nr);
 	}
 
 	return 0;
@@ -482,6 +482,8 @@ M0_INTERNAL void m0_be_dtm0_log_clear(struct m0_be_dtm0_log *log)
 
 	m0_tl_teardown(lrec, log->dl_tlist, rec) {
 		M0_ASSERT(m0_dtm0_log_rec__invariant(rec));
+		M0_ASSERT(m0_dtm0_tx_desc_state_eq(&rec->dlr_dtx.dd_txd,
+						   M0_DTPS_PERSISTENT));
 		m0_be_dtm0_log_rec_fini(&rec, NULL);
 	}
 	M0_POST(lrec_tlist_is_empty(log->dl_tlist));
@@ -507,7 +509,6 @@ M0_INTERNAL void m0_be_dtm0_log_update_volatile(struct m0_be_dtm0_log *log,
 	/* TODO: dissolve dlr_txd and remove this code */
 	m0_dtm0_tx_desc_apply(&rec->dlr_txd, &rec->dlr_dtx.dd_txd);
 }
-
 
 M0_INTERNAL int m0_be_dtm0_plog_can_prune(struct m0_be_dtm0_log	    *log,
 					  const struct m0_dtm0_tid  *id,
@@ -564,6 +565,47 @@ M0_INTERNAL int m0_be_dtm0_plog_prune(struct m0_be_dtm0_log    *log,
 
 	return 0;
 }
+
+M0_INTERNAL void
+m0_be_dtm0_log_post_pnotice(struct m0_be_dtm0_log *log,
+			    struct m0_fop         *fop)
+{
+	struct m0_dtm0_log_rec       *rec;
+	struct dtm0_req_fop          *req = m0_fop_data(fop);
+	const struct m0_dtm0_tx_desc *txd = &req->dtr_txr;
+	bool                          is_stable;
+
+	M0_PRE(log != NULL);
+	M0_PRE(!log->dl_is_plog);
+	M0_PRE(fop->f_type == &dtm0_req_fop_fopt);
+	M0_PRE(m0_dtm0_tx_desc__invariant(txd));
+
+	M0_ENTRY();
+
+	m0_mutex_lock(&log->dl_lock);
+	rec = m0_be_dtm0_log_find(log, &txd->dtd_id);
+	/* TODO: We do not handle the case where a P notice is received before
+	 * the corresponding DTX enters INPROGRESS state.
+	 */
+	M0_ASSERT_INFO(rec != NULL, "Log record must be inserted into the log "
+		       "in m0_dtx0_close().");
+	is_stable = m0_dtm0_tx_desc_state_eq(&rec->dlr_txd,
+					     M0_DTPS_PERSISTENT);
+	m0_mutex_unlock(&log->dl_lock);
+	/* NOTE: we do not need to hold the global mutex any longer
+	 * because of the following assumptions:
+	 * 1. Log record cannot be removed unless it is stable.
+	 *    We explicitly check that.
+	 * 2. The log record linkage is not shared with dtx_post_persistent,
+	 *    i.e. it should not try to remove or insert records.
+	 *    This point is not enforced.
+	 */
+	if (!is_stable)
+		m0_dtm0_dtx_post_pnotice(&rec->dlr_dtx, fop);
+
+	M0_LEAVE();
+}
+
 #undef M0_TRACE_SUBSYSTEM
 
 /** @} end of dtm group */

--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -262,6 +262,14 @@ M0_INTERNAL int m0_be_dtm0_log_insert_volatile(struct m0_be_dtm0_log *log,
 
 M0_INTERNAL void m0_be_dtm0_log_update_volatile(struct m0_be_dtm0_log *log,
 						struct m0_dtm0_log_rec *rec);
+
+/** Deliver a P notice to the log.
+ * TODO: Only volatile log is supported so far.
+ */
+M0_INTERNAL void
+m0_be_dtm0_log_post_pnotice(struct m0_be_dtm0_log *log,
+			    struct m0_fop         *fop);
+
 #endif /* __MOTR_BE_DTM0_LOG_H__ */
 
 /*

--- a/dtm0/clk_src.c
+++ b/dtm0/clk_src.c
@@ -19,7 +19,7 @@
  *
  */
 
-#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM0
 #include "lib/trace.h"
 
 #include "dtm0/clk_src.h"

--- a/dtm0/clk_src.h
+++ b/dtm0/clk_src.h
@@ -104,8 +104,8 @@ struct m0_dtm0_ts {
 /** Defines an invalid (but defined) value for a CS.TS. */
 #define M0_DTM0_TS_INIT (struct m0_dtm0_ts) { .dts_phys = UINT64_MAX }
 
-#define M0_DTM0_TS_P(_ts) ((_ts)->dts_phys)
-#define M0_DTM0_TS_FMT "@%" PRIu64
+#define DTS0_P(_ts) ((_ts)->dts_phys)
+#define DTS0_F "@%" PRIu64
 
 /** Timestamp ordering is the result of comparison of two timestamps
  * (see CS.TS.CMP for the details).

--- a/dtm0/doc/dtx.txt
+++ b/dtm0/doc/dtx.txt
@@ -513,3 +513,116 @@ A3: DTM0 service will take care of it. It will provide an API to properly
     lock the log (sm_group lock and/or DTM0 log locks).
 
 --------------------------------------------------------------------------------
+# Notes on DTX state transitions
+
+## Without DTM
+
+The following diagramm shows the sequence of state transitions
+of 3 CAS requests (CAS[i]), a DIX request (DIX) and a Motr client op (M0C).
+
+CAS[0] -- CAS_INPROGRESS -- CAS_FINAL
+CAS[1] -- CAS_INPROGRESS ---- CAS_FINAL
+CAS[2] -- CAS_INPROGRESS ------| CAS_FINAL
+DIX    -- DIX_INPROGRESS ------| <CLINK_CB -> AST> ----| DIX_FINAL
+IDX_DIX -----------------------------------------------| <CLINK_CB -> AST> ---|
+M0C    ------ LAUNCHED -------------------------------------------------------| EXECUTED&STABLE ----
+(Fig. 1)
+
+## With DTM and direct Exectued call
+
+The following diagramm shows the same scenario but with DTX states (DTX)
+and the states of DTX participants (DTX.pa[i]).
+
+CAS[0] -- CAS_INPROGRESS --| CAS_FINAL
+CAS[1] -- CAS_INPROGRESS ------------------------------------------| CAS_FINAL
+CAS[2] -- CAS_INPROGRESS ------------------------------------------| CAS_FINAL
+Persistent[i] --------------------------------------------------------------------------------------------------- PERSISTENT * 3
+DTX.pa[i] -----------------| <CLINK_CB -> AST> ---| [EII] ------|--| <CLINK_CB -> AST>[2] --| [EEE]        |-----| <AST>[3] | --| [PPP]
+DTX    -- INPROGRESS -----------------------------| EXECUTED ---|---------------------------| EXECUTED_ALL |--------------------| STABLE            |
+IDX_DIX ------------------------------------------| <CLINK_CB > |---------------------------------------------------------------| <CLINK_CB -> AST> |
+M0C    ------ LAUNCHED ---------------------------| EXECUTED    |--------------------------------------------------------------------------------------| STABLE
+M0C CB -------------------------------------------| Enter-Leave |--------------------------------------------------------------------------------------| STABLE
+(Fig. 2)
+
+## The Executed vs. Stable race condition for 1 PA when Executed called with AST
+
+When a DTX has only one participant and the P notice received before the reply,
+the transitions Executed -> ExecutedAll -> Stable might happen "instantly".
+In this case DTX must ensure that state_set(Stable) happens only after
+the user-provided callback have been called (and the client op has changed
+its state to Executed). Without such guarantee, the following situation
+may happen:
+
+DTX -- INPROGRESS -- <1 P notice> -- <1 Reply > ---| EXECUTED           -- EXEC_ALL                         |--| EXEC_ALL_CB        =>
+FORKQ  -[] ----------------------------------------| [IDX_DIX_EXECUTED] -- [EXEC_ALL_CB, IDX_DIX_EXECUTED ] |--| [IDX_DIX_EXECUTED] =>
+
+DTX     =>  EXEC_ALL ---------------- STABLE ---------------------------|-----------------------
+FORKQ   =>  [IDX_DIX_EXECUTED] ------[IDX_DIX_STABLE, IDX_DIX_EXECUTED] ------------------------
+IDX_DIX => |------------------------- <CLINK_CB -> AST_STABLE> ---------- IDX_DIX_STABLE -------
+M0C     => -------------------------------------------------------------- STABLE -> m0_panic ---
+(Fig. 3)
+
+--------------------------------------------------------------------------------
+
+                      <RPC reply>
+                       \|/
+CAS_SM: INIT ---> SENT ---> FINAL
+             \|/
+              <RPC sent>
+
+
+                            <DTX_SM.STABLE>
+                             \|/
+DIX_SM: INIT ---> INPROGRESS ---> FINAL
+             /|\
+             +----------------------+
+             | CAS_SM: INIT -> SENT |
+             | N times              |
+             +----------------------+
+
+
+DTX_SM:
+
+                INIT
+                 |
+                 | <- <CAS_SM: INIT -> SENT N times>
+                \|/
+                INPROGRESS
+                 |
+ [<P notice>] -> | <- <CAS_SM: SENT -> FINAL once>
+                \|/
+                EXECUTED
+                 |
+                 | -> M0C_SM: LAUNCHED -> EXECUTED
+ [<P notice>] -> | <- <CAS_SM: SENT -> FINAL N-1 times>
+                \|/
+                EXECUTED_ALL
+                 |
+ [<P notice>] -> |
+                 |
+               (is stable?)
+                 |
+                 |-------+
+                \|/      | -> M0C_SM: EXECUTED -> STABLE
+                STABLE ->+
+
+
+M0C_SM:
+        INIT
+         |
+         |
+        \|/
+        LAUNCHED <-+    +---------------------------+
+         |         | -> |DIX_SM: INIT -> INPROGRESS |
+         +---------+    |DTX_SM: INIT -> INPROGRESS |
+         |              +---------------------------+
+	 |
+         | <- DTX_SM: INPROGRESS -> EXECUTED
+        \|/
+        EXECUTED
+         |
+         | <- DTX_SM: EXECUTED_ALL -> STABLE
+        \|/
+        STABLE
+
+--------------------------------------------------------------------------------

--- a/dtm0/dtx.h
+++ b/dtm0/dtx.h
@@ -71,6 +71,19 @@ struct m0_dtm0_dtx {
 	 * any lists here. But we will have to some time later.
 	 */
 	const struct m0_fop    *dd_fop;
+
+	/** List of ASTs for persistent notices. */
+	struct m0_tl            dd_pnl;
+};
+
+/** An AST object for persistent notices. */
+struct m0_dtm0_pna {
+	/** AST where the update is applied */
+	struct m0_sm_ast       p_ast;
+	/** A FOP that contains a partial update to be applied. */
+	struct m0_fop         *p_fop;
+	/** A dtx that has to be update */
+	struct m0_dtm0_dtx    *p_dtx;
 };
 
 M0_INTERNAL void m0_dtm0_dtx_domain_init(void);
@@ -93,7 +106,7 @@ M0_INTERNAL int m0_dtx0_open(struct m0_dtx  *dtx, uint32_t nr);
 /** Fills in the FID of the given participant. */
 M0_INTERNAL int m0_dtx0_assign_fid(struct m0_dtx       *dtx,
 				   uint32_t             pa_idx,
-				   const struct m0_fid *pa_fid);
+				   const struct m0_fid *p_fid);
 
 /** Fills in the FOP associated with the given participant. */
 M0_INTERNAL void m0_dtx0_assign_fop(struct m0_dtx       *dtx,
@@ -102,6 +115,9 @@ M0_INTERNAL void m0_dtx0_assign_fop(struct m0_dtx       *dtx,
 M0_INTERNAL int m0_dtx0_close(struct m0_dtx *dtx);
 
 M0_INTERNAL void m0_dtx0_executed(struct m0_dtx *dtx, uint32_t pa_idx);
+
+M0_INTERNAL void m0_dtm0_dtx_post_pnotice(struct m0_dtm0_dtx *dtx,
+					  struct m0_fop      *fop);
 
 /** Puts a copy of dtx's transaction descriptor into "dst".
  * User is responsible for m0_dtm0_tx_desc_fini()lasing of 'dst'.

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -56,6 +56,7 @@ M0_INTERNAL void m0_dtm0_fop_fini(void);
 enum m0_dtm0s_msg {
 	DMT_EXECUTE,
 	DMT_EXECUTED,
+	/* XXX: Is it a typo? why do we have DMT everywhere except here? */
 	DTM_PERSISTENT,
 	DMT_REDO
 } M0_XCA_ENUM;
@@ -76,8 +77,11 @@ struct dtm0_rep_fop {
 /** Structure that describes dtm0 FOM. */
 struct dtm0_fom {
 	/** Caller FOM. */
-	struct m0_fom		     dtf_fom;
+	struct m0_fom dtf_fom;
 };
+
+M0_INTERNAL void m0_dtm0_on_committed(struct m0_reqh               *reqh,
+				      const struct m0_dtm0_tx_desc *txd);
 
 /* __MOTR_DTM0_FOP_H__ */
 #endif

--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -149,7 +149,7 @@ static void dtm0_service__fini(struct m0_dtm0_service *s)
 }
 
 static struct dtm0_process *dtm0_service_process__lookup(struct m0_reqh_service *reqh_dtm0_svc,
-							 struct m0_fid *remote_dtm0)
+							 const struct m0_fid *remote_dtm0)
 {
 	struct m0_dtm0_service *dtm0 =
 		container_of(reqh_dtm0_svc, struct m0_dtm0_service, dos_generic);
@@ -232,7 +232,7 @@ M0_INTERNAL int m0_dtm0_service_process_disconnect(struct m0_reqh_service *s,
 
 M0_INTERNAL struct m0_rpc_session *
 m0_dtm0_service_process_session_get(struct m0_reqh_service *s,
-				    struct m0_fid *remote_srv)
+				    const struct m0_fid *remote_srv)
 {
 	struct dtm0_process *process =
 		dtm0_service_process__lookup(s, remote_srv);
@@ -304,7 +304,7 @@ static int dtm_service__origin_fill(struct m0_reqh_service *service)
 
 out:
 	return dtm0->dos_origin == DTM0_ON_VOLATILE ?
-		m0_be_dtm0_log_init(&dtm0->dos_log, &dtm0->dos_clk_src, true) :
+		m0_be_dtm0_log_init(&dtm0->dos_log, &dtm0->dos_clk_src, false) :
 		0;
 }
 

--- a/dtm0/service.h
+++ b/dtm0/service.h
@@ -62,7 +62,7 @@ M0_INTERNAL int m0_dtm0_service_process_disconnect(struct m0_reqh_service *s,
 						   struct m0_fid *remote_srv);
 M0_INTERNAL struct m0_rpc_session *
 m0_dtm0_service_process_session_get(struct m0_reqh_service *s,
-				    struct m0_fid *remote_srv);
+				    const struct m0_fid *remote_srv);
 
 M0_INTERNAL bool m0_dtm0_is_a_volatile_dtm(struct m0_reqh_service *service);
 M0_INTERNAL bool m0_dtm0_is_a_persistent_dtm(struct m0_reqh_service *service);

--- a/dtm0/tx_desc.c
+++ b/dtm0/tx_desc.c
@@ -29,7 +29,7 @@
 
 #include "dtm0/clk_src.h"
 #include "lib/misc.h"
-#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM0
 #include "dtm0/tx_desc.h"
 #include "lib/assert.h" /* M0_PRE */
 #include "lib/memory.h" /* M0_ALLOC */
@@ -55,12 +55,12 @@ M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td)
 	 *     the descriptor should have a valid ID.
 	 */
 
-	return _0C(td->dtd_pg.dtpg_pa != NULL) &&
-		_0C(m0_forall(i, td->dtd_pg.dtpg_nr,
-			      td->dtd_pg.dtpg_pa[i].pa_state >= 0 &&
-			      td->dtd_pg.dtpg_pa[i].pa_state < M0_DTPS_NR)) &&
-		_0C(ergo(m0_forall(i, td->dtd_pg.dtpg_nr,
-			      td->dtd_pg.dtpg_pa[i].pa_state > M0_DTPS_INIT),
+	return _0C(td->dtd_ps.dtp_pa != NULL) &&
+		_0C(m0_forall(i, td->dtd_ps.dtp_nr,
+			      td->dtd_ps.dtp_pa[i].p_state >= 0 &&
+			      td->dtd_ps.dtp_pa[i].p_state < M0_DTPS_NR)) &&
+		_0C(ergo(m0_forall(i, td->dtd_ps.dtp_nr,
+			      td->dtd_ps.dtp_pa[i].p_state > M0_DTPS_INIT),
 			 m0_dtm0_tid__invariant(&td->dtd_id)));
 }
 
@@ -79,13 +79,13 @@ M0_INTERNAL int m0_dtm0_tx_desc_copy(const struct m0_dtm0_tx_desc *src,
 
 	M0_PRE(m0_dtm0_tx_desc__invariant(src));
 
-	rc = m0_dtm0_tx_desc_init(dst, src->dtd_pg.dtpg_nr);
+	rc = m0_dtm0_tx_desc_init(dst, src->dtd_ps.dtp_nr);
 	if (rc != 0)
 		return rc;
 
 	dst->dtd_id = src->dtd_id;
-	memcpy(dst->dtd_pg.dtpg_pa, src->dtd_pg.dtpg_pa,
-	       sizeof(src->dtd_pg.dtpg_pa[0]) * src->dtd_pg.dtpg_nr);
+	memcpy(dst->dtd_ps.dtp_pa, src->dtd_ps.dtp_pa,
+	       sizeof(src->dtd_ps.dtp_pa[0]) * src->dtd_ps.dtp_nr);
 
 	M0_POST(m0_dtm0_tx_desc__invariant(dst));
 	return 0;
@@ -94,17 +94,17 @@ M0_INTERNAL int m0_dtm0_tx_desc_copy(const struct m0_dtm0_tx_desc *src,
 M0_INTERNAL int m0_dtm0_tx_desc_init(struct m0_dtm0_tx_desc *td,
 				     uint32_t nr_pa)
 {
-	M0_ALLOC_ARR(td->dtd_pg.dtpg_pa, nr_pa);
-	if (td->dtd_pg.dtpg_pa == NULL)
+	M0_ALLOC_ARR(td->dtd_ps.dtp_pa, nr_pa);
+	if (td->dtd_ps.dtp_pa == NULL)
 		return M0_ERR(-ENOMEM);
-	td->dtd_pg.dtpg_nr = nr_pa;
+	td->dtd_ps.dtp_nr = nr_pa;
 	M0_POST(m0_dtm0_tx_desc__invariant(td));
 	return 0;
 }
 
 M0_INTERNAL void m0_dtm0_tx_desc_fini(struct m0_dtm0_tx_desc *td)
 {
-	m0_free(td->dtd_pg.dtpg_pa);
+	m0_free(td->dtd_ps.dtp_pa);
 	M0_SET0(td);
 }
 
@@ -126,25 +126,48 @@ M0_INTERNAL void m0_dtm0_tx_desc_apply(struct m0_dtm0_tx_desc *tgt,
 	M0_PRE(m0_dtm0_tx_desc__invariant(tgt));
 	M0_PRE(m0_dtm0_tx_desc__invariant(upd));
 	M0_PRE(memcmp(&tgt->dtd_id, &upd->dtd_id, sizeof(tgt->dtd_id)) == 0);
-	M0_PRE(upd->dtd_pg.dtpg_nr == tgt->dtd_pg.dtpg_nr);
-	M0_PRE(m0_forall(i, upd->dtd_pg.dtpg_nr,
-			 m0_fid_cmp(&tgt->dtd_pg.dtpg_pa[i].pa_fid,
-				    &upd->dtd_pg.dtpg_pa[i].pa_fid) == 0));
+	M0_PRE(upd->dtd_ps.dtp_nr == tgt->dtd_ps.dtp_nr);
+	M0_PRE(m0_forall(i, upd->dtd_ps.dtp_nr,
+			 m0_fid_cmp(&tgt->dtd_ps.dtp_pa[i].p_fid,
+				    &upd->dtd_ps.dtp_pa[i].p_fid) == 0));
 
-	for (i = 0; i < upd->dtd_pg.dtpg_nr; ++i) {
-		tgt_pa = &tgt->dtd_pg.dtpg_pa[i];
-		upd_pa = &upd->dtd_pg.dtpg_pa[i];
+	for (i = 0; i < upd->dtd_ps.dtp_nr; ++i) {
+		tgt_pa = &tgt->dtd_ps.dtp_pa[i];
+		upd_pa = &upd->dtd_ps.dtp_pa[i];
 
-		tgt_pa->pa_state = max_check(tgt_pa->pa_state,
-					     upd_pa->pa_state);
+		tgt_pa->p_state = max_check(tgt_pa->p_state,
+					     upd_pa->p_state);
 	}
 }
 
 M0_INTERNAL bool m0_dtm0_tx_desc_state_eq(const struct m0_dtm0_tx_desc *txd,
 					  enum m0_dtm0_tx_pa_state      state)
 {
-	return m0_forall(i, txd->dtd_pg.dtpg_nr,
-			 txd->dtd_pg.dtpg_pa[i].pa_state == state);
+	return m0_forall(i, txd->dtd_ps.dtp_nr,
+			 txd->dtd_ps.dtp_pa[i].p_state == state);
+}
+
+/* XXX: This function has only one purpose -- to aid debugging with GDB */
+M0_INTERNAL void m0_dtm0_tx_desc_print(const struct m0_dtm0_tx_desc *txd)
+{
+	int i;
+
+	static const struct {
+		char name;
+	} smap[M0_DTPS_NR] = {
+		[M0_DTPS_INIT       ] = { .name = '0' },
+		[M0_DTPS_INPROGRESS ] = { .name = 'I' },
+		[M0_DTPS_EXECUTED   ] = { .name = 'E' },
+		[M0_DTPS_PERSISTENT ] = { .name = 'P' },
+	};
+
+	M0_LOG(M0_ALWAYS, "txid=" DTID0_F, DTID0_P(&txd->dtd_id));
+
+	for (i = 0; i < txd->dtd_ps.dtp_nr; ++i) {
+		M0_LOG(M0_ALWAYS, "\tpa=" FID_F ", %c",
+		       FID_P(&txd->dtd_ps.dtp_pa[i].p_fid),
+		       smap[txd->dtd_ps.dtp_pa[i].p_state].name);
+	}
 }
 
 #undef M0_TRACE_SUBSYSTEM

--- a/dtm0/tx_desc.h
+++ b/dtm0/tx_desc.h
@@ -95,6 +95,9 @@ struct m0_dtm0_tid {
 	struct m0_fid     dti_fid;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc|be);
 
+#define DTID0_F "{" DTS0_F "," FID_F "}"
+#define DTID0_P(__tid) DTS0_P(&(__tid)->dti_ts), FID_P(&(__tid)->dti_fid)
+
 enum m0_dtm0_tx_pa_state {
 	M0_DTPS_INIT,
 	M0_DTPS_INPROGRESS,
@@ -104,19 +107,19 @@ enum m0_dtm0_tx_pa_state {
 } M0_XCA_ENUM M0_XCA_DOMAIN(rpc|be);
 
 struct m0_dtm0_tx_pa {
-	struct m0_fid pa_fid;
-	uint32_t      pa_state M0_XCA_FENUM(m0_dtm0_tx_pa_state);
+	struct m0_fid p_fid;
+	uint32_t      p_state M0_XCA_FENUM(m0_dtm0_tx_pa_state);
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc|be);
 
 /** A list of participants (and their states) of a transaction. */
-struct m0_dtm0_tx_pa_group {
-	uint32_t              dtpg_nr;
-	struct m0_dtm0_tx_pa *dtpg_pa;
+struct m0_dtm0_tx_participants {
+	uint32_t              dtp_nr;
+	struct m0_dtm0_tx_pa *dtp_pa;
 } M0_XCA_SEQUENCE M0_XCA_DOMAIN(rpc|be);
 
 struct m0_dtm0_tx_desc {
-	struct m0_dtm0_tid          dtd_id;
-	struct m0_dtm0_tx_pa_group  dtd_pg;
+	struct m0_dtm0_tid              dtd_id;
+	struct m0_dtm0_tx_participants  dtd_ps;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc|be);
 
 /** Writes a deep copy of "src" into "dst". */
@@ -158,8 +161,8 @@ M0_INTERNAL void m0_dtm0_tx_desc_apply(struct m0_dtm0_tx_desc *tgt,
 /* TODO: move them to a dtm0 internal header? */
 
 #define dtds_forall(__txd, __exp)                                    \
-	m0_forall(i, (__txd)->dtd_pg.dtpg_nr,                        \
-			 (__txd)->dtd_pg.dtpg_pa[i].pa_state __exp)
+	m0_forall(i, (__txd)->dtd_ps.dtp_nr,                        \
+			 (__txd)->dtd_ps.dtp_pa[i].p_state __exp)
 
 #define dtds_exists(__txd, __exp) !dtds_forall(__txd, __exp)
 

--- a/dtm0/ut/clk_src_ut.c
+++ b/dtm0/ut/clk_src_ut.c
@@ -35,7 +35,7 @@ static void ts_format(void)
 	struct m0_dtm0_ts ts = M0_DTM0_TS_MIN;
 	const char       *expected = "'@1'";
 
-	m0_asprintf(&str, "'" M0_DTM0_TS_FMT "'", M0_DTM0_TS_P(&ts));
+	m0_asprintf(&str, "'" DTS0_F "'", DTS0_P(&ts));
 	M0_UT_ASSERT(str);
 
 	M0_UT_ASSERT(m0_streq(expected, str));

--- a/motr/ut/dix_conf.cg
+++ b/motr/ut/dix_conf.cg
@@ -12,7 +12,7 @@
               service-22, service-23, service-24, service-25, service-126,
               service-11, service-28])
 (process-6 cores=[3] mem_limit_as=0 mem_limit_rss=0 mem_limit_stack=0
-    mem_limit_memlock=0 endpoint="0@lo:12345:34:1" services=[service-26])
+    mem_limit_memlock=0 endpoint="0@lo:12345:34:2" services=[service-26])
 (service-9 type=@M0_CST_IOS endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[sdev-15, sdev-71, sdev-72, sdev-73, sdev-74])
 (service-10 type=@M0_CST_MDS endpoints=["0@lo:12345:34:1"] params=[]
@@ -26,7 +26,7 @@
 (service-25 type=@M0_CST_SNS_REB endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[])
 
-(service-26 type=@M0_CST_DTM0 endpoints=["0@lo:12345:34:1"]
+(service-26 type=@M0_CST_DTM0 endpoints=["0@lo:12345:34:2"]
     params=["origin:in-volatile"] sdevs=[])
 (service-28 type=@M0_CST_DTM0 endpoints=["0@lo:12345:34:1"]
     params=["origin:in-persistent"] sdevs=[])
@@ -35,7 +35,7 @@
 (service-126 type=@M0_CST_DIX_REP endpoints=["0@lo:12345:34:1"] params=[]
     sdevs=[sdev-96, sdev-97])
 (service-11 type=@M0_CST_CAS endpoints=["0@lo:12345:34:1"] params=[]
-    sdevs=[sdev-100, sdev-101, sdev-102])
+    sdevs=[sdev-100])
 (sdev-96 dev_idx=1 iface=4 media=1 bsize=4096 size=0 last_state=3 flags=4
     filename="/var/motr/m0ut/ut-sandbox/d1")
 (sdev-97 dev_idx=2 iface=4 media=1 bsize=4096 size=0 last_state=3 flags=4
@@ -56,24 +56,18 @@
     flags=4 filename="/dev/sdev6")
 (sdev-100 dev_idx=10 iface=7 media=2 bsize=8192 size=1073741824 last_state=2
     flags=4 filename="/dev/sdev100")
-(sdev-101 dev_idx=11 iface=7 media=2 bsize=8192 size=1073741824 last_state=2
-    flags=4 filename="/dev/sdev101")
-(sdev-102 dev_idx=12 iface=7 media=2 bsize=8192 size=1073741824 last_state=2
-    flags=4 filename="/dev/sdev102")
 (site-2 racks=[rack-3, rack-52] pvers=[pver-8, pver-57, pver-100])
 (rack-3 encls=[enclosure-7] pvers=[pver-8, pver-100])
 (enclosure-7 ctrls=[controller-11] pvers=[pver-8, pver-100])
 (controller-11 node=node-2
     drives=[drive-16, drive-75, drive-76, drive-77, drive-78,
-    drive-100, drive-101, drive-102] pvers=[pver-8, pver-100])
+    drive-100] pvers=[pver-8, pver-100])
 (drive-16 dev=sdev-15 pvers=[pver-8])
 (drive-75 dev=sdev-71 pvers=[pver-8])
 (drive-76 dev=sdev-72 pvers=[pver-8])
 (drive-77 dev=sdev-73 pvers=[pver-8])
 (drive-78 dev=sdev-74 pvers=[pver-8])
 (drive-100 dev=sdev-100 pvers=[pver-100])
-(drive-101 dev=sdev-101 pvers=[pver-100])
-(drive-102 dev=sdev-102 pvers=[pver-100])
 (pool-4 pver_policy=0 pvers=[pver-8])
 (pver-8 N=3 K=1 P=5 tolerance=[0, 0, 0, 0, 1] sitevs=[objv-2:12])
 (objv-2:12 real=site-2 children=[objv-12])
@@ -131,17 +125,15 @@
 
 
 (pool-100 pver_policy=0 pvers=[pver-100])
-(pver-100 N=1 K=1 P=3 tolerance=[0, 0, 0, 0, 1] sitevs=[objv-2:100])
+(pver-100 N=1 K=0 P=1 tolerance=[0, 0, 0, 0, 1] sitevs=[objv-2:100])
 
 (objv-2:100 real=site-2 children=[objv-100])
 (objv-100 real=rack-3 children=[objv-101])
 (objv-101 real=enclosure-7 children=[objv-102])
 (objv-102 real=controller-11
-    children=[objv-103, objv-104, objv-105])
+    children=[objv-103])
 
 (objv-103 real=drive-100 children=[])
-(objv-104 real=drive-101 children=[])
-(objv-105 real=drive-102 children=[])
 
 (pool-5 pver_policy=0 pvers=[pver-11])
 (pver-11 N=1 K=0 P=1 tolerance=[0, 0, 0, 0, 1] sitevs=[objv-2:106])

--- a/utils/trace/m0trace
+++ b/utils/trace/m0trace
@@ -329,7 +329,7 @@ sub validate_subsys
         cas      formation  net     stob
         cm       ha         other   ut
         cob      ioservice  pool    xcode
-        conf     layout     rm
+        conf     layout     rm      dtm0
         console  lib        rpc
         dtm      lnet       sm
     );


### PR DESCRIPTION
The patch aimed at PERSISTENT (P) notice mechanism
implementation for the happy-path scenario.
P notice is sent by the server side when the corresponding
CAS operation gets comitted, and it is beign handled
by the log through the ast mechanism.
The patch also incudes several minor improvements
for DTM0 traces and fixes for the configuration
of the Motr client UT to enable proper communication
between the DTM0 services on the client and the server
sides of the UT.

Signed-off-by: Ivan Alekhin <ivan.alekhin@seagate.com>