### PR TITLE
lib: enhance m0_uint128_sscanf to allow dec/oct formats

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -50,7 +50,7 @@ M0_INTERNAL int m0_uint128_cmp(const struct m0_uint128 *u0,
 
 M0_INTERNAL int m0_uint128_sscanf(const char *s, struct m0_uint128 *u128)
 {
-	int rc = sscanf(s, U128X_F, U128_S(u128));
+	int rc = sscanf(s, U128I_F, U128_S(u128));
 	return rc == 2 ? 0 : -EINVAL;
 }
 

--- a/lib/types.h
+++ b/lib/types.h
@@ -41,6 +41,7 @@ struct m0_uint128 {
 
 #define U128X_F "%"PRIx64":%"PRIx64
 #define U128D_F "%"PRId64":%"PRId64
+#define U128I_F "%"PRIi64":%"PRIi64
 #define U128_P(x) (x)->u_hi, (x)->u_lo
 #define U128_S(u) &(u)->u_hi, &(u)->u_lo
 


### PR DESCRIPTION
Enhance m0_uint128_sscanf() to allow parsing the IDs specified in decimal and octal formats also. (Currently, it understands hex format only.)