### PR TITLE
client-io: simplify pargrp_iomap_init

### DIFF
--- a/motr/ut/io_pargrp.c
+++ b/motr/ut/io_pargrp.c
@@ -908,15 +908,12 @@ static void ut_test_pargrp_iomap_init(void)
 	M0_UT_ASSERT(map != NULL);
 
 	rc = pargrp_iomap_init(map, ioo, 1);
-	M0_UT_ASSERT(rc == 0 || rc == -ENOMEM);
-	if (rc == 0) {
-		M0_UT_ASSERT(map->pi_databufs != NULL);
-		for (i = 0; i < map->pi_max_row; i++) {
-			M0_UT_ASSERT(map->pi_databufs[i] != NULL);
-		}
-
-		ut_free_pargrp_iomap(map);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(map->pi_databufs != NULL);
+	for (i = 0; i < map->pi_max_row; i++) {
+		M0_UT_ASSERT(map->pi_databufs[i] != NULL);
 	}
+	ut_free_pargrp_iomap(map);
 	m0_free(map);
 
 	ut_dummy_ioo_delete(ioo, instance);


### PR DESCRIPTION
Simplify bufs allocations at pargrp_iomap_init() with help of new pargrp_iomap_bufs_alloc() and pargrp_iomap_bufs_free() routines.