### PR TITLE
EOS-18137 sns/parity_math: implement isal_diff() function

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -184,8 +184,8 @@ lib_LTLIBRARIES          += motr/libmotr.la
 motr_libmotr_la_CPPFLAGS  = -DM0_TARGET='libmotr' $(AM_CPPFLAGS)
 motr_libmotr_la_LDFLAGS   = -version-info @LT_VERSION@ -pthread $(AM_LDFLAGS)
 motr_libmotr_la_LIBADD    = @MATH_LIBS@ @PTHREAD_LIBS@ @AIO_LIBS@ @RT_LIBS@ \
-                            @YAML_LIBS@ @PROFILER_LIBS@ @UUID_LIBS@ @DL_LIBS@ \
-                            @CASSANDRA_LIBS@ @UV_LIBS@ @ISAL_LIBS@
+                            @YAML_LIBS@ @PROFILER_LIBS@ @UUID_LIBS@ @GALOIS_LIBS@ \
+                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@ @ISAL_LIBS@
 
 # install directory for public libmotr headers
 motr_includedir             = $(includedir)/motr

--- a/sns/Makefile.sub
+++ b/sns/Makefile.sub
@@ -3,7 +3,8 @@ nobase_motr_include_HEADERS += sns/ls_solve.h \
                                   sns/parity_math.h \
                                   sns/parity_ops.h \
                                   sns/sns.h \
-                                  sns/parity_repair.h
+                                  sns/parity_repair.h \
+                                  sns/parity_defs.h
 
 motr_libmotr_la_SOURCES  += sns/sns.c \
                                   sns/ls_solve.c \

--- a/sns/parity_defs.h
+++ b/sns/parity_defs.h
@@ -1,6 +1,5 @@
-/* -*- C -*- */
 /*
- * Copyright (c) 2011-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2012-2020 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,45 +19,19 @@
  */
 
 
-#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_SNS
-#include "lib/trace.h"
-#include "lib/misc.h"
-#include "lib/memory.h"
-#include "lib/assert.h"
-#include "sns/parity_ops.h"
+#pragma once
 
-M0_INTERNAL void m0_parity_fini(void)
-{
-#if RS_ENCODE_ENABLED
-	galois_calc_tables_release();
-#endif /* RS_ENCODE_ENABLED */
-}
+#ifndef __MOTR_SNS_PARITY_DEFS_H__
+#define __MOTR_SNS_PARITY_DEFS_H__
 
-M0_INTERNAL int m0_parity_init(void)
-{
-#if RS_ENCODE_ENABLED
-	int ret = galois_create_mult_tables(M0_PARITY_GALOIS_W);
-	M0_ASSERT(ret == 0);
-#endif /* RS_ENCODE_ENABLED */
-	return 0;
-}
+/**
+ *  Define the condition here to use Intel ISA library.
+ */
+#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__))
+#define RS_ENCODE_ENABLED	(!ISAL_ENCODE_ENABLED)
 
-M0_INTERNAL m0_parity_elem_t m0_parity_pow(m0_parity_elem_t x,
-					   m0_parity_elem_t p)
-{
-	m0_parity_elem_t ret = x;
-	int i = 1;
-
-	if (p == 0)
-		return 1;
-
-	for (i = 1; i < p; ++i)
-		ret = m0_parity_mul(ret, x);
-
-	return ret;
-}
-
-#undef M0_TRACE_SUBSYSTEM
+/* __MOTR_SNS_PARITY_DEFS_H__ */
+#endif
 
 /*
  *  Local variables:

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -410,7 +410,7 @@ static bool parity_math_invariant(const struct m0_parity_math *math)
 {
 	return  _0C(math != NULL) && _0C(math->pmi_data_count >= 1) &&
 		_0C(math->pmi_parity_count >= 1) &&
-		_0C(math->pmi_data_count >= math->pmi_parity_count);
+		_0C(math->pmi_data_count >= math->pmi_parity_count) &&
 		_0C(math->pmi_data_count <= SNS_PARITY_MATH_DATA_BLOCKS_MAX);
 }
 #endif /* ISAL_ENCODE_ENABLED */

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -311,7 +311,7 @@ static void (*fidx_recover[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
 };
 
 enum {
-	SNS_PARITY_MATH_DATA_BLOCKS_MAX = 1 << (M0_PARITY_W - 1),
+	SNS_PARITY_MATH_DATA_BLOCKS_MAX = 1 << (M0_PARITY_GALOIS_W - 1),
 	BAD_FAIL_INDEX = -1
 };
 

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -74,6 +74,8 @@ static void isal_diff(struct m0_parity_math *math,
 		      struct m0_buf         *new,
 		      struct m0_buf         *parity,
 		      uint32_t               index);
+
+static bool parity_math_invariant(const struct m0_parity_math *math);
 #else
 static void reed_solomon_diff(struct m0_parity_math *math,
 		              struct m0_buf         *old,
@@ -404,15 +406,12 @@ static int vandmat_norm(struct m0_matrix *m)
 #endif /* RS_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
-static inline void parity_math_validate(struct m0_parity_math *math)
+static bool parity_math_invariant(const struct m0_parity_math *math)
 {
-	M0_ENTRY();
-	M0_PRE(math != NULL);
-	M0_PRE(math->pmi_data_count >= 1);
-	M0_PRE(math->pmi_parity_count >= 1);
-	M0_PRE(math->pmi_data_count >= math->pmi_parity_count);
-	M0_PRE(math->pmi_data_count <= SNS_PARITY_MATH_DATA_BLOCKS_MAX);
-	M0_LEAVE();
+	return  _0C(math != NULL) && _0C(math->pmi_data_count >= 1) &&
+		_0C(math->pmi_parity_count >= 1) &&
+		_0C(math->pmi_data_count >= math->pmi_parity_count);
+		_0C(math->pmi_data_count <= SNS_PARITY_MATH_DATA_BLOCKS_MAX);
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
@@ -587,8 +586,7 @@ static void isal_diff(struct m0_parity_math *math,
 
 	M0_ENTRY();
 
-	parity_math_validate(math);
-
+	M0_PRE(parity_math_invariant(math));
 	M0_PRE(old    != NULL);
 	M0_PRE(new    != NULL);
 	M0_PRE(parity != NULL);
@@ -762,8 +760,7 @@ static void isal_encode(struct m0_parity_math *math,
 
 	M0_ENTRY();
 
-	parity_math_validate(math);
-
+	M0_PRE(parity_math_invariant(math));
 	M0_PRE(data != NULL);
 	M0_PRE(parity != NULL);
 
@@ -1158,8 +1155,7 @@ static void isal_recover(struct m0_parity_math *math,
 
 	M0_ENTRY();
 
-	parity_math_validate(math);
-
+	M0_PRE(parity_math_invariant(math));
 	M0_PRE(data != NULL);
 	M0_PRE(parity != NULL);
 	M0_PRE(fails != NULL);

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -464,8 +464,6 @@ M0_INTERNAL int m0_parity_math_init(struct m0_parity_math *math,
 	} else {
 		uint32_t total_count = data_count + parity_count;
 
-		math->pmi_parity_algo = M0_PARITY_CAL_ALGO_ISA;
-
 		ALLOC_ARR_INFO(math->pmi_encode_matrix,
 			       (total_count * data_count),
 			       "encode matrix", ret);
@@ -494,6 +492,7 @@ M0_INTERNAL int m0_parity_math_init(struct m0_parity_math *math,
 			       math->pmi_encode_tbls);
 
 		M0_LOG(M0_DEBUG, "use Intel ISA for parity calculation.");
+		math->pmi_parity_algo = M0_PARITY_CAL_ALGO_ISA;
 	}
 #else
 	} else {

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -29,6 +29,7 @@
 #include "lib/tlist.h"
 #include "matvec.h"
 #include "ls_solve.h"
+#include "parity_defs.h"
 
 /**
    @defgroup parity_math Parity Math Component
@@ -42,12 +43,6 @@
    @li Provide algorithms for SNS repair (recovery) in case of failure.
    @{
 */
-
-/**
- *  Define the condition here to use Intel ISA library.
- */
-#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__))
-#define RS_ENCODE_ENABLED	(!ISAL_ENCODE_ENABLED)
 
 /**
  * Parity calculation type indicating various algorithms of parity calculation.

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -44,6 +44,12 @@
 */
 
 /**
+ *  Define the condition here to use Intel ISA library.
+ */
+#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__))
+#define RS_ENCODE_ENABLED	(!ISAL_ENCODE_ENABLED)
+
+/**
  * Parity calculation type indicating various algorithms of parity calculation.
  */
 enum m0_parity_cal_algo {
@@ -107,21 +113,25 @@ struct m0_parity_math {
 
 	uint32_t		pmi_data_count;
 	uint32_t		pmi_parity_count;
+#if RS_ENCODE_ENABLED
 	/* structures used for parity calculation and recovery */
 	struct m0_matvec	pmi_data;
 	struct m0_matvec	pmi_parity;
+#endif /* RS_ENCODE_ENABLED */
 	/* Vandermonde matrix */
 	struct m0_matrix	pmi_vandmat;
 	/* Submatrix of Vandermonde matrix used to compute parity. */
 	struct m0_matrix	pmi_vandmat_parity_slice;
 	/* structures used for non-incremental recovery */
 	struct m0_matrix	pmi_sys_mat;
+#if RS_ENCODE_ENABLED
 	struct m0_matvec	pmi_sys_vec;
 	struct m0_matvec	pmi_sys_res;
 	struct m0_linsys	pmi_sys;
+#endif /* RS_ENCODE_ENABLED */
 	/* Data recovery matrix that's inverse of pmi_sys_mat. */
 	struct m0_matrix	pmi_recov_mat;
-#ifndef __KERNEL__
+#if ISAL_ENCODE_ENABLED
 	/* Pointer to sets of arrays of input coefficients used
 	 * to encode or decode data.*/
 	uint8_t		       *pmi_encode_matrix;
@@ -129,7 +139,7 @@ struct m0_parity_math {
 	uint8_t		       *pmi_encode_tbls;
 	/* Pointer to concatenated output tables for decode */
 	uint8_t		       *pmi_decode_tbls;
-#endif
+#endif /* ISAL_ENCODE_ENABLED */
 };
 
 /* Holds information essential for incremental recovery. */

--- a/sns/parity_ops.h
+++ b/sns/parity_ops.h
@@ -25,24 +25,17 @@
 #ifndef __MOTR_SNS_PARITY_OPS_H__
 #define __MOTR_SNS_PARITY_OPS_H__
 
-#ifndef __KERNEL__
+#include "parity_defs.h"
+
+#if ISAL_ENCODE_ENABLED
 #include <isa-l.h>
 #else
 #include "galois/galois.h"
-#endif /* __KERNEL__ */
+#endif /* ISAL_ENCODE_ENABLED */
 #include "lib/assert.h"
 
-#define M0_PARITY_ZERO (0)
-
-#ifdef __KERNEL__
-#define M0_PARITY_GALOIS_W (8)
-#endif
-
-#ifndef __KERNEL__
-#define M0_PARITY_W (8)
-#else
-#define M0_PARITY_W M0_PARITY_GALOIS_W
-#endif /* __KERNEL__ */
+#define M0_PARITY_ZERO		(0)
+#define M0_PARITY_GALOIS_W	(8)
 
 typedef int m0_parity_elem_t;
 
@@ -64,22 +57,22 @@ static inline m0_parity_elem_t m0_parity_sub(m0_parity_elem_t x, m0_parity_elem_
 
 static inline m0_parity_elem_t m0_parity_mul(m0_parity_elem_t x, m0_parity_elem_t y)
 {
-#ifndef __KERNEL__
+#if ISAL_ENCODE_ENABLED
 	return gf_mul(x, y);
 #else
 	/* return galois_single_multiply(x, y, M0_PARITY_GALOIS_W); */
 	return galois_multtable_multiply(x, y, M0_PARITY_GALOIS_W);
-#endif /* __KERNEL__ */
+#endif /* ISAL_ENCODE_ENABLED */
 }
 
 static inline m0_parity_elem_t m0_parity_div(m0_parity_elem_t x, m0_parity_elem_t y)
 {
-#ifndef __KERNEL__
+#if ISAL_ENCODE_ENABLED
 	return gf_mul(x, gf_inv(y));
 #else
 	/* return galois_single_divide(x, y, M0_PARITY_GALOIS_W); */
 	return galois_multtable_divide(x, y, M0_PARITY_GALOIS_W);
-#endif /* __KERNEL__ */
+#endif /* ISAL_ENCODE_ENABLED */
 }
 
 static inline m0_parity_elem_t m0_parity_lt(m0_parity_elem_t x, m0_parity_elem_t y)


### PR DESCRIPTION
- Implemented isal_diff() function to calculate differential parity.
- Added MACRO to check if ISA-L code is enabled or not.
- Use Galois library only in kernel space.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>