### PR TITLE
client-io: simplify pargrp_iomap_populate

### DIFF
--- a/lib/vec.c
+++ b/lib/vec.c
@@ -742,6 +742,29 @@ M0_INTERNAL bool m0_ivec_cursor_move_to(struct m0_ivec_cursor *cur,
 	return ret;
 }
 
+M0_INTERNAL m0_bcount_t m0_ivec_cursor_step_to(const struct m0_ivec_cursor *cur,
+					       m0_bindex_t dest)
+{
+	uint32_t i;
+	m0_bindex_t idx;
+	m0_bindex_t seg_end;
+	m0_bcount_t size = 0;
+	struct m0_indexvec *ivec;
+
+	ivec = container_of(cur->ic_cur.vc_vec, struct m0_indexvec, iv_vec);
+
+	for (i = cur->ic_cur.vc_seg; i < ivec->iv_vec.v_nr &&
+	                             ivec->iv_index[i] < dest; i++) {
+		idx = ivec->iv_index[i];
+		if (i == cur->ic_cur.vc_seg)
+			idx += cur->ic_cur.vc_offset;
+		seg_end = ivec->iv_index[i] + ivec->iv_vec.v_count[i];
+		size += min64u(seg_end, dest) - idx;
+	}
+
+	return size;
+}
+
 M0_INTERNAL void m0_0vec_fini(struct m0_0vec *zvec)
 {
 	if (zvec != NULL) {

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -92,7 +92,7 @@ struct m0_vec_cursor {
 	/** Segment that the cursor is currently in. */
 	uint32_t             vc_seg;
 	/** Offset within the segment that the cursor is positioned at. */
-	m0_bindex_t          vc_offset;
+	m0_bcount_t          vc_offset;
 };
 
 /**
@@ -483,6 +483,14 @@ M0_INTERNAL bool m0_ivec_cursor_move_to(struct m0_ivec_cursor *cursor,
 M0_INTERNAL m0_bcount_t m0_ivec_cursor_step(const struct m0_ivec_cursor *cur);
 
 /**
+ * Returns the number of bytes needed to move cursor to @dest.
+ * @param cur Index vector to be moved.
+ * @param dest Index uptil which cursor to be moved.
+ */
+M0_INTERNAL m0_bcount_t m0_ivec_cursor_step_to(const struct m0_ivec_cursor *cur,
+					       m0_bindex_t dest);
+
+/**
  * Returns index at current cursor position.
  * @param cur Given index vector cursor.
  * @ret   Index at current cursor position.
@@ -700,7 +708,7 @@ struct m0_ivec_varr_cursor {
 	/** Segment that the cursor is currently in. */
 	uint32_t             vc_seg;
 	/** Offset within the segment that the cursor is positioned at. */
-	m0_bindex_t          vc_offset;
+	m0_bcount_t          vc_offset;
 };
 
 /**

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -891,7 +891,7 @@ static int ioreq_iomaps_prepare(struct m0_op_io *ioo)
 
 		/* @cursor is advanced in the following function */
 		rc = ioo->ioo_iomaps[map]->pi_ops->
-		     pi_populate(ioo->ioo_iomaps[map], &ioo->ioo_ext, &cursor,
+		     pi_populate(ioo->ioo_iomaps[map], &cursor,
 				 bufvec ? &buf_cursor : NULL);
 		if (rc != 0)
 			goto failed;

--- a/motr/pg.h
+++ b/motr/pg.h
@@ -401,9 +401,9 @@ struct pargrp_iomap_ops {
 	 * read-old approach or read-rest approach.
 	 * pargrp_iomap::pi_rtype will be set to PIR_READOLD or
 	 * PIR_READREST accordingly.
-	 * @param ivec   Source index vector from which pargrp_iomap::pi_ivec
-	 * will be populated. Typically, this is m0_op_io::ioo_ext.
-	 * @param cursor Index vector cursor associated with ivec.
+	 * @param cursor Source index vector cursor from which
+	 *               pargrp_iomap::pi_ivec will be populated.
+	 *               Typically, this is m0_op_io::ioo_ext.
 	 * @pre iomap != NULL && ivec != NULL &&
 	 * m0_vec_count(&ivec->iv_vec) > 0 && cursor != NULL &&
 	 * m0_vec_count(&iomap->iv_vec) == 0
@@ -411,7 +411,6 @@ struct pargrp_iomap_ops {
 	 * iomap->pi_databufs != NULL.
 	 */
 	int (*pi_populate)  (struct pargrp_iomap      *iomap,
-			     const struct m0_indexvec *ivec,
 			     struct m0_ivec_cursor    *cursor,
 			     struct m0_bufvec_cursor  *buf_cursor);
 

--- a/motr/ut/io_pargrp.c
+++ b/motr/ut/io_pargrp.c
@@ -331,7 +331,7 @@ static void ut_test_pargrp_iomap_populate(void)
 
 	map->pi_ivec.iv_vec.v_nr = 0;
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 	m0_indexvec_free(&ivec);
 	map->pi_ivec.iv_vec.v_nr = 0;
@@ -347,7 +347,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ioo->ioo_data.ov_vec.v_count[0] = 2 * blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 
 	m0_indexvec_free(&ivec);
@@ -367,7 +367,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ioo->ioo_data.ov_vec.v_count[0] = 2 * blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_ivec_cursor_index(&cursor) == 2 * blk_size);
 
@@ -389,7 +389,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ioo->ioo_data.ov_vec.v_count[0] = 4 * blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_ivec_cursor_index(&cursor) == 2 * blk_size);
 
@@ -410,7 +410,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ivec.iv_vec.v_count[0] = blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 
 	m0_indexvec_free(&ivec);

--- a/motr/utils.c
+++ b/motr/utils.c
@@ -248,7 +248,7 @@ M0_INTERNAL uint32_t io_seg_size(void)
 /** TODO: obj can be retrieved from map->pi_ioo */
 M0_INTERNAL void page_pos_get(struct pargrp_iomap  *map,
 			      m0_bindex_t           index,
-			      m0_bindex_t           grp_size,
+			      m0_bindex_t           grp_off,
 			      uint32_t             *row,
 			      uint32_t             *col)
 {
@@ -263,7 +263,7 @@ M0_INTERNAL void page_pos_get(struct pargrp_iomap  *map,
 	obj = map->pi_ioo->ioo_obj;
 	play = pdlayout_get(map->pi_ioo);
 
-	pg_id = page_id(index - grp_size, obj);
+	pg_id = page_id(index - grp_off, obj);
 	*row  = pg_id % data_row_nr(play, obj);
 	*col = play->pl_attr.pa_K == 0 ? 0 : pg_id / data_row_nr(play, obj);
 }


### PR DESCRIPTION
Simplify pargrp_iomap_populate() by introducing and using m0_ivec_cursor_step_to() function.