### PR TITLE
client-io: fix & simplify pargrp_iomap_populate

### DIFF
--- a/lib/vec.c
+++ b/lib/vec.c
@@ -440,13 +440,16 @@ static uint32_t vec_pack(uint32_t nr, m0_bcount_t *cnt, m0_bindex_t *idx)
 {
 	uint32_t i = 0;
 	uint32_t j;
+	m0_bindex_t seg_end;
 
 	if (nr == 0)
 		return 0;
 
 	for (j = i + 1; j < nr; ++j) {
-		if (idx[i] + cnt[i] == idx[j]) {
-			cnt[i] += cnt[j];
+		seg_end = idx[i] + cnt[i];
+		if (idx[j] <= seg_end) {
+			if (cnt[j] > seg_end - idx[j])
+				cnt[i] += cnt[j] - (seg_end - idx[j]);
 		} else {
 			++i;
 			if (i != j) {

--- a/lib/vec.c
+++ b/lib/vec.c
@@ -712,12 +712,12 @@ M0_INTERNAL m0_bcount_t m0_ivec_cursor_step(const struct m0_ivec_cursor *cur)
 	return m0_vec_cursor_step(&cur->ic_cur);
 }
 
-M0_INTERNAL m0_bindex_t m0_ivec_cursor_index(struct m0_ivec_cursor *cur)
+M0_INTERNAL m0_bindex_t m0_ivec_cursor_index(const struct m0_ivec_cursor *cur)
 {
 	struct m0_indexvec *ivec;
 
 	M0_PRE(cur != NULL);
-	M0_PRE(!m0_vec_cursor_move(&cur->ic_cur, 0));
+	M0_PRE(cur->ic_cur.vc_seg < cur->ic_cur.vc_vec->v_nr);
 
 	ivec = container_of(cur->ic_cur.vc_vec, struct m0_indexvec, iv_vec);
 	return ivec->iv_index[cur->ic_cur.vc_seg] + cur->ic_cur.vc_offset;

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -487,7 +487,7 @@ M0_INTERNAL m0_bcount_t m0_ivec_cursor_step(const struct m0_ivec_cursor *cur);
  * @param cur Given index vector cursor.
  * @ret   Index at current cursor position.
  */
-M0_INTERNAL m0_bindex_t m0_ivec_cursor_index(struct m0_ivec_cursor *cur);
+M0_INTERNAL m0_bindex_t m0_ivec_cursor_index(const struct m0_ivec_cursor *cur);
 
 /**
    Zero vector is a full fledged IO vector containing IO extents

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -488,12 +488,12 @@ M0_INTERNAL m0_bindex_t m0_ivec_cursor_index(const struct m0_ivec_cursor *cur);
 
 /**
  * Returns the latest index through the contiguous segments up to @dest.
- * @pre   dest >= m0_ivec_cursor_index(cursor).
+ * @pre   dest >= m0_ivec_cursor_index(cur).
  * @param cur cursor to start from.
  * @param dest uptil where to check.
  */
-M0_INTERNAL m0_bindex_t m0_ivec_cursor_conti(const struct m0_ivec_cursor *cur,
-					     m0_bindex_t dest);
+M0_INTERNAL m0_bindex_t
+m0_ivec_cursor_conti(const struct m0_ivec_cursor *cur, m0_bindex_t dest);
 
 /**
    Zero vector is a full fledged IO vector containing IO extents
@@ -768,8 +768,17 @@ m0_ivec_varr_cursor_step(const struct m0_ivec_varr_cursor *cur);
  * @ret   Index at current cursor position.
  */
 M0_INTERNAL m0_bindex_t
-m0_ivec_varr_cursor_index(struct m0_ivec_varr_cursor *cur);
+m0_ivec_varr_cursor_index(const struct m0_ivec_varr_cursor *cur);
 
+/**
+ * Returns the latest index through the contiguous segments up to @dest.
+ * @pre   dest >= m0_ivec_varr_cursor_index(cur).
+ * @param cur cursor to start from.
+ * @param dest uptil where to check.
+ */
+M0_INTERNAL m0_bindex_t
+m0_ivec_varr_cursor_conti(const struct m0_ivec_varr_cursor *cur,
+			  m0_bindex_t dest);
 /** @} end of vec group */
 
 /* __MOTR_LIB_VEC_H__ */

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -275,7 +275,7 @@ M0_INTERNAL void m0_bufvec_free_aligned(struct m0_bufvec *bufvec,
 M0_INTERNAL void m0_bufvec_free_aligned_packed(struct m0_bufvec *bufvec,
 					       unsigned shift);
 /**
- * Packs buffers vector by squashing its contiguous chunks.
+ * Packs buffers vector by squashing its contiguous or overlapping chunks.
  * @pre bufvec->ov_vec.v_nr > 0.
  * @return the number of squashed chunks.
  */
@@ -308,7 +308,7 @@ M0_INTERNAL int m0_indexvec_alloc(struct m0_indexvec *ivec, uint32_t len);
 M0_INTERNAL void m0_indexvec_free(struct m0_indexvec *ivec);
 
 /**
- * Packs index vector by squashing its contiguous chunks.
+ * Packs index vector by squashing its contiguous or overlapping chunks.
  * @pre ivec->iv_vec.v_nr > 0.
  * @return the number of squashed chunks.
  */

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -92,7 +92,7 @@ struct m0_vec_cursor {
 	/** Segment that the cursor is currently in. */
 	uint32_t             vc_seg;
 	/** Offset within the segment that the cursor is positioned at. */
-	m0_bindex_t          vc_offset;
+	m0_bcount_t          vc_offset;
 };
 
 /**
@@ -469,7 +469,6 @@ M0_INTERNAL bool m0_ivec_cursor_move(struct m0_ivec_cursor *cur,
  * @param dest Index uptil which cursor has to be moved.
  * @ret   true iff end of vector has been reached while
  *             moving cursor. Returns false otherwise.
- * @post  m0_ivec_cursor_index(cursor) == to.
 */
 M0_INTERNAL bool m0_ivec_cursor_move_to(struct m0_ivec_cursor *cursor,
 					m0_bindex_t dest);
@@ -478,16 +477,23 @@ M0_INTERNAL bool m0_ivec_cursor_move_to(struct m0_ivec_cursor *cursor,
  * Returns the number of bytes needed to move cursor to next segment in given
  * index vector.
  * @param cur Index vector to be moved.
- * @ret   Number of bytes needed to move the cursor to next segment.
  */
 M0_INTERNAL m0_bcount_t m0_ivec_cursor_step(const struct m0_ivec_cursor *cur);
 
 /**
  * Returns index at current cursor position.
  * @param cur Given index vector cursor.
- * @ret   Index at current cursor position.
  */
 M0_INTERNAL m0_bindex_t m0_ivec_cursor_index(const struct m0_ivec_cursor *cur);
+
+/**
+ * Returns the latest index through the contiguous segments up to @dest.
+ * @pre   dest >= m0_ivec_cursor_index(cursor).
+ * @param cur cursor to start from.
+ * @param dest uptil where to check.
+ */
+M0_INTERNAL m0_bindex_t m0_ivec_cursor_conti(const struct m0_ivec_cursor *cur,
+					     m0_bindex_t dest);
 
 /**
    Zero vector is a full fledged IO vector containing IO extents
@@ -700,7 +706,7 @@ struct m0_ivec_varr_cursor {
 	/** Segment that the cursor is currently in. */
 	uint32_t             vc_seg;
 	/** Offset within the segment that the cursor is positioned at. */
-	m0_bindex_t          vc_offset;
+	m0_bcount_t          vc_offset;
 };
 
 /**

--- a/m0t1fs/linux_kernel/file_internal.h
+++ b/m0t1fs/linux_kernel/file_internal.h
@@ -1566,9 +1566,9 @@ struct pargrp_iomap_ops {
 	 * read-old approach or read-rest approach.
 	 * pargrp_iomap::pi_rtype will be set to PIR_READOLD or
 	 * PIR_READREST accordingly.
-	 * @param ivec   Source index vector from which pargrp_iomap::pi_ivec
-	 * will be populated. Typically, this is io_request::ir_ivec.
-	 * @param cursor Index vector cursor associated with ivec.
+	 * @param cursor Source index vector cursor from which
+	 *               pargrp_iomap::pi_ivec will be populated.
+	 *               Typically, this is io_request::ir_ivec.
 	 * @pre iomap != NULL && ivec != NULL &&
 	 * m0_vec_count(&ivec->iv_vec) > 0 && cursor != NULL &&
 	 * m0_vec_count(&iomap->iv_vec) == 0
@@ -1576,7 +1576,6 @@ struct pargrp_iomap_ops {
 	 * iomap->pi_databufs != NULL.
 	 */
 	int (*pi_populate)  (struct pargrp_iomap        *iomap,
-			     struct m0_indexvec_varr    *ivv,
 			     struct m0_ivec_varr_cursor *cursor);
 
 	/**

--- a/m0t1fs/linux_kernel/ut/file.c
+++ b/m0t1fs/linux_kernel/ut/file.c
@@ -695,7 +695,7 @@ static void pargrp_iomap_test(void)
 	};
 	m0_ivec_varr_cursor_init(&cur, &req.ir_ivv);
 	map.pi_ops = &piops;
-	rc = pargrp_iomap_populate(&map, &req.ir_ivv, &cur);
+	rc = pargrp_iomap_populate(&map, &cur);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(map.pi_databufs != NULL);
 	M0_UT_ASSERT(indexvec_varr_count(&map.pi_ivv) > 0);

--- a/motr/client.h
+++ b/motr/client.h
@@ -700,7 +700,7 @@ struct m0_entity {
  * the implementation when an object is opened.
  */
 struct m0_obj_attr {
-	/** Binary logarithm (bit-shift) of object IO buffer size. */
+	/** Binary logarithm (bit-shift) of object minimal block size. */
 	m0_bcount_t   oa_bshift;
 
 	/** Layout ID for an object. */

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -430,7 +430,8 @@ static int pargrp_iomap_populate(struct pargrp_iomap      *map,
 	grpend   = grpstart + grpsize;
 	pagesize = m0__page_size(ioo);
 
-	/* For a write, if this map does not span the whole parity group,
+	/*
+	 * For a write, if this map does not span the whole parity group,
 	 * it is a read-modify-write.
 	 *
 	 * Note (Sining): as Client objects don't have attribute SIZE,

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -473,8 +473,7 @@ static int pargrp_iomap_populate(struct pargrp_iomap      *map,
 	uint64_t                  rr_page_nr;
 	m0_bindex_t               grpstart;
 	m0_bindex_t               grpend;
-	m0_bindex_t               currindex;
-	m0_bindex_t               startindex;
+	m0_bindex_t               startindex = m0_ivec_cursor_index(cursor);
 	struct m0_pdclust_layout *play;
 	struct m0_op_io          *ioo;
 	struct m0_op             *op;
@@ -506,13 +505,12 @@ static int pargrp_iomap_populate(struct pargrp_iomap      *map,
 	 * zeroed?
 	 */
 	if (M0_IN(op->op_code, (M0_OC_FREE, M0_OC_WRITE))) {
+		m0_bindex_t idx;
 		for (seg = cursor->ic_cur.vc_seg; seg < SEG_NR(ivec) &&
 		     INDEX(ivec, seg) < grpend; ++seg) {
-			currindex = seg == cursor->ic_cur.vc_seg ?
-				    m0_ivec_cursor_index(cursor) :
-				    INDEX(ivec, seg);
-			size += min64u(seg_endpos(ivec, seg), grpend) -
-				currindex;
+			idx = seg == cursor->ic_cur.vc_seg ?
+				    startindex : INDEX(ivec, seg);
+			size += min64u(seg_endpos(ivec, seg), grpend) - idx;
 		}
 
 		if (size < grpsize)
@@ -521,28 +519,26 @@ static int pargrp_iomap_populate(struct pargrp_iomap      *map,
 	if (op->op_code == M0_OC_FREE && rmw)
 		map->pi_trunc_partial = true;
 
-	startindex = m0_ivec_cursor_index(cursor);
 	M0_LOG(M0_INFO, "Group id %"PRIu64" is %s", map->pi_grpid,
 	       rmw ? "rmw" : "aligned");
 
+	/* Populate pi_ivec. */
 	for (seg = 0; !m0_ivec_cursor_move(cursor, count) &&
-		      m0_ivec_cursor_index(cursor) < grpend;) {
+	               m0_ivec_cursor_index(cursor) < grpend;) {
 		/*
 		 * Skips the current segment if it is completely spanned by
-		 * rounding up/down of earlier segment.
+		 * rounding up/down of an earlier segment.
 		 */
 		if (map->pi_ops->pi_spans_seg(map,
-			m0_ivec_cursor_index(cursor),
-			m0_ivec_cursor_step(cursor)))
-		{
+					      m0_ivec_cursor_index(cursor),
+					      m0_ivec_cursor_step(cursor))) {
 			count = m0_ivec_cursor_step(cursor);
 			continue;
 		}
 
 		INDEX(&map->pi_ivec, seg) = m0_ivec_cursor_index(cursor);
-		endpos = min64u(grpend,
-				m0_ivec_cursor_index(cursor)
-				+ m0_ivec_cursor_step(cursor));
+		endpos = min64u(grpend, m0_ivec_cursor_index(cursor) +
+		                        m0_ivec_cursor_step(cursor));
 		segcount = seg_collate(map, cursor);
 		if (segcount > 0)
 			endpos = INDEX(&map->pi_ivec, seg) + segcount;
@@ -550,7 +546,7 @@ static int pargrp_iomap_populate(struct pargrp_iomap      *map,
 
 		/*
 		* If current segment is _partially_ spanned by previous
-		* segment in pargrp_iomp::pi_ivec, start of segment is
+		* segment in pargrp_iomap::pi_ivec, start of segment is
 		* rounded up to move to next page.
 		*/
 		/*
@@ -561,13 +557,13 @@ static int pargrp_iomap_populate(struct pargrp_iomap      *map,
 		 * EOS-5083 is created to handle this.
 		 */
 		if (seg > 0 && INDEX(&map->pi_ivec, seg) <
-			seg_endpos(&map->pi_ivec, seg - 1)) {
+		               seg_endpos(&map->pi_ivec, seg - 1)) {
 			m0_bindex_t newindex;
 
 			newindex = m0_round_up(INDEX(&map->pi_ivec, seg) + 1,
 					       pagesize);
-			COUNT(&map->pi_ivec, seg) -=
-				(newindex - INDEX(&map->pi_ivec, seg));
+			COUNT(&map->pi_ivec, seg) -= newindex -
+			                             INDEX(&map->pi_ivec, seg);
 			INDEX(&map->pi_ivec, seg)  = newindex;
 		}
 
@@ -578,19 +574,20 @@ static int pargrp_iomap_populate(struct pargrp_iomap      *map,
 				 INDEX(&map->pi_ivec, seg),
 				 COUNT(&map->pi_ivec, seg));
 
-		if (!(op->op_code == M0_OC_READ &&
-		      instance->m0c_config->mc_is_read_verify)) {
-			/* if not in 'verify mode', ... */
+		if (op->op_code != M0_OC_READ ||
+		    !instance->m0c_config->mc_is_read_verify) {
+			/* not in 'verify mode' */
 			rc = map->pi_ops->pi_seg_process(map, seg, rmw,
 					                 0, buf_cursor);
 			if (rc != 0)
 				return M0_ERR_INFO(rc, "seg_process failed");
 		}
 
-		INDEX(&map->pi_ivec, seg) =
-			round_down(INDEX(&map->pi_ivec, seg), pagesize);
+		/* make segment pagesize-aligned */
+		INDEX(&map->pi_ivec, seg) = round_down(INDEX(&map->pi_ivec,
+							     seg), pagesize);
 		COUNT(&map->pi_ivec, seg) = round_up(endpos, pagesize) -
-				 INDEX(&map->pi_ivec, seg);
+		                            INDEX(&map->pi_ivec, seg);
 		M0_LOG(M0_DEBUG, "post grpid = %"PRIu64" seg %"PRIu64
 				 " = [%"PRIu64", +%"PRIu64")",
 				 map->pi_grpid, seg,
@@ -790,7 +787,7 @@ static int pargrp_iomap_seg_process(struct pargrp_iomap *map,
 	struct m0_op_io          *ioo;
 	struct m0_obj            *obj;
 	struct m0_op             *op;
-	m0_bindex_t               grp_size;
+	m0_bindex_t               grp_off;
 
 	M0_ENTRY("map %p, seg %"PRIu64", %s", map, seg,
 		 rmw ? "rmw" : "aligned");
@@ -801,7 +798,7 @@ static int pargrp_iomap_seg_process(struct pargrp_iomap *map,
 	obj = ioo->ioo_obj;
 	play = pdlayout_get(ioo);
 	pagesize = m0__page_size(ioo);
-	grp_size = data_size(play) * map->pi_grpid;
+	grp_off = data_size(play) * map->pi_grpid;
 
 	m0_ivec_cursor_init(&cur, &map->pi_ivec);
 	ret = m0_ivec_cursor_move_to(&cur, INDEX(&map->pi_ivec, seg));
@@ -834,7 +831,7 @@ static int pargrp_iomap_seg_process(struct pargrp_iomap *map,
 			flags |= PA_READ;
 		}
 
-		page_pos_get(map, start, grp_size, &row, &col);
+		page_pos_get(map, start, grp_off, &row, &col);
 		M0_ASSERT(col <= map->pi_max_col);
 		M0_ASSERT(row <= map->pi_max_row);
 

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -891,7 +891,7 @@ static int ioreq_iomaps_prepare(struct m0_op_io *ioo)
 
 		/* @cursor is advanced in the following function */
 		rc = ioo->ioo_iomaps[map]->pi_ops->
-		     pi_populate(ioo->ioo_iomaps[map], &ioo->ioo_ext, &cursor,
+		     pi_populate(ioo->ioo_iomaps[map], &cursor,
 				 bufvec ? &buf_cursor : NULL);
 		if (rc != 0)
 			goto failed;

--- a/motr/pg.h
+++ b/motr/pg.h
@@ -401,9 +401,9 @@ struct pargrp_iomap_ops {
 	 * read-old approach or read-rest approach.
 	 * pargrp_iomap::pi_rtype will be set to PIR_READOLD or
 	 * PIR_READREST accordingly.
-	 * @param ivec   Source index vector from which pargrp_iomap::pi_ivec
-	 * will be populated. Typically, this is m0_op_io::ioo_ext.
-	 * @param cursor Index vector cursor associated with ivec.
+	 * @param cursor Source index vector cursor from which
+	 *               pargrp_iomap::pi_ivec will be populated.
+	 *               Typically, this is m0_op_io::ioo_ext.
 	 * @pre iomap != NULL && ivec != NULL &&
 	 * m0_vec_count(&ivec->iv_vec) > 0 && cursor != NULL &&
 	 * m0_vec_count(&iomap->iv_vec) == 0
@@ -411,7 +411,6 @@ struct pargrp_iomap_ops {
 	 * iomap->pi_databufs != NULL.
 	 */
 	int (*pi_populate)  (struct pargrp_iomap      *iomap,
-			     const struct m0_indexvec *ivec,
 			     struct m0_ivec_cursor    *cursor,
 			     struct m0_bufvec_cursor  *buf_cursor);
 

--- a/motr/ut/io_pargrp.c
+++ b/motr/ut/io_pargrp.c
@@ -331,7 +331,7 @@ static void ut_test_pargrp_iomap_populate(void)
 
 	map->pi_ivec.iv_vec.v_nr = 0;
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 	m0_indexvec_free(&ivec);
 	map->pi_ivec.iv_vec.v_nr = 0;
@@ -347,7 +347,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ioo->ioo_data.ov_vec.v_count[0] = 2 * blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 
 	m0_indexvec_free(&ivec);
@@ -367,7 +367,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ioo->ioo_data.ov_vec.v_count[0] = 2 * blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_ivec_cursor_index(&cursor) == 2 * blk_size);
 
@@ -389,7 +389,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ioo->ioo_data.ov_vec.v_count[0] = 4 * blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_ivec_cursor_index(&cursor) == 2 * blk_size);
 
@@ -410,7 +410,7 @@ static void ut_test_pargrp_iomap_populate(void)
 	ivec.iv_vec.v_count[0] = blk_size;
 
 	m0_ivec_cursor_init(&cursor, &ivec);
-	rc = pargrp_iomap_populate(map, &ivec, &cursor, NULL);
+	rc = pargrp_iomap_populate(map, &cursor, NULL);
 	M0_UT_ASSERT(rc == 0);
 
 	m0_indexvec_free(&ivec);

--- a/motr/utils.c
+++ b/motr/utils.c
@@ -249,7 +249,7 @@ M0_INTERNAL uint32_t io_seg_size(void)
 /** TODO: obj can be retrieved from map->pi_ioo */
 M0_INTERNAL void page_pos_get(struct pargrp_iomap  *map,
 			      m0_bindex_t           index,
-			      m0_bindex_t           grp_size,
+			      m0_bindex_t           grp_off,
 			      uint32_t             *row,
 			      uint32_t             *col)
 {
@@ -264,7 +264,7 @@ M0_INTERNAL void page_pos_get(struct pargrp_iomap  *map,
 	obj = map->pi_ioo->ioo_obj;
 	play = pdlayout_get(map->pi_ioo);
 
-	pg_id = page_id(index - grp_size, obj);
+	pg_id = page_id(index - grp_off, obj);
 	*row  = pg_id % data_row_nr(play, obj);
 	*col = play->pl_attr.pa_K == 0 ? 0 : pg_id / data_row_nr(play, obj);
 }

--- a/motr/utils.c
+++ b/motr/utils.c
@@ -84,6 +84,7 @@ M0_INTERNAL uint64_t layout_unit_size(struct m0_pdclust_layout *play)
 	return play->pl_attr.pa_unit_size;
 }
 
+/** Returns number of pages (rows) in the unit. */
 M0_INTERNAL uint32_t data_row_nr(struct m0_pdclust_layout *play,
 				 struct m0_obj *obj)
 {


### PR DESCRIPTION
Currently, pargrp_iomap_populate() might incorrectly determine
the RMW-mode if the segments in the user data index vector are
overlapping. The total size of the segments in this case may
be bigger than the parity group size and pargrp_iomap_populate()
would not set RMW-mode. But the segments are overlapping and the
data they collectively cover may not actually span the whole
parity group, in which case we do need RMW-mode.

Solution: fix & simplify pargrp_iomap_populate() by using new
m0_ivec_cursor_conti() function which returns the last index of
contiguous segments starting from cursor position up to the given
position. Comparing the result of this function with the parity
group boundary we can check reliably if the user data in the
index vector spans the whole parity group.

We can also get rid entirely of seg_collate() function by using
m0_ivec_cursor_conti() instead.
