### PR TITLE
Add -y flag

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -14,7 +14,7 @@ The prerequisite that is necessary to install the Motr component is mentioned be
 
   - Install EPEL repo:
   
-    **$ sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm**
+    **$ sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -y**
 
 **********
 Procedure


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>

## Problem

- You have to type 'y' to accept extra questions whether or not you are sure you want to complete this installation.

## Changes

- Added '-y' flag to prevent these prompts.

## Tested

- Tested on VMWare Workstation Pro 16 