### PR TITLE
EOS-18758 dtm0: extend all2all w.r.t. different hare and cluster configs

### DIFF
--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -106,7 +106,7 @@ function fail()
 
 function main()
 {
-    ${MOTR_UTILS_DIR}/m0setup --init-loop-only -d ${TEST_ROOT} --pool-width ${POOL_WIDTH} --ipool-width ${IPOOL_WIDTH}
+    ${MOTR_UTILS_DIR}/m0setup --init-loop-only -s 1 -d ${TEST_ROOT} --pool-width ${POOL_WIDTH} --ipool-width ${IPOOL_WIDTH}
 
     _info "Bootstrapping the cluster using Hare..."
     bootstrap_cluster
@@ -131,7 +131,7 @@ function main()
     ha_msg_send_online
 
     _info "Checking traces..."
-    expected_trace_lines_num "DTM0 service: connected" 2 || {
+    expected_trace_lines_num "DTM0 service: connected" $((${#M0D_ENDPOINTS[@]}-1)) || {
         fail "Process is not connected, exiting"
     }
 

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -50,13 +50,18 @@ function get_m0d_pids()
 
 function get_params_for_ha_msgs()
 {
-    M0D_ENDPOINTS=($(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice")) | .ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
-    M0D_FIDS_HEX=($(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice")) | .fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
-    M0D_FIDS_DEC=($(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice")) | .fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
+    local json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice"))')
+    M0D_ENDPOINTS=($(echo $json_out | jq -r '.ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
+    M0D_FIDS_HEX=($(echo $json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
+    M0D_FIDS_DEC=($(echo $json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
 }
 
 function ha_msg_send_transient()
 {
+    # Here we send "TRANSIENT" messages to trigger start of
+    # HA messages handling on the m0d side as dtm0 doesn't
+    # handle them until "TRANSIENT" received due to incomplete
+    # implementation on the Hare side.
     for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
         for j in $(seq 0 $((${#M0D_FIDS_DEC[@]}-1))) ; do
             if [[ $i -ne $j ]]; then
@@ -69,6 +74,7 @@ function ha_msg_send_transient()
 
 function ha_msg_send_online()
 {
+    # Here we send "ONLINE" messages to trigger connections logic.
     for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
         for j in $(seq 0 $((${#M0D_FIDS_DEC[@]}-1))) ; do
             if [[ $i -ne $j ]]; then
@@ -82,12 +88,10 @@ function expected_trace_lines_num()
 {
     local pattern="$1"
     local exp_cnt=$2
-    local m0d_dir
     local cnt
 
     for i in ${!M0D_PIDS[@]} ; do
-        m0d_dir=${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}
-        cnt=$($MOTR_ROOT/utils/trace/m0trace -i "${m0d_dir}/m0trace.${M0D_PIDS[i]}" | grep "$pattern" | wc -l)
+        cnt=$($MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/m0trace.${M0D_PIDS[i]}" | grep "$pattern" | wc -l)
         if [[ $cnt -ne $exp_cnt ]]; then
             return 1
         fi

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -3,6 +3,7 @@
 set -e
 
 MOTR_ROOT=$(realpath ../../..)
+MOTR_UTILS_DIR=${MOTR_ROOT}/utils
 MOTR_ST_UTILS_DIR=${MOTR_ROOT}/motr/st/utils/
 MOTR_VAR_DIR=/var/motr
 TEST_ROOT=$MOTR_VAR_DIR/all2all_test
@@ -19,7 +20,6 @@ M0D_PIDS=()
 
 POOL_WIDTH=4
 IPOOL_WIDTH=2
-IMGS_CNT=$((POOL_WIDTH + IPOOL_WIDTH))
 
 . ${MOTR_ROOT}/scripts/addb-py/chronometry/common/common_funcs
 
@@ -34,80 +34,12 @@ function bootstrap_cluster()
     hctl bootstrap --mkfs $CURRENT_CDF
 }
 
-#============= DEVICES SECTION =============#
-function init_loop_devices()
-{
-    fini_loop_devices()
-
-    if [[ ! -d $LOOP_IMG_DIR ]] ; then
-        _warn "'$LOOP_IMG_DIR' doesn't exist, creating.."
-        mkdir -p "$LOOP_IMG_DIR"
-    fi
-
-    create_loop_images
-    setup_loop_devices
-}
-
-function fini_loop_devices()
-{
-    cleanup_loop_devices
-    cleanup_loop_images
-}
-
-function create_loop_images()
-{
-    _info "Creating $IMGS_CNT file images, 10GiB each, in '$LOOP_IMG_DIR'"
-    for i in $(seq $IMGS_CNT) ; do
-        local img_file="$LOOP_IMG_DIR/disk$i.img"
-        dd if=/dev/zero of="$img_file" \
-           bs=1M seek=$(( 10 * 1024 - 1 )) count=1 &>/dev/null
-    done
-}
-
-function setup_loop_devices()
-{
-    _info "Setting up loop devices"
-    for i in $(seq $IMGS_CNT) ; do
-        local img_file="$LOOP_IMG_DIR/disk$i.img"
-        local free_loopdev=$(losetup -f)
-        loop_devsused[$i]=$free_loopdev
-        _info "$free_loopdev => $img_file"
-        [[ -e $img_file ]] ||
-            die "image file '$img_file' doesn't exist"
-        losetup $free_loopdev "$img_file"
-    done
-}
-
-function cleanup_loop_devices()
-{
-    _info "Removing loop devices"
-    for i in $(seq $IMGS_CNT) ; do
-        local img_file="$LOOP_IMG_DIR/disk$i.img"
-        if [[ -e $img_file ]] ; then
-            local loop_todel=$(losetup -j $img_file -O name | grep loop)
-            if [[ -n $loop_todel ]] ; then
-                losetup -d $loop_todel
-            fi
-        fi
-    done
-}
-
-function cleanup_loop_images()
-{
-    _info "Removing file images"
-    for i in $(seq $IMGS_CNT) ; do
-        local img_file="$LOOP_IMG_DIR/disk$i.img"
-        rm -f "$img_file"
-    done
-}
-############################################
-
 function get_m0d_pids()
 {
     local pids=""
     local pid
 
-    for fid in ${M0D_FIDS_HEX[@]}; do
+    for fid in ${M0D_FIDS_HEX[@]} ; do
         pid=$(ps ax | grep m0d | grep $fid | awk '{ print $1; }')
         M0D_PIDS+=($pid)
         pids+="$pid "
@@ -125,8 +57,8 @@ function get_params_for_ha_msgs()
 
 function ha_msg_send_transient()
 {
-    for i in `seq 0 $((${#M0D_ENDPOINTS[@]}-1))`; do
-        for j in `seq 0 $((${#M0D_FIDS_DEC[@]}-1))`; do
+    for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
+        for j in $(seq 0 $((${#M0D_FIDS_DEC[@]}-1))) ; do
             if [[ $i -ne $j ]]; then
                 $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_FIDS_DEC[$j]}" "transient"
                 break
@@ -137,8 +69,8 @@ function ha_msg_send_transient()
 
 function ha_msg_send_online()
 {
-    for i in `seq 0 $((${#M0D_ENDPOINTS[@]}-1))`; do
-        for j in `seq 0 $((${#M0D_FIDS_DEC[@]}-1))`; do
+    for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
+        for j in $(seq 0 $((${#M0D_FIDS_DEC[@]}-1))) ; do
             if [[ $i -ne $j ]]; then
                 $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_FIDS_DEC[$j]}" "online"
             fi
@@ -153,9 +85,9 @@ function expected_trace_lines_num()
     local m0d_dir
     local cnt
 
-    for i in ${!M0D_PIDS[@]}; do
+    for i in ${!M0D_PIDS[@]} ; do
         m0d_dir=${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}
-        cnt=`$MOTR_ROOT/utils/trace/m0trace -i "${m0d_dir}/m0trace.${M0D_PIDS[i]}" | grep "$pattern" | wc -l`
+        cnt=$($MOTR_ROOT/utils/trace/m0trace -i "${m0d_dir}/m0trace.${M0D_PIDS[i]}" | grep "$pattern" | wc -l)
         if [[ $cnt -ne $exp_cnt ]]; then
             return 1
         fi
@@ -174,7 +106,7 @@ function fail()
 
 function main()
 {
-    init_loop_devices
+    ${MOTR_UTILS_DIR}/m0setup --init-loop-only -d ${TEST_ROOT} --pool-width ${POOL_WIDTH} --ipool-width ${IPOOL_WIDTH}
 
     _info "Bootstrapping the cluster using Hare..."
     bootstrap_cluster
@@ -204,7 +136,6 @@ function main()
     }
 
     stop_cluster
-    fini_loop_devices
 
     _info "TEST STATUS: PASSED"
 }

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -10,12 +10,12 @@ CURRENT_CDF=$PWD/test.yaml
 CONFD_XC=/var/lib/hare/confd.xc
 LOOP_IMG_DIR=$TEST_ROOT
 
-M0D_DIR_COMMON=$MOTR_VAR_DIR/m0d-0x7200000000000001:0x
-M0D_IDS=(c 1a 28)
-M0D_PIDS=()
+M0D_DIR_COMMON=$MOTR_VAR_DIR/m0d-0x720000000000000
 
 M0D_ENDPOINTS=()
-M0D_SERV_FIDS=()
+M0D_FIDS_DEC=()
+M0D_FIDS_HEX=()
+M0D_PIDS=()
 
 POOL_WIDTH=4
 IPOOL_WIDTH=2
@@ -24,29 +24,9 @@ IMGS_CNT=$((POOL_WIDTH + IPOOL_WIDTH))
 . ${MOTR_ROOT}/scripts/addb-py/chronometry/common/common_funcs
 
 
-function check_hare()
-{
-    local rc
-    set +e
-    which hctl >/dev/null 2>&1
-    rc=`echo $?`
-    if [ $rc -ne 0 ]
-    then
-        _err "Hare is not installed, install it and try again."
-        exit 1
-    fi
-    set -e
-}
-
 function stop_cluster()
 {
-    set +e
-    hctl shutdown || {
-        _warn "Cluster stop FAILED! Trying to go further."
-    }
-    
-    #systemctl reset-failed hare-hax
-    set -e
+    hctl shutdown
 }
 
 function bootstrap_cluster()
@@ -76,11 +56,11 @@ function fini_loop_devices()
 
 function create_loop_images()
 {
-    _info "Creating $IMGS_CNT file images, 1GiB each, in '$LOOP_IMG_DIR'"
+    _info "Creating $IMGS_CNT file images, 10GiB each, in '$LOOP_IMG_DIR'"
     for i in $(seq $IMGS_CNT) ; do
         local img_file="$LOOP_IMG_DIR/disk$i.img"
         dd if=/dev/zero of="$img_file" \
-           bs=1M seek=$(( 1 * 1024 - 1 )) count=1 &>/dev/null
+           bs=1M seek=$(( 10 * 1024 - 1 )) count=1 &>/dev/null
     done
 }
 
@@ -124,13 +104,11 @@ function cleanup_loop_images()
 
 function get_m0d_pids()
 {
-    local m0d_dir
     local pids=""
+    local pid
 
-    for endp in ${M0D_IDS[@]}
-    do
-        m0d_dir=${M0D_DIR_COMMON}${endp}
-        pid=`ls -l ${m0d_dir}/m0trace.* | awk '{ print $NF; }' | awk -F"." '{ print $2; }' | awk  'BEGIN { pid=0; } { if (pid < $0) pid = $0; } END { print pid; }'`
+    for fid in ${M0D_FIDS_HEX[@]}; do
+        pid=$(ps ax | grep m0d | grep $fid | awk '{ print $1; }')
         M0D_PIDS+=($pid)
         pids+="$pid "
     done
@@ -140,49 +118,45 @@ function get_m0d_pids()
 
 function get_params_for_ha_msgs()
 {
-    local line
-    local srvc_ids=(`cat $CONFD_XC | grep M0_CST_CAS | awk '{ print $2; }' | awk -F"^" '{ print substr($2, 1, length($2) - 2); }'`)
-
-    for i in `seq 0 2`
-    do
-        line=`cat $CONFD_XC | grep "${srvc_ids[$i]}" | grep "r"`
-        M0D_SERV_FIDS[$i]=`echo $line | awk '{ print $2; }' | awk '{ print substr($1, 3, length($1) - 4); }'`
-        M0D_ENDPOINTS[$i]=`echo $line | awk '{ print $12; }' | awk -F":" '{ printf("%s:%s:%s", $2, $3, substr($4, 0, length($4) - 2));}'`
-    done
+    M0D_ENDPOINTS=($(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice")) | .ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
+    M0D_FIDS_HEX=($(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice")) | .fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
+    M0D_FIDS_DEC=($(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice")) | .fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
 }
 
 function ha_msg_send_transient()
 {
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[0]}" "${M0D_SERV_FIDS[1]}" "transient"
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[1]}" "${M0D_SERV_FIDS[0]}" "transient"
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[2]}" "${M0D_SERV_FIDS[0]}" "transient"
+    for i in `seq 0 $((${#M0D_ENDPOINTS[@]}-1))`; do
+        for j in `seq 0 $((${#M0D_FIDS_DEC[@]}-1))`; do
+            if [[ $i -ne $j ]]; then
+                $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_FIDS_DEC[$j]}" "transient"
+                break
+            fi
+        done
+    done
 }
 
 function ha_msg_send_online()
 {
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[0]}" "${M0D_SERV_FIDS[1]}" "online"
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[0]}" "${M0D_SERV_FIDS[2]}" "online"
-
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[1]}" "${M0D_SERV_FIDS[0]}" "online"
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[1]}" "${M0D_SERV_FIDS[2]}" "online"
-
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[2]}" "${M0D_SERV_FIDS[0]}" "online"
-    $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[2]}" "${M0D_SERV_FIDS[1]}" "online"
+    for i in `seq 0 $((${#M0D_ENDPOINTS[@]}-1))`; do
+        for j in `seq 0 $((${#M0D_FIDS_DEC[@]}-1))`; do
+            if [[ $i -ne $j ]]; then
+                $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_FIDS_DEC[$j]}" "online"
+            fi
+        done
+    done
 }
 
-function check_traces_ne()
+function expected_trace_lines_num()
 {
     local pattern="$1"
     local exp_cnt=$2
     local m0d_dir
     local cnt
 
-    for i in ${!M0D_PIDS[@]}
-    do
-        m0d_dir=${M0D_DIR_COMMON}${M0D_IDS[i]}
+    for i in ${!M0D_PIDS[@]}; do
+        m0d_dir=${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}
         cnt=`$MOTR_ROOT/utils/trace/m0trace -i "${m0d_dir}/m0trace.${M0D_PIDS[i]}" | grep "$pattern" | wc -l`
-        if [ $cnt -ne $exp_cnt ]
-        then
+        if [[ $cnt -ne $exp_cnt ]]; then
             return 1
         fi
     done
@@ -200,17 +174,16 @@ function fail()
 
 function main()
 {
-    check_hare
     init_loop_devices
 
     _info "Bootstrapping the cluster using Hare..."
     bootstrap_cluster
 
-    get_m0d_pids
     get_params_for_ha_msgs
+    get_m0d_pids
 
     _info "Checking traces..."
-    check_traces_ne "evented_proc_state" 0 || {
+    expected_trace_lines_num "evented_proc_state" 0 || {
         fail "HA event handled instead of to be skipped, exiting."
     }
 
@@ -218,7 +191,7 @@ function main()
     ha_msg_send_transient
 
     _info "Checking traces..."
-    check_traces_ne "TRANSIENT received" 1 || {
+    expected_trace_lines_num "TRANSIENT received" 1 || {
         fail "Trigger message is not received, exiting."
     }
 
@@ -226,7 +199,7 @@ function main()
     ha_msg_send_online
 
     _info "Checking traces..."
-    check_traces_ne "DTM0 service: connected" 2 || {
+    expected_trace_lines_num "DTM0 service: connected" 2 || {
         fail "Process is not connected, exiting"
     }
 

--- a/utils/m0setup
+++ b/utils/m0setup
@@ -42,6 +42,7 @@ verbose=false
 do_cleanup=false
 do_loop_cleanup=false
 use_existing_loop_imgs=false
+init_loop_only=false
 do_gendisk=true
 do_genfacts=false
 do_mkfs=false
@@ -189,7 +190,7 @@ parse_cli_options()
     # separate word. The quotes around `$@' are essential!
     # We need TEMP as the `eval set --' would nuke the return value of getopt.
     TEMP=$( getopt --options hvclICEGHVAMP:N:K:i:d:m:s:p:z:Z:: \
-                   --longoptions help,verbose,cleanup,use-existing-loop-imgs,no-directio,no-gendisk,halon-facts,client-apps,activate-singlenode-services,mkfs,list-disks,no-cas,no-m0t1fs,pool-width:,data-units:,parity-units:,ipool-width:,iparity-units:,ios-number:,loop-img-dir:,motr-dir:,disk-size:,disk-pattern:,linuxstob-path:,linuxstob-mode:: \
+                   --longoptions help,verbose,cleanup,init-loop-only,use-existing-loop-imgs,no-directio,no-gendisk,halon-facts,client-apps,activate-singlenode-services,mkfs,list-disks,no-cas,no-m0t1fs,pool-width:,data-units:,parity-units:,ipool-width:,iparity-units:,ios-number:,loop-img-dir:,motr-dir:,disk-size:,disk-pattern:,linuxstob-path:,linuxstob-mode:: \
                    --name "$PROG_NAME" -- "$@" )
 
     [[ $? -ne 0 ]] && help
@@ -204,6 +205,7 @@ parse_cli_options()
             -l|--list-disks)    only_list_disks=true; shift   ;;
             -I|--no-directio)   directio=false;       shift   ;;
             -C)                 do_cleanup=true;      shift   ;;
+            --init-loop-only)   init_loop_only=true;  shift   ;;
             -E|--use-existing-loop-imgs)
                                 use_existing_loop_imgs=true; shift ;;
             -M|--mkfs)          do_mkfs=true;         shift   ;;
@@ -229,7 +231,7 @@ parse_cli_options()
             -P|--pool-width)    pool_width=$2;        shift 2 ;;
             -N|--data-units)    data_units=$2;        shift 2 ;;
             -K|--parity-units)  parity_units=$2;      shift 2 ;;
-            --pool-width)       ipool_width=$2;       shift 2 ;;
+            --ipool-width)      ipool_width=$2;       shift 2 ;;
             --parity-units)     iparity_units=$2;     shift 2 ;;
             --no-cas)           cas_enabled=false;    shift   ;;
             -i|--ios-number)    ios_num=$2; ios_num_is_set=true; shift 2 ;;
@@ -569,6 +571,11 @@ parse_cli_options "$@"
 [[ $UID -eq 0 ]] ||
     die 'Please, run this script with "root" privileges.'
 
+if $init_loop_only ; then
+    init_loop_devices
+    exit 0
+fi
+
 if $use_m0t1fs ; then
     echo "Enabling m0t1fs in $MOTR_SYSCONF"
     sed -i 's/MOTR_M0T1FS=no/MOTR_M0T1FS=yes/g' $MOTR_SYSCONF
@@ -662,7 +669,7 @@ if [[ -n $disk_pattern ]] ; then
         $(path_of m0gendisks) -l -d $pool_width -p "$disk_pattern"
         exit 0
     fi
-elif ! $linuxstob_mode ; then
+elif ! $linuxstob_mode && ! $init_loop_only ; then
     init_loop_devices
 fi
 

--- a/utils/m0setup
+++ b/utils/m0setup
@@ -669,7 +669,7 @@ if [[ -n $disk_pattern ]] ; then
         $(path_of m0gendisks) -l -d $pool_width -p "$disk_pattern"
         exit 0
     fi
-elif ! $linuxstob_mode && ! $init_loop_only ; then
+elif ! $linuxstob_mode ; then
     init_loop_devices
 fi
 


### PR DESCRIPTION
Now all process FIDs, ids and endpoints are retrieved using
hctl status command. Also various number of m0ds supported.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>