### PR TITLE
Dtm0 m0_cas_op serialization and deserialization 

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -1015,8 +1015,38 @@ static void cas_fom_failure(struct cas_fom *fom, int rc, bool ctg_op_fini)
 	m0_fom_phase_move(&fom->cf_fom, rc, M0_FOPH_FAILURE);
 }
 
+static int cas_dtm0_logrec_add (struct m0_fom *fom0, struct m0_dtm0_tx_desc *txd,
+				enum m0_dtm0_tx_pa_state state) {
+	/* log the dtm0 logrec before completing the cas op */
+	struct m0_dtm0_service *dtms = m0_dtm0_service_find(fom0->fo_service->rs_reqh);
+	struct m0_dtm0_tx_desc *msg = &cas_op(fom0)->cg_txd;
+	void		       *buf = NULL;
+	m0_bcount_t	        len = 0;
+	int                     i;
+	int			rc;
+
+	for (i = 0; i < msg->dtd_ps.dtp_nr; ++i) {
+		if (m0_fid_eq(&msg->dtd_ps.dtp_pa[i].p_fid,
+					&dtms->dos_generic.rs_service_fid)) {
+			msg->dtd_ps.dtp_pa[i].p_state = (uint32_t) M0_DTPS_PERSISTENT;
+			break;
+		}
+	}
+	M0_ASSERT(i < msg->dtd_ps.dtp_nr);
+	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_op_xc, cas_op(fom0)),
+			&buf, &len);
+	M0_ASSERT(rc == 0);
+	m0_dtm0_update_logrec(dtms->dos_log, &fom0->fo_tx.tx_betx, msg, buf);
+	m0_buf_free(buf);
+
+	return rc;
+}
+
 static void cas_fom_success(struct cas_fom *fom, enum m0_cas_opcode opc)
 {
+	if (!m0_dtm0_tx_desc_is_none(&cas_op(&fom->cf_fom)->cg_txd)) {
+		cas_dtm0_logrec_add(&fom->cf_fom, &cas_op(&fom->cf_fom)->cg_txd, M0_DTPS_PERSISTENT);
+	}
 	cas_fom_cleanup(fom, opc == CO_CUR);
 	m0_fom_phase_set(&fom->cf_fom, M0_FOPH_SUCCESS);
 }
@@ -1111,34 +1141,6 @@ M0_UNUSED static int cas_op_decode( void *obj, struct m0_buf *buf)
 					buf->b_addr, buf->b_nob);
 	if (rc != 0)
 		return M0_ERR(rc);
-
-	return rc;
-}
-
-
-static int cas_dtm0_logrec_add (struct m0_fom *fom0, struct m0_dtm0_tx_desc *txd,
-				enum m0_dtm0_tx_pa_state state) {
-	/* log the dtm0 logrec before completing the cas op */
-	struct m0_dtm0_service *dtms = m0_dtm0_service_find(fom0->fo_service->rs_reqh);
-	struct m0_dtm0_tx_desc *msg = &cas_op(fom0)->cg_txd;
-	void		       *buf = NULL;
-	m0_bcount_t	        len = 0;
-	int                     i;
-	int			rc;
-
-	for (i = 0; i < msg->dtd_ps.dtp_nr; ++i) {
-		if (m0_fid_eq(&msg->dtd_ps.dtp_pa[i].p_fid,
-					&dtms->dos_generic.rs_service_fid)) {
-			msg->dtd_ps.dtp_pa[i].p_state = (uint32_t) M0_DTPS_PERSISTENT;
-			break;
-		}
-	}
-	M0_ASSERT(i < msg->dtd_ps.dtp_nr);
-	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_op_xc, cas_op(fom0)),
-			&buf, &len);
-	M0_ASSERT(rc == 0);
-	m0_dtm0_update_logrec(dtms->dos_log, &fom0->fo_tx.tx_betx, msg, buf);
-	m0_buf_free(buf);
 
 	return rc;
 }
@@ -2194,9 +2196,6 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 		else
 			m0_ctg_cursor_next(ctg_op, next);
 		break;
-	}
-	if (!m0_dtm0_tx_desc_is_none(&cas_op(fom0)->cg_txd)) {
-		cas_dtm0_logrec_add(fom0, &cas_op(fom0)->cg_txd, M0_DTPS_PERSISTENT);
 	}
 
 	return ret;

--- a/cas/service.c
+++ b/cas/service.c
@@ -1031,7 +1031,6 @@ static int cas_dtm0_logrec_add (struct m0_fom *fom0, struct m0_dtm0_tx_desc *txd
 			break;
 		}
 	}
-	M0_ASSERT(i < msg->dtd_ps.dtp_nr);
 	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_op_xc, cas_op(fom0)),
 				     &buf.b_addr, &buf.b_nob);
 	M0_ASSERT(rc == 0);

--- a/cas/service.c
+++ b/cas/service.c
@@ -1091,6 +1091,30 @@ static int op_sync_wait(struct m0_fom *fom)
 	return M0_FSO_AGAIN;
 }
 
+M0_UNUSED static int cas_op_encode( const void *obj, struct m0_buf *buf)
+{
+	int rc;
+
+	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_op_xc, (void*)obj),
+				      &buf->b_addr, &buf->b_nob);
+	if (rc != 0)
+		return M0_ERR(rc);
+
+	return rc;
+}
+
+M0_UNUSED static int cas_op_decode( void *obj, struct m0_buf *buf)
+{
+	int rc;
+
+	rc = m0_xcode_obj_dec_from_buf(&M0_XCODE_OBJ(m0_cas_op_xc, (void*)obj),
+					buf->b_addr, buf->b_nob);
+	if (rc != 0)
+		return M0_ERR(rc);
+
+	return rc;
+}
+
 static int cas_fom_tick(struct m0_fom *fom0)
 {
 	uint64_t            i;

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -247,7 +247,7 @@ static void m0_dtm0_send_notice(struct m0_dtm0_service *dtms,
 		 FID_P(&dtms->dos_generic.rs_service_fid), FID_P(tgt));
 }
 
-M0_INTERNAL void m0_dtm0_update_logrec(struct m0_be_dtm0_log  *log,
+M0_INTERNAL void m0_dtm0_logrec_update(struct m0_be_dtm0_log  *log,
                                        struct m0_be_tx        *tx,
                                        struct m0_dtm0_tx_desc *txd,
                                        struct m0_buf          *pyld)

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -247,6 +247,18 @@ static void m0_dtm0_send_notice(struct m0_dtm0_service *dtms,
 		 FID_P(&dtms->dos_generic.rs_service_fid), FID_P(tgt));
 }
 
+M0_INTERNAL void m0_dtm0_update_logrec(struct m0_be_dtm0_log  *log,
+                                       struct m0_be_tx        *tx,
+                                       struct m0_dtm0_tx_desc *txd,
+                                       struct m0_buf          *pyld)
+{
+	int rc;
+
+    m0_mutex_lock(&log->dl_lock);
+    rc = m0_be_dtm0_log_update(log, tx, txd, pyld);
+    m0_mutex_unlock(&log->dl_lock);
+    M0_ASSERT(rc == 0);
+}
 
 M0_INTERNAL void m0_dtm0_on_committed(struct m0_reqh               *reqh,
 				      const struct m0_dtm0_tx_desc *txd)

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -83,7 +83,7 @@ struct dtm0_fom {
 M0_INTERNAL void m0_dtm0_on_committed(struct m0_reqh               *reqh,
 				      const struct m0_dtm0_tx_desc *txd);
 
-M0_INTERNAL void m0_dtm0_update_logrec(struct m0_be_dtm0_log  *log,
+M0_INTERNAL void m0_dtm0_logrec_update(struct m0_be_dtm0_log  *log,
                                        struct m0_be_tx        *tx,
                                        struct m0_dtm0_tx_desc *txd,
                                        struct m0_buf          *pyld);

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -83,6 +83,10 @@ struct dtm0_fom {
 M0_INTERNAL void m0_dtm0_on_committed(struct m0_reqh               *reqh,
 				      const struct m0_dtm0_tx_desc *txd);
 
+M0_INTERNAL void m0_dtm0_update_logrec(struct m0_be_dtm0_log  *log,
+                                       struct m0_be_tx        *tx,
+                                       struct m0_dtm0_tx_desc *txd,
+                                       struct m0_buf          *pyld);
 /* __MOTR_DTM0_FOP_H__ */
 #endif
 

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -27,6 +27,8 @@
 #include "net/net.h"
 #include "rpc/rpclib.h"
 #include "ut/ut.h"
+#include "cas/cas.h"
+#include "cas/cas_xc.h"
 
 #define M0_FID(c_, k_)  { .f_container = c_, .f_key = k_ }
 #define SERVER_ENDPOINT_ADDR    "0@lo:12345:34:1"
@@ -183,10 +185,38 @@ static void dtm0_ut_service(void)
 	m0_fi_disable("m0_dtm0_in_ut", "ut");
 }
 
+
+static void cas_xcode_test(void)
+{
+	int         rc;
+	void       *buf;
+	m0_bcount_t len;
+	struct m0_cas_op op_out = {};
+	struct m0_cas_op op_in = {
+		.cg_txd = {
+			.dtd_ps = {
+				.dtp_nr = 1,
+				.dtp_pa = &(struct m0_dtm0_tx_pa) {
+					.p_state = 555,
+				},
+			},
+		},
+	};
+
+	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_op_xc, &op_in),
+				     &buf, &len);
+	M0_UT_ASSERT(rc == 0);
+
+	rc = m0_xcode_obj_dec_from_buf(&M0_XCODE_OBJ(m0_cas_op_xc, &op_out),
+				       buf, len);
+	M0_UT_ASSERT(rc == 0);
+}
+
 struct m0_ut_suite dtm0_ut = {
         .ts_name = "dtm0-ut",
         .ts_tests = {
-                { "service", dtm0_ut_service},
+                { "service", dtm0_ut_service },
+                { "xcode", cas_xcode_test },
 		{ NULL, NULL },
 	}
 };


### PR DESCRIPTION
Added code to serialize and deserialize an m0_cas_op for storing into the payload of a dtm0 logrecord.
Added changes to dtm0-ut to exercise and verify the code change.