### PR TITLE
Clearing up optional builds

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -70,7 +70,7 @@ Perform the below mentioned procedure to build the source code.
 RPM Generation
 ===============
 
-You can build RPMs instead of building from source. Do not do this if you have followed the above steps for build from source.
+You can also build RPMs by running the following command.
 
 - **$ make rpms**
 

--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -21,7 +21,7 @@ Procedure
 **********
 The below mentioned procedure must be followed to install the Motr component and to perform tests.
 
-1. Cloning the Source Code
+1. Cloning the Source Code (Either Build from Source or RPM Generation)
 
 2. Building the Source Code
 
@@ -66,11 +66,11 @@ Perform the below mentioned procedure to build the source code.
    - **$ scripts/m0 rebuild**
 
    **Note**: The **scripts/m0 rebuild** command includes some clean up.
-   
+ 
 RPM Generation
 ===============
 
-If you want to make sure about generating RPMs, run the below mentioned command.
+You can build RPMs instead of building from source. Do not do this if you have followed the above steps for build from source.
 
 - **$ make rpms**
 


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>

## Problem

- The current guide does not make it clear enough that you can optionally do RPM generation or build from source.

## Changes

- Specified that you should not do RPM generation if you have built from source.

## Tested

- Tested on VMWare Workstation Pro 16 