### PR TITLE
EOS-18604: Uniform distribution of CAS FOM locality index

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -1625,7 +1625,9 @@ static const struct m0_fid *cas_fid(const struct m0_fom *fom)
 
 static size_t cas_fom_home_locality(const struct m0_fom *fom)
 {
-	return m0_fid_hash(cas_fid(fom));
+	static uint64_t loc = 0;
+
+	return loc++;
 }
 
 static struct m0_cas_op *cas_op(const struct m0_fom *fom)

--- a/fop/fom.c
+++ b/fop/fom.c
@@ -632,6 +632,7 @@ M0_INTERNAL void m0_fom_queue(struct m0_fom *fom)
 	loc_idx = fom->fo_ops->fo_home_locality(fom) % dom->fd_localities_nr;
 	M0_ASSERT(loc_idx < dom->fd_localities_nr);
 	fom->fo_loc = dom->fd_localities[loc_idx];
+	fom->fo_loc_idx = loc_idx;
 	m0_fom_sm_init(fom);
 	fom->fo_cb.fc_ast.sa_cb = &queueit;
 	m0_sm_ast_post(&fom->fo_loc->fl_group, &fom->fo_cb.fc_ast);

--- a/fop/fom.h
+++ b/fop/fom.h
@@ -481,6 +481,7 @@ struct m0_fom_callback {
 struct m0_fom {
 	/** Locality this fom belongs to */
 	struct m0_fom_locality   *fo_loc;
+	size_t                    fo_loc_idx;
 	const struct m0_fom_type *fo_type;
 	const struct m0_fom_ops  *fo_ops;
 	/** AST call-back to wake up the FOM */

--- a/fop/fom_generic.c
+++ b/fop/fom_generic.c
@@ -68,7 +68,7 @@ M0_INTERNAL void m0_fom_mod_rep_fill(struct m0_fop_mod_rep *rep,
 				     struct m0_fom *fom)
 {
 	rep->fmr_remid.tri_txid = m0_fom_tx(fom)->t_id;
-	rep->fmr_remid.tri_locality = fom->fo_ops->fo_home_locality(fom);
+	rep->fmr_remid.tri_locality = fom->fo_loc_idx;
 }
 
 bool m0_rpc_item_is_generic_reply_fop(const struct m0_rpc_item *item)


### PR DESCRIPTION
Problem: CAS FOM locality index is calculated as a hash of
catalogue FID.

During performance profiling it has been found that the same
locality index is assigned to FOM if the CAS FOPs contain
the same FID. For instance, typical S3 client performs
operations on a single S3 bucket, which lead to limited set of
indecies (meta-index and ordinary index related to S3 bucket).
In that case, assigned localities' runq and waitq queues get
overloaded, while other localities' queues are not populated
by incoming CAS FOPs. It increases CAS FOP processing latency.

Solution: Locality index is implemented using incremental
static counter. It's updated by +1 value each time cas_fom_home_locality()
function is called.