### PR TITLE
m0gccxml2xcode: fix build with castxml on CentOS-8

### DIFF
--- a/xcode/m0gccxml2xcode
+++ b/xcode/m0gccxml2xcode
@@ -449,7 +449,7 @@ sub get_global_namespace_id
 
 sub get_header_file_id
 {
-    my ($header_file_node) = $dom->findnodes(qq{//File[\@name='$header_file_path']});
+    my ($header_file_node) = $dom->findnodes(qq{//File[contains(\@name, '$header_file_path')]});
 
     croak "Error: unable to find xml tag for header file '$header_file_path' in"
           . " the gccxml's output.\n\nPlease, notice that gccxml writes an exact"

--- a/xcode/m0gccxml2xcode
+++ b/xcode/m0gccxml2xcode
@@ -78,6 +78,9 @@ BEGIN {
 use 5.010;
 use strict;
 use warnings;
+# suppress experimental warnings about 'given' and 'when'
+use feature qw( switch );
+no warnings qw( experimental::smartmatch );
 
 # core modules
 use Carp;


### PR DESCRIPTION
When building with castxml the file path for motr/client.h
generated in the motr/client.gccxml appears to be the full path
instead of the relative one (for some reason):

    <File id="f80" name="/data/motr/motr/client.h"/>

As result, m0gccxml2xcode complains:

    Error: unable to find xml tag for header file 'motr/client.h' in the gccxml's output.

And the build fails.

Interesting, that the problem appears to be with motr/client.h
file only, and it works fine for the bunch of header files which
go before it during the build process. No idea why.

Solution: update m0gccxml2xcode Perl code so that instead of
the exact match on the file path, it only checks if the relative
path contains in the File name attribute which may appear to be
the full path sometimes. It makes m0gccxml2xcode more tolerant
for such issues with file paths.

Closes #502.