### PR TITLE
EOS-18143 sns: Intel ISA misc changes

### DIFF
--- a/m0t1fs/linux_kernel/file.c
+++ b/m0t1fs/linux_kernel/file.c
@@ -3113,6 +3113,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
+#if RS_ENCODE_ENABLED
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioreq),
@@ -3120,6 +3121,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
+#endif /* RS_ENCODE_ENABLED */
 	/* Populates data and failed buffers. */
 	for (row = 0; row < data_row_nr(play); ++row) {
 		for (col = 0; col < data_col_nr(play); ++col) {
@@ -3141,9 +3143,11 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 				       parity, &failed, M0_LA_INVERSE);
 	}
 
+#if RS_ENCODE_ENABLED
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioreq));
+#endif /* RS_ENCODE_ENABLED */
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -2012,6 +2012,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
+#if RS_ENCODE_ENABLED
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioo),
@@ -2019,6 +2020,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
+#endif /* RS_ENCODE_ENABLED */
 
 	/* Populates data and failed buffers. */
 	for (row = 0; row < data_row_nr(play, ioo->ioo_obj); ++row) {
@@ -2044,9 +2046,11 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 				       parity, &failed, M0_LA_INVERSE);
 	}
 
+#if RS_ENCODE_ENABLED
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioo));
+#endif /* RS_ENCODE_ENABLED */
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/sns/cm/repair/xform.c
+++ b/sns/cm/repair/xform.c
@@ -243,7 +243,7 @@ M0_INTERNAL int m0_sns_cm_repair_cp_xform(struct m0_cm_cp *cp)
 	pl = m0_layout_to_pdl(fctx->sf_layout);
 	M0_ASSERT_INFO(ergo(!m0_pdclust_is_replicated(pl), M0_IN(pm_algo,
 					(M0_PARITY_CAL_ALGO_XOR,
-					M0_PARITY_CAL_ALGO_REED_SOLOMON))),
+					M0_PARITY_CAL_ALGO_ISA))),
 		       "parity_algo=%d", (int)pm_algo);
 
 	m0_cm_ag_lock(ag);

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -212,12 +212,13 @@ M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
 				       struct m0_buf *parity,
 				       uint32_t data_ind_changed);
 
-
+#if RS_ENCODE_ENABLED
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 					uint8_t *fail);
 
 
 M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math);
+#endif /* RS_ENCODE_ENABLED */
 
 /**
    Recovers data units' data words from single or multiple errors.

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -29,7 +29,7 @@
 #include "ut/ut.h"
 #include "sns/parity_math.h"
 
-#define KB(x)	(x * 1024)
+#define KB(x)	((x) * 1024)
 #define MB(x)	(KB(x) * 1024)
 
 enum {

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -29,6 +29,9 @@
 #include "ut/ut.h"
 #include "sns/parity_math.h"
 
+#define KB(x)	(x * 1024)
+#define MB(x)	(KB(x) * 1024)
+
 enum {
 	MAX_NUM_ROWS = 20,
 };
@@ -37,7 +40,7 @@ enum {
 	DATA_UNIT_COUNT_MAX      = 30,
 	PARITY_UNIT_COUNT_MAX    = 12,
 	DATA_TO_PRTY_RATIO_MAX   = DATA_UNIT_COUNT_MAX / PARITY_UNIT_COUNT_MAX,
-	UNIT_BUFF_SIZE_MAX       = 1048576,
+	UNIT_BUFF_SIZE_MAX       = MB(1),
 	DATA_UNIT_COUNT          = 15,
 	PARITY_UNIT_COUNT        = 1,
 	RS_MAX_PARITY_UNIT_COUNT = DATA_UNIT_COUNT - 1,
@@ -1353,81 +1356,81 @@ void parity_math_tb(void)
 	}
 }
 
-static void ub_small_4096(int iter)
+static void ub_small_4K(int iter)
 {
-	UNIT_BUFF_SIZE = 4096;
+	UNIT_BUFF_SIZE = KB(4);
 	duc = 10;
 	puc = 5;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_medium_4096(int iter)
+static void ub_medium_4K(int iter)
 {
-	UNIT_BUFF_SIZE = 4096;
+	UNIT_BUFF_SIZE = KB(4);
 	duc = 20;
 	puc = 6;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_large_4096(int iter)
+static void ub_large_4K(int iter)
 {
-	UNIT_BUFF_SIZE = 4096;
+	UNIT_BUFF_SIZE = KB(4);
 	duc = 30;
 	puc = 12;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_small_1048576(int iter)
+static void ub_small_1M(int iter)
 {
-	UNIT_BUFF_SIZE = 1048576;
+	UNIT_BUFF_SIZE = MB(1);
 	duc = 3;
 	puc = 2;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_medium_1048576(int iter)
+static void ub_medium_1M(int iter)
 {
-	UNIT_BUFF_SIZE = 1048576;
+	UNIT_BUFF_SIZE = MB(1);
 	duc = 6;
 	puc = 3;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_large_1048576(int iter)
+static void ub_large_1M(int iter)
 {
-	UNIT_BUFF_SIZE = 1048576;
+	UNIT_BUFF_SIZE = MB(1);
 	duc = 8;
 	puc = 4;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_small_32768(int iter)
+static void ub_small_32K(int iter)
 {
-	UNIT_BUFF_SIZE = 32768;
+	UNIT_BUFF_SIZE = KB(32);
 	duc = 10;
 	puc = 5;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_medium_32768(int iter)
+static void ub_medium_32K(int iter)
 {
-	UNIT_BUFF_SIZE = 32768;
+	UNIT_BUFF_SIZE = KB(32);
 	duc = 20;
 	puc = 6;
 	fuc = duc+puc;
 	parity_math_tb();
 }
 
-static void ub_large_32768(int iter)
+static void ub_large_32K(int iter)
 {
-	UNIT_BUFF_SIZE = 32768;
+	UNIT_BUFF_SIZE = KB(32);
 	duc = 30;
 	puc = 12;
 	fuc = duc+puc;
@@ -1435,7 +1438,7 @@ static void ub_large_32768(int iter)
 }
 static void ub_small_4_2_4K(int iter)
 {
-	UNIT_BUFF_SIZE = 4096;
+	UNIT_BUFF_SIZE = KB(4);
 	duc = 4;
 	puc = 2;
 	fuc = duc+puc;
@@ -1444,7 +1447,7 @@ static void ub_small_4_2_4K(int iter)
 
 static void ub_small_4_2_256K(int iter)
 {
-	UNIT_BUFF_SIZE = 262144;
+	UNIT_BUFF_SIZE = KB(256);
 	duc = 4;
 	puc = 2;
 	fuc = duc+puc;
@@ -1453,7 +1456,7 @@ static void ub_small_4_2_256K(int iter)
 
 static void ub_small_4_2_1M(int iter)
 {
-	UNIT_BUFF_SIZE = 1048576;
+	UNIT_BUFF_SIZE = MB(1);
 	duc = 4;
 	puc = 2;
 	fuc = duc+puc;
@@ -1469,74 +1472,74 @@ struct m0_ub_set m0_parity_math_ub = {
 	.us_run  = {
 		{ .ub_name  = "s 10/05/ 4K",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_small_4096,
-		  .ub_block_size = 4096,
+		  .ub_round = ub_small_4K,
+		  .ub_block_size = KB(4),
 		  .ub_blocks_per_op = 15 },
 
 		{ .ub_name  = "m 20/06/ 4K",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_medium_4096,
-		  .ub_block_size = 4096,
+		  .ub_round = ub_medium_4K,
+		  .ub_block_size = KB(4),
 		  .ub_blocks_per_op = 26 },
 
 		{ .ub_name  = "l 30/12/ 4K",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_large_4096,
-		  .ub_block_size = 4096,
+		  .ub_round = ub_large_4K,
+		  .ub_block_size = KB(4),
 		  .ub_blocks_per_op = 42 },
 
 		{ .ub_name  = "s 10/05/32K",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_small_32768,
-		  .ub_block_size = 32768,
+		  .ub_round = ub_small_32K,
+		  .ub_block_size = KB(32),
 		  .ub_blocks_per_op = 15 },
 
 		{ .ub_name  = "m 20/06/32K",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_medium_32768,
-		  .ub_block_size = 32768,
+		  .ub_round = ub_medium_32K,
+		  .ub_block_size = KB(32),
 		  .ub_blocks_per_op = 26 },
 
 		{ .ub_name  = "l 30/12/32K",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_large_32768,
-		  .ub_block_size = 32768,
+		  .ub_round = ub_large_32K,
+		  .ub_block_size = KB(32),
 		  .ub_blocks_per_op = 42 },
 
 		{ .ub_name  = "s  03/02/ 1M",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_small_1048576,
-		  .ub_block_size = 1048576,
+		  .ub_round = ub_small_1M,
+		  .ub_block_size = MB(1),
 		  .ub_blocks_per_op = 5 },
 
 		{ .ub_name  = "m 06/03/ 1M",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_medium_1048576,
-		  .ub_block_size = 1048576,
+		  .ub_round = ub_medium_1M,
+		  .ub_block_size = MB(1),
 		  .ub_blocks_per_op = 9 },
 
 		{ .ub_name  = "l 08/04/ 1M",
 		  .ub_iter  = UB_ITER,
-		  .ub_round = ub_large_1048576,
-		  .ub_block_size = 1048576,
+		  .ub_round = ub_large_1M,
+		  .ub_block_size = MB(1),
 		  .ub_blocks_per_op = 12 },
 
 		{ .ub_name  = "s 04/02/4K",
 		  .ub_iter  = UB_ITER,
 		  .ub_round = ub_small_4_2_4K,
-		  .ub_block_size = 4096,
+		  .ub_block_size = KB(4),
 		  .ub_blocks_per_op = 6 },
 
 		{ .ub_name  = "m 04/02/256K",
 		  .ub_iter  = UB_ITER,
 		  .ub_round = ub_small_4_2_256K,
-		  .ub_block_size = 262144,
+		  .ub_block_size = KB(256),
 		  .ub_blocks_per_op = 6 },
 
 		{ .ub_name  = "l 04/02/1M",
 		  .ub_iter  = UB_ITER,
 		  .ub_round = ub_small_4_2_1M,
-		  .ub_block_size = 1048576,
+		  .ub_block_size = MB(1),
 		  .ub_blocks_per_op = 6 },
 
 		{ .ub_name = NULL}


### PR DESCRIPTION
- Added Reed Solomon code under Macro RS_ENCODE_ENABLED.
- Created empty function fail_idx_isal_recover(). Added assert in it as
  this functionality is not implemented for Reed Solomon as well.
- In function m0_sns_cm_repair_cp_xform(), added M0_PARITY_CAL_ALGO_ISA
  to check algo range.
- Removed debug messages.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>