### PR TITLE
DTM0: Fix plog initialization.

### DIFF
--- a/dtm0/helper.c
+++ b/dtm0/helper.c
@@ -102,8 +102,8 @@ M0_INTERNAL int m0_dtm0_log_create(struct m0_sm_group  *grp,
 		return M0_ERR(-ENOMEM);
 
 	m0_be_0type_add_credit(bedom, &m0_be_dtm0, logid, &data, &cred);
-	M0_BE_ALLOC_CREDIT_PTR(log, seg, &cred);
 	m0_be_tx_credit_add(&cred, &M0_BE_TX_CREDIT_PTR(log));
+	m0_be_dtm0_log_credit(M0_DTML_CREATE, NULL, NULL, seg, NULL, &cred);
 
 	m0_be_tx_init(tx, 0, bedom, grp, NULL, NULL, NULL, NULL);
 	m0_be_tx_prep(tx, &cred);
@@ -111,14 +111,9 @@ M0_INTERNAL int m0_dtm0_log_create(struct m0_sm_group  *grp,
 	if (rc != 0)
 		goto tx_fini;
 
-	M0_BE_ALLOC_PTR_SYNC(log, seg, tx);
-	if (log == NULL)
+	rc = m0_be_dtm0_log_create(tx, seg, &log);
+	if (rc != 0)
 		goto tx_fini;
-
-	/* TODO: as a part of log-related patches add the following code:
-	        persistent_log_init(log);
-		M0_BE_TX_CAPTURE_PTR(log);
-	 */
 
 	data = M0_BUF_INIT_PTR(&log);
 	rc = m0_be_0type_add(&m0_be_dtm0, bedom, tx, logid, &data);

--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -32,6 +32,7 @@
 #include "dtm0/dtx.h"                /* dtx_domain_init */
 #include "lib/tlist.h"               /* tlist API */
 #include "be/dtm0_log.h"             /* DTM0 log API */
+#include "module/instance.h"         /* m0_get */
 
 #include "conf/confc.h"   /* m0_confc */
 #include "conf/diter.h"   /* m0_conf_diter */
@@ -302,10 +303,15 @@ static int dtm_service__origin_fill(struct m0_reqh_service *service)
 			dtm0->dos_origin = DTM0_ON_PERSISTENT;
 	}
 
+	if (dtm0->dos_origin == DTM0_ON_PERSISTENT) {
+		dtm0->dos_log = m0_reqh_lockers_get(service->rs_reqh,
+						    m0_get()->i_dtm0_log_key);
+		M0_ASSERT(dtm0->dos_log != NULL);
+	}
+
 out:
-	return dtm0->dos_origin == DTM0_ON_VOLATILE ?
-		m0_be_dtm0_log_init(&dtm0->dos_log, &dtm0->dos_clk_src, false) :
-		0;
+	return m0_be_dtm0_log_init(&dtm0->dos_log, &dtm0->dos_clk_src,
+				   dtm0->dos_origin == DTM0_ON_PERSISTENT);
 }
 
 static int dtm0_service_start(struct m0_reqh_service *service)


### PR DESCRIPTION
DTM0 Persistent log is not initialized properly
when the service starts. The patch addresses
that issue.

Signed-off-by: Ivan Alekhin <ivan.alekhin@seagate.com>