### PR TITLE
m0crate: fix segv crash when MOTR_CONFIG is missing

### DIFF
--- a/motr/m0crate/parser.c
+++ b/motr/m0crate/parser.c
@@ -227,24 +227,32 @@ static int parse_int(const char *value, enum config_key_val tag)
 #define workload_index(t) (t->u.cw_index)
 #define workload_io(t) (t->u.cw_io)
 
+const char conf_section_name[] = "MOTR_CONFIG";
+
 int copy_value(struct workload *load, int max_workload, int *index,
 		char *key, char *value)
 {
+	int                       value_len = strlen(value);
 	struct workload          *w = NULL;
 	struct m0_fid            *obj_fid;
 	struct m0_workload_io    *cw;
 	struct m0_workload_index *ciw;
-	int                       value_len = strlen(value);
 
-	if (!strcmp(value, "MOTR_CONFIG")) {
+	if (m0_streq(value, conf_section_name)) {
 		if (conf != NULL) {
-			cr_log(CLL_ERROR, "YAML file error. More than one config sections");
+			cr_log(CLL_ERROR, "YAML file error: "
+			       "more than one config sections\n");
 			return -EINVAL;
 		}
 
 		conf = m0_alloc(sizeof(struct crate_conf));
 		if (conf == NULL)
 			return -ENOMEM;
+	}
+	if (conf == NULL) {
+		cr_log(CLL_ERROR, "YAML file error: %s section is missing\n",
+			conf_section_name);
+		return -EINVAL;
 	}
 	switch(get_index_from_key(key)) {
 		case LOCAL_ADDR:


### PR DESCRIPTION
When the MOTR_CONFIG section is missing in the configuration
file or it's named differently (for example MERO_CONFIG) -
m0crate just crashes with the following stack:
```
  0  0x000000000040c05e in atoi (__nptr=0x223a0f0 "8") at /usr/include/stdlib.h:280
  1  copy_value (load=0x2226010, max_workload=<optimized out>, index=0x7fff0f6bc524,
      key=<optimized out>, value=<optimized out>) at motr/m0crate/parser.c:281
  2  0x000000000040ccec in parse_yaml_file (load=load@entry=0x2226010, max_workload=max_workload@entry=32,
      index=index@entry=0x7fff0f6bc524, config_file=<optimized out>) at motr/m0crate/parser.c:588
  3  0x0000000000403eca in main (argc=3, argv=0x7fff0f6bc648) at motr/m0crate/crate.c:1345
```
Which is a bit confusing because the problem is actually at
frame 1 (not 0):
```
  (gdb) f 1
  1  copy_value (load=0x2226010, max_workload=<optimized out>, index=0x7fff0f6bc524,
      key=<optimized out>, value=<optimized out>) at motr/m0crate/parser.c:281
  281				conf->layout_id = atoi(value);
  (gdb) p conf
  $1 = (struct crate_conf *) 0x0
```
Solution: check the conf pointer at copy_value() and print
a proper error msg when MOTR_CONFIG section is missing in the
config file.