### PR TITLE
EOS-18140 sns/parity_math: implement incremental recovery using ISAL

### DIFF
--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2013-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -1484,8 +1484,8 @@ M0_INTERNAL int m0_sns_ir_init(const struct m0_parity_math *math,
 	M0_PRE(math != NULL);
 	M0_PRE(ir != NULL);
 #if ISAL_ENCODE_ENABLED
-	M0_PRE(math->pmi_encode_matrix);
-	M0_PRE(math->pmi_decode_tbls);
+	M0_PRE(math->pmi_encode_matrix != NULL);
+	M0_PRE(math->pmi_decode_tbls != NULL);
 #endif /* ISAL_ENCODE_ENABLED */
 
 	M0_SET0(ir);
@@ -1563,7 +1563,7 @@ M0_INTERNAL int m0_sns_ir_failure_register(struct m0_bufvec *recov_addr,
 	if (is_data(ir, failed_index))
 		M0_CNT_INC(ir->si_failed_data_nr);
 #endif /* ISAL_ENCODE_ENABLED */
-	return (ir->si_alive_nr < ir->si_data_nr) ? -EDQUOT : 0;
+	return (ir->si_alive_nr < ir->si_data_nr) ? M0_ERR(-EDQUOT) : 0;
 }
 
 M0_INTERNAL int m0_sns_ir_mat_compute(struct m0_sns_ir *ir)

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -1557,7 +1557,7 @@ M0_INTERNAL int m0_sns_ir_failure_register(struct m0_bufvec *recov_addr,
 
 	M0_CNT_DEC(ir->si_alive_nr);
 #if ISAL_ENCODE_ENABLED
-	/* Store failed index in buffer */
+	/* Store failed index in buffer and increase the failure number */
 	ir->si_failed_idx[ir->si_failed_nr++] = failed_index;
 #else
 	if (is_data(ir, failed_index))

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2013-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -156,6 +156,20 @@ struct m0_sns_ir {
 	 * math::pmi_vandmat_parity_slice.
 	 */
 	struct m0_matrix	si_parity_recovery_mat;
+
+#if ISAL_ENCODE_ENABLED
+	/* Pointer to sets of arrays of input coefficients used
+	 * to encode or decode data.*/
+	uint8_t		       *si_encode_matrix;
+	/* Pointer to concatenated output tables for decode */
+	uint8_t		       *si_decode_tbls;
+	/* Number of failed blocks */
+	uint32_t		si_failed_nr;
+	/* Array holding indices of all failed blocks */
+	uint8_t		       *si_failed_idx;
+	/* Array holding indices of all alive blocks */
+	uint8_t		       *si_alive_idx;
+#endif /* ISAL_ENCODE_ENABLED */
 };
 
 /**


### PR DESCRIPTION
- Updated functions m0_sns_ir_init(), m0_sns_ir_fini() and
  m0_sns_ir_failure_register().

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>