### PR TITLE
EOS-18776: bulk-server-ut fails with --enable-data-integrity

### DIFF
--- a/file/file.c
+++ b/file/file.c
@@ -488,7 +488,10 @@ M0_INTERNAL void m0_file_init(struct m0_file      *file,
 	if (dom != NULL)
 		m0_rm_resource_add(dom->rd_types[M0_RM_FLOCK_RT],
 				   &file->fi_res);
-	file->fi_di_ops = m0_di_ops_get(di_type);
+	if (M0_FI_ENABLED("skip_di_for_ut"))
+		file->fi_di_ops = m0_di_ops_get(M0_DI_NONE);
+	else
+		file->fi_di_ops = m0_di_ops_get(di_type);
 }
 M0_EXPORTED(m0_file_init);
 

--- a/ioservice/ut/bulkio_ut.c
+++ b/ioservice/ut/bulkio_ut.c
@@ -1769,6 +1769,7 @@ static void bulkio_init(void)
 	 * for the tests in order to avoid crashes.
 	 */
 	m0_fi_enable("io_fop_di_prepare", "skip_di_for_ut");
+	m0_fi_enable("m0_file_init", "skip_di_for_ut");
 
 	M0_ALLOC_PTR(bp);
 	M0_ASSERT(bp != NULL);
@@ -1797,6 +1798,7 @@ static void bulkio_fini(void)
 	m0_free(bp);
 
 	m0_fi_disable("io_fop_di_prepare", "skip_di_for_ut");
+	m0_fi_disable("m0_file_init", "skip_di_for_ut");
 }
 
 /*


### PR DESCRIPTION
Problem:
Configure the code with --enable-data-integrity flag and
compile it. bulk-server-ut:bulkio_server_single_read_write
starts failing with assert in file_checksum_check()

Root cause:
1. We have enabled following fault injection in bulkio_ut.c
m0_fi_enable("io_fop_di_prepare", "skip_di_for_ut");

2. Because of this fault injection, we skip adding checksum information
in io_fop_di_prepare()

3.Later in io_launch(), we try to verify the checksum.
But checksum was not added in first place. Thus our test
fails.

4. This test works without --enable-data-integrity
because when this flag is not set we do not do checksum check,
we call file_di_none_check() which does nothing.
But when ENABLE_DATA_INTEGRITY flag is set we call file_di_crc_check()
and does checksum check. This is the problem. Checksum was not added
because of fault point enabled and we are doing checksum check.

Solution:
1. Added another fult point to this test
m0_fi_enable("m0_file_init", "skip_di_for_ut");

2. When this newly fault point is hit,
m0_file_init() will init file->fi_di_ops with
M0_DI_NONE. Thus checksum check won't happen in io_launch()

Testing
Ran bulk-server-ut with the fix and --enable-data-integrity
Test passed.

Signed-off-by: Shipra Gupta <shipra.gupta@seagate.com>