### PR TITLE
[DTM0] EOS-17644: add the client to all2all integration test

### DIFF
--- a/dtm0/Kbuild.sub
+++ b/dtm0/Kbuild.sub
@@ -6,5 +6,4 @@ m0tr_objects += \
                   dtm0/tx_desc_xc.o \
                   dtm0/service.o \
                   dtm0/fop.o \
-                  dtm0/dtx.o \
-                  dtm0/helper.o
+                  dtm0/dtx.o

--- a/dtm0/Kbuild.sub
+++ b/dtm0/Kbuild.sub
@@ -6,4 +6,5 @@ m0tr_objects += \
                   dtm0/tx_desc_xc.o \
                   dtm0/service.o \
                   dtm0/fop.o \
-                  dtm0/dtx.o
+                  dtm0/dtx.o \
+                  dtm0/helper.o

--- a/dtm0/it/all2all/README.md
+++ b/dtm0/it/all2all/README.md
@@ -1,0 +1,59 @@
+# How to run the test
+
+## About
+
+This integration test is used to check whether whole
+chain including Hare, m0d processes and client process
+works and client can write key/value pairs with DTX
+enabled.
+
+What the test does:
+ - bootstraps the cluster of 3 m0d processes using Hare
+ - checks that no any handling of HA messages is done by
+   DTM0 service
+ - sends HA TRANSIENT messages to m0d's to trigger HA messages
+   handling by DTM0 services
+ - checks that all DTM0 services are ready to handle HA
+   messages
+ - sends HA ONLINE messages to m0d's to trigger connections
+   logic
+ - checks that all m0d's are connected with each other
+ - run the m0crate to write key/value pairs
+ - sends HA client ONLINE messages to m0d's to trigger
+   connections from m0d's to the client
+ - waits for m0crate completion
+
+## Hare usage
+
+Hare is used for cluster bootstrap and shutdown. Firstly
+it needs to be patched by the hare.patch in current directory
+to make it able to generate clusted configuration that includes
+DTM0 service. After that it should be built and installed into
+the system (see README.md in the root of Hare repo).
+
+## m0crate configuration
+
+Before running the test the m0crate.yaml should be modified
+according to local machine settings (IPs, service endpoints
+and so on). To get the required information (and also to check
+that Hare is able to bootstrap) the part related to m0crate run
+and cluster shutdown can be commented, after that the test can
+be run just typing the following:
+
+$ sudo ./all2all
+
+It bootstraps the cluster, does required checks and leaves m0d
+processes running. Then the hctl status command can be run to
+get the information about IPs and endpoints:
+
+$ hctl status
+
+After m0crate config file modififcations are done the cluster
+can be stopped manually:
+
+$ sudo hctl shutdown
+
+Then uncomment the part related to m0crate and cluster shutdown.
+Now the test is ready to be run:
+
+$ sudo ./all2all

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -7,7 +7,7 @@ MOTR_UTILS_DIR=${MOTR_ROOT}/utils
 MOTR_ST_UTILS_DIR=${MOTR_ROOT}/motr/st/utils/
 MOTR_VAR_DIR=/var/motr
 TEST_ROOT=$MOTR_VAR_DIR/all2all_test
-CURRENT_CDF=$PWD/test.yaml
+CURRENT_CDF=$PWD/cdf.yaml
 CONFD_XC=/var/lib/hare/confd.xc
 LOOP_IMG_DIR=$TEST_ROOT
 
@@ -17,6 +17,8 @@ M0D_ENDPOINTS=()
 M0D_FIDS_DEC=()
 M0D_FIDS_HEX=()
 M0D_PIDS=()
+
+M0D_CLI_FID_DEC=
 
 POOL_WIDTH=4
 IPOOL_WIDTH=2
@@ -50,10 +52,12 @@ function get_m0d_pids()
 
 function get_params_for_ha_msgs()
 {
-    local json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice"))')
-    M0D_ENDPOINTS=($(echo $json_out | jq -r '.ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
-    M0D_FIDS_HEX=($(echo $json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
-    M0D_FIDS_DEC=($(echo $json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
+    local svc_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice"))')
+    local cli_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("m0_client"))')
+    M0D_ENDPOINTS=($(echo $svc_json_out | jq -r '.ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
+    M0D_FIDS_HEX=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
+    M0D_FIDS_DEC=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
+    M0D_CLI_FID_DEC=$(echo $cli_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e')
 }
 
 function ha_msg_send_transient()
@@ -84,6 +88,14 @@ function ha_msg_send_online()
     done
 }
 
+function ha_msg_send_cli_online()
+{
+    # Here we send "ONLINE" messages to connect servers to client.
+    for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
+        $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_CLI_FID_DEC}" "online"
+    done
+}
+
 function expected_trace_lines_num()
 {
     local pattern="$1"
@@ -110,6 +122,8 @@ function fail()
 
 function main()
 {
+    local cli_pid
+
     ${MOTR_UTILS_DIR}/m0setup --init-loop-only -s 1 -d ${TEST_ROOT} --pool-width ${POOL_WIDTH} --ipool-width ${IPOOL_WIDTH}
 
     _info "Bootstrapping the cluster using Hare..."
@@ -138,6 +152,15 @@ function main()
     expected_trace_lines_num "DTM0 service: connected" $((${#M0D_ENDPOINTS[@]}-1)) || {
         fail "Process is not connected, exiting"
     }
+
+    _info "Run the client..."
+    $MOTR_ROOT/motr/m0crate/m0crate -S m0crate.yaml &
+    cli_pid=$!
+    sleep 3
+    _info "Sending client is ONLINE..."
+    ha_msg_send_cli_online
+    _info "Wait for client..."
+    wait $cli_pid
 
     stop_cluster
 

--- a/dtm0/it/all2all/cdf.yaml
+++ b/dtm0/it/all2all/cdf.yaml
@@ -8,19 +8,19 @@ nodes:
           data: []
       - io_disks:
           data:
+            - /dev/loop0
             - /dev/loop1
+      - io_disks:
+          data:
             - /dev/loop2
-      - io_disks:
-          data:
             - /dev/loop3
-            - /dev/loop4
       - io_disks:
           data:
+            - /dev/loop4
             - /dev/loop5
-            - /dev/loop6
     m0_clients:
         s3: 0
-        other: 2
+        other: 1
 
 pools:
   - name: SNS pool

--- a/dtm0/it/all2all/hare.patch
+++ b/dtm0/it/all2all/hare.patch
@@ -1,0 +1,52 @@
+diff --git a/cfgen/cfgen b/cfgen/cfgen
+index b7ce8bd..85cfba9 100755
+--- a/cfgen/cfgen
++++ b/cfgen/cfgen
+@@ -787,6 +787,7 @@ class SvcT(Enum):
+     M0_CST_M0T1FS = auto()
+     M0_CST_CLIENT = auto()
+     M0_CST_ISCS = auto()
++    M0_CST_DTM0 = auto()
+ 
+     def to_dhall(self) -> str:
+         return f'types.{self}'
+@@ -798,6 +799,8 @@ def service_types(proc_t: ProcT,
+     if proc_t is ProcT.hax:
+         ts.append(SvcT.M0_CST_HA)
+     ts.append(SvcT.M0_CST_RMS)
++    if proc_t is ProcT.m0_client_other:
++        ts.append(SvcT.M0_CST_DTM0)
+     if proc_t is ProcT.m0_server:
+         assert proc_desc is not None
+         if proc_desc.get('runs_confd'):
+@@ -809,7 +812,8 @@ def service_types(proc_t: ProcT,
+                        SvcT.M0_CST_ADDB2,
+                        SvcT.M0_CST_CAS,
+                        SvcT.M0_CST_ISCS,
+-                       SvcT.M0_CST_FDMI])
++                       SvcT.M0_CST_FDMI,
++                       SvcT.M0_CST_DTM0])
+     return ts
+ 
+ 
+diff --git a/cfgen/dhall/render/SvcT.dhall b/cfgen/dhall/render/SvcT.dhall
+index 0ec5afb..3efcfe4 100644
+--- a/cfgen/dhall/render/SvcT.dhall
++++ b/cfgen/dhall/render/SvcT.dhall
+@@ -44,5 +44,6 @@ in
+     , M0_CST_M0T1FS  = "M0_CST_M0T1FS"
+     , M0_CST_CLIENT  = "M0_CST_CLIENT"
+     , M0_CST_ISCS    = "M0_CST_ISCS"
++    , M0_CST_DTM0    = "M0_CST_DTM0"
+     }
+     x
+diff --git a/cfgen/dhall/types/SvcT.dhall b/cfgen/dhall/types/SvcT.dhall
+index 604ad1b..f5c54af 100644
+--- a/cfgen/dhall/types/SvcT.dhall
++++ b/cfgen/dhall/types/SvcT.dhall
+@@ -40,4 +40,5 @@
+ | M0_CST_M0T1FS
+ | M0_CST_CLIENT
+ | M0_CST_ISCS
++| M0_CST_DTM0
+ >

--- a/dtm0/it/all2all/m0crate.yaml
+++ b/dtm0/it/all2all/m0crate.yaml
@@ -1,0 +1,35 @@
+CrateConfig_Sections: [MOTR_CONFIG, WORKLOAD_SPEC]
+MOTR_CONFIG:
+   MOTR_LOCAL_ADDR:  10.230.248.89@tcp:12345:4:1
+   MOTR_HA_ADDR:    10.230.248.89@tcp:12345:1:1
+   PROF: 0x7000000000000001:0x5f
+   LAYOUT_ID: 1                           # Layout id defines the unit size.
+   IS_OOSTORE: 1                           # Is oostore-mode?
+   IS_READ_VERIFY: 0                       # Enable read-verify?
+   TM_RECV_QUEUE_MIN_LEN: 2         # Minimum length of the receive queue, default is 2
+   MAX_RPC_MSG_SIZE: 131072         # Maximum rpc message size, default is 131072 (128k)
+   PROCESS_FID: 0x7200000000000001:0x36
+   IDX_SERVICE_ID: 1
+   ADDB_INIT: 1
+
+WORKLOAD_SPEC:
+  WORKLOAD:
+      WORKLOAD_TYPE: 0           # Index
+      WORKLOAD_SEED: tstamp
+      WARMUP_PUT_CNT: 0        # Number of PUT operations in warmup stage or
+                                 # as "all" meaning to fill all keys in the index
+      WARMUP_DEL_RATIO: 0        # Ration of keys to be deleted in warmup
+      NUM_KVP: 1                # Number of key/value records for index ops
+      RECORD_SIZE: 64            # Size of an key/value record (int [K, M] or random)
+      MAX_RSIZE: 1M              # Maximum record size (int [K, M])
+      OP_COUNT: 10               # Total operation count (int [K, M] or
+                                 # unlimited = (2 ** 31 - 1) / (128 * NUM_KVP)
+      EXEC_TIME: unlimited       # Execution time (secs or "unlimited").
+      KEY_PREFIX: random         # Prefix defined for keys (a number of "random")
+      KEY_ORDER: ordered         # ordered or random
+      INDEX_FID: <7800000000000001:0> # fid
+      PUT: 100                    # Percentages of PUT, DEL, GET and NEXT ops
+      DEL: 0
+      GET: 0
+      NEXT: 0
+      LOG_LEVEL: 4               # err(0), warn(1), info(2), trace(3), debug(4)

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -40,7 +40,9 @@
 #include "net/lnet/lnet.h"            /* m0_net_lnet_xprt */
 #ifdef DTM0
 #include "dtm0/service.h"              /* m0_dtm0_service_find */
+#ifndef __KERNEL__
 #include "dtm0/helper.h"
+#endif
 #endif
 
 #include "motr/io.h"                /* io_sm_conf */
@@ -1618,12 +1620,14 @@ int m0_client_init(struct m0_client **m0c_p,
 					 M0_CST_DTM0, &cli_svc_fid);
 	M0_ASSERT(rc == 0);
 
+#ifndef __KERNEL__
 	(void) m0_dtm__client_service_start(&m0c->m0c_reqh, &cli_svc_fid);
-
+#endif
 	m0c->m0c_dtms = m0_dtm0_service_find(&m0c->m0c_reqh);
 	M0_ASSERT(m0c->m0c_dtms != NULL);
 
-	m0_nanosleep(m0_time(15, 0), NULL);
+	if (!m0_dtm0_in_ut())
+		m0_nanosleep(m0_time(15, 0), NULL);
 #endif
 	if (conf->mc_is_addb_init) {
 		char buf[64];
@@ -1663,7 +1667,7 @@ void m0_client_fini(struct m0_client *m0c, bool fini_m0)
 	M0_PRE(m0_sm_conf_is_initialized(&entity_conf));
 	M0_PRE(m0c != NULL);
 
-#ifdef DTM0
+#if defined(DTM0) && !defined(__KERNEL__)
 	if (m0c->m0c_dtms != NULL)
 		m0_dtm__client_service_stop(&m0c->m0c_dtms->dos_generic);
 #endif

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -26,6 +26,7 @@
 #include "lib/finject.h"              /* M0_FI_ENABLED */
 #include "lib/arith.h"                /* M0_CNT_INC */
 #include "lib/mutex.h"                /* m0_mutex_lock */
+#include "lib/time.h"                 /* m0_nanosleep */
 #include "addb2/global.h"
 #include "addb2/sys.h"
 #include "fid/fid.h"                  /* m0_fid */
@@ -37,7 +38,10 @@
 #include "rm/rm_service.h"            /* m0_rms_type */
 #include "net/lnet/lnet_core_types.h" /* M0_NET_LNET_NIDSTR_SIZE */
 #include "net/lnet/lnet.h"            /* m0_net_lnet_xprt */
+#ifdef DTM0
 #include "dtm0/service.h"              /* m0_dtm0_service_find */
+#include "dtm0/helper.h"
+#endif
 
 #include "motr/io.h"                /* io_sm_conf */
 #include "motr/client.h"
@@ -1499,6 +1503,9 @@ int m0_client_init(struct m0_client **m0c_p,
 {
 	int               rc;
 	struct m0_client *m0c;
+#ifdef DTM0
+	struct m0_fid     cli_svc_fid;
+#endif
 
 	M0_PRE(m0c_p != NULL);
 	M0_PRE(*m0c_p == NULL);
@@ -1605,8 +1612,19 @@ int m0_client_init(struct m0_client **m0c_p,
 	/* Init the hash-table for RM contexts */
 	rm_ctx_htable_init(&m0c->m0c_rm_ctxs, M0_RM_HBUCKET_NR);
 
-	m0c->m0c_dtms = m0_dtm0_service_find(&m0c->m0c_reqh);
+#ifdef DTM0
+	rc = m0_conf_process2service_get(m0_reqh2confc(&m0c->m0c_reqh),
+					 &m0c->m0c_reqh.rh_fid,
+					 M0_CST_DTM0, &cli_svc_fid);
+	M0_ASSERT(rc == 0);
 
+	(void) m0_dtm__client_service_start(&m0c->m0c_reqh, &cli_svc_fid);
+
+	m0c->m0c_dtms = m0_dtm0_service_find(&m0c->m0c_reqh);
+	M0_ASSERT(m0c->m0c_dtms != NULL);
+
+	m0_nanosleep(m0_time(15, 0), NULL);
+#endif
 	if (conf->mc_is_addb_init) {
 		char buf[64];
 		/* Default client addb record file size set to 128M */
@@ -1644,6 +1662,11 @@ void m0_client_fini(struct m0_client *m0c, bool fini_m0)
 	M0_PRE(m0_sm_conf_is_initialized(&m0_op_conf));
 	M0_PRE(m0_sm_conf_is_initialized(&entity_conf));
 	M0_PRE(m0c != NULL);
+
+#ifdef DTM0
+	if (m0c->m0c_dtms != NULL)
+		m0_dtm__client_service_stop(&m0c->m0c_dtms->dos_generic);
+#endif
 
 	if (m0c->m0c_config->mc_is_addb_init) {
 		m0_addb2_force_all();

--- a/pool/pool.c
+++ b/pool/pool.c
@@ -973,10 +973,10 @@ static int service_ctxs_create(struct m0_pools_common *pc,
 		 *
 		 * FI services need no service context either.
 		 */
-		if ((!rm_is_set && is_local_svc(svc, M0_CST_RMS)) ||
-		    is_local_svc(svc, M0_CST_DTM0) ||
+		if (((!rm_is_set && is_local_svc(svc, M0_CST_RMS)) ||
 		    !M0_IN(svc->cs_type, (M0_CST_CONFD, M0_CST_RMS, M0_CST_HA,
-					  M0_CST_FIS))) {
+					  M0_CST_FIS))) &&
+		    !is_local_svc(svc, M0_CST_DTM0)) {
 			rc = __service_ctx_create(pc, svc, service_connect);
 			if (rc != 0)
 				break;


### PR DESCRIPTION
Now the m0crate is used to put key/val pairs with DTX
enabled to check that whole chain works.

Some workarounds are added to start the DTM0 service
on the client side and wait for connections from the
cluster nodes. Some fixes provided.

Also the patch for Hare with partial DTM0 support is
attached to have the ability to run the integration
test.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>