### PR TITLE
Fix build on Gentoo Linux

### DIFF
--- a/lib/user_space/timer.c
+++ b/lib/user_space/timer.c
@@ -67,8 +67,8 @@ M0_TL_DEFINE(tid, static, struct m0_timer_tid);
    gettid(2) implementation.
    Thread-safe, async-signal-safe.
  */
-static pid_t gettid() {
-
+static pid_t _gettid()
+{
 	return syscall(SYS_gettid);
 }
 
@@ -132,7 +132,7 @@ M0_INTERNAL int m0_timer_thread_attach(struct m0_timer_locality *loc)
 
 	M0_PRE(loc != NULL);
 
-	tid = gettid();
+	tid = _gettid();
 	M0_ASSERT(locality_tid_find(loc, tid) == NULL);
 
 	M0_ALLOC_PTR(tt);
@@ -157,7 +157,7 @@ M0_INTERNAL void m0_timer_thread_detach(struct m0_timer_locality *loc)
 
 	M0_PRE(loc != NULL);
 
-	tid = gettid();
+	tid = _gettid();
 	tt = locality_tid_find(loc, tid);
 	M0_ASSERT(tt != NULL);
 
@@ -281,7 +281,7 @@ static void timer_sighandler(int signo, siginfo_t *si, void *u_ctx)
 	M0_PRE(signo == TIMER_SIGNO);
 
 	timer = si->si_value.sival_ptr;
-	M0_ASSERT_EX(ergo(timer->t_tid != 0, timer->t_tid == gettid()));
+	M0_ASSERT_EX(ergo(timer->t_tid != 0, timer->t_tid == _gettid()));
 	m0_timer_callback_execute(timer);
 	m0_semaphore_up(&timer->t_cb_sync_sem);
 }

--- a/lib/ut/timer.c
+++ b/lib/ut/timer.c
@@ -78,7 +78,7 @@ static struct m0_semaphore *test_locality_lock;
 
 static struct m0_atomic64 callbacks_executed;
 
-static pid_t gettid()
+static pid_t _gettid()
 {
 	return syscall(SYS_gettid);
 }
@@ -175,7 +175,7 @@ static void test_timers(enum m0_timer_type timer_type, int nr_timers,
 
 static unsigned long locality_default_callback(unsigned long data)
 {
-	M0_UT_ASSERT(gettid() == loc_default_tid);
+	M0_UT_ASSERT(_gettid() == loc_default_tid);
 	m0_semaphore_up(&loc_default_lock);
 	return 0;
 }
@@ -194,7 +194,7 @@ static void timer_locality_default_test()
 
 	sem_init_zero(&loc_default_lock);
 
-	loc_default_tid = gettid();
+	loc_default_tid = _gettid();
 	m0_timer_start(&timer, make_time_abs(100));
 	m0_semaphore_down(&loc_default_lock);
 
@@ -207,7 +207,7 @@ static void timer_locality_default_test()
 static unsigned long locality_test_callback(unsigned long data)
 {
 	M0_ASSERT(data >= 0);
-	M0_ASSERT(test_locality_tid == gettid());
+	M0_ASSERT(test_locality_tid == _gettid());
 	m0_semaphore_up(&test_locality_lock[data]);
 	return 0;
 }
@@ -231,7 +231,7 @@ static void timer_locality_test(int nr_timers,
 	if (test_locality_lock == NULL)
 		goto free_timers;
 
-	test_locality_tid = gettid();
+	test_locality_tid = _gettid();
 	for (i = 0; i < nr_timers; ++i)
 		sem_init_zero(&test_locality_lock[i]);
 
@@ -277,7 +277,7 @@ static unsigned long test_timer_callback_mt(unsigned long data)
 {
 	struct tg_timer *tgt = (struct tg_timer *)data;
 	bool		 found = false;
-	pid_t		 tid = gettid();
+	pid_t		 tid = _gettid();
 	int		 i;
 
 	M0_ASSERT(tgt != NULL);
@@ -297,7 +297,7 @@ static void test_timer_worker_mt(struct tg_worker *worker)
 {
 	int rc;
 
-	worker->tgs_tid = gettid();
+	worker->tgs_tid = _gettid();
 	/* add worker thread to locality */
 	rc = m0_timer_thread_attach(&worker->tgs_group->tg_loc);
 	M0_UT_ASSERT(rc == 0);

--- a/motr/cob.c
+++ b/motr/cob.c
@@ -512,10 +512,13 @@ static void cob_fail_op(struct m0_op *op, int rc)
 	case M0_ES_INIT:
 		break;
 	case M0_ES_OPENING:
+		/* fallthrough */
 	case M0_ES_CREATING:
 		m0_sm_move(&op->op_entity->en_sm, 0, M0_ES_OPEN);
+		/* fallthrough */
 	case M0_ES_OPEN:
 		m0_sm_move(&op->op_entity->en_sm, 0, M0_ES_CLOSING);
+		/* fallthrough */
 	default:
 		m0_sm_move(&op->op_entity->en_sm, 0, M0_ES_INIT);
 	}

--- a/net/bulk_emulation/mem_xprt_xo.c
+++ b/net/bulk_emulation/mem_xprt_xo.c
@@ -434,6 +434,7 @@ static int mem_xo_buf_add(struct m0_net_buffer *nb)
 		break;
 	case M0_NET_QT_PASSIVE_BULK_RECV:
 		nb->nb_length = 0;
+		/* fallthrough */
 	case M0_NET_QT_PASSIVE_BULK_SEND:
 		bp->xb_buf_id = ++dp->xd_buf_id_counter;
 		rc = mem_bmo_desc_create(&nb->nb_desc, tm,
@@ -443,6 +444,7 @@ static int mem_xo_buf_add(struct m0_net_buffer *nb)
 			return M0_RC(rc);
 		break;
 	case M0_NET_QT_ACTIVE_BULK_RECV:
+		/* fallthrough */
 	case M0_NET_QT_ACTIVE_BULK_SEND:
 		wi->xwi_op = M0_NET_XOP_ACTIVE_BULK;
 		break;


### PR DESCRIPTION
Gentoo Linux has rolling updates and thus provides latest toolchain versions. This patchset contains of a subset of the patches required to build Motr on Gentoo system with latest software versions. It doesn't contain patches conflicting with #523 and should be treated as addition to that PR.