### PR TITLE
[DTM0] EOS-19055: Fix DTM0 UTs (clnt and svc)

### DIFF
--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -579,7 +579,9 @@ static int dtm0_service__ha_unsubscribe(struct m0_reqh_service *reqh_service)
 {
 	struct dtm0_process *process;
 	struct m0_dtm0_service *service;
-	/* int rc; */
+#if 0
+	int rc;
+#endif
 
 	M0_PRE(reqh_service != NULL);
 	service = container_of(reqh_service, struct m0_dtm0_service, dos_generic);
@@ -587,11 +589,14 @@ static int dtm0_service__ha_unsubscribe(struct m0_reqh_service *reqh_service)
 	M0_ENTRY();
 
 	while ((process = dopr_tlist_pop(&service->dos_processes)) != NULL) {
-		/* if (process->dop_rserv_fid.f_key == 0x1a) { */
-		/* 	       rc = m0_dtm0_service_process_disconnect(reqh_service, */
-		/* 						       &process->dop_rserv_fid); */
-		/* 	       M0_ASSERT(rc == 0 || rc == -ENOENT); */
-		/* } */
+		/* FIXME: Explicit disconnect ends up with an endless loop. */
+#if 0
+		if (process->dop_rserv_fid.f_key == 0x1a) {
+			       rc = m0_dtm0_service_process_disconnect(reqh_service,
+								       &process->dop_rserv_fid);
+			       M0_ASSERT(rc == 0 || rc == -ENOENT);
+		}
+#endif
 		dtm0_process__ha_state_unsubscribe(process);
 		dopr_tlink_fini(process);
 		m0_free(process);

--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -386,15 +386,12 @@ M0_INTERNAL bool m0_dtm0_in_ut(void)
 
 /* --------------------------------- EVENTS --------------------------------- */
 
-struct m0_semaphore g_test_wait;
 static int ready_to_process_ha_msgs = 0;
 
 static bool service_connect_clink(struct m0_clink *link)
 {
 	M0_ENTRY();
 	M0_LOG(M0_DEBUG, "DTM0 service: connected");
-	if (m0_dtm0_in_ut())
-		m0_semaphore_up(&g_test_wait);
 	M0_LEAVE();
 	return true;
 }
@@ -433,6 +430,11 @@ static bool process_clink_cb(struct m0_clink *clink)
 	M0_PRE(m0_fid_eq(evented_proc_fid, &process->dop_rproc_fid));
 	M0_PRE(!m0_fid_eq(evented_proc_fid, &M0_FID0));
 	M0_PRE(!m0_fid_eq(evented_proc_fid, current_proc_fid));
+
+	if (m0_dtm0_in_ut()) {
+		M0_LOG(M0_DEBUG, "No HA handling in UT.");
+		goto out;
+	}
 
 	/**
 	 * A weird logic to make a workaround for current HA

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -87,7 +87,14 @@ static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
 
 	M0_PRE(cl_rpc_session != NULL);
 
-	txr.dtd_id = (struct m0_dtm0_tid) { .dti_ts = now, .dti_fid = g_process_fid};
+	rc = m0_dtm0_tx_desc_init(&txr, 1);
+	M0_UT_ASSERT(rc == 0);
+
+	txr.dtd_ps.dtp_pa[0].p_fid = g_process_fid;
+	txr.dtd_id = (struct m0_dtm0_tid) {
+		.dti_ts = now,
+		.dti_fid = g_process_fid
+	};
 	fop = m0_fop_alloc_at(cl_rpc_session,
 			      &dtm0_req_fop_fopt);
 	req = m0_fop_data(fop);

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -148,7 +148,6 @@ static void dtm0_ut_client_fini(struct cl_ctx *cctx)
 	m0_net_domain_fini(&cctx->cl_ndom);
 }
 
-extern struct m0_semaphore g_test_wait;
 static void dtm0_ut_service(void)
 {
 	int rc;
@@ -167,8 +166,6 @@ static void dtm0_ut_service(void)
 
 	m0_fi_enable("m0_dtm0_in_ut", "ut");
 
-	m0_semaphore_init(&g_test_wait, 0);
-
 	rc = m0_rpc_server_start(&sctx);
 	M0_UT_ASSERT(rc == 0);
 
@@ -176,21 +173,18 @@ static void dtm0_ut_service(void)
 	cli_srv = m0_dtm__client_service_start(&cctx.cl_ctx.rcx_reqh, &cli_srv_fid);
 	M0_UT_ASSERT(cli_srv != NULL);
 	srv_srv = m0_reqh_service_lookup(srv_reqh, &srv_dtm0_fid);
-	/* rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr, false); */
-	/* M0_UT_ASSERT(rc == 0); */
-
-	m0_semaphore_down(&g_test_wait);
+	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr, false);
+	M0_UT_ASSERT(rc == 0);
 
 	dtm0_ut_send_fops(&cctx.cl_ctx.rcx_session);
 
-	/* rc = m0_dtm0_service_process_disconnect(srv_srv, &cli_srv_fid); */
-	/* M0_UT_ASSERT(rc == 0); */
+	rc = m0_dtm0_service_process_disconnect(srv_srv, &cli_srv_fid);
+	M0_UT_ASSERT(rc == 0);
 	(void)srv_srv;
-	m0_rpc_server_stop(&sctx);
 
 	m0_dtm__client_service_stop(cli_srv);
 	dtm0_ut_client_fini(&cctx);
-	/* m0_rpc_server_stop(&sctx); */
+	m0_rpc_server_stop(&sctx);
 	m0_fi_disable("m0_dtm0_in_ut", "ut");
 }
 

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -1620,6 +1620,19 @@ int m0_client_init(struct m0_client **m0c_p,
 					 M0_CST_DTM0, &cli_svc_fid);
 	M0_ASSERT(rc == 0);
 
+	if (M0_FI_ENABLED("hardcoded-dtm0s-fid")) {
+		/* When in UT, m0c_reqh.rh_fid is the same as the
+		 * server process fid. It causes the client to use
+		 * the server-side service fid. Hard-coding of the client
+		 * service fid resolves this problem.
+		 * TODO: When in UT, walk over the list of processes in
+		 * the conf cache and get the service with "volatile"
+		 * property from there. It will help to get rid of the
+		 * hard-coded service fid.
+		 */
+		cli_svc_fid  = M0_FID_INIT(0x7300000000000001, 0x1a);
+	}
+
 #ifndef __KERNEL__
 	(void) m0_dtm__client_service_start(&m0c->m0c_reqh, &cli_svc_fid);
 #endif

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -42,6 +42,10 @@
 #include "dtm0/service.h"              /* m0_dtm0_service_find */
 #ifndef __KERNEL__
 #include "dtm0/helper.h"
+#include <stdlib.h>
+#include <unistd.h>
+#else
+#include <linux/delay.h>
 #endif
 #endif
 
@@ -1620,7 +1624,7 @@ int m0_client_init(struct m0_client **m0c_p,
 					 M0_CST_DTM0, &cli_svc_fid);
 	M0_ASSERT(rc == 0);
 
-	if (M0_FI_ENABLED("hardcoded-dtm0s-fid")) {
+	if (m0_dtm0_in_ut()) {
 		/* When in UT, m0c_reqh.rh_fid is the same as the
 		 * server process fid. It causes the client to use
 		 * the server-side service fid. Hard-coding of the client
@@ -1639,8 +1643,14 @@ int m0_client_init(struct m0_client **m0c_p,
 	m0c->m0c_dtms = m0_dtm0_service_find(&m0c->m0c_reqh);
 	M0_ASSERT(m0c->m0c_dtms != NULL);
 
-	if (!m0_dtm0_in_ut())
-		m0_nanosleep(m0_time(15, 0), NULL);
+	if (!m0_dtm0_in_ut()) {
+#ifndef __KERNEL__
+		sleep(15);
+#else
+		msleep(15000);
+#endif
+
+	}
 #endif
 	if (conf->mc_is_addb_init) {
 		char buf[64];

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -808,7 +808,7 @@ static int duc_setup(void)
 	int                      rc;
 	struct m0_container     *realm = &duc.duc_realm;
 
-	m0_fi_enable("m0_client_init", "hardcoded-dtm0s-fid");
+	m0_fi_enable("m0_dtm0_in_ut", "ut");
 	rc = ut_suite_mt_idx_dix_init();
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(ut_m0c->m0c_dtms != NULL);
@@ -883,7 +883,7 @@ static int duc_teardown(void)
 	M0_UT_ASSERT(rc == 0);
 
 	rc = ut_suite_mt_idx_dix_fini();
-	m0_fi_disable("m0_client_init", "hardcoded-dtm0s-fid");
+	m0_fi_disable("m0_dtm0_in_ut", "ut");
 	return rc;
 }
 


### PR DESCRIPTION
[DTM0] EOS-19055: Fix DTM0 UT for m0 client.

The patch addresses the issue where the UT
used to test DTM0 with M0 client failed.
The root cause was the part where the client
starts the DTM0 service: the FID of the client
matches with the FID of the server, and because
of that the wrong DTM0 service FID was selected,
that led to the situation where the server-side
DTM0 service sends P messages to itself (rather
than to the client-side DTM0 service).
Also the patch alleviates the failures of the DTM0
service UT: it still fails but only at the point
of finalization (connections are not terminated
properly and rconf complaints about objects
that disappeared without proper notice).

DTM0: Remove event-driven connectivity in UT.

The patch fixes the problem where the DTM0 service
UT does not work properly when the HA based
mechanism is used to establish connections
between the client and the server.
Also, the patch addresses the question on the
hardcoded-dtm0s-fid fault point by replacing it
with m0_dtm0_in_ut which a better choice for
UT-specific branches in non-UT code.

