### PR TITLE
EOS-17644 dtm0: override m0crate cfg in all2all test

### DIFF
--- a/dtm0/it/all2all/README.md
+++ b/dtm0/it/all2all/README.md
@@ -30,30 +30,3 @@ it needs to be patched by the hare.patch in current directory
 to make it able to generate clusted configuration that includes
 DTM0 service. After that it should be built and installed into
 the system (see README.md in the root of Hare repo).
-
-## m0crate configuration
-
-Before running the test the m0crate.yaml should be modified
-according to local machine settings (IPs, service endpoints
-and so on). To get the required information (and also to check
-that Hare is able to bootstrap) the part related to m0crate run
-and cluster shutdown can be commented, after that the test can
-be run just typing the following:
-
-$ sudo ./all2all
-
-It bootstraps the cluster, does required checks and leaves m0d
-processes running. Then the hctl status command can be run to
-get the information about IPs and endpoints:
-
-$ hctl status
-
-After m0crate config file modififcations are done the cluster
-can be stopped manually:
-
-$ sudo hctl shutdown
-
-Then uncomment the part related to m0crate and cluster shutdown.
-Now the test is ready to be run:
-
-$ sudo ./all2all

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -8,6 +8,8 @@ MOTR_ST_UTILS_DIR=${MOTR_ROOT}/motr/st/utils/
 MOTR_VAR_DIR=/var/motr
 TEST_ROOT=$MOTR_VAR_DIR/all2all_test
 CURRENT_CDF=$PWD/cdf.yaml
+M0CRATE_CFG_IN=$PWD/m0crate.yaml.in
+M0CRATE_CFG=$PWD/m0crate.yaml
 CONFD_XC=/var/lib/hare/confd.xc
 LOOP_IMG_DIR=$TEST_ROOT
 
@@ -50,10 +52,30 @@ function get_m0d_pids()
     _info "m0d PIDs: $pids"
 }
 
+function create_m0crate_cfg()
+{
+    local hctl_json_out=$(hctl status --json)
+    local svcs_json_out=$(echo $hctl_json_out | jq -r '.nodes[] | .svcs[]')
+
+    local PROF=$(echo $hctl_json_out | jq -r '.profiles[] | .fid')
+    local MOTR_LOCAL_ADDR=$(echo $svcs_json_out | jq -r 'select( .name | contains("m0_client")) | .ep')
+    local PROCESS_FID=$(echo $svcs_json_out | jq -r 'select( .name | contains("m0_client")) | .fid')
+    local MOTR_HA_ADDR=$(echo $svcs_json_out | jq -r 'select( .name | contains("hax")) | .ep')
+
+    local M0CRATE_CFG_TMP=m0crate_cfg.tmp
+    cp $M0CRATE_CFG_IN $M0CRATE_CFG_TMP
+    sed -i "s/###__PROF__###/$PROF/g" $M0CRATE_CFG_TMP
+    sed -i "s/###__MOTR_LOCAL_ADDR__###/$MOTR_LOCAL_ADDR/g" $M0CRATE_CFG_TMP
+    sed -i "s/###__PROCESS_FID__###/$PROCESS_FID/g" $M0CRATE_CFG_TMP
+    sed -i "s/###__MOTR_HA_ADDR__###/$MOTR_HA_ADDR/g" $M0CRATE_CFG_TMP
+    mv $M0CRATE_CFG_TMP $M0CRATE_CFG
+}
+
 function get_params_for_ha_msgs()
 {
-    local svc_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("ioservice"))')
-    local cli_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[] | select( .name | contains("m0_client"))')
+    local svcs_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[]')
+    local svc_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("ioservice"))')
+    local cli_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("m0_client"))')
     M0D_ENDPOINTS=($(echo $svc_json_out | jq -r '.ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
     M0D_FIDS_HEX=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
     M0D_FIDS_DEC=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
@@ -153,8 +175,11 @@ function main()
         fail "Process is not connected, exiting"
     }
 
+    _info "Create m0crate configuration..."
+    create_m0crate_cfg
+
     _info "Run the client..."
-    $MOTR_ROOT/motr/m0crate/m0crate -S m0crate.yaml &
+    $MOTR_ROOT/motr/m0crate/m0crate -S $M0CRATE_CFG &
     cli_pid=$!
     sleep 3
     _info "Sending client is ONLINE..."

--- a/dtm0/it/all2all/m0crate.yaml.in
+++ b/dtm0/it/all2all/m0crate.yaml.in
@@ -1,14 +1,14 @@
 CrateConfig_Sections: [MOTR_CONFIG, WORKLOAD_SPEC]
 MOTR_CONFIG:
-   MOTR_LOCAL_ADDR:  10.230.248.89@tcp:12345:4:1
-   MOTR_HA_ADDR:    10.230.248.89@tcp:12345:1:1
-   PROF: 0x7000000000000001:0x5f
+   MOTR_LOCAL_ADDR:  ###__MOTR_LOCAL_ADDR__###
+   MOTR_HA_ADDR:    ###__MOTR_HA_ADDR__###
+   PROF: ###__PROF__###
    LAYOUT_ID: 1                           # Layout id defines the unit size.
    IS_OOSTORE: 1                           # Is oostore-mode?
    IS_READ_VERIFY: 0                       # Enable read-verify?
    TM_RECV_QUEUE_MIN_LEN: 2         # Minimum length of the receive queue, default is 2
    MAX_RPC_MSG_SIZE: 131072         # Maximum rpc message size, default is 131072 (128k)
-   PROCESS_FID: 0x7200000000000001:0x36
+   PROCESS_FID: ###__PROCESS_FID__###
    IDX_SERVICE_ID: 1
    ADDB_INIT: 1
 


### PR DESCRIPTION
Now hctl status output is used to get cluster params
and set them in m0crate cfg file before running m0crate.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>