### PR TITLE
client-io: get rid of redundant code

### DIFF
--- a/m0t1fs/linux_kernel/ut/file.c
+++ b/m0t1fs/linux_kernel/ut/file.c
@@ -625,8 +625,8 @@ static void pargrp_iomap_test(void)
 	rc = pargrp_iomap_paritybufs_alloc(&map);
 	M0_UT_ASSERT(rc == 0);
 
-	for (row = 0; row < parity_row_nr(pdlay); ++row) {
-		for (col = 0; col < parity_col_nr(pdlay); ++col) {
+	for (row = 0; row < rows_nr(pdlay); ++row) {
+		for (col = 0; col < layout_k(pdlay); ++col) {
 			M0_UT_ASSERT(map.pi_paritybufs[row][col] != NULL);
 			M0_UT_ASSERT(map.pi_paritybufs[row][col]->db_flags &
 				     PA_WRITE);
@@ -642,8 +642,8 @@ static void pargrp_iomap_test(void)
 	rc = pargrp_iomap_readold_auxbuf_alloc(&map);
 	M0_UT_ASSERT(rc == 0);
 
-	for (row = 0; row < data_row_nr(pdlay); ++row) {
-		for (col = 0; col < data_col_nr(pdlay); ++col) {
+	for (row = 0; row < rows_nr(pdlay); ++row) {
+		for (col = 0; col < layout_n(pdlay); ++col) {
 			M0_UT_ASSERT(map.pi_databufs[row][col]->db_flags &
 				     ~PA_PARTPAGE_MODIFY);
 		}
@@ -747,9 +747,9 @@ static void helpers_test(void)
 	M0_UT_ASSERT(parity_units_page_nr(pdlay) ==
 			(UNIT_SIZE >> PAGE_SHIFT) * LAY_K);
 
-	M0_UT_ASSERT(data_row_nr(pdlay)   == UNIT_SIZE >> PAGE_SHIFT);
-	M0_UT_ASSERT(data_col_nr(pdlay)   == LAY_N);
-	M0_UT_ASSERT(parity_col_nr(pdlay) == LAY_K);
+	M0_UT_ASSERT(rows_nr(pdlay)  == UNIT_SIZE >> PAGE_SHIFT);
+	M0_UT_ASSERT(layout_n(pdlay) == LAY_N);
+	M0_UT_ASSERT(layout_k(pdlay) == LAY_K);
 
 	M0_UT_ASSERT(round_down(1000, 1024) == 0);
 	M0_UT_ASSERT(round_up(2000, 1024)   == 2048);
@@ -996,7 +996,7 @@ skip:
 
 	/* Addition of parity buffer */
 	buf = map->pi_paritybufs[page_id(0)]
-		[LAY_N % data_col_nr(pdlay)];
+		[LAY_N % layout_n(pdlay)];
 
 	src.sa_unit  = LAY_N;
 	target_ioreq_seg_add(ti, &src, &tgt, 0, PAGE_SIZE, map);
@@ -1156,7 +1156,7 @@ static void dgmode_readio_test(void)
 		 * Checks if all pages from given unit_id are marked
 		 * as failed.
 		 */
-		for (row = 0; row < data_row_nr(play); ++row)
+		for (row = 0; row < rows_nr(play); ++row)
 			M0_UT_ASSERT(map->pi_databufs[row][src.sa_unit]->
 				     db_flags & PA_READ_FAILED);
 
@@ -1168,8 +1168,8 @@ static void dgmode_readio_test(void)
 			continue;
 
 		/* Traversing unit by unit. */
-		for (col = 0; col < data_col_nr(play); ++col) {
-			for (row = 0; row < data_row_nr(play); ++row) {
+		for (col = 0; col < layout_n(play); ++col) {
+			for (row = 0; row < rows_nr(play); ++row) {
 				if (col == src.sa_unit)
 					M0_UT_ASSERT(map->pi_databufs
 						     [row][col]->db_flags &
@@ -1188,8 +1188,8 @@ static void dgmode_readio_test(void)
 		}
 
 		/* Parity units are needed for recovery. */
-		for (col = 0; col < parity_col_nr(play); ++col) {
-			for (row = 0; row < parity_row_nr(play); ++row) {
+		for (col = 0; col < layout_k(play); ++col) {
+			for (row = 0; row < rows_nr(play); ++row) {
 				M0_UT_ASSERT(map->pi_paritybufs[row][col]->
 					     db_flags & PA_DGMODE_READ);
 				memset(map->pi_paritybufs[row][col]->db_buf.
@@ -1204,7 +1204,7 @@ static void dgmode_readio_test(void)
 		M0_UT_ASSERT(rc == 0);
 
 		/* Validate the recovered data. */
-		for (row = 0; row < data_row_nr(play); ++row) {
+		for (row = 0; row < rows_nr(play); ++row) {
 			cont = (char *)map->pi_databufs[row][src.sa_unit]->
 				db_buf.b_addr;
 			for (col = 0; col < PAGE_SIZE; ++col, ++cont)

--- a/m0t1fs/linux_kernel/ut/file.c
+++ b/m0t1fs/linux_kernel/ut/file.c
@@ -995,8 +995,7 @@ skip:
 	M0_UT_ASSERT(PA(&ti->ti_pageattrs, 1) & PA_DATA);
 
 	/* Addition of parity buffer */
-	buf = map->pi_paritybufs[page_id(0)]
-		[LAY_N % layout_n(pdlay)];
+	buf = map->pi_paritybufs[page_id(0)][LAY_N % layout_n(pdlay)];
 
 	src.sa_unit  = LAY_N;
 	target_ioreq_seg_add(ti, &src, &tgt, 0, PAGE_SIZE, map);

--- a/motr/io.h
+++ b/motr/io.h
@@ -156,51 +156,20 @@ M0_INTERNAL uint64_t page_id(m0_bindex_t offset, struct m0_obj *obj);
 M0_INTERNAL uint64_t layout_unit_size(struct m0_pdclust_layout *play);
 
 /**
- * Determines the number of rows necessary to group the parity layout's
- * unit size, into a number of object:blocks.
+ * Determines the size of data/parity unit in pages.
+ * This is essentially the rows number in the
+ * pargrp_iomap::pi_databufs[row][col] 2-dimentional array,
+ * hence the name.
  *
  * @param play The Parity layout.
  * @param obj The object.
- * @return The number of rows required.
+ * @return The number of pages.
  */
-M0_INTERNAL uint32_t data_row_nr(struct m0_pdclust_layout *play,
-				 struct m0_obj *obj);
+M0_INTERNAL uint32_t rows_nr(struct m0_pdclust_layout *play,
+			     struct m0_obj *obj);
 
 /**
- * Determines the number of columns necessary for data in this parity layout.
- * This is the N parameter of the layout.
- *
- * @param play The Parity layout.
- * @return The number of columns required.
- */
-M0_INTERNAL uint32_t data_col_nr(struct m0_pdclust_layout *play);
-
-/**
- * Determines the number of columns necessary for parity in this parity layout.
- * This is the K parameter of the layout.
- *
- * @param play The Parity layout.
- * @return The number of columns required.
- */
-M0_INTERNAL uint32_t parity_col_nr(struct m0_pdclust_layout *play);
-
-/**
- * Determines the number of parity rows, this should always be the same
- * as the number of data_rows.
- *
- * @param play The Parity layout.
- * @param obj The object.
- * @return The number of rows required.
- */
-/** TODO: This is clearly useless */
-M0_INTERNAL uint32_t parity_row_nr(struct m0_pdclust_layout *play,
-				   struct m0_obj *obj);
-
-/**
- * Determines the size of data in a row of the parity group.
- *
- * @param play The Parity layout.
- * @return The amount of data this row will contain.
+ * Determines the total size of data units in a parity group.
  */
 M0_INTERNAL uint64_t data_size(struct m0_pdclust_layout *play);
 

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -134,8 +134,8 @@ static void parity_page_pos_get(struct pargrp_iomap *map,
 	play = pdlayout_get(map->pi_ioo);
 
 	pg_id = page_id(index, map->pi_ioo->ioo_obj);
-	*row  = pg_id % parity_row_nr(play, map->pi_ioo->ioo_obj);
-	*col  = pg_id / parity_row_nr(play, map->pi_ioo->ioo_obj);
+	*row  = pg_id % rows_nr(play, map->pi_ioo->ioo_obj);
+	*col  = pg_id / rows_nr(play, map->pi_ioo->ioo_obj);
 }
 
 /**
@@ -565,7 +565,7 @@ static void target_ioreq_seg_add(struct target_ioreq              *ti,
 			M0_LOG(M0_DEBUG, "Data seg %u added", seg);
 		} else {
 			buf = map->pi_paritybufs[page_id(goff, ioo->ioo_obj)]
-			[unit - data_col_nr(play)];
+			[unit - layout_n(play)];
 			pattr[seg] |= PA_PARITY;
 			M0_LOG(M0_DEBUG, "Parity seg %u added", seg);
 		}
@@ -1333,7 +1333,7 @@ static int nw_xfer_io_distribute(struct nw_xfer_request *xfer)
 				parity_page_pos_get(iomap, unit * unit_size,
 						    &row, &col);
 
-				for (; row < parity_row_nr(play, ioo->ioo_obj);
+				for (; row < rows_nr(play, ioo->ioo_obj);
 				     ++row) {
 					dbuf = iomap->pi_paritybufs[row][col];
 					M0_ASSERT(dbuf != NULL);

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -171,9 +171,9 @@ static bool data_buf_invariant_nr(const struct pargrp_iomap *map)
 	obj = map->pi_ioo->ioo_obj;
 	play = pdlayout_get(map->pi_ioo);
 
-	for (row = 0; row < data_row_nr(play, obj); ++row) {
+	for (row = 0; row < rows_nr(play, obj); ++row) {
 		M0_ASSERT(row < map->pi_max_row);
-		for (col = 0; col < data_col_nr(play); ++col) {
+		for (col = 0; col < layout_n(play); ++col) {
 			M0_ASSERT(col < map->pi_max_col);
 			if (map->pi_databufs[row][col] != NULL &&
 				!data_buf_invariant(map->pi_databufs[row][col]))
@@ -182,9 +182,9 @@ static bool data_buf_invariant_nr(const struct pargrp_iomap *map)
 	}
 
 	if (map->pi_paritybufs != NULL) {
-		for (row = 0; row < parity_row_nr(play, obj); ++row) {
+		for (row = 0; row < rows_nr(play, obj); ++row) {
 			M0_ASSERT(row < map->pi_max_row);
-			for (col = 0; col < parity_col_nr(play); ++col) {
+			for (col = 0; col < layout_k(play); ++col) {
 				M0_ASSERT(row < map->pi_max_row);
 				if (map->pi_paritybufs[row][col] != NULL &&
 					!data_buf_invariant(map->pi_paritybufs
@@ -640,9 +640,9 @@ static uint64_t pargrp_iomap_fullpages_count(struct pargrp_iomap *map)
 
 	play = pdlayout_get(ioo);
 
-	for (row = 0; row < data_row_nr(play, obj); ++row) {
+	for (row = 0; row < rows_nr(play, obj); ++row) {
 		M0_ASSERT(row <= map->pi_max_row);
-		for (col = 0; col < data_col_nr(play); ++col) {
+		for (col = 0; col < layout_n(play); ++col) {
 			M0_ASSERT(col <= map->pi_max_col);
 			if (map->pi_databufs[row][col] &&
 			    map->pi_databufs[row][col]->db_flags &
@@ -792,8 +792,8 @@ static int pargrp_iomap_seg_process(struct pargrp_iomap *map,
 
 	return M0_RC(0);
 err:
-	for (row = 0; row < data_row_nr(play, obj); ++row) {
-		for (col = 0; col < data_col_nr(play); ++col) {
+	for (row = 0; row < rows_nr(play, obj); ++row) {
+		for (col = 0; col < layout_n(play); ++col) {
 			if (map->pi_databufs[row][col] != NULL) {
 				data_buf_dealloc_fini(
 						map->pi_databufs[row][col]);
@@ -1150,8 +1150,8 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 			goto last;
 		}
 
-		for (row = 0; row < data_row_nr(play, ioo->ioo_obj); ++row) {
-			for (col = 0; col < data_col_nr(play); ++col)
+		for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
+			for (col = 0; col < layout_n(play); ++col)
 				if (map->pi_databufs[row][col] != NULL) {
 					dbufs[col] =
 					    map->pi_databufs[row][col]->db_buf;
@@ -1184,12 +1184,12 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 			goto last;
 		}
 
-		for (row = 0; row < data_row_nr(play, ioo->ioo_obj); ++row) {
+		for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
 			for (col = 0; col < layout_k(play); ++col)
 				pbufs[col] = map->pi_paritybufs[row][col]->
 					db_buf;
 
-			for (col = 0; col < data_col_nr(play); ++col) {
+			for (col = 0; col < layout_n(play); ++col) {
 				/*
 				 * During rmw-IO request with read-old approach
 				 * we allocate primary and auxiliary buffers
@@ -1253,8 +1253,8 @@ static int pargrp_iomap_paritybufs_alloc(struct pargrp_iomap *map)
 	op_code = op->op_code;
 
 	play = pdlayout_get(map->pi_ioo);
-	for (row = 0; row < parity_row_nr(play, obj); ++row) {
-		for (col = 0; col < parity_col_nr(play); ++col) {
+	for (row = 0; row < rows_nr(play, obj); ++row) {
+		for (col = 0; col < layout_k(play); ++col) {
 			map->pi_paritybufs[row][col] =
 				data_buf_alloc_init(obj, PA_NONE);
 			if (map->pi_paritybufs[row][col] == NULL)
@@ -1274,8 +1274,8 @@ static int pargrp_iomap_paritybufs_alloc(struct pargrp_iomap *map)
 
 	return M0_RC(0);
 err:
-	for (row = 0; row < parity_row_nr(play, obj); ++row) {
-		for (col = 0; col < parity_col_nr(play); ++col)
+	for (row = 0; row < rows_nr(play, obj); ++row) {
+		for (col = 0; col < layout_k(play); ++col)
 			m0_free0(&map->pi_paritybufs[row][col]);
 	}
 
@@ -1301,8 +1301,8 @@ static int pargrp_iomap_databuf_replicate(struct pargrp_iomap *map)
 	M0_PRE(m0__is_update_op(op));
 
 	play = pdlayout_get(map->pi_ioo);
-	for (row = 0; row < parity_row_nr(play, obj); ++row) {
-		for (col = 0; col < parity_col_nr(play); ++col) {
+	for (row = 0; row < rows_nr(play, obj); ++row) {
+		for (col = 0; col < layout_k(play); ++col) {
 			if (map->pi_databufs[row][0] == NULL) {
 				map->pi_paritybufs[row][col] =
 					data_buf_alloc_init(obj, PA_NONE);
@@ -1327,7 +1327,7 @@ static int pargrp_iomap_databuf_replicate(struct pargrp_iomap *map)
 	return M0_RC(0);
 err:
 	for (; row > -1; --row) {
-		for (col = 0; col < parity_col_nr(play); ++col) {
+		for (col = 0; col < layout_k(play); ++col) {
 			if (map->pi_databufs[row][0] == NULL) {
 				data_buf_dealloc_fini(map->
 					pi_paritybufs[row][col]);
@@ -1373,12 +1373,12 @@ static int pargrp_iomap_pages_mark_as_failed(struct pargrp_iomap       *map,
 
 	if (type == M0_PUT_DATA) {
 		M0_ASSERT(map->pi_databufs != NULL);
-		row_nr = data_row_nr(play, ioo->ioo_obj);
-		col_nr = data_col_nr(play);
+		row_nr = rows_nr(play, ioo->ioo_obj);
+		col_nr = layout_n(play);
 		bufs   = map->pi_databufs;
 	} else {
-		row_nr = parity_row_nr(play, ioo->ioo_obj);
-		col_nr = parity_col_nr(play);
+		row_nr = rows_nr(play, ioo->ioo_obj);
+		col_nr = layout_k(play);
 		bufs   = map->pi_paritybufs;
 	}
 
@@ -1676,13 +1676,13 @@ static int pargrp_iomap_dgmode_process(struct pargrp_iomap *map,
 	 */
 	if (map->pi_paritybufs == NULL) {
 		M0_ALLOC_ARR(map->pi_paritybufs,
-			     parity_row_nr(play, ioo->ioo_obj));
+			     rows_nr(play, ioo->ioo_obj));
 		if (map->pi_paritybufs == NULL)
 			return M0_ERR(-ENOMEM);
 
-		for (row = 0; row < parity_row_nr(play, ioo->ioo_obj); ++row) {
+		for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
 			M0_ALLOC_ARR(map->pi_paritybufs[row],
-				     parity_col_nr(play));
+				     layout_k(play));
 			if (map->pi_paritybufs[row] == NULL) {
 				rc = -ENOMEM;
 				goto par_fail;
@@ -1694,7 +1694,7 @@ static int pargrp_iomap_dgmode_process(struct pargrp_iomap *map,
 
 par_fail:
 	M0_ASSERT(rc != 0);
-	for (row = 0; row < parity_row_nr(play, ioo->ioo_obj); ++row)
+	for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row)
 		m0_free0(&map->pi_paritybufs[row]);
 	m0_free0(&map->pi_paritybufs);
 
@@ -1745,8 +1745,8 @@ static int pargrp_iomap_dgmode_postprocess(struct pargrp_iomap *map)
 	 * increasing file offset.
 	 * This is necessary in order to generate correct index vector.
 	 */
-	for (col = 0; col < data_col_nr(play); ++col) {
-		for (row = 0; row < data_row_nr(play, obj); ++row) {
+	for (col = 0; col < layout_n(play); ++col) {
+		for (row = 0; row < rows_nr(play, obj); ++row) {
 
 			if (map->pi_databufs[row][col] != NULL &&
 			    map->pi_databufs[row][col]->db_flags &
@@ -1810,8 +1810,8 @@ static int pargrp_iomap_dgmode_postprocess(struct pargrp_iomap *map)
 	/*indexvec_dump(&map->pi_ivec);*/
 
 	/* parity matrix from parity group. */
-	for (row = 0; row < parity_row_nr(play, obj); ++row) {
-		for (col = 0; col < parity_col_nr(play); ++col) {
+	for (row = 0; row < rows_nr(play, obj); ++row) {
+		for (col = 0; col < layout_k(play); ++col) {
 
 			if (map->pi_paritybufs[row][col] == NULL) {
 				map->pi_paritybufs[row][col] =
@@ -1846,7 +1846,7 @@ static uint32_t iomap_dgmode_recov_prepare(struct pargrp_iomap *map,
 	uint32_t                  K = 0;
 
 	play = pdlayout_get(map->pi_ioo);
-	for (col = 0; col < data_col_nr(play); ++col) {
+	for (col = 0; col < layout_n(play); ++col) {
 		if (map->pi_databufs[0][col] != NULL &&
 		    map->pi_databufs[0][col]->db_flags &
 		    PA_READ_FAILED) {
@@ -1855,7 +1855,7 @@ static uint32_t iomap_dgmode_recov_prepare(struct pargrp_iomap *map,
 		}
 
 	}
-	for (col = 0; col < parity_col_nr(play); ++col) {
+	for (col = 0; col < layout_k(play); ++col) {
 		M0_ASSERT(map->pi_paritybufs[0][col] != NULL);
 		if (map->pi_paritybufs[0][col]->db_flags &
 		    PA_READ_FAILED) {
@@ -1942,8 +1942,8 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 	}
 
 	/* Populates data and failed buffers. */
-	for (row = 0; row < data_row_nr(play, ioo->ioo_obj); ++row) {
-		for (col = 0; col < data_col_nr(play); ++col) {
+	for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
+		for (col = 0; col < layout_n(play); ++col) {
 			data[col].b_nob = pagesize;
 
 			if (map->pi_databufs[row][col] == NULL) {
@@ -1954,7 +1954,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 					   db_buf.b_addr;
 		}
 
-		for (col = 0; col < parity_col_nr(play); ++col) {
+		for (col = 0; col < layout_k(play); ++col) {
 			M0_ASSERT(map->pi_paritybufs[row][col] != NULL);
 			parity[col].b_addr =
 			    map->pi_paritybufs[row][col]->db_buf.b_addr;
@@ -2066,7 +2066,7 @@ static int pargrp_iomap_replica_elect(struct pargrp_iomap *map)
 	 * CRC. The page corresponding to the value that holds majority in
 	 * a row shall be returned to user.
 	 */
-	for (row = 0, crc_idx = 0; row < data_row_nr(play, ioo->ioo_obj);
+	for (row = 0, crc_idx = 0; row < rows_nr(play, ioo->ioo_obj);
 	     ++row, crc_idx = 0) {
 		dbuf = map->pi_databufs[row][0];
 		/* Degraded pages won't contend the election. */
@@ -2178,9 +2178,9 @@ static int pargrp_iomap_parity_verify(struct pargrp_iomap *map)
 		pbufs[col].b_nob = pagesize;
 	}
 
-	for (row = 0; row < data_row_nr(play, ioo->ioo_obj); ++row) {
+	for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
 		/* data */
-		for (col = 0; col < data_col_nr(play); ++col) {
+		for (col = 0; col < layout_n(play); ++col) {
 			if (map->pi_databufs[row][col] != NULL)	{
 				dbufs[col] =
 					map->pi_databufs[row][col]->db_buf;
@@ -2322,11 +2322,11 @@ M0_INTERNAL int pargrp_iomap_init(struct pargrp_iomap  *map,
 	 */
 	map->pi_ivec.iv_vec.v_nr = 0;
 
-	map->pi_max_row = data_row_nr(play, ioo->ioo_obj);
+	map->pi_max_row = rows_nr(play, ioo->ioo_obj);
 	map->pi_max_col = layout_n(play);
 
 	rc = pargrp_iomap_bufs_alloc(&map->pi_databufs,
-				     data_row_nr(play, ioo->ioo_obj),
+				     rows_nr(play, ioo->ioo_obj),
 				     layout_n(play));
 	if (rc != 0)
 		goto fail;
@@ -2337,8 +2337,8 @@ M0_INTERNAL int pargrp_iomap_init(struct pargrp_iomap  *map,
 	 */
 	if (M0_IN(ioo->ioo_pbuf_type, (M0_PBUF_DIR, M0_PBUF_IND))) {
 		rc = pargrp_iomap_bufs_alloc(&map->pi_paritybufs,
-					     parity_row_nr(play, ioo->ioo_obj),
-					     parity_col_nr(play));
+					     rows_nr(play, ioo->ioo_obj),
+					     layout_k(play));
 		if (rc != 0)
 			goto fail;
 	}
@@ -2348,7 +2348,7 @@ M0_INTERNAL int pargrp_iomap_init(struct pargrp_iomap  *map,
 
 fail:
 	pargrp_iomap_bufs_free(map->pi_databufs,
-			       data_row_nr(play, ioo->ioo_obj));
+			       rows_nr(play, ioo->ioo_obj));
 	m0_indexvec_free(&map->pi_ivec);
 
 	return M0_ERR(-ENOMEM);
@@ -2385,17 +2385,17 @@ M0_INTERNAL void pargrp_iomap_fini(struct pargrp_iomap *map,
 	pargrp_iomap_bob_fini(map);
 	m0_indexvec_free(&map->pi_ivec);
 
-	for (row = 0; row < data_row_nr(play, obj); ++row) {
+	for (row = 0; row < rows_nr(play, obj); ++row) {
 		if (map->pi_ioo->ioo_pbuf_type == M0_PBUF_IND &&
 		    map->pi_databufs[row][0] == NULL) {
-			for (col_r = 0; col_r < parity_col_nr(play); ++col_r) {
+			for (col_r = 0; col_r < layout_k(play); ++col_r) {
 				data_buf_dealloc_fini(map->
 					pi_paritybufs[row][col_r]);
 				map->pi_paritybufs[row][col_r] = NULL;
 			}
 		}
 
-		for (col = 0; col < data_col_nr(play); ++col) {
+		for (col = 0; col < layout_n(play); ++col) {
 			if (map->pi_databufs[row][col] != NULL) {
 				data_buf_dealloc_fini(map->
 					pi_databufs[row][col]);
@@ -2407,8 +2407,8 @@ M0_INTERNAL void pargrp_iomap_fini(struct pargrp_iomap *map,
 	}
 
 	if (map->pi_paritybufs != NULL) {
-		for (row = 0; row < parity_row_nr(play, obj); ++row) {
-			for (col = 0; col < parity_col_nr(play); ++col) {
+		for (row = 0; row < rows_nr(play, obj); ++row) {
+			for (col = 0; col < layout_k(play); ++col) {
 				buf = map->pi_paritybufs[row][col];
 				if (buf != NULL) {
 					if (are_pbufs_allocated(map->pi_ioo)) {

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -1675,14 +1675,12 @@ static int pargrp_iomap_dgmode_process(struct pargrp_iomap *map,
 	 * since they are needed for recovering lost data.
 	 */
 	if (map->pi_paritybufs == NULL) {
-		M0_ALLOC_ARR(map->pi_paritybufs,
-			     rows_nr(play, ioo->ioo_obj));
+		M0_ALLOC_ARR(map->pi_paritybufs, rows_nr(play, ioo->ioo_obj));
 		if (map->pi_paritybufs == NULL)
 			return M0_ERR(-ENOMEM);
 
 		for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
-			M0_ALLOC_ARR(map->pi_paritybufs[row],
-				     layout_k(play));
+			M0_ALLOC_ARR(map->pi_paritybufs[row], layout_k(play));
 			if (map->pi_paritybufs[row] == NULL) {
 				rc = -ENOMEM;
 				goto par_fail;
@@ -2347,8 +2345,7 @@ M0_INTERNAL int pargrp_iomap_init(struct pargrp_iomap  *map,
 	return M0_RC(0);
 
 fail:
-	pargrp_iomap_bufs_free(map->pi_databufs,
-			       rows_nr(play, ioo->ioo_obj));
+	pargrp_iomap_bufs_free(map->pi_databufs, rows_nr(play, ioo->ioo_obj));
 	m0_indexvec_free(&map->pi_ivec);
 
 	return M0_ERR(-ENOMEM);

--- a/motr/pg.h
+++ b/motr/pg.h
@@ -356,7 +356,14 @@ struct pargrp_iomap {
 	 * Each element of matrix is worth PAGE_SIZE;
 	 * A unit size worth of data holds a contiguous chunk of file data.
 	 * The file offset grows vertically first (by rows) and then to
-	 * the next data unit (by columns).
+	 * the next data unit (by columns). For example, if the PAGE_SIZE is
+	 * 4K, and unit size is 16K, for a file/object of 112K length,
+	 * there will be following bufs, with corresponding offsets:
+	 *
+	 * [0k   ][16k  ][32k  ][48k  ][64k  ][80k  ][96k   ]
+	 * [4k   ][20k  ][36k  ][52k  ][68k  ][84k  ][100k  ]
+	 * [8k   ][24k  ][40k  ][56k  ][72k  ][88k  ][104k  ]
+	 * [12k  ][28k  ][44k  ][60k  ][76k  ][92k  ][108k  ]
 	 */
 	struct data_buf              ***pi_databufs;
 

--- a/motr/pg.h
+++ b/motr/pg.h
@@ -355,24 +355,30 @@ struct pargrp_iomap {
 	 * - number of columns = N.
 	 * Each element of matrix is worth PAGE_SIZE;
 	 * A unit size worth of data holds a contiguous chunk of file data.
-	 * The file offset grows vertically first and then to the next
-	 * data unit.
+	 * The file offset grows vertically first (by rows) and then to
+	 * the next data unit (by columns).
 	 */
 	struct data_buf              ***pi_databufs;
 
-	/** The maximum row value to use when accessing pi_databufs */
+	/**
+	 * The maximum row value to use when accessing pi_databufs.
+	 * This is essentially the unit size in pages.
+	 */
 	uint32_t                        pi_max_row;
 
-	/** The maximum col value to use when accessing pi_databufs */
+	/**
+	 * The maximum col value to use when accessing pi_databufs. This
+	 * is essentially the number of data units in parity group (N).
+	 */
 	uint32_t                        pi_max_col;
 
 	/**
 	 * Parity units in a parity group.
 	 * Unit size should be multiple of PAGE_SIZE.
-	 * This is a matrix with
+	 * Similar to pi_databufs, this is a matrix with
 	 * - number of rows    = Unit_size / PAGE_SIZE and
 	 * - number of columns = K.
-	 * Each element of matrix is worth PAGE_SIZE;
+	 * Each element of matrix is worth PAGE_SIZE.
 	 */
 	struct data_buf              ***pi_paritybufs;
 

--- a/motr/ut/io.c
+++ b/motr/ut/io.c
@@ -216,9 +216,9 @@ static void ut_test_layout_unit_size(void)
 }
 
 /*
- * Helper function for ut_test_data_row_nr().
+ * Helper function for ut_test_rows_nr().
  */
-static void ut_helper_data_row_nr(uint64_t size, m0_bcount_t bshift,
+static void ut_helper_rows_nr(uint64_t size, m0_bcount_t bshift,
 				  uint64_t exp_row_nr)
 {
 	struct m0_pdclust_layout play;
@@ -227,14 +227,14 @@ static void ut_helper_data_row_nr(uint64_t size, m0_bcount_t bshift,
 
 	play.pl_attr.pa_unit_size = size;
 	obj.ob_attr.oa_bshift = bshift;
-	row_nr = data_row_nr(&play, &obj);
+	row_nr = rows_nr(&play, &obj);
 	M0_UT_ASSERT(row_nr == exp_row_nr);
 }
 
 /*
- * Tests data_row_nr().
+ * Tests rows_nr().
  */
-static void ut_test_data_row_nr(void)
+static void ut_test_rows_nr(void)
 {
 	struct m0_pdclust_layout play;
 	struct m0_obj             obj;
@@ -244,63 +244,12 @@ static void ut_test_data_row_nr(void)
 	M0_SET0(&play);
 
 	/* Base case. */
-	ut_helper_data_row_nr(511, M0_MIN_BUF_SHIFT, 0);
-	ut_helper_data_row_nr(512, M0_MIN_BUF_SHIFT, 1);
-	ut_helper_data_row_nr(513, M0_MIN_BUF_SHIFT, 1);
-	ut_helper_data_row_nr(777, M0_MIN_BUF_SHIFT, 1);
-	ut_helper_data_row_nr(1023, M0_MIN_BUF_SHIFT, 1);
-	ut_helper_data_row_nr(1024, M0_MIN_BUF_SHIFT, 2);
-}
-
-/*
- * Tests data_col_nr().
- */
-static void ut_test_data_col_nr(void)
-{
-	struct m0_pdclust_layout play;
-	uint32_t                  col_nr;
-
-	/* Base case. */
-	play.pl_attr.pa_N = 777;
-	col_nr = data_col_nr(&play);
-	M0_UT_ASSERT(col_nr == 777);
-	play.pl_attr.pa_N = 0;
-	col_nr = data_col_nr(&play);
-	M0_UT_ASSERT(col_nr == 0);
-}
-
-/*
- * Tests parity_col_nr().
- */
-static void ut_test_parity_col_nr(void)
-{
-	struct m0_pdclust_layout play;
-	uint32_t                 col_nr;
-
-	/* Base case. */
-	play.pl_attr.pa_K = 777;
-	col_nr = parity_col_nr(&play);
-	M0_UT_ASSERT(col_nr == 777);
-	play.pl_attr.pa_K = 0;
-	col_nr = parity_col_nr(&play);
-	M0_UT_ASSERT(col_nr == 0);
-}
-
-/**
- * Tests parity_row_nr().
- * @see ut_test_data_row_nr().
- */
-static void ut_test_parity_row_nr(void)
-{
-	struct m0_pdclust_layout play;
-	struct m0_obj             obj;
-	uint32_t                  row_nr;
-
-	/* Base case. */
-	play.pl_attr.pa_unit_size = 511;
-	obj.ob_attr.oa_bshift = M0_MIN_BUF_SHIFT;
-	row_nr = parity_row_nr(&play, &obj);
-	M0_UT_ASSERT(row_nr == 0);
+	ut_helper_rows_nr(511, M0_MIN_BUF_SHIFT, 0);
+	ut_helper_rows_nr(512, M0_MIN_BUF_SHIFT, 1);
+	ut_helper_rows_nr(513, M0_MIN_BUF_SHIFT, 1);
+	ut_helper_rows_nr(777, M0_MIN_BUF_SHIFT, 1);
+	ut_helper_rows_nr(1023, M0_MIN_BUF_SHIFT, 1);
+	ut_helper_rows_nr(1024, M0_MIN_BUF_SHIFT, 2);
 }
 
 /**
@@ -873,14 +822,8 @@ struct m0_ut_suite ut_suite_io = {
 				    &ut_test_page_id},
 		{ "layout_unit_size",
 				    &ut_test_layout_unit_size},
-		{ "data_row_nr",
-				    &ut_test_data_row_nr},
-		{ "data_col_nr",
-				    &ut_test_data_col_nr},
-		{ "parity_col_nr",
-				    &ut_test_parity_col_nr},
-		{ "parity_row_nr",
-				    &ut_test_parity_row_nr},
+		{ "rows_nr",
+				    &ut_test_rows_nr},
 		{ "data_size",
 				    &ut_test_data_size},
 		{ "pdlayout_instance",

--- a/motr/ut/io_pargrp.c
+++ b/motr/ut/io_pargrp.c
@@ -872,7 +872,7 @@ static void ut_free_pargrp_iomap(struct pargrp_iomap *map)
 
 	if (map->pi_paritybufs != NULL) {
 		for (row = 0; row < map->pi_max_row; ++row) {
-			for (col = 0; col < parity_col_nr(play); ++col) {
+			for (col = 0; col < layout_k(play); ++col) {
 				if (map->pi_paritybufs[row][col] != NULL)
 					m0_free(map->pi_paritybufs[row][col]);
 			}

--- a/motr/utils.c
+++ b/motr/utils.c
@@ -84,38 +84,12 @@ M0_INTERNAL uint64_t layout_unit_size(struct m0_pdclust_layout *play)
 	return play->pl_attr.pa_unit_size;
 }
 
-/** Returns number of pages (rows) in the unit. */
-M0_INTERNAL uint32_t data_row_nr(struct m0_pdclust_layout *play,
-				 struct m0_obj *obj)
+M0_INTERNAL uint32_t rows_nr(struct m0_pdclust_layout *play, struct m0_obj *obj)
 {
 	M0_PRE(play != NULL);
 	M0_PRE(obj != NULL);
 
 	return page_nr(layout_unit_size(play), obj);
-}
-
-M0_INTERNAL uint32_t data_col_nr(struct m0_pdclust_layout *play)
-{
-	M0_PRE(play != NULL);
-
-	return layout_n(play);
-}
-
-M0_INTERNAL uint32_t parity_col_nr(struct m0_pdclust_layout *play)
-{
-	M0_PRE(play != NULL);
-
-	return layout_k(play);
-}
-
-/** TODO: This is clearly useless */
-M0_INTERNAL uint32_t parity_row_nr(struct m0_pdclust_layout *play,
-				   struct m0_obj *obj)
-{
-	M0_PRE(play != NULL);
-	M0_PRE(obj != NULL);
-
-	return data_row_nr(play, obj);
 }
 
 M0_INTERNAL uint64_t data_size(struct m0_pdclust_layout *play)
@@ -265,8 +239,8 @@ M0_INTERNAL void page_pos_get(struct pargrp_iomap  *map,
 	play = pdlayout_get(map->pi_ioo);
 
 	pg_id = page_id(index - grp_off, obj);
-	*row  = pg_id % data_row_nr(play, obj);
-	*col = play->pl_attr.pa_K == 0 ? 0 : pg_id / data_row_nr(play, obj);
+	*row = pg_id % rows_nr(play, obj);
+	*col = play->pl_attr.pa_K == 0 ? 0 : pg_id / rows_nr(play, obj);
 }
 
 M0_INTERNAL m0_bindex_t data_page_offset_get(struct pargrp_iomap *map,
@@ -282,8 +256,8 @@ M0_INTERNAL m0_bindex_t data_page_offset_get(struct pargrp_iomap *map,
 	ioo = map->pi_ioo;
 	play = pdlayout_get(ioo);
 
-	M0_PRE(row < data_row_nr(play, ioo->ioo_obj));
-	M0_PRE(col < data_col_nr(play));
+	M0_PRE(row < rows_nr(play, ioo->ioo_obj));
+	M0_PRE(col < layout_n(play));
 
 	out = data_size(play) * map->pi_grpid +
 	      col * layout_unit_size(play) + row * m0__page_size(ioo);


### PR DESCRIPTION
Get rid of clobbering code in the client-io, like data_row_nr(),
data_col_nr(), parity_col_nr() and parity_row_nr(). These are
just wrappers which rather confuse and clobber the code rather
than clarify anything.

Introduce rows_nr() instead of data_row_nr() and parity_row_nr().
And use layout_n() and layout_k() directly instead of data_col_nr()
and parity_col_nr().