### PR TITLE
[DTM0] Use rt checks agains DTM0 configure flag.

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -1172,14 +1172,12 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	is_index_drop = op_is_index_drop(opc, ct);
 	M0_PRE(ctidx != NULL);
 	M0_PRE(cas_fom_invariant(fom));
-#if defined(DTM0)
-	M0_PRE(ergo(!M0_IS0(&op->cg_txd),
+	M0_PRE(ergo(ENABLE_DTM0 && !M0_IS0(&op->cg_txd),
 		    m0_dtm0_tx_desc__invariant(&op->cg_txd)));
 	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT) {
 		M0_LOG(M0_DEBUG, "Got CAS with txid: " DTID0_F,
 		       DTID0_P(&op->cg_txd.dtd_id));
 	}
-#endif
 	switch (phase) {
 	case M0_FOPH_INIT ... M0_FOPH_NR - 1:
 

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,7 @@ AH_TEMPLATE([ENABLE_DATA_INTEGRITY],  [Enable data integrity.])
 AH_TEMPLATE([ENABLE_FREE_POISON],     [Poison freed memory for debugging.])
 AH_TEMPLATE([ENABLE_DETAILED_BACKTRACE],[Enable detailed backtraces on crash using gdb.])
 AH_TEMPLATE([M0_NDEBUG],              [Disable M0_ASSERT.])
-AH_TEMPLATE([DTM0],                   [Enable DTM0 mode.])
+AH_TEMPLATE([ENABLE_DTM0],            [Enable DTM0 mode.])
 AH_TEMPLATE([M0_BE_SEGMENT_SIZE],     [BE segment size in MiB.])
 AH_TEMPLATE([M0_TRACE_KBUF_SIZE],     [Kernel space trace buffer size in MiB.])
 AH_TEMPLATE([M0_TRACE_UBUF_SIZE],     [User space trace buffer size in MiB.])
@@ -321,7 +321,8 @@ AC_ARG_ENABLE([dtm0],
         [], [enable_dtm0=no]
 )
 AS_IF([test x$enable_dtm0 = xyes],
-      AC_DEFINE([DTM0]))
+      AC_DEFINE([ENABLE_DTM0], [1]),
+      AC_DEFINE([ENABLE_DTM0], [0]))
 
 # expensive-checks {{{3
 AC_ARG_ENABLE([expensive_checks],

--- a/dix/ut/client_ut.c
+++ b/dix/ut/client_ut.c
@@ -1465,13 +1465,13 @@ static void dix_create_crow(void)
 
 static void dix_create_dgmode(void)
 {
-#ifdef DTM0
-	return;
-#endif
 	struct m0_dix indices[COUNT_INDEX];
 	uint32_t      indices_nr = ARRAY_SIZE(indices);
 	int           i;
 	int           rc;
+
+	if (ENABLE_DTM0)
+		return;
 
 	ut_service_init();
 	for (i = 0; i < indices_nr; i++)
@@ -1565,13 +1565,13 @@ static void dix_delete_crow(void)
 
 static void dix_delete_dgmode(void)
 {
-#ifdef DTM0
-	return;
-#endif
 	struct m0_dix indices[COUNT_INDEX];
 	uint32_t      indices_nr = ARRAY_SIZE(indices);
 	int           i;
 	int           rc;
+
+	if (ENABLE_DTM0)
+		return;
 
 	ut_service_init();
 	for (i = 0; i < indices_nr; i++)
@@ -1809,15 +1809,15 @@ static void dix_put_crow(void)
 
 static void dix_put_dgmode(void)
 {
-#ifdef DTM0
-	return;
-#endif
 	struct m0_dix      index;
 	struct m0_bufvec   keys;
 	struct m0_bufvec   vals;
 	struct dix_rep_arr rep;
 	uint32_t           sdev_id;
 	int                rc;
+
+	if (ENABLE_DTM0)
+		return;
 
 	ut_service_init();
 	dix_predictable_index_init(&index, 1);
@@ -2004,9 +2004,6 @@ static void dix_dgmode_disks_unprep(enum ut_pg_unit        unit1,
 
 static void dix_get_dgmode(void)
 {
-#ifdef DTM0
-	return;
-#endif
 	struct m0_dix         index;
 	struct m0_bufvec      keys;
 	struct m0_bufvec      vals;
@@ -2016,6 +2013,9 @@ static void dix_get_dgmode(void)
 	enum m0_pool_nd_state s2;
 	struct dix_rep_arr    rep;
 	int                   rc;
+
+	if (ENABLE_DTM0)
+		return;
 
 	ut_service_init();
 	dix_predictable_index_init(&index, 1);
@@ -2229,9 +2229,6 @@ static void dix_next_crow(void)
 
 static void dix_next_dgmode(void)
 {
-#ifdef DTM0
-	return;
-#endif
 	struct m0_dix      index;
 	struct m0_bufvec   keys;
 	struct m0_bufvec   start_key;
@@ -2239,6 +2236,9 @@ static void dix_next_dgmode(void)
 	struct dix_rep_arr rep;
 	uint32_t           recs_nr = COUNT;
 	int                rc;
+
+	if (ENABLE_DTM0)
+		return;
 
 	ut_service_init();
 	dix_index_init(&index, 1);
@@ -2339,15 +2339,15 @@ static void dix_records_restore(struct m0_dix *index, struct m0_bufvec *keys,
 
 static void dix_del_dgmode(void)
 {
-#ifdef DTM0
-	return;
-#endif
 	struct m0_dix      index;
 	struct m0_bufvec   keys;
 	struct m0_bufvec   vals;
 	struct dix_rep_arr rep;
 	uint32_t           sdev_id;
 	int                rc;
+
+	if (ENABLE_DTM0)
+		return;
 
 	ut_service_init();
 	dix_predictable_index_init(&index, 1);

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -38,16 +38,11 @@
 #include "rm/rm_service.h"            /* m0_rms_type */
 #include "net/lnet/lnet_core_types.h" /* M0_NET_LNET_NIDSTR_SIZE */
 #include "net/lnet/lnet.h"            /* m0_net_lnet_xprt */
-#ifdef DTM0
-#include "dtm0/service.h"              /* m0_dtm0_service_find */
 #ifndef __KERNEL__
-#include "dtm0/helper.h"
-#include <stdlib.h>
-#include <unistd.h>
-#else
-#include <linux/delay.h>
-#endif
-#endif
+#include <unistd.h>                   /* sleep */
+#include "dtm0/service.h"             /* m0_dtm0_service_find */
+#include "dtm0/helper.h"              /* m0_dtm__client_service_start */
+#endif /* __KERNEL__ */
 
 #include "motr/io.h"                /* io_sm_conf */
 #include "motr/client.h"
@@ -1509,9 +1504,9 @@ int m0_client_init(struct m0_client **m0c_p,
 {
 	int               rc;
 	struct m0_client *m0c;
-#ifdef DTM0
+#ifndef __KERNEL__
 	struct m0_fid     cli_svc_fid;
-#endif
+#endif /* __KERNEL__ */
 
 	M0_PRE(m0c_p != NULL);
 	M0_PRE(*m0c_p == NULL);
@@ -1618,40 +1613,39 @@ int m0_client_init(struct m0_client **m0c_p,
 	/* Init the hash-table for RM contexts */
 	rm_ctx_htable_init(&m0c->m0c_rm_ctxs, M0_RM_HBUCKET_NR);
 
-#ifdef DTM0
-	rc = m0_conf_process2service_get(m0_reqh2confc(&m0c->m0c_reqh),
-					 &m0c->m0c_reqh.rh_fid,
-					 M0_CST_DTM0, &cli_svc_fid);
-	M0_ASSERT(rc == 0);
+#ifndef __KERNEL__
+	if (ENABLE_DTM0) {
+		rc = m0_conf_process2service_get(m0_reqh2confc(&m0c->m0c_reqh),
+						 &m0c->m0c_reqh.rh_fid,
+						 M0_CST_DTM0, &cli_svc_fid);
+		M0_ASSERT(rc == 0);
 
-	if (m0_dtm0_in_ut()) {
-		/* When in UT, m0c_reqh.rh_fid is the same as the
-		 * server process fid. It causes the client to use
-		 * the server-side service fid. Hard-coding of the client
-		 * service fid resolves this problem.
-		 * TODO: When in UT, walk over the list of processes in
-		 * the conf cache and get the service with "volatile"
-		 * property from there. It will help to get rid of the
-		 * hard-coded service fid.
+		if (m0_dtm0_in_ut()) {
+			/* When in UT, m0c_reqh.rh_fid is the same as the
+			 * server process fid. It causes the client to use
+			 * the server-side service fid. Hard-coding of the client
+			 * service fid resolves this problem.
+			 * TODO: When in UT, walk over the list of processes in
+			 * the conf cache and get the service with "volatile"
+			 * property from there. It will help to get rid of the
+			 * hard-coded service fid.
+			 */
+			cli_svc_fid  = M0_FID_INIT(0x7300000000000001, 0x1a);
+		}
+
+		(void) m0_dtm__client_service_start(&m0c->m0c_reqh, &cli_svc_fid);
+		m0c->m0c_dtms = m0_dtm0_service_find(&m0c->m0c_reqh);
+		M0_ASSERT(m0c->m0c_dtms != NULL);
+
+		/* When in non-UT, we should wait until all the servers
+		 * have established connections with this client.
+		 * TODO: remove this sleep() when a proper start/stop
+		 * procedure is implemented.
 		 */
-		cli_svc_fid  = M0_FID_INIT(0x7300000000000001, 0x1a);
+		if (!m0_dtm0_in_ut())
+			sleep(15);
 	}
-
-#ifndef __KERNEL__
-	(void) m0_dtm__client_service_start(&m0c->m0c_reqh, &cli_svc_fid);
-#endif
-	m0c->m0c_dtms = m0_dtm0_service_find(&m0c->m0c_reqh);
-	M0_ASSERT(m0c->m0c_dtms != NULL);
-
-	if (!m0_dtm0_in_ut()) {
-#ifndef __KERNEL__
-		sleep(15);
-#else
-		msleep(15000);
-#endif
-
-	}
-#endif
+#endif /* __KERNEL__ */
 	if (conf->mc_is_addb_init) {
 		char buf[64];
 		/* Default client addb record file size set to 128M */
@@ -1689,11 +1683,12 @@ void m0_client_fini(struct m0_client *m0c, bool fini_m0)
 	M0_PRE(m0_sm_conf_is_initialized(&m0_op_conf));
 	M0_PRE(m0_sm_conf_is_initialized(&entity_conf));
 	M0_PRE(m0c != NULL);
+	M0_PRE(ergo(ENABLE_DTM0, m0c->m0c_dtms != NULL));
 
-#if defined(DTM0) && !defined(__KERNEL__)
+#ifndef __KERNEL__
 	if (m0c->m0c_dtms != NULL)
 		m0_dtm__client_service_stop(&m0c->m0c_dtms->dos_generic);
-#endif
+#endif /* __KERNEL__ */
 
 	if (m0c->m0c_config->mc_is_addb_init) {
 		m0_addb2_force_all();

--- a/motr/idx.c
+++ b/motr/idx.c
@@ -113,9 +113,7 @@ static int idx_op_init(struct m0_idx *idx, int opcode,
 	struct m0_op_idx    *oi;
 	struct m0_entity    *entity;
 	struct m0_locality  *locality;
-#if defined(DTM0)
 	struct m0_client    *m0c;
-#endif
 	uint64_t cid;
 	uint64_t did;
 
@@ -126,6 +124,7 @@ static int idx_op_init(struct m0_idx *idx, int opcode,
 
 	/* Initialise the operation's generic part. */
 	entity = &idx->in_entity;
+	m0c = entity->en_realm->re_instance;
 	op->op_code = opcode;
 	rc = m0_op_init(op, &m0_op_conf, entity);
 	if (rc != 0)
@@ -157,9 +156,7 @@ static int idx_op_init(struct m0_idx *idx, int opcode,
 	m0_op_idx_bob_init(oi);
 	m0_ast_rc_bob_init(&oi->oi_ar);
 
-#if defined(DTM0)
-	if (M0_IN(op->op_code, (M0_IC_PUT, M0_IC_DEL))) {
-		m0c = entity->en_realm->re_instance;
+	if (ENABLE_DTM0 && M0_IN(op->op_code, (M0_IC_PUT, M0_IC_DEL))) {
 		M0_ASSERT(m0c->m0c_dtms != NULL);
 		oi->oi_dtx = m0_dtx0_alloc(m0c->m0c_dtms, oi->oi_sm_grp);
 		if (oi->oi_dtx == NULL)
@@ -167,10 +164,8 @@ static int idx_op_init(struct m0_idx *idx, int opcode,
 		did = m0_sm_id_get(&oi->oi_dtx->tx_dtx->dd_sm);
 		cid = m0_sm_id_get(&op->op_sm);
 		M0_ADDB2_ADD(M0_AVI_CLIENT_TO_DIX, cid, did);
-	}
-#else
-	oi->oi_dtx = NULL;
-#endif
+	} else
+		oi->oi_dtx = NULL;
 
 	return M0_RC(0);
 }


### PR DESCRIPTION
The patch renames the DTM0 configure flag
into ENABLE_DTM0, sets this flag to zero when
"enable-dtm0" was not defined at the configure
step, and, finally, this patch converts
the DTM0-related pre-processor conditions into
runtime (rt in the title) conditions.