### PR TITLE
EOS-14402: BE log header doesn't always point to a valid log record

### DIFF
--- a/be/engine.c
+++ b/be/engine.c
@@ -814,6 +814,10 @@ M0_INTERNAL int m0_be_engine_start(struct m0_be_engine *en)
 	if (rc != 0)
 		return M0_ERR(rc);
 
+	rc = be_log_header_inc_generation(&(en->eng_log), &(en->eng_log.lg_header));
+	if (rc != 0)
+		return M0_ERR(rc);
+
 	recovery_time = m0_time_now();
 	be_engine_try_recovery(en);
 

--- a/be/fmt.h
+++ b/be/fmt.h
@@ -200,7 +200,7 @@ struct m0_be_fmt_log_store_header {
 struct m0_be_fmt_group_cfg;
 
 struct m0_be_fmt_log_header {
-	uint64_t    flh_serial;
+	uint64_t    flh_serial_num;
 	m0_bindex_t flh_discarded;
 	m0_bindex_t flh_group_lsn;
 	m0_bcount_t flh_group_size;
@@ -208,7 +208,7 @@ struct m0_be_fmt_log_header {
 
 #define BFLH_F "(flh_serial=%"PRIu64" flh_discarded=%"PRIu64" " \
 		"flh_group_lsn=%"PRIu64" flh_group_size=%"PRIu64")"
-#define BFLH_P(log_hdr) (log_hdr)->flh_serial, (log_hdr)->flh_discarded, \
+#define BFLH_P(log_hdr) (log_hdr)->flh_serial_num, (log_hdr)->flh_discarded, \
 			(log_hdr)->flh_group_lsn, (log_hdr)->flh_group_size
 
 struct m0_be_fmt_group {
@@ -262,6 +262,7 @@ struct m0_be_fmt_log_record_header {
 	m0_bindex_t                            lrh_prev_pos;
 	m0_bindex_t                            lrh_prev_size;
 	uint64_t                               lrh_io_nr_max;
+	uint64_t			       lrh_serial_num;
 	struct m0_be_fmt_log_record_header_io_size lrh_io_size;
 } M0_XCA_RECORD M0_XCA_DOMAIN(be);
 

--- a/be/log.h
+++ b/be/log.h
@@ -465,7 +465,8 @@ M0_INTERNAL uint32_t m0_be_log_bshift(struct m0_be_log *log);
 M0_INTERNAL void m0_be_log_header__set(struct m0_be_fmt_log_header *hdr,
 				       m0_bindex_t                  discarded,
 				       m0_bindex_t                  lsn,
-				       m0_bcount_t                  size);
+				       m0_bcount_t                  size,
+				       uint64_t                     serial_num);
 M0_INTERNAL bool m0_be_log_header__is_eq(struct m0_be_fmt_log_header *hdr1,
 					 struct m0_be_fmt_log_header *hdr2);
 M0_INTERNAL bool m0_be_log_header__repair(struct m0_be_fmt_log_header **hdrs,
@@ -510,6 +511,9 @@ m0_be_log_recovery_discarded(struct m0_be_log *log);
 
 M0_INTERNAL bool m0_be_log_contains_stob(struct m0_be_log        *log,
                                          const struct m0_stob_id *stob_id);
+
+M0_INTERNAL int be_log_header_inc_generation(struct m0_be_log            *log,
+					     struct m0_be_fmt_log_header *log_hdr);
 /** @} end of be group */
 
 #endif /* __MOTR_BE_LOG_H__ */


### PR DESCRIPTION
Problem:
If log IO fails just after the log header is updated just before log record overwrites
old record the header was pointing for, then the log header may point to a garbage
instead of pointing to a valid log record. When the engine starts again
recovery won't happen properly.

Soution
1. Add a counter to log header and record header structure.
2. Intiate log header counter to 0 when log is created.
3. Populate the record header counter with log header counter
at the time of record write.
4. Check the record header counter and log header counter at the
time of creating a list of records for recovery. If they do not match
than skip the record and further records.
5. Increment the log header counter at the time of be_engine start, after
recovery completes.

Testing
All UT tests passed.

Signed-off-by: Shipra Gupta <shipra.gupta@seagate.com>