### PR TITLE
utils: enable kernel module tracing

### DIFF
--- a/utils/linux_kernel/core_debugfs.c
+++ b/utils/linux_kernel/core_debugfs.c
@@ -19,8 +19,6 @@
  *
  */
 
-#if 0
-
 #include <linux/kernel.h>    /* pr_info */
 #include <linux/debugfs.h>   /* debugfs_create_dir */
 #include <linux/module.h>    /* THIS_MODULE */
@@ -97,7 +95,6 @@ void core_dfs_cleanup(void)
 }
 
 /** @} end of m0ctl group */
-#endif
 
 /*
  *  Local variables:

--- a/utils/linux_kernel/m0ctl_main.c
+++ b/utils/linux_kernel/m0ctl_main.c
@@ -2,17 +2,18 @@
 /*
  * Copyright (c) 2011-2020 Seagate Technology LLC and/or its Affiliates
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * For any questions about this software or licensing,
  * please email opensource@seagate.com or cortx-questions@seagate.com.
@@ -45,7 +46,6 @@
  * into a separate *.c file. @see finject_debugfs.c for example.
  */
 
-#if 0
 struct dentry  *dfs_root_dir;
 const char      dfs_root_name[] = "motr";
 
@@ -112,19 +112,10 @@ void __exit m0ctl_exit(void)
 	dfs_cleanup();
 }
 
-#endif
-
-int __init m0ctl_init(void)
-{
-        return 0;
-}
-
-void __exit m0ctl_exit(void)
-{
-}
-
 module_init(m0ctl_init);
 module_exit(m0ctl_exit);
+
+MODULE_LICENSE("GPL");
 
 /*
  *  Local variables:

--- a/utils/linux_kernel/trace_debugfs.c
+++ b/utils/linux_kernel/trace_debugfs.c
@@ -19,8 +19,6 @@
  *
  */
 
-#if 0
-
 #include <linux/kernel.h>    /* pr_info */
 #include <linux/debugfs.h>   /* debugfs_create_dir */
 #include <linux/module.h>    /* THIS_MODULE */
@@ -597,7 +595,7 @@ static void trc_buffer_mmap_close(struct vm_area_struct *vma)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)
-static int trc_buffer_mmap_fault(struct vm_fault *vmf)
+static vm_fault_t trc_buffer_mmap_fault(struct vm_fault *vmf)
 #else
 static int trc_buffer_mmap_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #endif
@@ -782,7 +780,6 @@ void trc_dfs_cleanup(void)
 {
 	debugfs_remove_recursive(trc_dir);
 }
-#endif
 
 /** @} end of m0ctl group */
 


### PR DESCRIPTION
Previously, it was disabled due to licensing issues in
m0ctl.ko which uses GPL-exported kernel function(s).
But GPLv3-licensed projects do allow to use Apache 2.0 code
in them. (See more at
https://www.apache.org/licenses/GPL-compatibility.html)
So we can make m0ctl.ko module GPLv3 and still keep all the
rest code under Apache 2.0. Including m0tr.ko, which does
not use any code from m0ctl.ko.

Solution: make m0ctl.ko GPLv3 and enable its code which
allows to use m0trace with m0tr.ko.