### PR TITLE
EOS-18854 sns/parity_math: implement incremental recovery using ISAL

### DIFF
--- a/m0t1fs/linux_kernel/file.c
+++ b/m0t1fs/linux_kernel/file.c
@@ -3045,7 +3045,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioreq),
@@ -3053,7 +3053,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	/* Populates data and failed buffers. */
 	for (row = 0; row < data_row_nr(play); ++row) {
 		for (col = 0; col < data_col_nr(play); ++col) {
@@ -3075,11 +3075,11 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 				       parity, &failed, M0_LA_INVERSE);
 	}
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioreq));
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -1933,7 +1933,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioo),
@@ -1941,7 +1941,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 	/* Populates data and failed buffers. */
 	for (row = 0; row < data_row_nr(play, ioo->ioo_obj); ++row) {
@@ -1967,11 +1967,11 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 				       parity, &failed, M0_LA_INVERSE);
 	}
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioo));
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/sns/parity_defs.h
+++ b/sns/parity_defs.h
@@ -27,8 +27,7 @@
 /**
  *  Define the condition here to use Intel ISA library.
  */
-#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__))
-#define RS_ENCODE_ENABLED	(!ISAL_ENCODE_ENABLED)
+#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__) && defined(HAVE_ISAL))
 
 /* __MOTR_SNS_PARITY_DEFS_H__ */
 #endif

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -99,22 +99,22 @@ static void isal_recover(struct m0_parity_math *math,
 #if ISAL_ENCODE_ENABLED
 /**
  * This is wrapper function for Intel ISA API ec_encode_data_update().
- * @param[out] dest_buf - Array of pointers to coded output buffers
- * @param[in]  src_buf  - Pointer to single input source used to update output
- *                        parity.
+ * @param[out] dest_buf - Array of coded output buffers i.e. struct m0_buf
+ * @param[in]  src_buf  - Pointer to single input source (struct m0_buf) used to
+ *                        update output parity.
  * @param[in]  vec_idx  - The vector index corresponding to the single
  *                        input source.
  * @param[in]  g_tbls   - Pointer to array of input tables generated from
  *                        coding coefficients in ec_init_tables().
- *                        Must be of size 32*src_nr*dest_nr
- * @param[in]  src_nr   - The number of vector sources for coding.
- * @param[in]  dest_nr  - The number of output vectors to concurrently
+ *                        Must be of size 32*data_nr*dest_nr
+ * @param[in]  data_nr  - The number of data blocks for coding.
+ * @param[in]  dest_nr  - The number of output blocks to concurrently
  *                        encode/decode.
  * @retval     0        - success otherwise failure
  */
 static int isal_encode_data_update(struct m0_buf *dest_buf, struct m0_buf *src_buf,
 				   uint32_t vec_idx, uint8_t *g_tbls,
-				   uint32_t src_nr, uint32_t dest_nr);
+				   uint32_t data_nr, uint32_t dest_nr);
 #endif /* ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
@@ -535,15 +535,15 @@ static bool parity_math_invariant(const struct m0_parity_math *math)
 #if ISAL_ENCODE_ENABLED
 static int isal_encode_data_update(struct m0_buf *dest_buf, struct m0_buf *src_buf,
 				   uint32_t vec_idx, uint8_t *g_tbls,
-				   uint32_t src_nr, uint32_t dest_nr)
+				   uint32_t data_nr, uint32_t dest_nr)
 {
 	uint32_t i;
 	uint32_t block_size;
 	int	 ret = 0;
 
 	M0_ENTRY("dest_buf=%p, src_buf=%p, vec_idx=%u, "
-		 "g_tbls=%p, src_nr=%u, dest_nr=%u",
-		 dest_buf, src_buf, vec_idx, g_tbls, src_nr, dest_nr);
+		 "g_tbls=%p, data_nr=%u, dest_nr=%u",
+		 dest_buf, src_buf, vec_idx, g_tbls, data_nr, dest_nr);
 
 	M0_PRE(dest_buf != NULL);
 	M0_PRE(src_buf != NULL);
@@ -565,7 +565,7 @@ static int isal_encode_data_update(struct m0_buf *dest_buf, struct m0_buf *src_b
 		dest_frags[i] = (uint8_t *)dest_buf[i].b_addr;
 	}
 
-	ec_encode_data_update(block_size, src_nr, dest_nr, vec_idx,
+	ec_encode_data_update(block_size, data_nr, dest_nr, vec_idx,
 			      g_tbls, (uint8_t *)src_buf->b_addr, dest_frags);
 
 	return M0_RC(ret);

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -45,8 +45,6 @@ enum {
 		(ret) = M0_RC_INFO(0, "allocated memory for " msg);		\
 })
 
-#define MIN(_x, _y) ((_x) < (_y) ? (_x) : (_y))
-
 /* Forward declarations */
 static void xor_calculate(struct m0_parity_math *math,
                           const struct m0_buf *data,
@@ -186,25 +184,25 @@ static bool fails_sort(uint8_t *fail, uint32_t unit_count,
 		       struct m0_buf *failed_idx, struct m0_buf *alive_idx);
 #endif /* ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static void reed_solomon_recover(struct m0_parity_math *math,
                                  struct m0_buf *data,
                                  struct m0_buf *parity,
                                  struct m0_buf *fails,
 				 enum m0_parity_linsys_algo algo);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static void fail_idx_xor_recover(struct m0_parity_math *math,
 				 struct m0_buf *data,
 				 struct m0_buf *parity,
 				 const uint32_t failure_index);
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
 					  struct m0_buf *data,
 					  struct m0_buf *parity,
 					  const uint32_t failure_index);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
 static void fail_idx_isal_recover(struct m0_parity_math *math,
@@ -222,7 +220,7 @@ static void fail_idx_isal_recover(struct m0_parity_math *math,
 static int ir_gen_decode_matrix(struct m0_sns_ir *ir);
 #endif /* ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 /**
  * Inverts the encoding matrix and generates a recovery matrix for lost data.
  * When all failed blocks are parity blocks this function plays no role.
@@ -239,7 +237,7 @@ static void submatrix_construct(struct m0_matrix *in_mat,
 				struct m0_sns_ir_block *blocks,
 				enum m0_sns_ir_block_status status,
 				struct m0_matrix *out_mat);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 /**
  * Recovery of each failed block depends upon subset of alive blocks.
@@ -295,7 +293,7 @@ static void buf2bufvec(struct m0_bufvec *bvec, const struct m0_buf *buf);
 static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block);
 #endif /* ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static inline uint32_t recov_mat_col(const struct m0_sns_ir_block *alive_block,
 				     const struct m0_sns_ir_block *failed_block,
 				     const struct m0_sns_ir *ir);
@@ -313,7 +311,7 @@ static void dependency_bitmap_update(struct m0_sns_ir_block *f_block,
 static void incr_recover(struct m0_sns_ir_block *failed_block,
 			 const struct m0_sns_ir_block *available_block,
 			 struct m0_sns_ir *ir);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 /**
  * Constant times x plus y, over galois field. Naming convention for this
@@ -322,7 +320,7 @@ static void incr_recover(struct m0_sns_ir_block *failed_block,
 static void gfaxpy(struct m0_bufvec *y, struct m0_bufvec *x,
 		   m0_parity_elem_t alpha);
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 /**
  * Adds correction for a remote block that is received before all blocks
  * local to a node are transformed. This correction is needed only when
@@ -337,13 +335,13 @@ static void forward_rectification(struct m0_sns_ir *ir,
  * for computing failed parity.
  */
 static void failed_data_blocks_xform(struct m0_sns_ir *ir);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 static inline bool is_valid_block_idx(const  struct m0_sns_ir *ir,
 				      uint32_t block_idx);
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static bool is_data(const struct m0_sns_ir *ir, uint32_t index);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static bool is_usable(const struct m0_sns_ir *ir,
 		      const struct m0_bitmap *in_bmap,
@@ -352,13 +350,13 @@ static bool is_usable(const struct m0_sns_ir *ir,
 static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 				     uint32_t block_idx);
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static inline  bool are_failures_mixed(const struct m0_sns_ir *ir);
 
 static inline const struct m0_matrix* recovery_mat_get(const struct m0_sns_ir
 						       *ir,
 						       uint32_t failed_idx);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static inline uint32_t ir_blocks_count(const struct m0_sns_ir *ir);
 
@@ -440,19 +438,19 @@ static int gadd(int x, int y)
 	return m0_parity_add(x, y);
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static int gsub(int x, int y)
 {
 	return m0_parity_sub(x, y);
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static int gmul(int x, int y)
 {
 	return m0_parity_mul(x, y);
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static int gdiv(int x, int y)
 {
 	return m0_parity_div(x, y);
@@ -522,7 +520,7 @@ static int vandmat_norm(struct m0_matrix *m)
 
 	return 0;
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
 static bool parity_math_invariant(const struct m0_parity_math *math)
@@ -788,7 +786,7 @@ fini:
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static void reed_solomon_diff(struct m0_parity_math *math,
 			      struct m0_buf         *old,
 			      struct m0_buf         *new,
@@ -821,7 +819,7 @@ static void reed_solomon_diff(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* ISAL_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static void xor_diff(struct m0_parity_math *math,
 		     struct m0_buf         *old,
@@ -846,7 +844,7 @@ static void xor_diff(struct m0_parity_math *math,
 	}
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static void reed_solomon_encode(struct m0_parity_math *math,
 				const struct m0_buf *data,
 				struct m0_buf *parity)
@@ -903,7 +901,7 @@ static void reed_solomon_encode(struct m0_parity_math *math,
 
 #undef PARITY_MATH_REGION_ENABLE
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
 static void isal_encode(struct m0_parity_math *math,
@@ -1000,7 +998,7 @@ static uint32_t fails_count(uint8_t *fail, uint32_t unit_count)
 	return count;
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 /* Fills 'mat' and 'vec' with data passed to recovery algorithm. */
 static void recovery_vec_fill(struct m0_parity_math *math,
 			       uint8_t *fail, uint32_t unit_count, /* in. */
@@ -1024,9 +1022,9 @@ static void recovery_vec_fill(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 /* Fills 'mat' with data passed to recovery algorithm. */
 static void recovery_mat_fill(struct m0_parity_math *math,
 			      uint8_t *fail, uint32_t unit_count, /* in. */
@@ -1046,9 +1044,9 @@ static void recovery_mat_fill(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 /* Updates internal structures of 'math' with recovered data. */
 static void parity_math_recover(struct m0_parity_math *math,
 				uint8_t *fail, uint32_t unit_count,
@@ -1073,9 +1071,9 @@ static void parity_math_recover(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 					uint8_t *fail)
 {
@@ -1089,14 +1087,14 @@ M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 
 	return rc == 0 ? M0_RC(0) : M0_ERR(rc);
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math)
 {
 	m0_matrix_fini(&math->pmi_recov_mat);
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static void xor_recover(struct m0_parity_math *math,
 			struct m0_buf *data,
@@ -1424,7 +1422,7 @@ fini:
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static void reed_solomon_recover(struct m0_parity_math *math,
 				 struct m0_buf *data,
 				 struct m0_buf *parity,
@@ -1473,7 +1471,7 @@ static void reed_solomon_recover(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 M0_INTERNAL void m0_parity_math_recover(struct m0_parity_math *math,
 					struct m0_buf *data,
@@ -1521,7 +1519,7 @@ static void fail_idx_xor_recover(struct m0_parity_math *math,
 
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 /** @todo Iterative reed-solomon decode to be implemented. */
 static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
 					  struct m0_buf *data,
@@ -1529,7 +1527,7 @@ static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
 					  const uint32_t failure_index)
 {
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
 static void fail_idx_isal_recover(struct m0_parity_math *math,
@@ -1614,11 +1612,11 @@ M0_INTERNAL int m0_sns_ir_init(const struct m0_parity_math *math,
 	ir->si_data_nr		   = math->pmi_data_count;
 	ir->si_parity_nr	   = math->pmi_parity_count;
 	ir->si_local_nr		   = local_nr;
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	ir->si_vandmat		   = math->pmi_vandmat;
 	ir->si_parity_recovery_mat = math->pmi_vandmat_parity_slice;
 	ir->si_failed_data_nr	   = 0;
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	ir->si_alive_nr		   = ir_blocks_count(ir);
 
 #if ISAL_ENCODE_ENABLED
@@ -1643,9 +1641,9 @@ M0_INTERNAL int m0_sns_ir_init(const struct m0_parity_math *math,
 	for (i = 0; i < ir_blocks_count(ir); ++i) {
 		ir->si_blocks[i].sib_idx = i;
 		ir->si_blocks[i].sib_status = M0_SI_BLOCK_ALIVE;
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 		ir->si_blocks[i].sib_data_recov_mat_col = IR_INVALID_COL;
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 		ret = m0_bitmap_init(&ir->si_blocks[i].sib_bitmap,
 				     ir_blocks_count(ir));
 		if (ret != 0){
@@ -1709,7 +1707,7 @@ M0_INTERNAL int m0_sns_ir_mat_compute(struct m0_sns_ir *ir)
 	blocks = ir->si_blocks;
 	total_blocks_nr = ir_blocks_count(ir);
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	if (ir->si_failed_data_nr != 0) {
 		for (j = 0, i = 0; j < total_blocks_nr && i < ir->si_data_nr;
 		     ++j) {
@@ -1743,7 +1741,7 @@ M0_INTERNAL int m0_sns_ir_mat_compute(struct m0_sns_ir *ir)
 	for (i = 0; i < ir->si_failed_nr; i++) {
 		dependency_bitmap_prepare(&blocks[ir->si_failed_idx[i]], ir);
 	}
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	return M0_RC(ret);
 }
 
@@ -1776,7 +1774,7 @@ static int ir_gen_decode_matrix(struct m0_sns_ir *ir)
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static int data_recov_mat_construct(struct m0_sns_ir *ir)
 {
 	int		 ret = 0;
@@ -1836,14 +1834,14 @@ static void submatrix_construct(struct m0_matrix *in_mat,
 		}
 	}
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static void dependency_bitmap_prepare(struct m0_sns_ir_block *f_block,
 				      struct m0_sns_ir *ir)
 {
 	uint32_t i;
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	M0_PRE(f_block != NULL && ir != NULL);
 	M0_PRE(f_block->sib_status == M0_SI_BLOCK_FAILED);
 
@@ -1868,7 +1866,7 @@ static void dependency_bitmap_prepare(struct m0_sns_ir_block *f_block,
 #endif /* ISAL_ENCODE_ENABLED */
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static inline uint32_t recov_mat_col(const struct m0_sns_ir_block *alive_block,
 				     const struct m0_sns_ir_block *failed_block,
 				     const struct m0_sns_ir *ir)
@@ -1878,7 +1876,7 @@ static inline uint32_t recov_mat_col(const struct m0_sns_ir_block *alive_block,
 	return is_data(ir, failed_block->sib_idx) ?
 		alive_block->sib_data_recov_mat_col : alive_block->sib_idx;
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 M0_INTERNAL void m0_sns_ir_fini(struct m0_sns_ir *ir)
 {
@@ -1892,7 +1890,7 @@ M0_INTERNAL void m0_sns_ir_fini(struct m0_sns_ir *ir)
 			m0_bitmap_fini(&ir->si_blocks[j].sib_bitmap);
 	}
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	m0_matrix_fini(&ir->si_data_recovery_mat);
 #else /* ISAL_ENCODE_ENABLED */
 	isal_ir_fini(ir);
@@ -1939,7 +1937,7 @@ static void bufvec2buf(struct m0_buf *buf, const struct m0_bufvec *bvec)
 		seg_size = bvec->ov_vec.v_count[i++];
 
 		/* Get minimum bytes to copy */
-		copy_bytes = MIN(free_bytes, seg_size);
+		copy_bytes = min_check(free_bytes, seg_size);
 
 		memcpy(&buf_data[idx],
 		       m0_bufvec_cursor_addr(&cursor),
@@ -1991,7 +1989,7 @@ static void buf2bufvec(struct m0_bufvec *bvec, const struct m0_buf *buf)
 		seg_size = bvec->ov_vec.v_count[i++];
 
 		/* Get minimum bytes to copy */
-		copy_bytes = MIN(free_bytes, seg_size);
+		copy_bytes = min_check(free_bytes, seg_size);
 
 		memcpy(m0_bufvec_cursor_addr(&cursor),
 		       &buf_data[idx],
@@ -2096,9 +2094,9 @@ M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
 				   uint32_t failed_index,
 				   enum m0_sns_ir_block_type block_type)
 {
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	uint32_t		j;
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	size_t			block_idx = 0;
 	size_t		        b_set_nr;
 	struct m0_sns_ir_block *blocks;
@@ -2158,20 +2156,20 @@ M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
 			break;
 		gfaxpy(blocks[failed_index].sib_addr, bufvec,
 		       1);
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 		dependency_bitmap_update(&blocks[failed_index],
 					 bitmap);
 		if (is_data(ir, failed_index) && are_failures_mixed(ir) &&
 		    ir->si_local_nr != 0)
 			forward_rectification(ir, bufvec, failed_index);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 		break;
 	}
 
 	M0_LEAVE();
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static void incr_recover(struct m0_sns_ir_block *failed_block,
 			 const struct m0_sns_ir_block *alive_block,
 			 struct m0_sns_ir *ir)
@@ -2196,7 +2194,7 @@ static void incr_recover(struct m0_sns_ir_block *failed_block,
 		       mat_elem);
 	}
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static void gfaxpy(struct m0_bufvec *y, struct m0_bufvec *x,
 		   m0_parity_elem_t alpha)
@@ -2248,7 +2246,7 @@ static void gfaxpy(struct m0_bufvec *y, struct m0_bufvec *x,
 	M0_LEAVE();
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static void dependency_bitmap_update(struct m0_sns_ir_block *block,
 				     const struct m0_bitmap *bitmap)
 {
@@ -2312,7 +2310,7 @@ static void failed_data_blocks_xform(struct m0_sns_ir *ir)
 			}
 	}
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static inline bool is_valid_block_idx(const struct m0_sns_ir *ir,
 				      uint32_t block_idx)
@@ -2320,13 +2318,13 @@ static inline bool is_valid_block_idx(const struct m0_sns_ir *ir,
 	return block_idx < ir_blocks_count(ir);
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static bool is_data(const struct m0_sns_ir *ir, uint32_t index)
 {
 	M0_PRE(is_valid_block_idx(ir, index));
 	return index < ir->si_data_nr;
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static bool is_usable(const struct m0_sns_ir *ir,
 		      const struct m0_bitmap *in_bmap,
@@ -2352,7 +2350,7 @@ static bool is_usable(const struct m0_sns_ir *ir,
 static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 				     uint32_t block_idx)
 {
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	uint32_t i;
 	uint32_t last_usable_bid = ir_blocks_count(ir);
 
@@ -2370,10 +2368,10 @@ static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 	return last_usable_bid;
 #else
 	return ir->si_alive_idx[ir->si_data_nr - 1];
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 }
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 static inline const struct m0_matrix* recovery_mat_get(const struct m0_sns_ir
 						       *ir, uint32_t failed_idx)
 {
@@ -2386,7 +2384,7 @@ static inline  bool are_failures_mixed(const struct m0_sns_ir *ir)
 	return !!ir->si_failed_data_nr &&
 		ir_blocks_count(ir) != ir->si_failed_data_nr + ir->si_alive_nr;
 }
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 static inline uint32_t ir_blocks_count(const struct m0_sns_ir *ir)
 {

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -86,7 +86,7 @@ struct m0_sns_ir_block {
 	 * blocks required for its recovery.
 	 */
 	struct m0_bitmap	     sib_bitmap;
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	/* Column associated with the block within
 	 * m0_parity_math::pmi_data_recovery_mat. This field is meaningful
 	 * when status of a block is M0_SI_BLOCK_ALIVE.
@@ -96,7 +96,7 @@ struct m0_sns_ir_block {
 	 * The field is meaningful when status of a block is M0_SI_BLOCK_FAILED.
 	 */
 	uint32_t		     sib_recov_mat_row;
-#endif
+#endif /* !ISAL_ENCODE_ENABLED */
 	/* Indicates whether a block is available, failed or restored. */
 	enum m0_sns_ir_block_status  sib_status;
 };
@@ -110,22 +110,22 @@ struct m0_parity_math {
 
 	uint32_t		pmi_data_count;
 	uint32_t		pmi_parity_count;
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	/* structures used for parity calculation and recovery */
 	struct m0_matvec	pmi_data;
 	struct m0_matvec	pmi_parity;
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	/* Vandermonde matrix */
 	struct m0_matrix	pmi_vandmat;
 	/* Submatrix of Vandermonde matrix used to compute parity. */
 	struct m0_matrix	pmi_vandmat_parity_slice;
 	/* structures used for non-incremental recovery */
 	struct m0_matrix	pmi_sys_mat;
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	struct m0_matvec	pmi_sys_vec;
 	struct m0_matvec	pmi_sys_res;
 	struct m0_linsys	pmi_sys;
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	/* Data recovery matrix that's inverse of pmi_sys_mat. */
 	struct m0_matrix	pmi_recov_mat;
 #if ISAL_ENCODE_ENABLED
@@ -143,9 +143,9 @@ struct m0_parity_math {
 struct m0_sns_ir {
 	uint32_t		si_data_nr;
 	uint32_t		si_parity_nr;
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	uint32_t		si_failed_data_nr;
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	uint32_t		si_alive_nr;
 	/* Number of blocks from a parity group that are available locally
 	 * on a node. */
@@ -153,11 +153,11 @@ struct m0_sns_ir {
 	/* Array holding all blocks */
 	struct m0_sns_ir_block *si_blocks;
 	/* Vandermonde matrix used during RS encoding */
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	struct m0_matrix	si_vandmat;
 	/* Recovery matrix for failed data blocks */
 	struct m0_matrix	si_data_recovery_mat;
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	/* Recovery matrix for failed parity blocks. This is same as
 	 * math::pmi_vandmat_parity_slice.
 	 */
@@ -233,13 +233,13 @@ M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
 				       struct m0_buf *parity,
 				       uint32_t data_ind_changed);
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 					uint8_t *fail);
 
 
 M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 /**
  * Recovers data units' data words from single or multiple errors.

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -86,6 +86,7 @@ struct m0_sns_ir_block {
 	 * blocks required for its recovery.
 	 */
 	struct m0_bitmap	     sib_bitmap;
+#if RS_ENCODE_ENABLED
 	/* Column associated with the block within
 	 * m0_parity_math::pmi_data_recovery_mat. This field is meaningful
 	 * when status of a block is M0_SI_BLOCK_ALIVE.
@@ -95,6 +96,7 @@ struct m0_sns_ir_block {
 	 * The field is meaningful when status of a block is M0_SI_BLOCK_FAILED.
 	 */
 	uint32_t		     sib_recov_mat_row;
+#endif
 	/* Indicates whether a block is available, failed or restored. */
 	enum m0_sns_ir_block_status  sib_status;
 };
@@ -141,7 +143,9 @@ struct m0_parity_math {
 struct m0_sns_ir {
 	uint32_t		si_data_nr;
 	uint32_t		si_parity_nr;
+#if RS_ENCODE_ENABLED
 	uint32_t		si_failed_data_nr;
+#endif /* RS_ENCODE_ENABLED */
 	uint32_t		si_alive_nr;
 	/* Number of blocks from a parity group that are available locally
 	 * on a node. */
@@ -149,9 +153,11 @@ struct m0_sns_ir {
 	/* Array holding all blocks */
 	struct m0_sns_ir_block *si_blocks;
 	/* Vandermonde matrix used during RS encoding */
+#if RS_ENCODE_ENABLED
 	struct m0_matrix	si_vandmat;
 	/* Recovery matrix for failed data blocks */
 	struct m0_matrix	si_data_recovery_mat;
+#endif /* RS_ENCODE_ENABLED */
 	/* Recovery matrix for failed parity blocks. This is same as
 	 * math::pmi_vandmat_parity_slice.
 	 */

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -220,12 +220,13 @@ M0_INTERNAL void m0_parity_math_diff(struct m0_parity_math *math,
 				     struct m0_buf *parity, uint32_t index);
 
 /**
-   Parity block refinement iff one data word of one data unit had changed.
-   @param data[in] - data block, treated as uint8_t block with b_nob elements.
-   @param parity[out] - parity block, treated as uint8_t block with
-                        b_nob elements.
-   @param data_ind_changed[in] - index of data unit recently changed.
-   @pre m0_parity_math_init() succeeded.
+ * Parity block refinement iff one data word of one data unit had changed.
+ * @param[in]  data             - data block, treated as uint8_t block with
+ *                                b_nob elements.
+ * @param[out] parity           - parity block, treated as uint8_t block with
+ *                                b_nob elements.
+ * @param[in]  data_ind_changed - index of data unit recently changed.
+ * @pre m0_parity_math_init() succeeded.
  */
 M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
 				       struct m0_buf *data,
@@ -241,19 +242,19 @@ M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math);
 #endif /* RS_ENCODE_ENABLED */
 
 /**
-   Recovers data units' data words from single or multiple errors.
-   If parity also needs to be recovered, user of the function needs
-   to place a separate call for m0_parity_math_calculate().
-   @param data[inout] - data block, treated as uint8_t block with
-			b_nob elements.
-   @param parity[inout] - parity block, treated as uint8_t block with
-                          b_nob elements.
-   @param fail[in] - block with flags, treated as uint8_t block with
-                     b_nob elements, if element is '1' then data or parity
-                     block with given index is treated as broken.
-   @param algo[in] - algorithm for recovery of data in case reed solomon
-                     encoding is used.
-   @pre m0_parity_math_init() succeded.
+ * Recovers data units' data words from single or multiple errors.
+ * If parity also needs to be recovered, user of the function needs
+ * to place a separate call for m0_parity_math_calculate().
+ * @param[in,out] data   - data block, treated as uint8_t block with
+ *                         b_nob elements.
+ * @param[in,out] parity - parity block, treated as uint8_t block with
+ *                         b_nob elements.
+ * @param[in]     fail   - block with flags, treated as uint8_t block with
+ *                         b_nob elements, if element is '1' then data or
+ *                         parityblock with given index is treated as broken.
+ * @param[in]     algo   - algorithm for recovery of data in case reed solomon
+ *                         encoding is used.
+ * @pre m0_parity_math_init() succeded.
  */
 M0_INTERNAL void m0_parity_math_recover(struct m0_parity_math *math,
 					struct m0_buf *data,

--- a/sns/parity_ops.c
+++ b/sns/parity_ops.c
@@ -29,17 +29,17 @@
 
 M0_INTERNAL void m0_parity_fini(void)
 {
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	galois_calc_tables_release();
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 }
 
 M0_INTERNAL int m0_parity_init(void)
 {
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	int ret = galois_create_mult_tables(M0_PARITY_GALOIS_W);
 	M0_ASSERT(ret == 0);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	return 0;
 }
 

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -717,7 +717,7 @@ static void direct_recover(struct m0_parity_math *math,  struct m0_bufvec *x,
 	ret = m0_sns_ir_mat_compute(&ir);
 	M0_UT_ASSERT(ret == 0);
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	M0_UT_ASSERT(ergo(ir.si_failed_data_nr != 0,
 			  ir.si_data_recovery_mat.m_width ==
 			  ir.si_data_nr));
@@ -725,7 +725,7 @@ static void direct_recover(struct m0_parity_math *math,  struct m0_bufvec *x,
 	ret = m0_matvec_init(&r, ir.si_failed_data_nr);
 #else
 	ret = m0_matvec_init(&r, ir.si_failed_nr);
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	M0_UT_ASSERT(ret == 0);
 
 	reconstruct(&ir, &b, &r);
@@ -842,7 +842,7 @@ static bool compare(const struct m0_sns_ir *ir, const uint32_t *failed_arr,
 	uint32_t i;
 	uint32_t j;
 
-#if RS_ENCODE_ENABLED
+#if !ISAL_ENCODE_ENABLED
 	for (i = 0, j = 0; j < ir->si_failed_data_nr && i <
 	     ir->si_data_nr; ++i) {
 		if (failed_arr[j] == i) {
@@ -860,7 +860,7 @@ static bool compare(const struct m0_sns_ir *ir, const uint32_t *failed_arr,
 				(((uint8_t **)x[i].ov_buf)[0])[0])
 				return false;
 	}
-#endif /* RS_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 
 	return true;
 }


### PR DESCRIPTION
- Updated functions m0_sns_ir_mat_compute() and m0_sns_ir_recover().
- Added new recover function for incremental recovery using Intel ISA.
- Updated unit test for direct_recover().
- Updated few more functions to log return value.
- Updated year in Copyright notice.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>