### PR TITLE
Fix minor typo in text: motr -> Motr

### DIFF
--- a/doc/reading-list.md
+++ b/doc/reading-list.md
@@ -14,7 +14,7 @@ For non-hyperlinked documentation links, please refer to this file : [doc/motr-d
 
 Motr Clients
 ------------
-[Client API](../motr/client.h) is the direct interface to motr; our [developer guide](motr-developer-guide.md) shows how to build client applications using this API.  [m0cp](../motr/st/utils/copy.c), [m0cat](../motr/st/utils/cat.c), and [m0kv](../motr/m0kv) are example applications using this API.  In our CORTX parent repo, the [Cluster Setup guide](https://github.com/Seagate/cortx/blob/main/doc/Cluster_Setup.md) has useful information about using these tools.
+[Client API](../motr/client.h) is the direct interface to Motr; our [developer guide](motr-developer-guide.md) shows how to build client applications using this API.  [m0cp](../motr/st/utils/copy.c), [m0cat](../motr/st/utils/cat.c), and [m0kv](../motr/m0kv) are example applications using this API.  In our CORTX parent repo, the [Cluster Setup guide](https://github.com/Seagate/cortx/blob/main/doc/Cluster_Setup.md) has useful information about using these tools.
 
 [Go bindings](../bindings/go) allow to write Motr client applications in Go language quickly and efficiently.
 


### PR DESCRIPTION
"Motr" should start with a capital letter in texts.

-----
[View rendered doc/reading-list.md](https://github.com/Seagate/cortx-motr/blob/andriytk-patch-1/doc/reading-list.md)