### PR TITLE
[DTM0] Fix use-after-free in STABLE.

### DIFF
--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -791,8 +791,8 @@ static void dixreq_stable_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	M0_ENTRY();
 	oi->oi_ar.ar_ast.sa_cb = (rc == 0) ? idx_op_ast_stable : NULL;
 	M0_ASSERT(grp == oi->oi_sm_grp);
-	idx_op_ast_stable(oi->oi_sm_grp, &oi->oi_ar.ar_ast);
 	dix_req_destroy(req);
+	idx_op_ast_stable(oi->oi_sm_grp, &oi->oi_ar.ar_ast);
 	M0_LEAVE();
 }
 


### PR DESCRIPTION
There is a race condition between the user
thread and the locality thread where
a motr client operation gets stabilized
and the dix_req is getting destroyed.

Here is the scheme:

```
User thread:
	await on STABLE for op1
	...
	fini_entity(op1->entity) <- frees the entity
				    and poisons it.

Locality:
	set op1 state to STABLE <- unblocks the "awaiting".
	dix_req_destroy(op1->dix_req) <- enity is finalized already.
		...
		read op1->entity->id <- reads poisoned bytes.
```

The patch reorders the calls, so that the dix_req is getting
destroyed right before the state of the operation is changed
to "STABLE". In this case, we are always operating on a
valid entity structure inside the dix_req_destroy call.