### PR TITLE
[DTM0] EOS-19239: Move op to E state when E_ALL reached.

### DIFF
--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -849,11 +849,11 @@ static bool dixreq_clink_dtx_cb(struct m0_clink *cl)
 
 	state = m0_dtx0_sm_state(dtx);
 
-	if (!M0_IN(state, (M0_DDS_EXECUTED, M0_DDS_STABLE, M0_DDS_FAILED)))
+	if (!M0_IN(state, (M0_DDS_EXECUTED_ALL, M0_DDS_STABLE, M0_DDS_FAILED)))
 		return false;
 
 	switch (state) {
-	case M0_DDS_EXECUTED:
+	case M0_DDS_EXECUTED_ALL:
 		/* TODO: we have a single kv pair; probably, it does not have
 		 * to be a loop.
 		 */


### PR DESCRIPTION
The patch addresses a flaw in the original DTX
design where a client operation was marked as "EXECUTED"
when the corresponding dtx reached "EXECUTED" state.
With this patch applied, the operation reaches EXECUTED
state only after the dtx enters EXECUTED_ALL. In other
words, the client operation is executed when all
the CAS replies are received.
This change helps to enforce isolation of the operations:
once an dtx reached E_ALL state, another dependent dtx
can be submitted.

NOTE: The patch is a "band-aid" that helps to support the
isolation property. However, this change can lead to a significant
clean up of the DTX states and the DTX integration with the client:
the DTX.EXECUTED state could be removed and the connections
between DIX/CAS and DTX SMs could be re-wired. This could be
addressed in consequent patches.