### PR TITLE
EOS-19147: crash in mem_alloc on VM when running 1 million object write

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -267,7 +267,7 @@ def create_lvm(self, index, metadata_dev):
     except MotrError:
         pass
     else:
-        sys.stdout.write(f"Already volumes are created on {metadata_dev}\n {out[0]}")
+        sys.stdout.write(f"Volumes are already created on {metadata_dev}\n{out[0]}\n")
         return False
 
     index = index + 1
@@ -379,7 +379,6 @@ def get_cvg_cnt_and_cvg(self):
 def update_bgsize(self):
     dev_count = 0
     lvm_min_size = None
-    lvm_min_size = None
 
     cvg_cnt, cvg = get_cvg_cnt_and_cvg(self)
     for i in range(int(cvg_cnt)):
@@ -395,8 +394,10 @@ def update_bgsize(self):
             vgname = (execute_command(self, cmd)[0]).split(sep=None)[1]
             cmd = "lvdisplay | grep \"LV Path\" | grep {} | grep -v swap".format(vgname)
             lv_list = (execute_command(self, cmd)[0]).replace("LV Path", '').split('\n')[0:-1]
-            for i in range(len(lv_list)):
-                lv_list[i] = "".join(lv_list[i].split())
+            len_lv_list = len(lv_list)
+            for i in range(len_lv_list):
+                # lv_list[i] contains initial spaces. So removing these spaces.
+                lv_list[i] = lv_list[i].strip()
                 lv_path = lv_list[i]
                 lvm_min_size = calc_lvm_min_size(self, lv_path, lvm_min_size)
     if lvm_min_size:
@@ -428,7 +429,7 @@ def config_lvm(self):
             cmd = f"lvs -o lv_path | grep {lv_md_name}"
             res = execute_command(self, cmd)
             lv_path = res[0].rstrip("\n")
-            lvm_min_size = calc_lvm_min_size(self, lv_path, lvm_min_size) 
+            lvm_min_size = calc_lvm_min_size(self, lv_path, lvm_min_size)
     if lvm_min_size:
         sys.stdout.write(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}\n")
         cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {MOTR_SYS_CFG}'

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -24,7 +24,6 @@ import re
 import subprocess
 from cortx.utils.conf_store import Conf
 
-MOTR_SYS_FILE = "/etc/sysconfig/motr"
 MOTR_CONFIG_SCRIPT = "/opt/seagate/cortx/motr/libexec/motr_cfg.sh"
 LNET_CONF_FILE = "/etc/modprobe.d/lnet.conf"
 SYS_CLASS_NET_DIR = "/sys/class/net/"
@@ -126,8 +125,8 @@ def validate_motr_rpm(self):
     sys.stdout.write(f"Checking for {kernel_module}\n")
     validate_file(kernel_module)
 
-    sys.stdout.write(f"Checking for {MOTR_SYS_FILE}\n")
-    validate_file(MOTR_SYS_FILE)
+    sys.stdout.write(f"Checking for {MOTR_SYS_CFG}\n")
+    validate_file(MOTR_SYS_CFG)
 
 
 def motr_config(self):
@@ -183,7 +182,6 @@ def configure_lnet(self):
 def configure_libfabric(self):
     raise MotrError(errno.EINVAL, "libfabric not implemented\n")
 
-
 def swap_on(self):
     cmd = "swapon -a"
     execute_command(self, cmd)
@@ -225,7 +223,6 @@ def add_swap_fstab(self, dev_name):
         swap_on(self)
 
 def del_swap_fstab_by_vg_name(self, vg_name):
-
     swap_off(self)
 
     cmd = f"sed -i '/{vg_name}/d' {FSTAB}"
@@ -234,7 +231,6 @@ def del_swap_fstab_by_vg_name(self, vg_name):
     swap_on(self)
 
 def create_swap(self, swap_dev):
-
     sys.stdout.write(f"Make swap of {swap_dev}\n")
     cmd = f"mkswap -f {swap_dev}"
     execute_command(self, cmd)
@@ -257,7 +253,6 @@ def create_lvm(self, index, metadata_dev):
         5. If not exist, create volume group and lvm
         6. create swap from lvm
     '''
-
     try:
         cmd = f"fdisk -l {metadata_dev}2"
         execute_command(self, cmd)
@@ -265,6 +260,7 @@ def create_lvm(self, index, metadata_dev):
         pass
     else:
         metadata_dev = f"{metadata_dev}2"
+
     try:
         cmd = f"pvdisplay {metadata_dev}"
         out = execute_command(self, cmd)
@@ -345,14 +341,25 @@ def create_lvm(self, index, metadata_dev):
         sys.stdout.write(f"swap size before allocation ={allocated_swap_size_before}M\n")
         sys.stdout.write(f"swap_size after allocation ={allocated_swap_size_after}M\n")
 
-def config_lvm(self):
+def calc_lvm_min_size(self, lv_path, lvm_min_size):
+    cmd = f"lvs {lv_path} -o LV_SIZE --noheadings --units b --nosuffix"
+    res = execute_command(self, cmd)
+    lv_size = res[0].rstrip("\n")
+    lv_size = int(lv_size)
+    sys.stdout.write(f"{lv_path} size = {lv_size} \n")
+    if lvm_min_size is None:
+        lvm_min_size = lv_size
+        return lvm_min_size
+    lvm_min_size = min(lv_size, lvm_min_size)
+    return lvm_min_size
+
+def get_cvg_cnt_and_cvg(self):
     try:
         cvg_cnt = self.server_node['storage']['cvg_count']
     except:
         raise MotrError(errno.EINVAL, "cvg_cnt not found\n")
 
     check_type(cvg_cnt, str, "cvg_count")
-
 
     try:
         cvg = self.server_node['storage']['cvg']
@@ -365,10 +372,42 @@ def config_lvm(self):
     # Check if cvg is non empty
     if not cvg:
         raise MotrError(errno.EINVAL, "cvg is empty\n")
+    return cvg_cnt, cvg
 
+def update_bgsize(self):
     dev_count = 0
     lvm_min_size = None
-    motr_config_file = '/etc/sysconfig/motr'
+    lvm_min_size = None
+
+    cvg_cnt, cvg = get_cvg_cnt_and_cvg(self)
+    for i in range(int(cvg_cnt)):
+        cvg_item = cvg[i]
+        try:
+            metadata_devices = cvg_item["metadata_devices"]
+        except:
+            raise MotrError(errno.EINVAL, "metadata devices not found\n")
+        check_type(metadata_devices, list, "metadata_devices")
+        sys.stdout.write(f"\nlvm metadata_devices: {metadata_devices}\n\n")
+        for device in metadata_devices:
+            cmd = f"pvs --noheadings {device}"
+            vgname = (execute_command(self, cmd)[0]).split(sep=None)[1]
+            cmd = "lvdisplay | grep \"LV Path\" | grep {} | grep -v swap".format(vgname)
+            lv_list = (execute_command(self, cmd)[0]).replace("LV Path", '').split('\n')[0:-1]
+            for i in range(len(lv_list)):
+                lv_list[i] = "".join(lv_list[i].split())
+                lv_path = lv_list[i]
+                lvm_min_size = calc_lvm_min_size(self, lv_path, lvm_min_size)
+    if lvm_min_size:
+        sys.stdout.write(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}\n")
+        cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {MOTR_SYS_CFG}'
+        execute_command(self, cmd)
+
+def config_lvm(self):
+    dev_count = 0
+    lvm_min_size = None
+    lvm_min_size = None
+
+    cvg_cnt, cvg = get_cvg_cnt_and_cvg(self)
     for i in range(int(cvg_cnt)):
         cvg_item = cvg[i]
         try:
@@ -385,17 +424,10 @@ def config_lvm(self):
             cmd = f"lvs -o lv_path | grep {lv_md_name}"
             res = execute_command(self, cmd)
             lv_path = res[0].rstrip("\n")
-            cmd = f"lvs {lv_path} -o LV_SIZE --noheadings --units b --nosuffix"
-            res = execute_command(self, cmd)
-            lv_size = res[0].rstrip("\n")
-            lv_size = int(lv_size)
-            sys.stdout.write(f"{lv_path} size = {lv_size} \n")
-            if lvm_min_size is None:
-                lvm_min_size = lv_size
-            lvm_min_size = min(lv_size, lvm_min_size)
+            lvm_min_size = calc_lvm_min_size(self, lv_path, lvm_min_size) 
     if lvm_min_size:
         sys.stdout.write(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}\n")
-        cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {motr_config_file}'
+        cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {MOTR_SYS_CFG}'
         execute_command(self, cmd)
 
 def get_lnet_xface() -> str:
@@ -463,7 +495,6 @@ def get_nodes(self):
 
 def lnet_ping(self):
     """Lnet lctl ping on all available nodes in cluster."""
-
     nodes = get_nodes(self)
     # nodes is a list of hostnames
     nids = get_nids(self, nodes)
@@ -506,27 +537,8 @@ def test_lnet(self):
     lnet_ping(self)
 
 def get_metadata_disks_count(self):
-    try:
-        cvg_cnt = self.server_node['storage']['cvg_count']
-    except:
-        raise MotrError(errno.EINVAL, "cvg_cnt not found\n")
-
-    check_type(cvg_cnt, str, "cvg_count")
-
-
-    try:
-        cvg = self.server_node['storage']['cvg']
-    except:
-        raise MotrError(errno.EINVAL, "cvg not found\n")
-
-     # Check if cvg type is list
-    check_type(cvg, list, "cvg")
-
-    # Check if cvg is non empty
-    if not cvg:
-        raise MotrError(errno.EINVAL, "cvg is empty\n")
-
     dev_count = 0
+    cvg_cnt, cvg = get_cvg_cnt_and_cvg(self)
     for i in range(int(cvg_cnt)):
         cvg_item = cvg[i]
         try:

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -391,8 +391,10 @@ def config_lvm(self):
             if lvm_min_size is None:
                 lvm_min_size = lv_size
             lvm_min_size = min(lv_size, lvm_min_size)
-    if lvm_min_size: 	    
-        cmd = f'sed -i "s/^\(MOTR_M0D_IOS_BESEG_SIZE=*\).*/\1{lvm_min_size}/" {motr_config_file}'
+    if lvm_min_size:
+        lvm_min_size=lvm_min_size.strip()
+        sys.stdout.write(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}")
+        cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {motr_config_file}'
         execute_command(self, cmd)
 
 def get_lnet_xface() -> str:

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -268,7 +268,8 @@ def create_lvm(self, index, metadata_dev):
         pass
     else:
         sys.stdout.write(f"Already volumes are created on {metadata_dev}\n {out[0]}")
-        return
+        return False
+
     index = index + 1
     node_name = self.server_node['name']
     vg_name = f"vg_{node_name}_md{index}"
@@ -340,6 +341,7 @@ def create_lvm(self, index, metadata_dev):
     else:
         sys.stdout.write(f"swap size before allocation ={allocated_swap_size_before}M\n")
         sys.stdout.write(f"swap_size after allocation ={allocated_swap_size_after}M\n")
+    return True
 
 def calc_lvm_min_size(self, lv_path, lvm_min_size):
     cmd = f"lvs {lv_path} -o LV_SIZE --noheadings --units b --nosuffix"
@@ -418,7 +420,9 @@ def config_lvm(self):
         sys.stdout.write(f"\nlvm metadata_devices: {metadata_devices}\n\n")
 
         for device in metadata_devices:
-            create_lvm(self, dev_count, device)
+            ret = create_lvm(self, dev_count, device)
+            if ret == False:
+                continue
             dev_count += 1
             lv_md_name = f"lv_raw_md{dev_count}"
             cmd = f"lvs -o lv_path | grep {lv_md_name}"

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -388,12 +388,13 @@ def config_lvm(self):
             cmd = f"lvs {lv_path} -o LV_SIZE --noheadings --units b --nosuffix"
             res = execute_command(self, cmd)
             lv_size = res[0].rstrip("\n")
+            lv_size = int(lv_size)
+            sys.stdout.write(f"{lv_path} size = {lv_size} \n")
             if lvm_min_size is None:
                 lvm_min_size = lv_size
             lvm_min_size = min(lv_size, lvm_min_size)
     if lvm_min_size:
-        lvm_min_size=lvm_min_size.strip()
-        sys.stdout.write(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}")
+        sys.stdout.write(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}\n")
         cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {motr_config_file}'
         execute_command(self, cmd)
 

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -120,7 +120,7 @@ class PostInstallCmd(Cmd):
         if not lvm_exist(self):
             config_lvm(self)
         else:
-            sys.stderr.write("lvm's already exist. "
+            sys.stderr.write("lvm already exists. "
                              "Skipping lvm creation.\n")
             sys.stderr.write("Updating bgsize.\n")
             update_bgsize(self)

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -120,9 +120,10 @@ class PostInstallCmd(Cmd):
         if not lvm_exist(self):
             config_lvm(self)
         else:
-            sys.stderr.write(f"lvm's already exist. "
-                              "Skipping lvm creation.\n")
-
+            sys.stderr.write("lvm's already exist. "
+                             "Skipping lvm creation.\n")
+            sys.stderr.write("Updating bgsize.\n")
+            update_bgsize(self)
         sys.stdout.write("SUCCESS\n")
 
 class ConfigCmd(Cmd):


### PR DESCRIPTION
On VM, MOTR_M0D_IOS_BESEG_SIZE is set to default size(128M) which leads
to panic during mem_alloc.
Solution: configure MOTR_M0D_IOS_BESEG_SIZE to the same size as minimum
of available metadata volume.

backtrace:
 #5  btree_save (tree=tree@entry=0x400000123930,
 tx=tx@entry=0x7f6d48011e68,
    op=op@entry=0x7f6d667fb450, key=key@entry=0x7f6d667fb6c0,
        val=val@entry=0x7f6d667fb6d0, anchor=anchor@entry=0x0,
	    optype=optype@entry=BTREE_SAVE_INSERT,
	    zonemask=zonemask@entry=2)
    at be/btree.c:1454
 #6  0x00007f6de9dbf298 in be_btree_insert
    (tree=tree@entry=0x400000123930,
        tx=tx@entry=0x7f6d48011e68, op=op@entry=0x7f6d667fb450,
	    key=key@entry=0x7f6d667fb6c0, val=val@entry=0x7f6d667fb6d0,
	        anchor=anchor@entry=0x0, zonemask=zonemask@entry=2) at
		be/btree.c:1908
 #7  0x00007f6de9dc02d8 in m0_be_btree_insert
		(tree=tree@entry=0x400000123930,
		    tx=tx@entry=0x7f6d48011e68,
		    op=op@entry=0x7f6d667fb450,
		        key=key@entry=0x7f6d667fb6c0,
			val=val@entry=0x7f6d667fb6d0)
		    at be/btree.c:1939