### PR TITLE
Update Quick-Start-Guide.rst

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -74,7 +74,7 @@ You can also build RPMs by running the following command.
 
 - **$ make rpms**
 
-The following RPMs are generated in the **$HOME/rpmbuild/RPMS/x86_64** directory.
+The following RPMs are generated in the **/root/rpmbuild/RPMS/x86_64** directory.
 
 - cortx-motr-1.0.0-1_git*_3.10.0_1062.el7.x86_64.rpm
 
@@ -84,7 +84,7 @@ The following RPMs are generated in the **$HOME/rpmbuild/RPMS/x86_64** directory
  
 - cortx-motr-tests-ut-1.0.0-1_git*_3.10.0_1062.el7.x86_64.rpm
 
-Note : Check contents of **$HOME/rpmbuild/RPMS/x86_64** directory.
+Note : Check contents of **/root/rpmbuild/RPMS/x86_64** directory.
 
 Running Tests
 =============


### PR DESCRIPTION
RPMs are not in the home, but in the root directory

[root@ssc-vm-2736 /]# ls
bin  boot  dev  etc  home  lib  lib64  lost+found  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
[root@ssc-vm-2736 /]# cd home
[root@ssc-vm-2736 home]# ls
670951
[root@ssc-vm-2736 home]# cd 670951
[root@ssc-vm-2736 670951]# ls
[root@ssc-vm-2736 670951]# cd ..
[root@ssc-vm-2736 home]# cd ..
[root@ssc-vm-2736 /]# cd root
[root@ssc-vm-2736 ~]# ls
lustre-2.12.5-1.src.rpm  rpmbuild
[root@ssc-vm-2736 ~]# cd rpmbuild/RPMS/x86_64
[root@ssc-vm-2736 x86_64]# ls
cortx-motr-2.0.0-1_git2d26847_3.10.0_1127.el7.x86_64.rpm            kmod-lustre-client-2.12.5-99.el7.x86_64.rpm
cortx-motr-debuginfo-2.0.0-1_git2d26847_3.10.0_1127.el7.x86_64.rpm  lustre-client-2.12.5-99.el7.x86_64.rpm
cortx-motr-devel-2.0.0-1_git2d26847_3.10.0_1127.el7.x86_64.rpm      lustre-client-debuginfo-2.12.5-99.el7.x86_64.rpm
cortx-motr-tests-ut-2.0.0-1_git2d26847_3.10.0_1127.el7.x86_64.rpm   lustre-client-devel-2.12.5-99.el7.x86_64.rpm
isa-l-2.30.0-1.el7.x86_64.rpm                                       lustre-iokit-2.12.5-99.el7.x86_64.rpm


Signed-off-by: Yanqing Fu <yanqing.f.fu@seagate.com>