### PR TITLE
scripts/systemd: fix m0d startup on Ubuntu

### DIFF
--- a/scripts/install/usr/lib/systemd/system/m0d@.service
+++ b/scripts/install/usr/lib/systemd/system/m0d@.service
@@ -29,6 +29,5 @@ Type=notify
 TimeoutStopSec=5min
 Restart=no
 Environment=SHELL=/bin/bash
-EnvironmentFile=/etc/sysconfig/m0d-%i
 Group=motr
 ExecStart=/usr/libexec/cortx-motr/motr-server m0d-%i


### PR DESCRIPTION
EnvironmentFile is hardcoded at /etc/sysconfig directory
which is absent in Ubuntu/Debian, so the startup fails.

Solution: drop EnvironmentFile configuration, it's redundant
for m0d@.service. motr-server script which is used to startup
m0d service can automatically determine the location of the
environment files and use them.