### PR TITLE
EOS-20326: Fixed the regression occurred after adding support to Ubuntu

### DIFF
--- a/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
@@ -33,7 +33,7 @@ import json
 
 LIBMOTR_PATH = "/usr/lib64/libmotr.so"
 SYSCONF_DIR = "/etc/sysconfig"
-if not path.isdir(SYSCONF_DIR)
+if not os.path.isdir(SYSCONF_DIR):
     SYSCONF_DIR = "/etc/default"
 MOTR_CONFIG = SYSCONF_DIR + "/motr"
 TOTAL_SPACE = "fs_total_disk"


### PR DESCRIPTION
Fixed the syntax error observed in motr-free-space-monitor.It was regression
occured after adding free-space-monitor support for Ubuntu.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>