### PR TITLE
Handling of send and receipt of persistent messages in Dtm0

### DIFF
--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -611,32 +611,6 @@ M0_INTERNAL int m0_be_dtm0_plog_prune(struct m0_be_dtm0_log    *log,
 	return 0;
 }
 
-
-M0_INTERNAL bool m0_be_dtm0_logrec_is_persistent(struct m0_be_dtm0_log *log,
-						 struct m0_dtm0_tid    *tid)
-{
-	struct m0_dtm0_log_rec *rec;
-	bool                    is_persistent;
-
-	M0_ENTRY();
-
-	M0_PRE(log != NULL);
-	if (!log->dl_is_persistent)
-		return(false);
-
-	m0_mutex_lock(&log->dl_lock);
-	rec = m0_be_dtm0_log_find(log, tid);
-	if (rec == NULL)
-		return(false);
-	M0_ASSERT(m0_dtm0_tx_desc__invariant(&rec->dlr_txd));
-	is_persistent = m0_dtm0_tx_desc_state_eq(&rec->dlr_txd,
-						 M0_DTPS_PERSISTENT);
-	m0_mutex_unlock(&log->dl_lock);
-
-	M0_LEAVE();
-	return(is_persistent);
-}
-
 M0_INTERNAL void m0_be_dtm0_log_pmsg_post(struct m0_be_dtm0_log *log,
 					  struct m0_fop         *fop)
 {

--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -323,12 +323,12 @@ static int plog_rec_init(struct m0_dtm0_log_rec **out,
 		M0_BE_ALLOC_BUF_SYNC(&rec->dlr_payload, seg, tx);
 		M0_ASSERT(&rec->dlr_payload.b_addr != NULL); /* TODO: handle error */
 		m0_buf_memcpy(&rec->dlr_payload, payload);
+		M0_BE_TX_CAPTURE_BUF(seg, tx, &rec->dlr_payload);
 	} else {
 		rec->dlr_payload.b_addr = NULL;
 		rec->dlr_payload.b_nob = 0;
 	}
 
-	M0_BE_TX_CAPTURE_BUF(seg, tx, &rec->dlr_payload);
 	M0_BE_TX_CAPTURE_ARR(seg, tx,
 			     rec->dlr_txd.dtd_ps.dtp_pa,
 			     rec->dlr_txd.dtd_ps.dtp_nr);

--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -611,6 +611,32 @@ M0_INTERNAL int m0_be_dtm0_plog_prune(struct m0_be_dtm0_log    *log,
 	return 0;
 }
 
+
+M0_INTERNAL bool m0_be_dtm0_logrec_is_persistent(struct m0_be_dtm0_log *log,
+						 struct m0_dtm0_tid    *tid)
+{
+	struct m0_dtm0_log_rec *rec;
+	bool                    is_persistent;
+
+	M0_ENTRY();
+
+	M0_PRE(log != NULL);
+	if (!log->dl_is_persistent)
+		return(false);
+
+	m0_mutex_lock(&log->dl_lock);
+	rec = m0_be_dtm0_log_find(log, tid);
+	if (rec == NULL)
+		return(false);
+	M0_ASSERT(m0_dtm0_tx_desc__invariant(&rec->dlr_txd));
+	is_persistent = m0_dtm0_tx_desc_state_eq(&rec->dlr_txd,
+						 M0_DTPS_PERSISTENT);
+	m0_mutex_unlock(&log->dl_lock);
+
+	M0_LEAVE();
+	return(is_persistent);
+}
+
 M0_INTERNAL void m0_be_dtm0_log_pmsg_post(struct m0_be_dtm0_log *log,
 					  struct m0_fop         *fop)
 {

--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -503,21 +503,6 @@ M0_INTERNAL void m0_be_dtm0_volatile_log_update(struct m0_be_dtm0_log  *log,
 						struct m0_dtm0_log_rec *rec);
 
 /**
- * This routine is used to query whether the record with the given tid is
- * persistent on all the dtm0 participants.
- *
- * @pre log is a persistent log
- * @post None
- *
- * @param log Pointer to the dtm0 log which we wish to query.
- * @param tid Pointer to a dtm0 log record tid.
- * @return bool value which true if the record is persistent on all the
- *	  participants else false.
- */
-M0_INTERNAL bool m0_be_dtm0_logrec_is_persistent(struct m0_be_dtm0_log *log,
-						 struct m0_dtm0_tid    *tid);
-
-/**
  * Deliver a persistent message to the log.
  *
  * @pre log is a volatile log

--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -503,6 +503,21 @@ M0_INTERNAL void m0_be_dtm0_volatile_log_update(struct m0_be_dtm0_log  *log,
 						struct m0_dtm0_log_rec *rec);
 
 /**
+ * This routine is used to query whether the record with the given tid is
+ * persistent on all the dtm0 participants.
+ *
+ * @pre log is a persistent log
+ * @post None
+ *
+ * @param log Pointer to the dtm0 log which we wish to query.
+ * @param tid Pointer to a dtm0 log record tid.
+ * @return bool value which true if the record is persistent on all the
+ *	  participants else false.
+ */
+M0_INTERNAL bool m0_be_dtm0_logrec_is_persistent(struct m0_be_dtm0_log *log,
+						 struct m0_dtm0_tid    *tid);
+
+/**
  * Deliver a persistent message to the log.
  *
  * @pre log is a volatile log

--- a/cas/service.c
+++ b/cas/service.c
@@ -20,6 +20,7 @@
  */
 
 
+#include "dtm0/tx_desc.h"
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_CAS
 #include "be/op.h"
 #include "be/tx_credit.h"
@@ -1052,29 +1053,28 @@ static int cas_dtm0_logrec_credit_add(struct m0_fom *fom0)
 	return M0_RC(rc);
 }
 
-static int cas_dtm0_logrec_add(struct m0_fom *fom0, struct m0_dtm0_tx_desc *txd,
+static int cas_dtm0_logrec_add(struct m0_fom *fom0,
 			       enum m0_dtm0_tx_pa_state state)
 {
 	/* log the dtm0 logrec before completing the cas op */
 	struct m0_dtm0_service *dtms =
 		m0_dtm0_service_find(fom0->fo_service->rs_reqh);
 	struct m0_dtm0_tx_desc *msg = &cas_op(fom0)->cg_txd;
-	struct m0_buf	        buf = {};
+	struct m0_buf           buf = {};
 	int                     i;
-	int			rc;
+	int                     rc;
 
 	for (i = 0; i < msg->dtd_ps.dtp_nr; ++i) {
 		if (m0_fid_eq(&msg->dtd_ps.dtp_pa[i].p_fid,
-					&dtms->dos_generic.rs_service_fid)) {
-			msg->dtd_ps.dtp_pa[i].p_state =
-				(uint32_t)M0_DTPS_PERSISTENT;
+			      &dtms->dos_generic.rs_service_fid)) {
+			msg->dtd_ps.dtp_pa[i].p_state = state;
 			break;
 		}
 	}
 	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_op_xc, cas_op(fom0)),
 				     &buf.b_addr, &buf.b_nob) ?:
-		m0_dtm0_logrec_update(dtms->dos_log, &fom0->fo_tx.tx_betx, msg,
-				      &buf);
+	     m0_dtm0_logrec_update(dtms->dos_log, &fom0->fo_tx.tx_betx, msg,
+				   &buf);
 	m0_buf_free(&buf);
 
 	return rc;
@@ -1232,7 +1232,7 @@ static int cas_fom_tick(struct m0_fom *fom0)
 		 */
 		if (phase == M0_FOPH_TXN_COMMIT_WAIT &&
 		    m0_fom_phase(fom0) == M0_FOPH_FINISH && is_dtm0_used) {
-			rc = m0_dtm0_on_committed(fom0, &cas_op(fom0)->cg_txd);
+			rc = m0_dtm0_on_committed(fom0, &cas_op(fom0)->cg_txd.dtd_id);
 			if (rc != 0)
 				M0_LOG(M0_WARN, "Could not send PERSISTENT "
 				       "messages out");
@@ -1691,7 +1691,6 @@ static int cas_fom_tick(struct m0_fom *fom0)
 		break;
 	case CAS_DTM0:
 		rc = cas_dtm0_logrec_add(&fom->cf_fom,
-					 &cas_op(&fom->cf_fom)->cg_txd,
 					 M0_DTPS_PERSISTENT);
 		if (rc != 0)
 			cas_fom_failure(fom, M0_ERR(rc), opc == CO_CUR);

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -353,7 +353,7 @@ M0_INTERNAL int m0_dtm0_on_committed(struct m0_fom            *fom,
 
 static int dtm0_fom_tick(struct m0_fom *fom)
 {
-	int                       rc;
+	int                       rc = 0;
 	struct   m0_dtm0_service *svc;
 	struct   m0_buf           buf = {};
 	struct   dtm0_rep_fop    *rep;

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -80,8 +80,8 @@ struct dtm0_fom {
 	struct m0_fom dtf_fom;
 };
 
-M0_INTERNAL int m0_dtm0_on_committed(struct m0_fom                *fom,
-				     const struct m0_dtm0_tx_desc *txd);
+M0_INTERNAL int m0_dtm0_on_committed(struct m0_fom            *fom,
+				     const struct m0_dtm0_tid *id);
 
 M0_INTERNAL int m0_dtm0_logrec_update(struct m0_be_dtm0_log  *log,
 				      struct m0_be_tx        *tx,

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -29,6 +29,7 @@
 #include "ut/ut.h"
 #include "cas/cas.h"
 #include "cas/cas_xc.h"
+#include "dtm0/service.h"             /* m0_dtm0_service_find */
 
 #define M0_FID(c_, k_)  { .f_container = c_, .f_key = k_ }
 #define SERVER_ENDPOINT_ADDR    "0@lo:12345:34:1"
@@ -39,6 +40,8 @@
 enum { MAX_RPCS_IN_FLIGHT = 10,
        NUM_CAS_RECS = 10,
 };
+
+struct m0_reqh  *dtm0_cli_srv_reqh;
 
 static struct m0_fid cli_srv_fid = M0_FID(0x7300000000000001, 0x1a);
 static struct m0_fid srv_dtm0_fid = M0_FID(0x7300000000000001, 0x1c);
@@ -75,6 +78,9 @@ static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
 
 	struct m0_dtm0_clk_src dcs;
 	struct m0_dtm0_ts      now;
+	struct m0_dtm0_service *dtm0 = m0_dtm0_service_find(dtm0_cli_srv_reqh);
+	struct m0_be_dtm0_log  *log = dtm0->dos_log;
+
 
 
 	m0_dtm0_clk_src_init(&dcs, M0_DTM0_CS_PHYS);
@@ -86,6 +92,7 @@ static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
 	M0_UT_ASSERT(rc == 0);
 
 	txr.dtd_ps.dtp_pa[0].p_fid = srv_dtm0_fid;
+	/* txr.dtd_ps.dtp_pa[0].p_state = M0_DTPS_INIT; */
 	txr.dtd_id = (struct m0_dtm0_tid) {
 		.dti_ts = now,
 		.dti_fid = cli_srv_fid
@@ -105,7 +112,41 @@ static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
 	M0_ASSERT(m0_dtm0_ts__invariant(&reply_data.dti_ts));
 
 	M0_UT_ASSERT(m0_dtm0_tid_cmp(&dcs, &txr.dtd_id, &reply_data) == M0_DTS_EQ);
+	m0_fop_put_lock(fop);
 
+
+	/* Test PERSISTENT message */
+
+	rc = m0_dtm0_tx_desc_init(&txr, 1);
+	M0_UT_ASSERT(rc == 0);
+	txr.dtd_ps.dtp_pa[0].p_fid = srv_dtm0_fid;
+	txr.dtd_ps.dtp_pa[0].p_state = M0_DTPS_PERSISTENT;
+
+	txr.dtd_ps.dtp_pa[0].p_fid = srv_dtm0_fid;
+	txr.dtd_id = (struct m0_dtm0_tid) {
+		.dti_ts = now,
+		.dti_fid = cli_srv_fid
+	};
+	fop = m0_fop_alloc_at(cl_rpc_session,
+			      &dtm0_req_fop_fopt);
+	req = m0_fop_data(fop);
+	req->dtr_msg = DTM_PERSISTENT;
+	req->dtr_txr = txr;
+
+	m0_mutex_lock(&log->dl_lock);
+	rc = m0_be_dtm0_log_update(log, NULL, &txr, &(struct m0_buf){});
+	m0_mutex_unlock(&log->dl_lock);
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_rpc_post_sync(fop, cl_rpc_session,
+			      &dtm0_req_fop_rpc_item_ops,
+			      M0_TIME_IMMEDIATELY);
+	M0_UT_ASSERT(rc == 0);
+	rep = reply(fop->f_item.ri_reply);
+	reply_data = rep->dr_txr.dtd_id;
+
+	M0_ASSERT(m0_dtm0_ts__invariant(&reply_data.dti_ts));
+
+	M0_UT_ASSERT(m0_dtm0_tid_cmp(&dcs, &txr.dtd_id, &reply_data) == M0_DTS_EQ);
 	m0_fop_put_lock(fop);
 }
 
@@ -174,6 +215,8 @@ static void dtm0_ut_service(void)
 	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr,
 					     false);
 	M0_UT_ASSERT(rc == 0);
+
+	dtm0_cli_srv_reqh = &cctx.cl_ctx.rcx_reqh;
 
 	dtm0_ut_send_fops(&cctx.cl_ctx.rcx_session);
 


### PR DESCRIPTION

This PR is for merges all the commits related to handling persistent messages sending, receiving and UT testing under ticket EOS-18924.


[root@ssc-vm-0122 motr]# ./utils/m0run "m0ut -t dtm0-log-ut"
START Iteration: 1 out of 1
dtm0-log-ut
  dtm0-log-list                                   0.00 sec   26 KiB
  dtm0-log-persistent                             0.58 sec   78 MiB
  [ time: 0.58 sec, mem: 78 MiB, leaked: 3 MiB ]

Time: 0.58 sec, Mem: 78 MiB, Leaked: 3 MiB, Asserts: 157
Unit tests status: SUCCESS
END   Iteration: 1 out of 1

utime 0.544857 stime 0.321624 maxrss 236976 nvcsw 2567 nivcsw 17
minflt 22175 majflt 4 inblock 0 oublock 66208
rchar 97390 wchar 1316 syscr 200 syscw 48
read_bytes 0 write_bytes 33898496 cancelled_write_bytes 49152
[root@ssc-vm-0122 motr]# ./utils/m0run "m0ut -t dtm0-ut"
START Iteration: 1 out of 1
dtm0-ut
  service                                         3.27 sec  101 MiB
  xcode                                           0.00 sec    2 KiB
  [ time: 3.27 sec, mem: 101 MiB, leaked: 12 MiB ]

Time: 3.27 sec, Mem: 101 MiB, Leaked: 12 MiB, Asserts: 17
Unit tests status: SUCCESS
END   Iteration: 1 out of 1

utime 1.001010 stime 0.464460 maxrss 336656 nvcsw 3974 nivcsw 20
minflt 41654 majflt 4 inblock 0 oublock 330696
rchar 109514 wchar 1326 syscr 240 syscw 50
read_bytes 0 write_bytes 169316352 cancelled_write_bytes 16384
[root@ssc-vm-0122 motr]#
