### PR TITLE
Upgrade Go bindings to compatible with Go version 1.16 and above.

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -53,6 +53,8 @@ In order to build:
    (or install pre-built motr-devel package).
  2. Install Go: `sudo yum install go`.
 
+Note: Go version 1.16 or above is required, you could follow installation instruction from Go [site](https://golang.org/doc/install).
+
 Then run:
 
 ```sh

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,3 @@
+module motr
+
+go 1.16

--- a/bindings/go/mcp/mcp.go
+++ b/bindings/go/mcp/mcp.go
@@ -26,7 +26,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "../mio"
+    "motr/mio"
 )
 
 func usage() {


### PR DESCRIPTION
Existing code no longer work with Go version 1.16 because of Go module.

Hence, update existing code to support module, so it could work with latest version of Go. ( Go version 1.17 above will only support module ).

-----
[View rendered bindings/go/README.md](https://github.com/kiwionly2/cortx-motr/blob/main/bindings/go/README.md)