### PR TITLE
update Go binding code to enabled module so can work with Go version 1.16

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,3 @@
+module motr
+
+go 1.15

--- a/bindings/go/mcp/mcp.go
+++ b/bindings/go/mcp/mcp.go
@@ -26,7 +26,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "../mio"
+    "motr/mio"
 )
 
 func usage() {


### PR DESCRIPTION
mcp: enabled go module (#466)

Signed-off-by: kiwi <gheewooi.ong@seagate.com>

-----
[View rendered bindings/go/README.md](https://github.com/kiwionly2/cortx-motr/blob/go1.16/bindings/go/README.md)