### PR TITLE
Problem: Early reset of ha and halink variable in m0 leads to failures

### DIFF
--- a/ha/halon/interface.c
+++ b/ha/halon/interface.c
@@ -809,6 +809,7 @@ static void halon_interface_level_leave(struct m0_module *module)
 		break;
 	case M0_HALON_INTERFACE_LEVEL_HA_INIT:
 		m0_ha_fini(&hii->hii_ha);
+		m0_get()->i_ha      = NULL;
 		break;
 	case M0_HALON_INTERFACE_LEVEL_DISPATCHER:
 		m0_ha_dispatcher_fini(&hii->hii_dispatcher);
@@ -823,7 +824,6 @@ static void halon_interface_level_leave(struct m0_module *module)
 	case M0_HALON_INTERFACE_LEVEL_INSTANCE_SET:
 		M0_ASSERT(m0_get()->i_ha      == &hii->hii_ha);
 		M0_ASSERT(m0_get()->i_ha_link ==  hii->hii_outgoing_link);
-		m0_get()->i_ha      = NULL;
 		m0_get()->i_ha_link = NULL;
 		break;
 	case M0_HALON_INTERFACE_LEVEL_EVENTS_STARTING:

--- a/rm/rm.c
+++ b/rm/rm.c
@@ -1016,7 +1016,8 @@ static struct m0_sm_state_descr inc_states[] = {
 	},
 	[RI_WAIT] = {
 		.sd_name      = "Wait",
-		.sd_allowed   = M0_BITS(RI_WAIT, RI_FAILURE, RI_CHECK)
+		.sd_allowed   = M0_BITS(RI_WAIT, RI_FAILURE, RI_CHECK,
+                                        RI_RELEASED)
 	},
 	[RI_RELEASED] = {
 		.sd_name      = "Released",

--- a/rpc/link.c
+++ b/rpc/link.c
@@ -633,6 +633,7 @@ M0_INTERNAL int m0_rpc_link_init(struct m0_rpc_link *rlink,
 
 M0_INTERNAL void m0_rpc_link_fini(struct m0_rpc_link *rlink)
 {
+	M0_ENTRY();
 	M0_PRE(!rlink->rlk_connected);
 	m0_chan_fini_lock(&rlink->rlk_wait);
 	m0_mutex_fini(&rlink->rlk_wait_mutex);
@@ -645,6 +646,7 @@ M0_INTERNAL void m0_rpc_link_fini(struct m0_rpc_link *rlink)
 		m0_rpc_session_fini(&rlink->rlk_sess);
 	if (conn_state(&rlink->rlk_conn) != M0_RPC_CONN_FINALISED)
 		m0_rpc_conn_fini(&rlink->rlk_conn);
+	M0_LEAVE();
 }
 
 M0_INTERNAL void m0_rpc_link_reset(struct m0_rpc_link *rlink)

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -64,6 +64,7 @@ M0_INTERNAL void m0_sm_group_init(struct m0_sm_group *grp)
 
 M0_INTERNAL void m0_sm_group_fini(struct m0_sm_group *grp)
 {
+	M0_ENTRY();
 	M0_PRE(grp->s_forkq == &eoq);
 
 	if (m0_clink_is_armed(&grp->s_clink))
@@ -71,6 +72,7 @@ M0_INTERNAL void m0_sm_group_fini(struct m0_sm_group *grp)
 	m0_clink_fini(&grp->s_clink);
 	m0_chan_fini_lock(&grp->s_chan);
 	m0_mutex_fini(&grp->s_lock);
+	M0_LEAVE();
 }
 
 static void _sm_group_lock(struct m0_sm_group *grp)
@@ -326,9 +328,11 @@ M0_INTERNAL void m0_sm_init(struct m0_sm *mach, const struct m0_sm_conf *conf,
 
 M0_INTERNAL void m0_sm_fini(struct m0_sm *mach)
 {
+	M0_ENTRY();
 	M0_ASSERT(sm_invariant0(mach));
 	M0_PRE(sm_state(mach)->sd_flags & (M0_SDF_TERMINAL | M0_SDF_FINAL));
 	m0_chan_fini(&mach->sm_chan);
+	M0_LEAVE();
 }
 
 M0_INTERNAL void (*m0_sm__conf_init)(const struct m0_sm_conf *conf) = NULL;


### PR DESCRIPTION
Premature nullification of m0_get()->i_ha and m0_get()->i_ha_link leads
failure of m0_entrypoint_client_state_get() when accessing ecl_sm_group
lock in ha_clink_cb() where the entrypoint client object is extracted
from m0_get()->i_ha, which is already set to NULL.

Solution:
Delay the nullification of m0_get()->i_ha and m0_get()->i_ha_link post
m0_ha_disconnect() and m0_ha_fini() respectively.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>