### PR TITLE
st: improve SNS tests coverage

### DIFF
--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
@@ -45,18 +45,45 @@ file=(
 	10000:10000
 	10001:10001
 	10002:10002
-)
-
-file_size=(
-	50
-	70
-	30
+	10003:10003
+	10004:10004
+	10005:10005
+	10006:10006
+	10007:10007
+	10008:10008
+	10009:10009
+	10010:10010
+	10011:10011
 )
 
 unit_size=(
-	$stride
-	$stride
-	$stride
+	4
+	8
+	16
+	32
+	64
+	128
+	256
+	512
+	1024
+	2048
+	4096
+	8192
+)
+
+file_size=(
+	503
+	263
+	251
+	0
+	211
+	3
+	41
+	23
+	17
+	5
+	3
+	1
 )
 
 sns_repair_mount()
@@ -312,7 +339,8 @@ _dd()
 	local BS=$2
 	local COUNT=$3
 
-	dd if=$MOTR_M0T1FS_TEST_DIR/srcfile bs=$BS count=$COUNT \
+	dd if=$MOTR_M0T1FS_TEST_DIR/srcfile ibs=$BS count=$COUNT \
+	   obs=$((BS * 100)) \
 	   of=$MOTR_M0T1FS_MOUNT_DIR/$FILE &>> $MOTR_TEST_LOGFILE || {
 		echo "Failed: dd failed.."
 		unmount_and_clean &>> $MOTR_TEST_LOGFILE
@@ -366,13 +394,13 @@ read_and_verify()
 
 	dd if=$MOTR_M0T1FS_MOUNT_DIR/$FILE of=$MOTR_M0T1FS_TEST_DIR/$FILE \
 		bs=$BS count=$COUNT &>> $MOTR_TEST_LOGFILE || {
-                        echo "m0t1fs read failed"
+                        echo "m0t1fs read of $FILE failed"
                         unmount_and_clean &>> $MOTR_TEST_LOGFILE
                         return 1
         }
 
 	diff $MOTR_M0T1FS_TEST_DIR/file-$BS-$COUNT $MOTR_M0T1FS_TEST_DIR/$FILE &>> $MOTR_TEST_LOGFILE || {
-		echo "files differ"
+		echo "$FILE check failed - files differ"
 		unmount_and_clean &>>$MOTR_TEST_LOGFILE
 		return 1
 	}

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1f.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1f.sh
@@ -30,38 +30,20 @@
 # because ios need to hash gfid to mds. In COPYTOOL
 # mode, filename is the string format of gfid.
 ###################################################
-file=(
-	0:10000
-	0:10001
-	0:10002
-)
-
-file_size=(
-	50
-	70
-	30
-)
-
-N=2
-K=1
-S=1
-P=4
-stride=32
-src_bs=10M
-src_count=2
 
 sns_repair_test()
 {
 	local rc=0
 	local fail_device=1
-	local unit_size=$((stride * 1024))
 
 	echo "Starting SNS repair testing ..."
 
 	local_write $src_bs $src_count || return $?
 
 	for ((i=0; i < ${#file[*]}; i++)) ; do
-		_dd "${file[$i]}" $unit_size "${file_size[$i]}" || return $?
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) "${file_size[$i]}" ||
+			return $?
 		_md5sum "${file[$i]}" || return $?
 	done
 

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1k_1f.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1k_1f.sh
@@ -45,10 +45,12 @@ sns_repair_test()
 
 	local_write $src_bs $src_count || return $?
 
-	for i in 0:10{0..2}{1001..1020}; do touch $MOTR_M0T1FS_MOUNT_DIR/$i ; done
-	for i in 0:10{0..2}{1001..1020}; do setfattr -n lid -v 1 $MOTR_M0T1FS_MOUNT_DIR/$i ; done
-	for i in 0:10{0..2}{1001..1020}; do dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$i bs=1K count=1 ; done
-	for i in 0:10{0..2}{1001..1020}; do _md5sum $i || return $? ; done
+	for ((i=0; i < ${#file[*]}; i++)) ; do
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		_md5sum "${file[$i]}" || return $?
+	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
 		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1n_1f.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1n_1f.sh
@@ -35,15 +35,16 @@ sns_repair_test()
 {
 	local rc=0
 	local fail_device1=1
-	local unit_size=$((stride * 1024))
 
 	echo "Starting SNS repair testing ..."
 
 	local_write $src_bs $src_count || return $?
 
 	for ((i=0; i < ${#file[*]}; i++)) ; do
-		_dd ${file[$i]} $unit_size ${file_size[$i]} || return $?
-		_md5sum ${file[$i]} || return $?
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		_md5sum "${file[$i]}" || return $?
 	done
 
 	ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[0]}"

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort.sh
@@ -30,68 +30,22 @@
 # because ios need to hash gfid to mds. In COPYTOOL
 # mode, filename is the string format of gfid.
 ###################################################
-files=(
-	0:10000
-	0:10001
-	0:10002
-	0:10003
-	0:10004
-	0:10005
-	0:10006
-	0:10007
-	0:10008
-	0:10009
-	0:10010
-	0:10011
-)
-
-unit_size=(
-	4
-	8
-	16
-	32
-	64
-	128
-	256
-	512
-	1024
-	2048
-	2048
-	2048
-)
-
-file_size=(
-	500
-	700
-	300
-	0
-	400
-	0
-	600
-	200
-	100
-	60
-	60
-	60
-)
-
 
 N=3
 K=3
 S=3
 P=15
-stride=32
-src_bs=10M
-src_count=2
 
 testname="sns-repair-abort"
 
 verify()
 {
 	echo "verifying ..."
-	for ((i=0; i < ${#files[*]}; i++)) ; do
-		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
-		read_and_verify ${files[$i]} $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
+	for ((i=0; i < ${#file[*]}; i++)) ; do
+		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		read_and_verify "${file[$i]}" $((${unit_size[$i]} * 1024)) \
+			${file_size[$i]} || return $?
 	done
 
 	echo "file verification sucess"
@@ -106,9 +60,10 @@ sns_repair_test()
 	local_write $src_bs $src_count || return $?
 
 	echo "Starting SNS repair testing ..."
-	for ((i=0; i < ${#files[*]}; i++)) ; do
-		touch_file $MOTR_M0T1FS_MOUNT_DIR/${files[$i]} ${unit_size[$i]}
-		_dd ${files[$i]} $((${unit_size[$i]} * 1024)) ${file_size[$i]}
+	for ((i=0; i < ${#file[*]}; i++)) ; do
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
 	done
 
 	verify || return $?

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort_quiesce.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort_quiesce.sh
@@ -25,27 +25,10 @@
 . `dirname $0`/m0t1fs_server_inc.sh
 . `dirname $0`/m0t1fs_sns_common_inc.sh
 
-file=(
-	0:10000
-	0:10001
-	0:10002
-)
-
-file_size=(
-	200
-	100
-	400
-)
-
 N=3
 K=3
 S=3
 P=15
-stride=32
-src_bs=10M
-src_count=20
-
-unit_size=$((stride * 1024))
 
 testname="sns-repair-abort-repair-quiesce-rebalance-quiesce"
 
@@ -53,8 +36,10 @@ verify()
 {
 	echo "verifying ..."
 	for ((i=0; i < ${#file[*]}; i++)) ; do
-		local_read $unit_size ${file_size[$i]} || return $?
-		read_and_verify ${file[$i]} $unit_size ${file_size[$i]} || return $?
+		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		read_and_verify "${file[$i]}" $((${unit_size[$i]} * 1024)) \
+			${file_size[$i]} || return $?
 	done
 
 	echo "file verification sucess"
@@ -65,15 +50,16 @@ sns_repair_rebalance_quiesce_test()
 	local rc=0
 	local fail_device1=1
 	local fail_device2=9
-	local unit_size=$((stride * 1024))
 
 	echo "Starting SNS repair/rebalance quiesce testing ..."
 
 	local_write $src_bs $src_count || return $?
 
 	for ((i=0; i < ${#file[*]}; i++)) ; do
-		_dd ${file[$i]} $unit_size ${file_size[$i]} || return $?
-		_md5sum ${file[$i]} || return $?
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		_md5sum "${file[$i]}" || return $?
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_ios_fail.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_ios_fail.sh
@@ -30,68 +30,22 @@
 # because ios need to hash gfid to mds. In COPYTOOL
 # mode, filename is the string format of gfid.
 ###################################################
-files=(
-	0:10000
-	0:10001
-	0:10002
-	0:10003
-	0:10004
-	0:10005
-	0:10006
-	0:10007
-	0:10008
-	0:10009
-	0:10010
-	0:10011
-)
-
-unit_size=(
-	4
-	8
-	16
-	32
-	64
-	128
-	256
-	512
-	1024
-	2048
-	2048
-	2048
-)
-
-file_size=(
-	500
-	700
-	300
-	0
-	400
-	0
-	600
-	200
-	100
-	60
-	60
-	60
-)
-
 
 N=3
 K=3
 S=3
 P=15
-stride=32
-src_bs=10M
-src_count=2
 
 testname="sns-repair-ios-fail"
 
 verify()
 {
 	echo "verifying ..."
-	for ((i=0; i < ${#files[*]}; i++)) ; do
-		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
-		read_and_verify ${files[$i]} $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
+	for ((i=0; i < ${#file[*]}; i++)) ; do
+		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		read_and_verify "${file[$i]}" $((${unit_size[$i]} * 1024)) \
+			${file_size[$i]} || return $?
 	done
 
 	echo "file verification sucess"
@@ -106,9 +60,10 @@ sns_repair_test()
 	local_write $src_bs $src_count || return $?
 
 	echo "Starting SNS repair testing ..."
-	for ((i=0; i < ${#files[*]}; i++)) ; do
-		touch_file $MOTR_M0T1FS_MOUNT_DIR/${files[$i]} ${unit_size[$i]}
-		_dd ${files[$i]} $((${unit_size[$i]} * 1024)) ${file_size[$i]}
+	for ((i=0; i < ${#file[*]}; i++)) ; do
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
 	done
 
 	verify || return $?

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_mf.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_mf.sh
@@ -30,59 +30,11 @@
 # because ios need to hash gfid to mds. In COPYTOOL
 # mode, filename is the string format of gfid.
 ###################################################
-files=(
-	0:10000
-	0:10001
-	0:10002
-	0:10003
-	0:10004
-	0:10005
-	0:10006
-	0:10007
-	0:10008
-	0:10009
-	0:10010
-	0:10011
-)
-
-unit_size=(
-	4
-	8
-	16
-	32
-	64
-	128
-	256
-	512
-	1024
-	2048
-	2048
-	2048
-)
-
-file_size=(
-	50
-	70
-	30
-	0
-	40
-	0
-	60
-	20
-	10
-	6
-	6
-	6
-)
-
 
 N=3
 K=3
 S=3
 P=15
-stride=32
-src_bs=10M
-src_count=2
 
 testname="sns-repair-mf"
 
@@ -90,10 +42,12 @@ verify()
 {
 	start_file=$1;
 
-	for ((i=$start_file; i < ${#files[*]}; i++)) ; do
-		echo "Verifying ${files[$i]} ..."
-		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
-		read_and_verify ${files[$i]} $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
+	for ((i=$start_file; i < ${#file[*]}; i++)) ; do
+		echo "Verifying ${file[$i]} ..."
+		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		read_and_verify "${file[$i]}" $((${unit_size[$i]} * 1024)) \
+			${file_size[$i]} || return $?
 	done
 
 	echo "file verification sucess"
@@ -102,7 +56,7 @@ verify()
 delete_files()
 {
 	for ((i=0; i < 7; i++)) ; do
-		_rm ${files[$i]} || return $?
+		_rm "${file[$i]}" || return $?
 	done
 
 	echo "files deleted"
@@ -117,9 +71,10 @@ sns_repair_test()
 	local_write $src_bs $src_count || return $?
 
 	echo "Starting SNS repair testing ..."
-	for ((i=0; i < ${#files[*]}; i++)) ; do
-		touch_file $MOTR_M0T1FS_MOUNT_DIR/${files[$i]} ${unit_size[$i]}
-		_dd ${files[$i]} $((${unit_size[$i]} * 1024)) ${file_size[$i]}
+	for ((i=0; i < ${#file[*]}; i++)) ; do
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
 	done
 
 	verify 0 || return $?

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_quiesce.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_quiesce.sh
@@ -30,25 +30,11 @@
 # because ios need to hash gfid to mds. In COPYTOOL
 # mode, filename is the string format of gfid.
 ###################################################
-file=(
-	0:10000
-	0:10001
-	0:10002
-)
-
-file_size=(
-	500
-	700
-	300
-)
 
 N=3
 K=3
 S=3
 P=15
-stride=32
-src_bs=10M
-src_count=20
 
 testname="sns-repair-rebalance-quiesce"
 
@@ -57,15 +43,16 @@ sns_repair_rebalance_quiesce_test()
 	local rc=0
 	local fail_device1=1
 	local fail_device2=9
-	local unit_size=$((stride * 1024))
 
 	echo "Starting SNS repair/rebalance quiesce testing ..."
 
 	local_write $src_bs $src_count || return $?
 
 	for ((i=0; i < ${#file[*]}; i++)) ; do
-		_dd ${file[$i]} $unit_size ${file_size[$i]} || return $?
-		_md5sum ${file[$i]} || return $?
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		_md5sum "${file[$i]}" || return $?
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_shutdown.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_shutdown.sh
@@ -30,31 +30,11 @@
 # because ios need to hash gfid to mds. In COPYTOOL
 # mode, filename is the string format of gfid.
 ###################################################
-file=(
-	0:10000
-	0:10001
-	0:10002
-)
-
-file_size=(
-	50
-	70
-	30
-)
-
-N=2
-K=1
-S=1
-P=4
-stride=32
-src_bs=10M
-src_count=2
 
 sns_repair_test()
 {
 	local rc=0
 	local fail_device=1
-	local unit_size=$((stride * 1024))
 	local m0d_4_pid=`pgrep m0d | tail -1`
 	echo  "mod pid is $m0d_4_pid"
 
@@ -63,8 +43,10 @@ sns_repair_test()
 	local_write $src_bs $src_count || return $?
 
 	for ((i=0; i < ${#file[*]}; i++)) ; do
-		_dd ${file[$i]} $unit_size ${file_size[$i]} || return $?
-		_md5sum ${file[$i]} || return $?
+		touch_file "$MOTR_M0T1FS_MOUNT_DIR/${file[$i]}" ${unit_size[$i]}
+		_dd "${file[$i]}" $((${unit_size[$i]} * 1024)) ${file_size[$i]} ||
+			return $?
+		_md5sum "${file[$i]}" || return $?
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do

--- a/motr/st/utils/sns_repair_common_inc.sh
+++ b/motr/st/utils/sns_repair_common_inc.sh
@@ -21,6 +21,7 @@ prepare_datafiles_and_objects()
 {
 	local rc=0
 
+	echo "creating the source file"
 	dd if=/dev/urandom bs=$src_bs count=$src_count \
 	   of="$MOTR_M0T1FS_TEST_DIR/srcfile" || return $?
 
@@ -29,18 +30,18 @@ prepare_datafiles_and_objects()
 		local us=$((${unit_size[$i]} * 1024))
 
 		MOTR_PARAM="-l ${lnet_nid}:$SNS_MOTR_CLI_EP  \
-			      -H ${lnet_nid}:$HA_EP -p $PROF_OPT \
-			      -P $M0T1FS_PROC_ID -L ${lid} -s ${us} "
+			    -H ${lnet_nid}:$HA_EP -p '$PROF_OPT' \
+			    -P '$M0T1FS_PROC_ID' -L ${lid} -s ${us} "
 
 		echo "creating object ${file[$i]} bs=${us} * c=${file_size[$i]}"
 		dd bs=${us} count=${file_size[$i]}            \
 		   if="$MOTR_M0T1FS_TEST_DIR/srcfile"         \
 		   of="$MOTR_M0T1FS_TEST_DIR/src${file[$i]}"
 
-		$M0_SRC_DIR/motr/st/utils/m0cp ${MOTR_PARAM}     \
-						 -c ${file_size[$i]} \
-						 -o ${file[$i]}      \
-					 "$MOTR_M0T1FS_TEST_DIR/srcfile" || {
+		run "$M0_SRC_DIR/motr/st/utils/m0cp" ${MOTR_PARAM}  \
+						-c ${file_size[$i]} \
+						-o ${file[$i]}      \
+				"$MOTR_M0T1FS_TEST_DIR/srcfile" || {
 			rc=$?
 			echo "Writing object ${file[$i]} failed"
 		}
@@ -58,15 +59,15 @@ motr_read_verify()
 		local us=$((${unit_size[$i]} * 1024))
 
 		MOTR_PARAM="-l ${lnet_nid}:$SNS_MOTR_CLI_EP       \
-			      -H ${lnet_nid}:$HA_EP -p $PROF_OPT      \
-			      -P $M0T1FS_PROC_ID -L ${lid} -s ${us} "
+			      -H ${lnet_nid}:$HA_EP -p '$PROF_OPT' \
+			      -P '$M0T1FS_PROC_ID' -L ${lid} -s ${us} "
 
 		echo "Reading object ${file[$i]} ... and diff ..."
 		rm -f "$MOTR_M0T1FS_TEST_DIR/${file[$i]}"
-		$M0_SRC_DIR/motr/st/utils/m0cat ${MOTR_PARAM}     \
-						  -c ${file_size[$i]} \
-						  -o ${file[$i]}      \
-					"$MOTR_M0T1FS_TEST_DIR/${file[$i]}" || {
+		run "$M0_SRC_DIR/motr/st/utils/m0cat" ${MOTR_PARAM}  \
+						 -c ${file_size[$i]} \
+						 -o ${file[$i]}      \
+				"$MOTR_M0T1FS_TEST_DIR/${file[$i]}" || {
 			rc=$?
 			echo "reading ${file[$i]} failed"
 		}

--- a/motr/st/utils/sns_repair_motr_1f.sh
+++ b/motr/st/utils/sns_repair_motr_1f.sh
@@ -28,7 +28,6 @@ TOPDIR=`dirname $0`/../../../
 . ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
 . ${TOPDIR}/motr/st/utils/sns_repair_common_inc.sh
 
-
 export MOTR_CLIENT_ONLY=1
 
 sns_repair_motr_test()

--- a/motr/st/utils/sns_repair_motr_1k_1f.sh
+++ b/motr/st/utils/sns_repair_motr_1k_1f.sh
@@ -28,7 +28,6 @@ TOPDIR=`dirname $0`/../../../
 . ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
 . ${TOPDIR}/motr/st/utils/sns_repair_common_inc.sh
 
-
 export P=15
 export MOTR_CLIENT_ONLY=1
 

--- a/motr/st/utils/sns_repair_motr_1n_1f.sh
+++ b/motr/st/utils/sns_repair_motr_1n_1f.sh
@@ -28,7 +28,6 @@ TOPDIR=`dirname $0`/../../../
 . ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
 . ${TOPDIR}/motr/st/utils/sns_repair_common_inc.sh
 
-
 export MOTR_CLIENT_ONLY=1
 
 sns_repair_motr_test()

--- a/motr/st/utils/sns_repair_motr_abort.sh
+++ b/motr/st/utils/sns_repair_motr_abort.sh
@@ -28,13 +28,11 @@ TOPDIR=`dirname $0`/../../../
 . ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
 . ${TOPDIR}/motr/st/utils/sns_repair_common_inc.sh
 
-
-
-S=3
 N=3
 K=3
+S=3
 P=15
-src_count=15
+
 export MOTR_CLIENT_ONLY=1
 
 sns_repair_motr_test()

--- a/motr/st/utils/sns_repair_motr_mf.sh
+++ b/motr/st/utils/sns_repair_motr_mf.sh
@@ -28,11 +28,10 @@ TOPDIR=`dirname $0`/../../../
 . ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
 . ${TOPDIR}/motr/st/utils/sns_repair_common_inc.sh
 
-S=3
 N=3
 K=3
+S=3
 P=15
-src_count=15
 
 export MOTR_CLIENT_ONLY=1
 


### PR DESCRIPTION
Improve SNS tests coverage by creating few more objects with
different unit sizes and lengths of primary number of units.

Also, show the m0cp and m0cat commands with their parameters
running during the tests. Useful for debugging.