### PR TITLE
doc: edit quick start guide

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -1,210 +1,161 @@
 =================
 Quick Start Guide
 =================
-This guide provides information to get Motr component ready.
+This guide provides information on how to get Motr ready.
 
 *************
 Prerequisites
 *************
 The prerequisite that is necessary to install the Motr component is mentioned below.
 
-- If you are using CentOS version 7.8 or lower, you'll have to install the kernel dependencies by following this link: `http://vault.centos.org/centos/<CentOS-version>/os/x86_64/Packages/` where <CentOS-version> is replaced with you version of CentOS. For example, if you are using CentOS 7.8.2003, you'll have to install this kernel dependency:
-
-  **$ sodu yum install https://vault.centos.org/centos/7.8.2003/os/x86_64/Packages/kernel-devel-3.10.0-1127.el7.x86_64.rpm**
-
 - CentOS-7 for x86_64 platform (ARM64 platform support work is in progress).
 
-- **Ansible** is needed. 
+- **Ansible** is needed::
 
-  - Install EPEL repo:
-  
-    **$ sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm**
+    sudo yum install epel-release # Install EPEL yum repo
+    sudo yum install ansible
 
-**********
-Procedure
-**********
-The below mentioned procedure must be followed to install the Motr component and to perform tests.
+Get the Sources
+===============
+Clone Motr::
 
-1. Cloning the Source Code (Either Build from Source or RPM Generation)
+    git clone --recursive https://github.com/Seagate/cortx-motr.git
 
-2. Building the Source Code
+Build
+=====
 
-3. Running the Tests
+1. Build and install the necessary dependencies::
 
-**Note**: The procedure mentioned above must be initiated in accordance with the order of listing.
+    cd cortx-motr
+    sudo scripts/install-build-deps
 
-Cloning the Source Code
-=======================
-To clone the source code, perform the following steps:
+2. Check the Lustre network interface configuration::
 
-Run the following commands:
+    vi /etc/modprobe.d/lnet.conf
 
-- **$ git clone --recursive https://github.com/Seagate/cortx-motr.git**
+   Use ``ip a`` command to get a list of network interfaces.
+   Then modify ``lnet.conf`` to use one of the listed network interfaces.
+   After this run::
 
-- **$ cd cortx-motr**
+    sudo modprobe lnet
+    sudo lctl list_nids
 
+3. To build Motr, run::
 
-Building the Source Code
-========================
-Perform the below mentioned procedure to build the source code.
+    scripts/m0 make
 
-1. Build and install the necessary dependencies. Run the following command to install all the dependent packages.
-
-   - **$ sudo ./scripts/install-build-deps**
-
-2. Reboot your system. After reboot, run the following commands to check if the lustre network is functioning accurately.
-
-   - **$ vi /etc/modprobe.d/lnet.conf**
-
-     A proper configuration file is needed for LNet. Please use the command *ip a* to get a list of network interfaces and then modify the *lnet.conf* to use one of the network interfaces. Please refer to the `<#Troubleshooting>`_ section for more information.
-              
-
-   - **$ sudo modprobe lnet**
-
-   - **$ sudo lctl list_nids**
-
-3. To compile, run either of the following commands:
-
-   - **$ scripts/m0 make**
-
-   - **$ scripts/m0 rebuild**
-
-   **Note**: The **scripts/m0 rebuild** command includes some clean up.
+   Note: use ``scripts/m0 rebuild`` command to re-build Motr.
  
-RPM Generation
+RPMs Generation
 ===============
 
-You can also build RPMs by running the following command.
+To build RPMs, run::
 
-- **$ make rpms**
+    make rpms
 
-The following RPMs are generated in the **$HOME/rpmbuild/RPMS/x86_64** directory.
-
-- cortx-motr-1.0.0-1_git*_3.10.0_1062.el7.x86_64.rpm
-
-- cortx-motr-debuginfo-1.0.0-1_git*_3.10.0_1062.el7.x86_64.rpm
-
-- cortx-motr-devel-1.0.0-1_git*_3.10.0_1062.el7.x86_64.rpm
- 
-- cortx-motr-tests-ut-1.0.0-1_git*_3.10.0_1062.el7.x86_64.rpm
-
-Note : Check contents of **$HOME/rpmbuild/RPMS/x86_64** directory.
+The generated RPMs will be placed at ``$HOME/rpmbuild/RPMS/$(arch)/`` directory.
 
 Running Tests
 =============
+
 Unit Test
 ---------
-- To perform unit tests, run the following command:
+- To run unit tests, use this command::
 
-  - **$ sudo ./scripts/m0 run-ut**
+    sudo scripts/m0 run-ut
 
-  Running Time (approximate) - 20 to 30 minutes
+  Note: running Time (approximate) - 20 to 30 minutes
 
-- To list all available unit tests, run the following command:
+- To list all available unit tests::
 
-  - **$ sudo ./scripts/m0 run-ut -l**
+    sudo scripts/m0 run-ut -l
 
-- To run some unit test(s), e.g. "libm0-ut", run the following command:
+- To run some specific unit test(s)::
 
-  - **$ sudo ./scripts/m0 run-ut -t libm0-ut**
+    sudo scripts/m0 run-ut -t libm0-ut,be-ut
 
 Kernel Space Unit Test
 ----------------------
-- To perform kernel space unit tests, run the following command:
+- To run kernel space unit tests, use this command::
 
-  - **$ sudo ./scripts/m0 run-kut**
+    sudo scripts/m0 run-kut
 
 System Tests
 ------------
-- To list all the system tests, run the following command:
+- To list all available system tests, run the following command::
 
-  - **$ sudo ./scripts/m0 run-st -l**
+    sudo scripts/m0 run-st -l
 
-- To perform the motr sanity test, run the following command:
+- To run Motr sanity test, use the following command::
 
-  - **$ sudo ./scripts/m0 run-st 52motr-singlenode-sanity**
+    sudo scripts/m0 run-st 52motr-singlenode-sanity
 
-- To perform all the system tests, run the following command:
+- To run all system tests::
 
-  - **$ sudo ./scripts/m0 run-st**
+    sudo scripts/m0 run-st
+
+  Note: it might take several hours to finish.
   
 Unit Benchmark
----------
-- To perform unit benchmarks, run the following command:
+--------------
+- To run unit benchmarks, use the following command::
 
-  - **$ sudo ./scripts/m0 run-ub**
+    sudo scripts/m0 run-ub
 
   Running Time (approximate) - 60 to 70 minutes
 
-- To list all available unit benchmarks, run the following command:
+- To list all available unit benchmarks::
 
-  - **$ sudo ./scripts/m0 run-ub -l**
+    sudo scripts/m0 run-ub -l
 
-- To run some unit benchmark(s), e.g. "ad-ub", run the following command:
+- To run some specific unit benchmark(s), e.g. "ad-ub"::
 
-  - **$ sudo ./scripts/m0 run-ub -t ad-ub**
+    sudo scripts/m0 run-ub -t ad-ub
 
 Troubleshooting
 ================
-- If the pip installation fails while installing build dependencies, run the following commands:
+- If the pip installation fails while installing build dependencies,
+  run the following commands::
 
-  - **$ python -m pip uninstall pip setuptools**
-  - **$ sudo ./scripts/install-build-deps**
+    python -m pip uninstall pip setuptools
+    sudo scripts/install-build-deps
 
-- If an installation failure occurs due to the dependency of *pip3* , run the following commands:
+- If an installation failure occurs due to the dependency of ``pip3`` ,
+  run the following commands::
 
-  - **$ sudo yum install -y python36-setuptools**
-  - **$ sudo easy_install-3.6 pip**
+    sudo yum install -y python36-setuptools
+    sudo easy_install-3.6 pip
 
-- If an installation failure occurs due to *ply* dependency, run the following command:
+- If an installation failure occurs due to ``ply`` dependency,
+  run the following command::
 
-  - **$ pip3 install ply**
+    pip3 install ply
 
-- If **lctl list_nids** does not render an output, perform the following steps:
+- If ``lctl list_nids`` does not render an output, do the following:
 
-  1. Create the **lnet.conf** file, if it does not exist.
+  1. Create the ``lnet.conf`` file, if it does not exist. And make sure
+     the interface name is specified correctly there::
 
-  2. Restart the **lnet** service, and run the following commands:
+       $ cat /etc/modprobe.d/lnet.conf
+       options lnet networks=tcp(eth1) config_on_load=1
 
-     - **cat /etc/modprobe.d/lnet.conf**
+     Check the network interfaces in your system with ``ip a`` command.
 
-       - **options lnet networks=tcp(eth1) config_on_load=1**
+  2. Restart the ``lnet`` service, and check LNet NIDs::
 
-     - **sudo systemctl restart lnet**
+       sudo systemctl restart lnet
+       sudo lctl list_nids
 
-     - **sudo lctl list_nids**
+Build the documentation
+=======================
 
-       - 192.168.1.160@tcp
+To create Motr documentation files, in Motr folder run::
 
-     **Note**: Make sure that the eth1 interface is present in the node by checking ifconfig. Else, update the new interface in the file.
+    make doc
 
-- **Build the documents**
+The files will be generated at doc/html/ folder.
 
-  - Steps used to 'make' this doc:
-    
-  - install pip itself:
-      
-    - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        
-    - python get-pip.py
-  
-    - pip install -U sphinx (you may need to do "rpm -e --nodeps pyparsing.noarch")
-    
-    - pip install sphinxcontrib.plantuml
-    
-    - install jre (java runtime environment) from Java.com
-    
-    - install plantuml from plantuml.com
-    
-    - create such an executable shell script:
-    
-      .. code-block:: bash
-      
-       $ cat /bin/plantuml
-       #!/bin/sh
-       /somewhere_to_your/bin/java -jar /somewhere_to_your/plantuml.jar $@
-       
-        
+
 Tested by:
 
 - May 2, 2021: Christina Ku (christina.ku@seagate.com) in Red Hat Enterprise Linux Server release 7.7 (Maipo)


### PR DESCRIPTION
Drop needless stuff (it's a *quick* start guide after all),
fix formatting of the commands.

This should be landed after https://github.com/Seagate/cortx-motr/pull/656 fix.