### PR TITLE
[DTM0] EOS-20249: Versioned pairs in btree and CAS.

### DIFF
--- a/be/btree.h
+++ b/be/btree.h
@@ -403,6 +403,18 @@ M0_INTERNAL void m0_be_btree_delete(struct m0_be_btree *tree,
 				    struct m0_be_op *op,
 				    const struct m0_buf *key);
 
+/**
+ * Marks an key-value pair as "dead" (deleted).
+ * The call does not affect the value stored in the tree,
+ * it only updates the version and it sets the tombstone
+ * flag.
+ * Note, the user should calculate credits for "insertion" rather than
+ * for "deletion" of a key-value pair.
+ *
+ * @see ::m0_be_btree_lookup_alive_inplace()
+ * @see ::m0_be_btree_cursor_alive_get()
+ * @see ::m0_be_btree_save_inplace()
+ */
 M0_INTERNAL void m0_be_btree_kill(struct m0_be_btree *tree,
 				  struct m0_be_tx *tx,
 				  struct m0_be_op *op,

--- a/be/btree.h
+++ b/be/btree.h
@@ -427,45 +427,16 @@ M0_INTERNAL void m0_be_btree_update(struct m0_be_btree *tree,
  *
  * -ENOENT is set to @op->bo_u.u_btree.t_rc if not found.
  *
+ * With a versioned tree (see M0_BBF_IS_VERSIONED), this function will try
+ * to AMB 'key' to 'm0_verbuf::v_ver', and if its version is not zero then
+ * it will insert a tombstone on the pair instead of removing this pair.
+ *
  * @see m0_be_btree_insert()
  */
 M0_INTERNAL void m0_be_btree_delete(struct m0_be_btree *tree,
 				    struct m0_be_tx *tx,
 				    struct m0_be_op *op,
 				    const struct m0_buf *key);
-
-/*
- * TODO: Consider an alternative way to provide versioned insert/delete:
- * Option1:
- *   Wrap m0_buf structure:
- *	struct m0_versioned_buf { .version = X, .buf = m0_buf } + container_of
- *	Pros: an isolated change.
- *	Cons: requires new types and wrappers.
- * Option2:
- *   Use container_of on the transaction:
- *      m0_dtx::tx_betx + bob_of/container_of => m0_dtm0_dtx => txd => version.
- *      Pros: no changes in the existing API.
- *      Cons: may not work with UTs.
- */
-
-/**
- * Marks an key-value pair as "dead" (deleted).
- * The call does not affect the value stored in the tree,
- * it only updates the version and it sets the tombstone
- * flag.
- * Note, the user should calculate credits for "insertion" rather than
- * for "deletion" of a key-value pair.
- *
- * @see ::m0_be_btree_lookup_alive_inplace()
- * @see ::m0_be_btree_cursor_alive_get()
- * @see ::m0_be_btree_save_inplace()
- */
-M0_INTERNAL void m0_be_btree_kill(struct m0_be_btree *tree,
-				  struct m0_be_tx *tx,
-				  struct m0_be_op *op,
-				  const struct m0_buf *key,
-				  uint64_t ver);
-
 /**
  * Looks up for a @dest_value by the given @key in btree.
  * The result is copied into provided @dest_value buffer.

--- a/be/btree.h
+++ b/be/btree.h
@@ -66,6 +66,10 @@ struct m0_be_btree {
 	struct m0_be_btree_backlink      bb_backlink;
 	/** Root node of the tree. */
 	struct m0_be_bnode              *bb_root;
+	/* TODO: Consider setting up the field before or after btree_create. */
+#if 0
+	uint64_t                         bb_is_versioned;
+#endif
 	struct m0_format_footer          bb_footer;
 	/*
 	 * volatile-only fields
@@ -76,6 +80,7 @@ struct m0_be_btree {
 	struct m0_be_seg                *bb_seg;
 	/** operation vector, treating keys and values, given by the user */
 	const struct m0_be_btree_kv_ops *bb_ops;
+
 } M0_XCA_RECORD M0_XCA_DOMAIN(be);
 
 enum m0_be_btree_format_version {
@@ -403,6 +408,20 @@ M0_INTERNAL void m0_be_btree_delete(struct m0_be_btree *tree,
 				    struct m0_be_op *op,
 				    const struct m0_buf *key);
 
+/*
+ * TODO: Consider an alternative way to provide versioned insert/delete:
+ * Option1:
+ *   Wrap m0_buf structure:
+ *	struct m0_versioned_buf { .version = X, .buf = m0_buf } + container_of
+ *	Pros: an isolated change.
+ *	Cons: requires new types and wrappers.
+ * Option2:
+ *   Use container_of on the transaction:
+ *      m0_dtx::tx_betx + bob_of/container_of => m0_dtm0_dtx => txd => version.
+ *      Pros: no changes in the existing API.
+ *      Cons: may not work with UTs.
+ */
+
 /**
  * Marks an key-value pair as "dead" (deleted).
  * The call does not affect the value stored in the tree,
@@ -694,7 +713,7 @@ M0_INTERNAL void m0_be_btree_cursor_next(struct m0_be_btree_cursor *it);
 /**
  * Tombstone-aware version of cursor_next().
  * The function finds next position in the tree where the pair is alive.
- * TODO: THis function is under construction!
+ * TODO: This function is under construction!
  */
 M0_INTERNAL void m0_be_btree_cursor_alive_next(struct m0_be_btree_cursor *cur);
 

--- a/be/ut/main.c
+++ b/be/ut/main.c
@@ -144,6 +144,7 @@ extern void m0_be_ut_alloc_spare(void);
 extern void m0_be_ut_list(void);
 extern void m0_be_ut_btree_create_destroy(void);
 extern void m0_be_ut_btree_create_truncate(void);
+extern void m0_be_ut_btree_ver_and_tbs(void);
 extern void m0_be_ut_emap(void);
 extern void m0_be_ut_seg_dict(void);
 extern void m0_be_ut_seg0_test(void);
@@ -266,7 +267,8 @@ struct m0_ut_suite be_ut = {
 		{ "list",                    m0_be_ut_list                    },
 		{ "btree-create_destroy",    m0_be_ut_btree_create_destroy    },
 		{ "btree-create_truncate",   m0_be_ut_btree_create_truncate   },
-		{ "seg_dict",                m0_be_ut_seg_dict                },
+		{ "btree-create_truncate",   m0_be_ut_btree_create_truncate   },
+		{ "btree-ver_and_tbs",       m0_be_ut_btree_ver_and_tbs       },
 #ifndef __KERNEL__
 		{ "seg0",                    m0_be_ut_seg0_test               },
 #endif /* __KERNEL__ */

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -1008,7 +1008,7 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
 		anchor->ba_value.b_nob = M0_CAS_CTG_KV_HDR_SIZE +
 					 ctg_op->co_val.b_nob;
-		m0_be_btree_save_inplace(btree, tx, beop, key, anchor,
+		m0_be_btree_save_inplace(btree, tx, beop, key, 0, anchor,
 					 !!(ctg_op->co_flags & COF_OVERWRITE),
 					 zones);
 		break;

--- a/cas/service.c
+++ b/cas/service.c
@@ -1184,15 +1184,20 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	int                 next_phase;
 
 	M0_ENTRY("fom %p phase %d", fom, phase);
-	is_index_drop = op_is_index_drop(opc, ct);
 	M0_PRE(ctidx != NULL);
 	M0_PRE(cas_fom_invariant(fom));
 	M0_PRE(ergo(ENABLE_DTM0 && !M0_IS0(&op->cg_txd),
 		    m0_dtm0_tx_desc__invariant(&op->cg_txd)));
-	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT) {
+
+	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT)
 		M0_LOG(M0_DEBUG, "Got CAS with txid: " DTID0_F,
 		       DTID0_P(&op->cg_txd.dtd_id));
-	}
+
+	if (M0_FI_ENABLED("skip-dtm0-phases"))
+		is_dtm0_used = false;
+
+	is_index_drop = op_is_index_drop(opc, ct);
+
 	switch (phase) {
 	case M0_FOPH_INIT ... M0_FOPH_NR - 1:
 

--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -451,13 +451,13 @@ static void ut_dtx_fini(struct m0_dtx *dtx)
 		m0_free(dtx->tx_dtx);
 }
 
-static int ut_rec_common_put(struct cl_ctx                 *cctx,
-			     struct m0_cas_id              *index,
-			     const struct m0_bufvec        *keys,
-			     const struct m0_bufvec        *values,
-			     struct m0_dtx                 *dtx,
-			     struct m0_cas_rec_reply       *rep,
-			     uint32_t                       flags)
+static int ut_rec_common_put(struct cl_ctx           *cctx,
+			     struct m0_cas_id        *index,
+			     const struct m0_bufvec  *keys,
+			     const struct m0_bufvec  *values,
+			     struct m0_dtx           *dtx,
+			     struct m0_cas_rec_reply *rep,
+			     uint32_t                 flags)
 {
 	struct m0_cas_req  req;
 	struct m0_chan    *chan;
@@ -539,10 +539,10 @@ static void ut_get_rep_clear(struct m0_cas_get_reply *rep, uint32_t nr)
 		m0_free(rep[i].cge_val.b_addr);
 }
 
-static int ut_rec_get(struct cl_ctx                *cctx,
-		      struct m0_cas_id             *index,
-		      const struct m0_bufvec       *keys,
-		      struct m0_cas_get_reply      *rep)
+static int ut_rec_get(struct cl_ctx           *cctx,
+		      struct m0_cas_id        *index,
+		      const struct m0_bufvec  *keys,
+		      struct m0_cas_get_reply *rep)
 {
 	struct m0_cas_req  req;
 	struct m0_chan    *chan;
@@ -683,11 +683,11 @@ static int ut_rec_common_del(struct cl_ctx           *cctx,
 }
 
 /* Submits CAS requests separately one-by-one for each key. */
-static int ut_rec_common_del_seq(struct cl_ctx                 *cctx,
-				 struct m0_cas_id              *index,
-				 struct m0_bufvec              *keys,
-				 struct m0_dtx                 *dtx,
-				 struct m0_cas_rec_reply       *rep)
+static int ut_rec_common_del_seq(struct cl_ctx           *cctx,
+				 struct m0_cas_id        *index,
+				 struct m0_bufvec        *keys,
+				 struct m0_dtx           *dtx,
+				 struct m0_cas_rec_reply *rep)
 {
 	struct m0_bufvec k;
 	m0_bcount_t      i;
@@ -1303,7 +1303,7 @@ static void next_common(struct m0_bufvec *keys,
 
 static void del_get_verified(struct m0_cas_id *index,
 			     struct m0_bufvec *keys,
-			     uint64_t version)
+			     uint64_t          version)
 {
 	int                       rc;
 	struct m0_cas_get_reply  *get_rep;
@@ -1330,9 +1330,9 @@ static void del_get_verified(struct m0_cas_id *index,
 
 static void next_verified(struct m0_cas_id *index,
 			  struct m0_bufvec *start_key,
-			  uint32_t requested_keys_nr,
+			  uint32_t          requested_keys_nr,
 			  struct m0_bufvec *expected_keys,
-			  int flags)
+			  int               flags)
 {
 	struct m0_cas_next_reply *next_rep;
 	uint64_t                  rep_count;
@@ -1413,7 +1413,7 @@ static void put_get_verified(struct m0_cas_id *index,
 }
 
 /*
- * Initialize a single-element bufvec using an element taken from
+ * Initialise a single-element bufvec using an element taken from
  * the target bufvec at position specified by __idx:
  * @verbatim
  *   bufvec target = [buf A, buf B, buf C]

--- a/dtm0/it/all2all/README.md
+++ b/dtm0/it/all2all/README.md
@@ -16,20 +16,26 @@ works and client can write key/value pairs with DTX
 enabled.
 
 What the test does:
- - bootstraps the cluster of 3 m0d processes using Hare
- - checks that no any handling of HA messages is done by
-   DTM0 service
- - sends HA TRANSIENT messages to m0d's to trigger HA messages
-   handling by DTM0 services
- - checks that all DTM0 services are ready to handle HA
-   messages
- - sends HA ONLINE messages to m0d's to trigger connections
-   logic
- - checks that all m0d's are connected with each other
- - run the m0crate to write key/value pairs
- - sends HA client ONLINE messages to m0d's to trigger
-   connections from m0d's to the client
- - waits for m0crate completion
+-   bootstraps the cluster of 3 m0d processes using Hare
+
+-   checks that no any handling of HA messages is done by
+    DTM0 service
+
+-   sends HA TRANSIENT messages to m0d's to trigger HA messages
+    handling by DTM0 services
+
+-   checks that all DTM0 services are ready to handle HA messages
+
+-   sends HA ONLINE messages to m0d's to trigger connections logic
+
+-   checks that all m0d's are connected with each other
+
+-   run the m0crate to write key/value pairs
+
+-   sends HA client ONLINE messages to m0d's to trigger
+    connections from m0d's to the client
+
+-   waits for m0crate completion
 
 ## Command to run this test
 ```sh

--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -580,7 +580,7 @@ static bool conf_obj_is_process(const struct m0_conf_obj *obj)
 
 static int dtm0_service__ha_subscribe(struct m0_reqh_service *service)
 {
-	struct m0_confc        *confc = m0_reqh2confc(service->rs_reqh);
+	struct m0_confc        *confc;
 	struct m0_conf_root    *root;
 	struct m0_conf_diter    it;
 	struct m0_conf_obj     *obj;
@@ -589,13 +589,15 @@ static int dtm0_service__ha_subscribe(struct m0_reqh_service *service)
 	struct m0_dtm0_service *s;
 	struct m0_fid           rproc_fid;
 	struct m0_fid           rserv_fid;
-	struct m0_fid          *current_proc_fid = &service->rs_reqh->rh_fid;
-
-	int rc;
+	struct m0_fid          *current_proc_fid;
+	int                     rc;
 
 	M0_ENTRY();
 
 	M0_PRE(service != NULL);
+
+	confc = m0_reqh2confc(service->rs_reqh);
+	current_proc_fid = &service->rs_reqh->rh_fid;
 	s = container_of(service, struct m0_dtm0_service, dos_generic);
 
 	/** UT workaround */

--- a/motr/st/utils/ha_msg_send.sh
+++ b/motr/st/utils/ha_msg_send.sh
@@ -14,7 +14,7 @@ m0t1fs_dir="$motr_st_util_dir/../../../m0t1fs/linux_kernel/st"
 
 proc_state_change()
 {
-    local lnet_nid=`sudo lctl list_nids | head -1`
+    local lnet_nid=$(sudo lctl list_nids | head -1)
     local c_endpoint="$lnet_nid:$M0HAM_CLI_EP"
     local s_endpoint="$lnet_nid:$1"
     local fid=$2

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -924,6 +924,7 @@ static void run_m0ops(uint64_t nr, enum m0_idx_opcode opcode,
 	/* Execute the ops */
 	for (i = 0; i < nr; ++i) {
 		rc = m0_bufvec_alloc(&key_vecs[i], 1, sizeof(i));
+		M0_UT_ASSERT(rc == 0);
 		M0_UT_ASSERT(key_vecs[i].ov_vec.v_count[0] == sizeof(i));
 		memcpy(key_vecs[i].ov_buf[0], &i, sizeof(i));
 


### PR DESCRIPTION
The patch introduces tombstones and versions into btree.
Tombstones and versions may be used to enable the
"conflict-free" behavior: a set of key-value pairs
can always be merged with another set (for example,
a set of REDO records sent from another process).

Human-readable list of changes:
- Version field followed by the key-value data.
- The most significant bit of the version field
  used as the tombstone flag.
- A flag into btree was added. The flag helps
  to distinguish versioned trees from ordinary trees.
- btree_save and btree_delete are trying to AMB the key
  to get the versioned buffer, and they use the version
  specified there.
- btree cursor can be initialized in a way where it
  iterates over only alive or only dead pairs.
- New version-related UTs for btree.
- CAS using versioned btrees for ordinary catalogues.
- New version-related UTs for CAS.

Here is a list of changes of the on-disk format.

1. A new member of the btree - bb_flags.

2. Storage for version.

Right now the version+tombstone field is stored in the following way:
```
 |<- Buffer allocated for kv data     ->|
 |                                      |
 |<- bit  ->|<- u63 ->|                 |
 [ TOMBSTONE, VERSION ] [ KEY ] [ VALUE ]
                       / \      /\
                        |        |
                        |       btree_val
                       btree_key
```

Signed-off-by: Ivan Alekhin <ivan.alekhin@seagate.com>