### PR TITLE
EOS-20841 fdmi/source_dock: make M0_FDMI_SOURCE_POST_RECORD() void

### DIFF
--- a/cas/index_gc.c
+++ b/cas/index_gc.c
@@ -266,7 +266,7 @@ static int cgc_fom_tick(struct m0_fom *fom0)
 		 * not need.
 		 */
 		if (phase == M0_FOPH_TXN_COMMIT)
-			m0_fom_phase_set(fom0, M0_FOPH_TXN_DONE_WAIT);
+			m0_fom_phase_set(fom0, M0_FOPH_TXN_LOGGED_WAIT);
 		break;
 	case CGC_LOOKUP:
 		m0_ctg_op_init(ctg_op, fom0, 0);

--- a/cas/index_gc.c
+++ b/cas/index_gc.c
@@ -266,7 +266,7 @@ static int cgc_fom_tick(struct m0_fom *fom0)
 		 * not need.
 		 */
 		if (phase == M0_FOPH_TXN_COMMIT)
-			m0_fom_phase_set(fom0, M0_FOPH_TXN_COMMIT_WAIT);
+			m0_fom_phase_set(fom0, M0_FOPH_TXN_DONE_WAIT);
 		break;
 	case CGC_LOOKUP:
 		m0_ctg_op_init(ctg_op, fom0, 0);

--- a/cas/service.c
+++ b/cas/service.c
@@ -520,7 +520,7 @@ M0_INTERNAL void m0_cas_svc_init(void)
 	cas_fom_phases[M0_FOPH_INIT].sd_allowed |= M0_BITS(CAS_CHECK_PRE);
 	cas_fom_phases[M0_FOPH_TXN_OPEN].sd_allowed |= M0_BITS(CAS_START);
 	cas_fom_phases[M0_FOPH_QUEUE_REPLY].sd_allowed |=
-		M0_BITS(M0_FOPH_TXN_COMMIT_WAIT);
+		M0_BITS(M0_FOPH_TXN_DONE_WAIT);
 	m0_sm_conf_init(&cas_sm_conf);
 	m0_reqh_service_type_register(&m0_cas_service_type);
 	m0_cas_gc_init();
@@ -1223,14 +1223,14 @@ static int cas_fom_tick(struct m0_fom *fom0)
 				result = op_sync_wait(fom0);
 		}
 		if (cas_in_ut() && m0_fom_phase(fom0) == M0_FOPH_QUEUE_REPLY) {
-			m0_fom_phase_set(fom0, M0_FOPH_TXN_COMMIT_WAIT);
+			m0_fom_phase_set(fom0, M0_FOPH_TXN_DONE_WAIT);
 		}
 
 		/*
-		 * Once the transition TXN_COMMIT_WAIT->FINISH is completed,
+		 * Once the transition TXN_DONE_WAIT->FINISH is completed,
 		 * we need to send out P-msg if DTM0 is in use.
 		 */
-		if (phase == M0_FOPH_TXN_COMMIT_WAIT &&
+		if (phase == M0_FOPH_TXN_DONE_WAIT &&
 		    m0_fom_phase(fom0) == M0_FOPH_FINISH && is_dtm0_used) {
 			rc = m0_dtm0_on_committed(fom0, &cas_op(fom0)->cg_txd);
 			if (rc != 0)
@@ -2866,7 +2866,7 @@ struct m0_sm_trans_descr cas_fom_trans[] = {
 	{ "dtm0-op-done",         CAS_DTM0,             M0_FOPH_SUCCESS },
 	{ "dtm0-op-fail",         CAS_DTM0,             M0_FOPH_FAILURE },
 
-	{ "ut-short-cut",         M0_FOPH_QUEUE_REPLY, M0_FOPH_TXN_COMMIT_WAIT }
+	{ "ut-short-cut",         M0_FOPH_QUEUE_REPLY, M0_FOPH_TXN_DONE_WAIT }
 };
 
 static struct m0_sm_conf cas_sm_conf = {

--- a/fdmi/fol_fdmi_src.c
+++ b/fdmi/fol_fdmi_src.c
@@ -541,12 +541,11 @@ M0_INTERNAL int m0_fol_fdmi_src_deinit(void)
  * Entry point for FOM to start FDMI processing
  * ------------------------------------------------------------------ */
 
-M0_INTERNAL int m0_fol_fdmi_post_record(struct m0_fom *fom)
+M0_INTERNAL void m0_fol_fdmi_post_record(struct m0_fom *fom)
 {
 	struct m0_fdmi_module *m = m0_fdmi_module__get();
 	struct m0_dtx         *dtx;
 	struct m0_be_tx       *be_tx;
-	int                    rc;
 
 	M0_ENTRY("fom: %p", fom);
 
@@ -570,15 +569,10 @@ M0_INTERNAL int m0_fol_fdmi_post_record(struct m0_fom *fom)
 	dtx->tx_fol_rec.fr_fdmi_rec.fsr_dryrun = false;
 	dtx->tx_fol_rec.fr_fdmi_rec.fsr_data = NULL;
 
-	rc = M0_FDMI_SOURCE_POST_RECORD(&dtx->tx_fol_rec.fr_fdmi_rec);
-	if (rc < 0) {
-		M0_LOG(M0_ERROR, "Failed to post FDMI record.");
-		goto error_post_record;
-	} else {
-		M0_ENTRY("Posted FDMI rec, src_rec %p, rec id " U128X_F,
-			 &dtx->tx_fol_rec.fr_fdmi_rec,
-			 U128_P(&dtx->tx_fol_rec.fr_fdmi_rec.fsr_rec_id));
-	}
+	M0_FDMI_SOURCE_POST_RECORD(&dtx->tx_fol_rec.fr_fdmi_rec);
+	M0_LOG(M0_DEBUG, "M0_FDMI_SOURCE_POST_RECORD fr_fdmi_rec=%p "
+	       "fsr_rec_id="U128X_F, &dtx->tx_fol_rec.fr_fdmi_rec,
+	       U128_P(&dtx->tx_fol_rec.fr_fdmi_rec.fsr_rec_id));
 
 	/* Aftermath. */
 
@@ -588,10 +582,7 @@ M0_INTERNAL int m0_fol_fdmi_post_record(struct m0_fom *fom)
 	 * done before the M0_FDMI_SOURCE_POST_RECORD call above.
 	 */
 
-	return M0_RC(rc);
-error_post_record:
-	ffs_tx_dec_refc(be_tx, NULL);
-	return M0_RC(rc);
+	M0_LEAVE();
 }
 
 /**

--- a/fdmi/fol_fdmi_src.h
+++ b/fdmi/fol_fdmi_src.h
@@ -82,10 +82,8 @@ M0_INTERNAL void m0_fol_fdmi_src_fini(void);
  */
 M0_INTERNAL int m0_fol_fdmi_src_deinit(void);
 
-/**
- * Submit new FOL entry to FDMI.
- */
-M0_INTERNAL int m0_fol_fdmi_post_record(struct m0_fom *fom);
+/** Submit new FOL entry to FDMI. */
+M0_INTERNAL void m0_fol_fdmi_post_record(struct m0_fom *fom);
 
 /** @} group fdmi_fol_src */
 

--- a/fdmi/source_dock.c
+++ b/fdmi/source_dock.c
@@ -209,7 +209,7 @@ M0_INTERNAL void m0_fdmi__rec_id_gen(struct m0_fdmi_src_rec *src_rec)
 	M0_LEAVE();
 }
 
-M0_INTERNAL int m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec)
+M0_INTERNAL void m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec)
 {
 	struct m0_fdmi_src_dock *src_dock = m0_fdmi_src_dock_get();
 
@@ -233,7 +233,7 @@ M0_INTERNAL int m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec)
 	m0_fdmi__src_dock_fom_wakeup(&src_dock->fsdc_sd_fom);
 	m0_mutex_unlock(&src_dock->fsdc_list_mutex);
 
-	return M0_RC(0);
+	M0_LEAVE();
 }
 
 M0_INTERNAL int m0_fdmi_source_alloc(enum m0_fdmi_rec_type_id type_id,

--- a/fdmi/source_dock.h
+++ b/fdmi/source_dock.h
@@ -51,7 +51,7 @@ struct m0_fdmi_src {
 	/* Data owned and populated by source dock. */
 
 	/** Function to post FDMI data */
-	int (*fs_record_post)(struct m0_fdmi_src_rec *src_rec);
+	void (*fs_record_post)(struct m0_fdmi_src_rec *src_rec);
 
 	/* Data owned and populated by source. */
 

--- a/fdmi/source_dock_internal.h
+++ b/fdmi/source_dock_internal.h
@@ -116,11 +116,8 @@ struct m0_fdmi_src_dock {
 	struct fdmi_sd_fom    fsdc_sd_fom;
 };
 
-/**
- * Function posts new fdmi data for analysis by FDMI source dock.
- * @return Returns 0 on success, error code otherwise.
- */
-M0_INTERNAL int m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec);
+/** Function posts new fdmi data for analysis by FDMI source dock. */
+M0_INTERNAL void m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec);
 
 /**
  * Function generates new fdmi record ID unque across the cluster.

--- a/fdmi/ut/filterc_ut.c
+++ b/fdmi/ut/filterc_ut.c
@@ -281,8 +281,7 @@ static void filterc_connect_to_confd(void)
 		.fsr_data    = g_fdmi_data,
 	};
 
-	rc = M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
-	M0_UT_ASSERT(rc == 0);
+	M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
 
 	m0_mutex_lock(&cond_mutex);
 	m0_cond_wait(&match_cond);

--- a/fdmi/ut/sd_apply_filter.c
+++ b/fdmi/ut/sd_apply_filter.c
@@ -190,8 +190,7 @@ static void fdmi_sd_apply_filter_internal(const struct m0_filterc_ops *ops)
 		.fsr_src    = src,
 		.fsr_data   = g_fdmi_data,
 	};
-	rc = M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
-	M0_UT_ASSERT(rc == 0);
+	M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
 	/* Wait until record is processed and released */
 	m0_semaphore_down(&g_sem);
 	m0_fdmi_source_deregister(src);

--- a/fdmi/ut/sd_post_record.c
+++ b/fdmi/ut/sd_post_record.c
@@ -109,8 +109,7 @@ void fdmi_sd_post_record(void)
 		.fsr_src    = src,
 		.fsr_data   = fdmi_data,
 	};
-	rc = M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
-	M0_UT_ASSERT(rc == 0);
+	M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
 	/* Wait until record is processed and released */
 	m0_semaphore_down(&g_sem);
 	m0_fdmi_source_deregister(src);

--- a/fdmi/ut/sd_send_not.c
+++ b/fdmi/ut/sd_send_not.c
@@ -277,8 +277,7 @@ void fdmi_sd_send_notif(void)
 		.fsr_data = g_fdmi_data,
 	};
 
-	rc = M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
-	M0_UT_ASSERT(rc == 0);
+	M0_FDMI_SOURCE_POST_RECORD(&g_src_rec);
 	/* Wait until record is sent over RPC */
 	m0_semaphore_down(&g_sem1);
 	fdmi_ut_packet_send_failed(&g_rpc_env.tre_rpc_machine,

--- a/fop/fom.c
+++ b/fop/fom.c
@@ -1741,16 +1741,11 @@ M0_INTERNAL int m0_fom_fol_rec_add(struct m0_fom *fom)
 	M0_ENTRY();
 
 	rc = m0_dtx_fol_add(&fom->fo_tx);
-	if (rc != 0)
-		goto done;
 
 #ifndef __KERNEL__
-	rc = m0_fol_fdmi_post_record(fom);
-	if (rc != 0)
-		goto done;
+	if (rc == 0)
+		m0_fol_fdmi_post_record(fom);
 #endif
-
-done:
 	return M0_RC(rc);
 }
 

--- a/fop/fom_generic.c
+++ b/fop/fom_generic.c
@@ -429,7 +429,7 @@ static int fom_tx_commit(struct m0_fom *fom)
  * Resumes fom execution after completing a blocking operation
  * in M0_FOPH_TXN_COMMIT phase.
  */
-M0_INTERNAL int m0_fom_tx_commit_wait(struct m0_fom *fom)
+M0_INTERNAL int m0_fom_tx_done_wait(struct m0_fom *fom)
 {
 	struct m0_dtx   *dtx = &fom->fo_tx;
 	struct m0_be_tx *tx = m0_fom_tx(fom);
@@ -561,12 +561,12 @@ static const struct fom_phase_desc fpd_table[] = {
 					M0_FOPH_QUEUE_REPLY_WAIT, "queue_reply",
 					M0_BITS(M0_FOPH_QUEUE_REPLY) },
 	[M0_FOPH_QUEUE_REPLY_WAIT] =  { &fom_queue_reply_wait,
-					M0_FOPH_TXN_COMMIT_WAIT,
+					M0_FOPH_TXN_DONE_WAIT,
 					"queue_reply_wait",
 					M0_BITS(M0_FOPH_QUEUE_REPLY_WAIT) },
-	[M0_FOPH_TXN_COMMIT_WAIT] =   { &m0_fom_tx_commit_wait, M0_FOPH_FINISH,
-					"tx_commit_wait",
-					M0_BITS(M0_FOPH_TXN_COMMIT_WAIT) },
+	[M0_FOPH_TXN_DONE_WAIT] =     { &m0_fom_tx_done_wait, M0_FOPH_FINISH,
+					"tx_done_wait",
+					M0_BITS(M0_FOPH_TXN_DONE_WAIT) },
 	[M0_FOPH_TIMEOUT] =	      { &fom_timeout, M0_FOPH_FAILURE,
 					"timeout", M0_BITS(M0_FOPH_TIMEOUT) },
 	[M0_FOPH_FAILURE] =	      { &fom_failure, M0_FOPH_TXN_COMMIT,
@@ -664,17 +664,17 @@ static struct m0_sm_state_descr generic_phases[] = {
 	},
 	[M0_FOPH_QUEUE_REPLY] = {
 		.sd_name      = "queue_reply",
-		.sd_allowed   = M0_BITS(M0_FOPH_TXN_COMMIT_WAIT,
+		.sd_allowed   = M0_BITS(M0_FOPH_TXN_DONE_WAIT,
 					M0_FOPH_QUEUE_REPLY_WAIT,
 					M0_FOPH_FINISH)
 	},
 	[M0_FOPH_QUEUE_REPLY_WAIT] = {
 		.sd_name      = "queue_reply_wait",
-		.sd_allowed   = M0_BITS(M0_FOPH_TXN_COMMIT_WAIT,
+		.sd_allowed   = M0_BITS(M0_FOPH_TXN_DONE_WAIT,
 					M0_FOPH_FINISH)
 	},
-	[M0_FOPH_TXN_COMMIT_WAIT] = {
-		.sd_name      = "tx_commit_wait",
+	[M0_FOPH_TXN_DONE_WAIT] = {
+		.sd_name      = "tx_done_wait",
 		.sd_allowed   = M0_BITS(M0_FOPH_TXN_INIT, M0_FOPH_FINISH)
 	},
 	[M0_FOPH_TIMEOUT] = {
@@ -753,15 +753,15 @@ struct m0_sm_trans_descr m0_generic_phases_trans[] = {
 	{"tx-opened",  M0_FOPH_TXN_WAIT, M0_FOPH_TYPE_SPECIFIC},
 	{"completed", M0_FOPH_SUCCESS, M0_FOPH_FOL_REC_ADD},
 	{"fol-record-added", M0_FOPH_FOL_REC_ADD, M0_FOPH_TXN_COMMIT},
-	{"tx-commit-start", M0_FOPH_TXN_COMMIT, M0_FOPH_QUEUE_REPLY},
+	{"tx-done-start", M0_FOPH_TXN_COMMIT, M0_FOPH_QUEUE_REPLY},
 	{"reply-queue-wait", M0_FOPH_QUEUE_REPLY, M0_FOPH_QUEUE_REPLY_WAIT},
-	{"tx-commit-wait", M0_FOPH_QUEUE_REPLY, M0_FOPH_TXN_COMMIT_WAIT},
+	{"tx-done-wait", M0_FOPH_QUEUE_REPLY, M0_FOPH_TXN_DONE_WAIT},
 	{"reply-complete", M0_FOPH_QUEUE_REPLY, M0_FOPH_FINISH},
 	{"reply-wait-finished",
-	 M0_FOPH_QUEUE_REPLY_WAIT, M0_FOPH_TXN_COMMIT_WAIT},
+	 M0_FOPH_QUEUE_REPLY_WAIT, M0_FOPH_TXN_DONE_WAIT},
 	{"reply-wait-finished", M0_FOPH_QUEUE_REPLY_WAIT, M0_FOPH_FINISH},
-	{"next", M0_FOPH_TXN_COMMIT_WAIT, M0_FOPH_TXN_INIT},
-	{"tx-commit-wait-complete", M0_FOPH_TXN_COMMIT_WAIT, M0_FOPH_FINISH},
+	{"next", M0_FOPH_TXN_DONE_WAIT, M0_FOPH_TXN_INIT},
+	{"tx-done-wait-complete", M0_FOPH_TXN_DONE_WAIT, M0_FOPH_FINISH},
 	{"timeout", M0_FOPH_TIMEOUT, M0_FOPH_FAILURE},
 	{"failed", M0_FOPH_FAILURE, M0_FOPH_TXN_COMMIT},
 };

--- a/fop/fom_generic.h
+++ b/fop/fom_generic.h
@@ -76,8 +76,8 @@ enum m0_fom_standard_phase {
 	M0_FOPH_TXN_COMMIT,         /*< commit local transaction context. */
 	M0_FOPH_QUEUE_REPLY,        /*< queuing fop reply.  */
 	M0_FOPH_QUEUE_REPLY_WAIT,   /*< waiting for fop cache space. */
-	M0_FOPH_TXN_COMMIT_WAIT,    /*< waiting to commit local transaction
-	                                context. */
+	M0_FOPH_TXN_DONE_WAIT,      /*< waiting for local transaction to become
+				        done. */
 	M0_FOPH_TIMEOUT,            /*< fom timed out. */
 	M0_FOPH_FAILURE,            /*< fom execution failed. */
 	M0_FOPH_NR,                  /*< number of standard phases. fom type
@@ -169,7 +169,7 @@ enum m0_fom_standard_phase {
 		     |			 |
 		     |			 v
 		     +------------FOPH_TXN_COMMIT-------------->+
-					 |            FOPH_TXN_COMMIT_WAIT
+					 |              FOPH_TXN_DONE_WAIT
 			    send reply	 v<---------------------+
 				FOPH_QUEUE_REPLY------------->+
 					 |            FOPH_QUEUE_REPLY_WAIT
@@ -248,7 +248,7 @@ M0_INTERNAL void m0_fom_mod_rep_fill(struct m0_fop_mod_rep *rep,
  */
 int32_t m0_rpc_item_generic_reply_rc(const struct m0_rpc_item *item);
 
-M0_INTERNAL int m0_fom_tx_commit_wait(struct m0_fom *fom);
+M0_INTERNAL int m0_fom_tx_done_wait(struct m0_fom *fom);
 
 /** @} end of fom group */
 

--- a/fop/fom_generic.h
+++ b/fop/fom_generic.h
@@ -76,6 +76,8 @@ enum m0_fom_standard_phase {
 	M0_FOPH_TXN_COMMIT,         /*< commit local transaction context. */
 	M0_FOPH_QUEUE_REPLY,        /*< queuing fop reply.  */
 	M0_FOPH_QUEUE_REPLY_WAIT,   /*< waiting for fop cache space. */
+	M0_FOPH_TXN_LOGGED_WAIT,    /*< waiting for local transaction to become
+	                                logged. */
 	M0_FOPH_TXN_DONE_WAIT,      /*< waiting for local transaction to become
 				        done. */
 	M0_FOPH_TIMEOUT,            /*< fom timed out. */
@@ -132,6 +134,9 @@ enum m0_fom_standard_phase {
    transition function.
 
    Fom execution proceeds as follows:
+
+   TODO update to reflect changes (FOPH_FOL_REC_ADD, FOPH_TXN_LOGGED_WAIT,
+   absence of FOPH_FAILED)
 
    @verbatim
 
@@ -207,7 +212,7 @@ M0_INTERNAL void m0_fom_generic_fini(void);
 M0_INTERNAL int m0_fom_generic_init(void);
 
 enum {
-	M0_FOM_GENERIC_TRANS_NR = 47,
+	M0_FOM_GENERIC_TRANS_NR = 48,
 };
 
 extern struct m0_sm_trans_descr

--- a/ioservice/cob_foms.c
+++ b/ioservice/cob_foms.c
@@ -718,11 +718,11 @@ static int cob_ops_fom_tick(struct m0_fom *fom)
 			 * into multiple trasactions.
 			 * As the the operation is incomplete, skip the sending
 			 * of reply and reinitialise the trasaction.
-			 * i.e move fom phase to M0_FOPH_TXN_DONE_WAIT and
+			 * i.e move fom phase to M0_FOPH_TXN_LOGGED_WAIT and
 			 * then to M0_FOPH_TXN_INIT.
 			 */
 			if (!cob_op->fco_is_done && m0_fom_rc(fom) == 0) {
-				m0_fom_phase_set(fom, M0_FOPH_TXN_DONE_WAIT);
+				m0_fom_phase_set(fom, M0_FOPH_TXN_LOGGED_WAIT);
 				return M0_FSO_AGAIN;
 			}
 

--- a/ioservice/cob_foms.c
+++ b/ioservice/cob_foms.c
@@ -718,11 +718,11 @@ static int cob_ops_fom_tick(struct m0_fom *fom)
 			 * into multiple trasactions.
 			 * As the the operation is incomplete, skip the sending
 			 * of reply and reinitialise the trasaction.
-			 * i.e move fom phase to M0_FOPH_TXN_COMMIT_WAIT and
+			 * i.e move fom phase to M0_FOPH_TXN_DONE_WAIT and
 			 * then to M0_FOPH_TXN_INIT.
 			 */
 			if (!cob_op->fco_is_done && m0_fom_rc(fom) == 0) {
-				m0_fom_phase_set(fom, M0_FOPH_TXN_COMMIT_WAIT);
+				m0_fom_phase_set(fom, M0_FOPH_TXN_DONE_WAIT);
 				return M0_FSO_AGAIN;
 			}
 
@@ -733,9 +733,9 @@ static int cob_ops_fom_tick(struct m0_fom *fom)
 				return M0_FSO_WAIT;
 			}
 			break;
-		case M0_FOPH_TXN_COMMIT_WAIT:
+		case M0_FOPH_TXN_DONE_WAIT:
 			if (!cob_op->fco_is_done && m0_fom_rc(fom) == 0) {
-				rc = m0_fom_tx_commit_wait(fom);
+				rc = m0_fom_tx_done_wait(fom);
 				if (rc == M0_FSO_AGAIN) {
 					M0_SET0(tx);
 					m0_fom_phase_set(fom, M0_FOPH_TXN_INIT);


### PR DESCRIPTION
FDMI is a reliable transport by design, so there is no way for the
caller to handle M0_FDMI_SOURCE_POST_RECORD failure. The only
implementation that exists currently in fdmi/fol_fdmi_src always
returns 0. This patch shifts failure handing for
M0_FDMI_SOURCE_POST_RECORD() from the caller to FDMI source
implementations.

Signed-off-by: Maksym Medvied <max.medved@seagate.com>