### PR TITLE
EOS-20316: Implement btree key-value operations kv-put

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -2622,7 +2622,7 @@ static int64_t m0_btree_put_root_split_handle(struct m0_btree_op *bop,
 	node_slot.s_rec = temp_rec_2;
 	node_rec(&node_slot);
 
-	p_val = &(oi->i_extra_node->n_addr);
+	temp_rec.r_val.ov_buf[0] = &(oi->i_extra_node->n_addr);
 	m0_bufvec_copy(&node_slot.s_rec.r_val, &temp_rec.r_val,
 		       m0_vec_count(&temp_rec.r_val.ov_vec));
 	/* if we need to update vec_count for root slot, update at this place */
@@ -2925,6 +2925,9 @@ static int64_t btree_put_tick(struct m0_sm_op *smop)
 			 * ksize, vsize for variable key, value needs to be
 			 * discussed yet
 			 * */
+			ksize = -1;
+			vsize = -1;
+			/* initializing ksize, vsize for codacy check */
 		}
 		if (m0_btree_overflow_is_possible(curr_level->l_node, ksize,
 						  vsize))

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -2922,12 +2922,11 @@ static int64_t btree_put_tick(struct m0_sm_op *smop)
 			vsize = node_valsize(curr_level->l_node);
 		} else {
 			/**
-			 * ksize, vsize for variable key, value needs to be
-			 * discussed yet
+			 * @todo : ksize, vsize for variable key:
+			 * get the correct max key size at runtime
 			 * */
-			ksize = -1;
-			vsize = -1;
-			/* initializing ksize, vsize for codacy check */
+			ksize = MAX_KEY_SIZE;
+			vsize = MAX_VAL_SIZE;
 		}
 		if (m0_btree_overflow_is_possible(curr_level->l_node, ksize,
 						  vsize))


### PR DESCRIPTION
Updated put function for btree:

- Handled scenario if key already exist while insertion
- added changes to support different values for ksize and vsize
