### PR TITLE
EOS-19921 dtm0: add m0trace instrumentation for connection and session

### DIFF
--- a/lib/trace.h
+++ b/lib/trace.h
@@ -171,6 +171,12 @@
 #define M0_ENTRY(...) M0_LOG(M0_CALL, "> " __VA_ARGS__)
 #define M0_LEAVE(...) M0_LOG(M0_CALL, "< " __VA_ARGS__)
 
+#define M0_MEAS(fmt, ...) ({				\
+	m0_time_t __meas_time = m0_time_now();		\
+	M0_LOG(M0_DEBUG, "[MEAS] " fmt " time: "TIME_F,	\
+	       __VA_ARGS__, TIME_P(__meas_time));	\
+})
+
 #define M0_RC(rc) ({                        \
 	typeof(rc) __rc = (rc);             \
 	M0_LOG(M0_CALL, "< rc=%d", __rc);   \

--- a/rpc/conn.c
+++ b/rpc/conn.c
@@ -324,8 +324,11 @@ M0_INTERNAL int m0_rpc_conn_init(struct m0_rpc_conn      *conn,
 	if (rc == 0) {
 		m0_sm_init(&conn->c_sm, &conn_conf, M0_RPC_CONN_INITIALISED,
 			   &machine->rm_sm_grp);
+		m0_sm_state_trace_enable(&conn->c_sm);
 		m0_rpc_machine_add_conn(machine, conn);
 		M0_LOG(M0_INFO, "%p INITIALISED \n", conn);
+		M0_MEAS("conn-sm-to-uuid sm_id: %"PRIu64" uuid: "U128X_F,
+			conn->c_sm.sm_id, U128_P(&conn->c_uuid));
 	}
 
 	M0_POST(ergo(rc == 0, m0_rpc_conn_invariant(conn) &&
@@ -543,8 +546,11 @@ M0_INTERNAL int m0_rpc_rcv_conn_init(struct m0_rpc_conn *conn,
 	if (rc == 0) {
 		m0_sm_init(&conn->c_sm, &conn_conf, M0_RPC_CONN_INITIALISED,
 			   &machine->rm_sm_grp);
+		m0_sm_state_trace_enable(&conn->c_sm);
 		m0_rpc_machine_add_conn(machine, conn);
 		M0_LOG(M0_INFO, "%p INITIALISED \n", conn);
+		M0_MEAS("conn-uuid-to-sm uuid: "U128X_F" sm_id: %"PRIu64,
+			U128_P(&conn->c_uuid), conn->c_sm.sm_id);
 	}
 
 	M0_POST(ergo(rc == 0, m0_rpc_conn_invariant(conn) &&
@@ -731,6 +737,10 @@ M0_INTERNAL void m0_rpc_conn_add_session(struct m0_rpc_conn *conn,
 		if (watch->mw_session_added != NULL)
 			watch->mw_session_added(watch, session);
 	} m0_tl_endfor;
+
+	M0_MEAS("conn-to-session conn_uuid: "U128X_F" conn_sm_id: %"
+		PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
+		conn->c_sm.sm_id, session->s_sm.sm_id);
 }
 
 M0_INTERNAL void m0_rpc_conn_remove_session(struct m0_rpc_session *session)

--- a/rpc/conn.c
+++ b/rpc/conn.c
@@ -737,10 +737,11 @@ M0_INTERNAL void m0_rpc_conn_add_session(struct m0_rpc_conn *conn,
 		if (watch->mw_session_added != NULL)
 			watch->mw_session_added(watch, session);
 	} m0_tl_endfor;
-
+#if 0
 	M0_MEAS("conn-to-session conn_uuid: "U128X_F" conn_sm_id: %"
 		PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
 		conn->c_sm.sm_id, session->s_sm.sm_id);
+#endif
 }
 
 M0_INTERNAL void m0_rpc_conn_remove_session(struct m0_rpc_session *session)

--- a/rpc/session.c
+++ b/rpc/session.c
@@ -240,6 +240,7 @@ M0_INTERNAL int m0_rpc_session_init_locked(struct m0_rpc_session *session,
 	m0_sm_init(&session->s_sm, &session_conf,
 		   M0_RPC_SESSION_INITIALISED,
 		   &conn->c_rpc_machine->rm_sm_grp);
+	m0_sm_state_trace_enable(&session->s_sm);
 	m0_rpc_conn_add_session(conn, session);
 	M0_ASSERT(m0_rpc_session_invariant(session));
 	rc = m0_rpc_item_cache_init(&session->s_reply_cache,
@@ -248,6 +249,7 @@ M0_INTERNAL int m0_rpc_session_init_locked(struct m0_rpc_session *session,
 				    &conn->c_rpc_machine->rm_sm_grp.s_lock);
 	if (rc == 0)
 		M0_LOG(M0_INFO, "Session %p INITIALISED", session);
+
 	else
 		M0_LOG(M0_ERROR, "Session %p initialisation failed: %d",
 		       session, rc);
@@ -531,6 +533,10 @@ M0_INTERNAL void m0_rpc_session_establish_reply_received(struct m0_rpc_item
 		    reply->rser_sender_id != SENDER_ID_INVALID) {
 			session->s_session_id = session_id;
 			session_state_set(session, M0_RPC_SESSION_IDLE);
+			M0_MEAS("sm-to-session conn_uuid: "U128X_F
+				" session_id: %" PRIu64" session_sm_id: %"PRIu64,
+				U128_P(&session->s_conn->c_uuid),
+				session->s_session_id, session->s_sm.sm_id);
 		} else {
 			rc = M0_ERR(-EPROTO);
 		}

--- a/rpc/session.c
+++ b/rpc/session.c
@@ -453,6 +453,10 @@ M0_INTERNAL int m0_rpc_session_establish(struct m0_rpc_session *session,
 	}
 	m0_fop_put(fop);
 
+	M0_MEAS("conn-to-session conn_uuid: "U128X_F" conn_sm_id: %"
+		PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
+		conn->c_sm.sm_id, session->s_sm.sm_id);
+
 	M0_POST(ergo(rc != 0, session_state(session) == M0_RPC_SESSION_FAILED));
 	M0_POST(m0_rpc_session_invariant(session));
 

--- a/rpc/session_foms.c
+++ b/rpc/session_foms.c
@@ -402,6 +402,9 @@ M0_INTERNAL int m0_rpc_fom_session_establish_tick(struct m0_fom *fom)
 			 session->s_session_id >  SESSION_ID_MAX);
 		session_state_set(session, M0_RPC_SESSION_IDLE);
 		reply->rser_session_id = session->s_session_id;
+		M0_MEAS("session-to-sm conn_uuid: "U128X_F" session_id: %"
+			PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
+			session->s_session_id, session->s_sm.sm_id);
 	}
 	m0_rpc_machine_unlock(machine);
 

--- a/rpc/session_foms.c
+++ b/rpc/session_foms.c
@@ -402,6 +402,11 @@ M0_INTERNAL int m0_rpc_fom_session_establish_tick(struct m0_fom *fom)
 			 session->s_session_id >  SESSION_ID_MAX);
 		session_state_set(session, M0_RPC_SESSION_IDLE);
 		reply->rser_session_id = session->s_session_id;
+
+		M0_MEAS("conn-to-session conn_uuid: "U128X_F" conn_sm_id: %"
+			PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
+			conn->c_sm.sm_id, session->s_sm.sm_id);
+
 		M0_MEAS("session-to-sm conn_uuid: "U128X_F" session_id: %"
 			PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
 			session->s_session_id, session->s_sm.sm_id);

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -335,6 +335,10 @@ struct m0_sm {
 	 */
 	int32_t                    sm_rc;
 	/**
+           State tracing could be expensive for some state machines.
+         */
+	bool                       sm_state_trace_off;
+	/**
            Sm invariant check could be expensive for some state machines.
          */
 	bool                       sm_invariant_chk_off;
@@ -532,6 +536,8 @@ M0_INTERNAL void m0_sm_init(struct m0_sm *mach, const struct m0_sm_conf *conf,
    @pre conf->scf_state[state].sd_flags & (M0_SDF_TERMINAL | M0_SDF_FINAL)
  */
 M0_INTERNAL void m0_sm_fini(struct m0_sm *mach);
+
+M0_INTERNAL void m0_sm_state_trace_enable(struct m0_sm *mach);
 
 M0_INTERNAL void m0_sm_group_init(struct m0_sm_group *grp);
 M0_INTERNAL void m0_sm_group_fini(struct m0_sm_group *grp);


### PR DESCRIPTION
A new instrumentation schema similar to ADDB2-based instrumentation
is introduced. This schema is based on m0traces. The reason for that
is failures testing when the latest portion of ADDB2 data may not be
flushed on disk so that the entities states before failure can not
be retrieved. Solution for that is to use m0traces as an
instrumentation tool as m0traces are flushed right before the crash.

Current implementation covers generic code of state machines,
connection and sessions.
With respect to perfortmance an addintional field is added to state
machine structure that enables/disables states transitions tracing.
Tracing is disabled by default.
For the states machines that correspond to connections and sessions
tracing is enabled. Also added local and node-to-node mappings for
connections and sessions.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>