### PR TITLE
EOS-20422: Remove the need for m0d to get UUID

### DIFF
--- a/lib/user_space/uuuid.c
+++ b/lib/user_space/uuuid.c
@@ -36,6 +36,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+enum {
+	MACHINE_ID_LEN = 32
+};
 /** path to read node uuid parameter */
 static const char *uuid_file = "/etc/machine-id";
 /**
@@ -72,7 +75,9 @@ int m0_node_uuid_string_get(char buf[M0_UUID_STRLEN + 1])
 {
 	int fd;
 	int rc = 0;
-	char buf1[M0_UUID_STRLEN + 1];
+	char buf1[MACHINE_ID_LEN + 1];
+
+	M0_BASSERT(MACHINE_ID_LEN == M0_UUID_STRLEN - 4);
 
 	if (use_default_node_uuid) {
 		strncpy(buf, default_node_uuid, M0_UUID_STRLEN + 1);
@@ -85,7 +90,7 @@ int m0_node_uuid_string_get(char buf[M0_UUID_STRLEN + 1])
 			                   "errno=%d: ",
 					   uuid_file, fd, errno);
 		}
-		if (read(fd, buf1, M0_UUID_STRLEN - 4) == M0_UUID_STRLEN - 4) {
+		if (read(fd, buf1, MACHINE_ID_LEN) == MACHINE_ID_LEN) {
 			rc = 0;
 			strncpy(buf, buf1, 8);
 			strncpy(buf + 8, "-", 1);

--- a/lib/user_space/uuuid.c
+++ b/lib/user_space/uuuid.c
@@ -92,8 +92,9 @@ int m0_node_uuid_string_get(char buf[M0_UUID_STRLEN + 1])
 		}
 		if (read(fd, mid, MACHINE_ID_LEN) == MACHINE_ID_LEN) {
 			rc = 0;
-			snprintf(buf, 37, "%.8s-%.4s-%.4s-%.4s-%.12s", mid,
-				mid + 8, mid + 8 + 4, mid + 8 + 4 + 4,
+			snprintf(buf, M0_UUID_STRLEN + 1,
+				"%.8s-%.4s-%.4s-%.4s-%.12s",
+				mid, mid + 8, mid + 8 + 4, mid + 8 + 4 + 4,
 				mid + 8 + 4 + 4 + 4);
 			buf[M0_UUID_STRLEN] = '\0';
 		} else {

--- a/lib/user_space/uuuid.c
+++ b/lib/user_space/uuuid.c
@@ -75,7 +75,7 @@ int m0_node_uuid_string_get(char buf[M0_UUID_STRLEN + 1])
 {
 	int fd;
 	int rc = 0;
-	char buf1[MACHINE_ID_LEN + 1];
+	char mid[MACHINE_ID_LEN + 1];
 
 	M0_BASSERT(MACHINE_ID_LEN == M0_UUID_STRLEN - 4);
 
@@ -90,17 +90,11 @@ int m0_node_uuid_string_get(char buf[M0_UUID_STRLEN + 1])
 			                   "errno=%d: ",
 					   uuid_file, fd, errno);
 		}
-		if (read(fd, buf1, MACHINE_ID_LEN) == MACHINE_ID_LEN) {
+		if (read(fd, mid, MACHINE_ID_LEN) == MACHINE_ID_LEN) {
 			rc = 0;
-			strncpy(buf, buf1, 8);
-			strncpy(buf + 8, "-", 1);
-			strncpy(buf + 9, buf1 + 8, 4);
-			strncpy(buf + 13, "-", 1);
-			strncpy(buf + 14, buf1 + 12, 4);
-			strncpy(buf + 18, "-", 1);
-			strncpy(buf + 19, buf1 + 16, 4);
-			strncpy(buf + 23, "-", 1);
-			strncpy(buf + 24, buf1 + 20, 12);
+			snprintf(buf, 37, "%.8s-%.4s-%.4s-%.4s-%.12s", mid,
+				mid + 8, mid + 8 + 4, mid + 8 + 4 + 4,
+				mid + 8 + 4 + 4 + 4);
 			buf[M0_UUID_STRLEN] = '\0';
 		} else {
 			rc = M0_ERR_INFO(-EINVAL, "Incorrect data in %s",

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -28,7 +28,6 @@
 #include "lib/misc.h"        /* ARRAY_SIZE, m0_strtou64 */
 
 #ifdef __KERNEL__
-//#  include <linux/random.h>  /* get_random_uuid */
 #  include <linux/uuid.h>    /* generate_random_uuid */
 #else
 #  include <uuid/uuid.h>     /* generate_uuid */

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -28,7 +28,7 @@
 #include "lib/misc.h"        /* ARRAY_SIZE, m0_strtou64 */
 
 #ifdef __KERNEL__
-#  include <linux/random.h>  /* get_random_uuid */
+//#  include <linux/random.h>  /* get_random_uuid */
 #  include <linux/uuid.h>    /* generate_random_uuid */
 #else
 #  include <uuid/uuid.h>     /* generate_uuid */


### PR DESCRIPTION
Taking uuid from /etc/machine-id instead of /sys/module/m0tr/parameters/node_uuid.

Signed-off-by: Papan Kumar Singh <papan.kumarsingh@seagate.com>