### PR TITLE
EOS-20883: Enabled ADDB logs rotation for VM deployments as well

### DIFF
--- a/scripts/install/etc/sysconfig/motr
+++ b/scripts/install/etc/sysconfig/motr
@@ -44,8 +44,10 @@ MOTR_M0T1FS_MOUNTPOINT='/mnt/m0t1fs'
 # Where m0d stores it's data, by default it's /var/motr.
 #MOTR_M0D_DATA_DIR=/var/motr
 
-#Override default addd stobs location
-#MOTR_M0D_ADDB_STOB_DIR=$MOTR_LOG_DIR
+# Override default addb stobs location, /var/motr/m0d-* is default
+# location for VM deployment. For HW setup it is expected to be
+# overwrite by m0provison config
+MOTR_M0D_ADDB_STOB_DIR=/var/motr/m0d-*
 
 #Override default trace files location
 #MOTR_M0D_TRACE_DIR=$MOTR_LOG_DIR

--- a/scripts/install/etc/sysconfig/motr
+++ b/scripts/install/etc/sysconfig/motr
@@ -44,10 +44,8 @@ MOTR_M0T1FS_MOUNTPOINT='/mnt/m0t1fs'
 # Where m0d stores it's data, by default it's /var/motr.
 #MOTR_M0D_DATA_DIR=/var/motr
 
-# Override default addb stobs location, /var/motr/m0d-* is default
-# location for VM deployment. For HW setup it is expected to be
-# overwrite by m0provison config
-MOTR_M0D_ADDB_STOB_DIR=/var/motr/m0d-*
+#Override default addd stobs location
+#MOTR_M0D_ADDB_STOB_DIR=$MOTR_LOG_DIR
 
 #Override default trace files location
 #MOTR_M0D_TRACE_DIR=$MOTR_LOG_DIR

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -59,6 +59,9 @@ addb_rec_dirs=`ls -d $ADDB_DIR`
 if [ -n "$ADDB_DIR" ]; then
     addb_rec_dirs="$addb_rec_dirs $ADDB_DIR"
 fi
+if [ -z "$ADDB_RECORD_DIR" ]; then
+   ADDB_RECORD_DIR="/var/motr/m0d-*"
+fi
 
 while getopts ":n:" option; do
     case "${option}" in


### PR DESCRIPTION
* Generally we set MOTR_M0D_ADDB_STOB_DIR path in
  /etc/sysconfig/motr from motr.conf for hardware deployment,
  But for VM deployment we do not change sysconfig/motr params
  and it leaves "MOTR_M0D_ADDB_STOB_DIR" parameter unset, that
  restricts m0addb_logrotate.sh to cleanup addb logs from VM setups.

* Enabling logrotation for addb logs in VM as well by setting addb
  log directory to default valuse "/var/motr/m0d-*"

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>