### PR TITLE
EOS-19418: Skip cob lookup, upon receiving pver from s3

### DIFF
--- a/motr/client.h
+++ b/motr/client.h
@@ -597,14 +597,33 @@ enum m0_entity_type {
  */
  enum m0_entity_flags {
 	/**
-	 * During create if this flag is set, thant means application has
-	 * capability to store meta-data and hence pver and lid will be
-	 * returned to application to store.
+	 * During create if this flag is set in entity->en_flags, that means
+	 * application has capability to store meta-data and hence pver and
+	 * lid can be store in  application's meta-data.
+	 * Before application call to m0_entity_create/open(), applications is
+	 * expected to set obj>ob_entity->en_flags != M0_ENF_META, so when
+	 * m0_entity_create() returns to application, pool version and layout id
+	 * will be available to application into obj->ob_attr.oa_pver and
+	 * obj->ob_attr.oa_lid respectively and can be store into applications
+	 * meta-data.
+	 *
+	 * For example:
+	 * Create workflow would be like:
+	 *   obj->ob_entity.en_flags |= M0_ENF_META;
+	 *   m0_entity_create((NULL, &obj.ob_entity, &ops[0]);
+	 *   //  Save the returned pool version and lid into app_meta_data
+	 *   app_meta_data.pver = obj->ob_attr.oa_pver;
+	 *   app_meta_data.lid = obj->ob_attr.oa_lid;
+	 *
+	 * Read workflow:
+	 *   obj->ob_attr.oa_pver = app_meta_data.pver;
+	 *   obj->ob_attr.oa_lid =  app_meta_data.lid;
+	 *   m0_entity_open(NULL, &obj.ob_entity, &ops[0]);
 	 */
 	M0_ENF_META = 1 << 0,
 	/**
 	 * If this flags is set during entity_create() that means application
-	 * do not support update operation.
+	 * do not support update operation. This flag is not in use yet.
 	 */
 	M0_ENF_NO_RMW =  1 << 1
  } M0_XCA_ENUM;

--- a/motr/client.h
+++ b/motr/client.h
@@ -579,12 +579,7 @@ enum m0_op_obj_flags {
 	 * Write, alloc and free operations wait for the transaction to become
 	 * persistent before returning.
 	 */
-	M0_OOF_SYNC   = 1 << 1,
-        /**
-         * This flag is to describe that this write is from clovis/motr 
-         * application and not from s3.
-         */
-        M0_OOF_MOTR_APP = 1<<2
+	M0_OOF_SYNC   = 1 << 1
 } M0_XCA_ENUM;
 
 /**
@@ -595,6 +590,24 @@ enum m0_entity_type {
 	M0_ET_OBJ,
 	M0_ET_IDX
 } M0_XCA_ENUM;
+
+/**
+ * Flags passed to m0_entitiy_create(), m0_entity_open() to specify applications's 
+ * behaviour.
+ */
+ enum m0_entity_flags {
+	/**
+	 * During create if this flag is set, thant means application has
+	 * capability to store meta-data and hence pver and lid will be
+	 * retirned to application to store.
+	 */
+	M0_EOF_META = 1 << 0,
+	/**
+	 * If this flags is set during entity_create() that means application
+	 * do not support update operation.
+	 */
+	M0_EOF_NO_RMW =  1 << 1
+ } M0_XCA_ENUM;
 
 /**
  * Generic client operation structure.
@@ -696,7 +709,7 @@ struct m0_entity {
 	/** list of pending transactions. */
 	struct m0_tl        en_pending_tx;
 	struct m0_mutex     en_pending_tx_lock;
-	uint32_t            en_app_type;
+	uint32_t            en_flags;
 };
 
 /**

--- a/motr/client.h
+++ b/motr/client.h
@@ -599,14 +599,14 @@ enum m0_entity_type {
 	/**
 	 * During create if this flag is set, thant means application has
 	 * capability to store meta-data and hence pver and lid will be
-	 * retirned to application to store.
+	 * returned to application to store.
 	 */
-	M0_EOF_META = 1 << 0,
+	M0_ENF_META = 1 << 0,
 	/**
 	 * If this flags is set during entity_create() that means application
 	 * do not support update operation.
 	 */
-	M0_EOF_NO_RMW =  1 << 1
+	M0_ENF_NO_RMW =  1 << 1
  } M0_XCA_ENUM;
 
 /**

--- a/motr/client.h
+++ b/motr/client.h
@@ -579,7 +579,12 @@ enum m0_op_obj_flags {
 	 * Write, alloc and free operations wait for the transaction to become
 	 * persistent before returning.
 	 */
-	M0_OOF_SYNC   = 1 << 1
+	M0_OOF_SYNC   = 1 << 1,
+        /**
+         * This flag is to describe that this write is from clovis/motr 
+         * application and not from s3.
+         */
+        M0_OOF_MOTR_APP = 1<<2
 } M0_XCA_ENUM;
 
 /**
@@ -691,6 +696,7 @@ struct m0_entity {
 	/** list of pending transactions. */
 	struct m0_tl        en_pending_tx;
 	struct m0_mutex     en_pending_tx_lock;
+	uint32_t            en_app_type;
 };
 
 /**

--- a/motr/client.h
+++ b/motr/client.h
@@ -601,7 +601,7 @@ enum m0_entity_type {
 	 * application has capability to store meta-data and hence pver and
 	 * lid can be stored in  application's meta-data.
 	 * Before calling to m0_entity_create/open(), application is
-	 * expected to set obj>ob_entity->en_flags != M0_ENF_META, so when
+	 * expected to set obj>ob_entity->en_flags |= M0_ENF_META, so when
 	 * m0_entity_create() returns to application, pool version and layout id
 	 * will be available to application into obj->ob_attr.oa_pver and
 	 * obj->ob_attr.oa_lid respectively and can be stored into application's

--- a/motr/client.h
+++ b/motr/client.h
@@ -592,19 +592,19 @@ enum m0_entity_type {
 } M0_XCA_ENUM;
 
 /**
- * Flags passed to m0_entitiy_create(), m0_entity_open() to specify applications's 
- * behaviour.
+ * Flags passed to m0_entitiy_create(), m0_entity_open() to specify
+ * application's behaviour.
  */
  enum m0_entity_flags {
 	/**
 	 * During create if this flag is set in entity->en_flags, that means
 	 * application has capability to store meta-data and hence pver and
-	 * lid can be store in  application's meta-data.
-	 * Before application call to m0_entity_create/open(), applications is
+	 * lid can be stored in  application's meta-data.
+	 * Before calling to m0_entity_create/open(), application is
 	 * expected to set obj>ob_entity->en_flags != M0_ENF_META, so when
 	 * m0_entity_create() returns to application, pool version and layout id
 	 * will be available to application into obj->ob_attr.oa_pver and
-	 * obj->ob_attr.oa_lid respectively and can be store into applications
+	 * obj->ob_attr.oa_lid respectively and can be stored into application's
 	 * meta-data.
 	 *
 	 * For example:

--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -69,11 +69,16 @@ struct m0_dtm0_service;
 struct m0_dtx;
 
 #ifdef CLIENT_FOR_M0T1FS
+
+/**
+ * motr clients other than S3, may not store pver in meta-data,
+ * thus they have to use md-cob lookup to get pver attribute.
+ */
+#define M0TR_COB_LOOKUP_SKIPPED 3
+
 /**
  * Maximum length for an object's name.
  */
-
-#define M0TR_COB_LOOKUP_SKIPPED 3
 enum {
 	M0_OBJ_NAME_MAX_LEN = 64
 };

--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -72,6 +72,8 @@ struct m0_dtx;
 /**
  * Maximum length for an object's name.
  */
+
+#define M0TR_COB_LOOKUP_SKIPPED 3
 enum {
 	M0_OBJ_NAME_MAX_LEN = 64
 };

--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -74,7 +74,7 @@ struct m0_dtx;
  * motr clients other than S3, may not store pver in meta-data,
  * thus they have to use md-cob lookup to get pver attribute.
  */
-#define M0TR_COB_LOOKUP_SKIPPED 3
+#define MOTR_MDCOB_LOOKUP_SKIP 3
 
 /**
  * Maximum length for an object's name.

--- a/motr/cob.c
+++ b/motr/cob.c
@@ -1865,7 +1865,7 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 	/* Set layout id and pver for CREATE op.*/
 	if (cr->cr_opcode == M0_EO_CREATE) {
 		cr->cr_cob_attr->ca_lid = obj->ob_attr.oa_layout_id;
-		 if (obj->ob_entity.en_flags == M0_EOF_META) {
+		 if (obj->ob_entity.en_flags == M0_ENF_META) {
 			/* For create operation setting up pool version locally
 			* found in pools common, so cob lookup call to server
 			* can be skipped */
@@ -1892,7 +1892,7 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 		m0_sm_group_unlock(&cr->cr_op->op_sm_group);
 		cob_complete_op(cr->cr_op);
 		m0_sm_group_lock(&cr->cr_op->op_sm_group);
-		rc = M0TR_COB_LOOKUP_SKIPPED;
+		rc = MOTR_MDCOB_LOOKUP_SKIP;
 	}
 
 	return M0_RC(rc);

--- a/motr/cob.c
+++ b/motr/cob.c
@@ -1863,12 +1863,14 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 	/* Set layout id and pver for CREATE op.*/
 	if (cr->cr_opcode == M0_EO_CREATE) {
 		cr->cr_cob_attr->ca_lid = obj->ob_attr.oa_layout_id;
-		/* For create operation setting up pool version locally
-		 * found in pools common, so cob lookup call to server
-		 * can be skipped */
-		obj->ob_attr.oa_pver.f_container = pv->pv_id.f_container;
-		obj->ob_attr.oa_pver.f_key = pv->pv_id.f_key;
-		skip_lookup = true;
+		 if (obj->ob_entity.en_app_type != M0_OOF_MOTR_APP) {
+			/* For create operation setting up pool version locally
+			* found in pools common, so cob lookup call to server
+			* can be skipped */
+			obj->ob_attr.oa_pver.f_container = pv->pv_id.f_container;
+			obj->ob_attr.oa_pver.f_key = pv->pv_id.f_key;
+			skip_lookup = true;
+		 }
 	}
 
 	if (! skip_lookup ) {

--- a/motr/cob.c
+++ b/motr/cob.c
@@ -1855,10 +1855,9 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 	skip_lookup = false;
 	obj = m0__obj_entity(oo->oo_oc.oc_op.op_entity);
 	if ((cr->cr_opcode == M0_EO_GETATTR) &&
-	     m0_fid_is_set(&obj->ob_attr.oa_pver)) {
+	     m0_fid_is_set(&obj->ob_attr.oa_pver) &&
+	     m0_fid_is_valid(&obj->ob_attr.oa_pver)) {
 		skip_lookup = true;
-		M0_LOG(M0_DEBUG, "pver "FID_F" is valid, lookup can be skipped",
-		       FID_P(&obj->ob_attr.oa_pver));
 	}
 
 	/* Set layout id and pver for CREATE op.*/
@@ -1867,7 +1866,6 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 		/* For create operation setting up pool version locally
 		 * found in pools common, so cob lookup call to server
 		 * can be skipped */
-		M0_LOG(M0_DEBUG, "pool version from pools common pv->pv_id:"FID_F, FID_P(&pv->pv_id));
 		obj->ob_attr.oa_pver.f_container = pv->pv_id.f_container;
 		obj->ob_attr.oa_pver.f_key = pv->pv_id.f_key;
 		skip_lookup = true;
@@ -1875,7 +1873,6 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 
 	if (! skip_lookup ) {
 	/* Send requests to services. */
-		M0_LOG(M0_DEBUG, "proceeding for lookup, cr_opcode: %d", cr->cr_opcode);
 		rc = cob_req_send(cr);
 		if (rc != 0) {
 			cr->cr_ar.ar_ast.sa_cb = &cob_ast_fail_cr;

--- a/motr/cob.c
+++ b/motr/cob.c
@@ -1808,7 +1808,7 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 	struct cob_req         *cr;
 	struct m0_pool_version *pv;
 	struct m0_op           *op;
-	bool                    skip_lookup;
+	bool                    skip_meta_data;
 
 	M0_ENTRY();
 	M0_PRE(oo != NULL);
@@ -1849,31 +1849,32 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 	}
 	cr->cr_cob_attr = cob_attr;
 
-	/* Skip cob lookup if obj.ob_attr.oa_pver is not empty.
-	 * We are assuming here, if pver is not empty that means we
-	 * have received pver from s3 */
-	skip_lookup = false;
+	/** Skip meta-data lookup if obj.ob_attr.oa_pver is not empty.
+	 * pver is not empty that means  calling application has
+	 * capability to store meta-data(pver, LID) and has sent pver
+	 * to open entity.
+	 */
+	skip_meta_data = false;
 	obj = m0__obj_entity(oo->oo_oc.oc_op.op_entity);
 	if ((cr->cr_opcode == M0_EO_GETATTR) &&
 	     m0_fid_is_set(&obj->ob_attr.oa_pver) &&
 	     m0_fid_is_valid(&obj->ob_attr.oa_pver)) {
-		skip_lookup = true;
+		skip_meta_data = true;
 	}
 
 	/* Set layout id and pver for CREATE op.*/
 	if (cr->cr_opcode == M0_EO_CREATE) {
 		cr->cr_cob_attr->ca_lid = obj->ob_attr.oa_layout_id;
-		 if (obj->ob_entity.en_app_type != M0_OOF_MOTR_APP) {
+		 if (obj->ob_entity.en_flags == M0_EOF_META) {
 			/* For create operation setting up pool version locally
 			* found in pools common, so cob lookup call to server
 			* can be skipped */
-			obj->ob_attr.oa_pver.f_container = pv->pv_id.f_container;
-			obj->ob_attr.oa_pver.f_key = pv->pv_id.f_key;
-			skip_lookup = true;
+			obj->ob_attr.oa_pver = pv->pv_id;
+			skip_meta_data = true;
 		 }
 	}
 
-	if (! skip_lookup ) {
+	if (! skip_meta_data ) {
 	/* Send requests to services. */
 		rc = cob_req_send(cr);
 		if (rc != 0) {
@@ -1884,8 +1885,8 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 	} else {
 		M0_LOG(M0_DEBUG, "skipped lookup, obj pver is :"FID_F,
 		       FID_P(&obj->ob_attr.oa_pver));
-		/* We are skipping cob lookup here as we have received pver
-		 * and LID from s3, and hence need to move op state
+		/* We are skipping meta-data lookup here as we have received pver
+		 * and LID from application, and hence need to move op state
 		 * LAUNCHED, EXECUTED and STABLE explicitly */
 		m0_sm_move(&cr->cr_op->op_sm, 0, M0_OS_LAUNCHED);
 		m0_sm_group_unlock(&cr->cr_op->op_sm_group);

--- a/motr/obj.c
+++ b/motr/obj.c
@@ -268,7 +268,7 @@ static void obj_namei_cb_launch(struct m0_op_common *oc)
 		 * moved to LAUNCHED --> EXECUTED --> STABLE, so
 		 * skipped m0_sm_move() and resetting rc state to 0
 		 * */
-		rc = 0;
+		(void)rc;
 	}
 
 	M0_LEAVE();

--- a/motr/obj.c
+++ b/motr/obj.c
@@ -261,8 +261,15 @@ static void obj_namei_cb_launch(struct m0_op_common *oc)
 	m0_sm_group_unlock(&op->op_entity->en_sm_group);
 
 	rc = m0__obj_namei_send(oo);
-	if (rc == 0)
+	if (rc == 0) {
 		m0_sm_move(&op->op_sm, 0, M0_OS_LAUNCHED);
+	} else if (rc == M0TR_COB_LOOKUP_SKIPPED) {
+		/* This is M0_EO_GETATTR and op state is already
+		 * moved to LAUNCHED --> EXECUTED --> STABLE, so
+		 * skipped m0_sm_move() and resetting rc state to 0
+		 * */
+		rc = 0;
+	}
 
 	M0_LEAVE();
 }

--- a/motr/obj.c
+++ b/motr/obj.c
@@ -264,8 +264,8 @@ static void obj_namei_cb_launch(struct m0_op_common *oc)
 	if (rc == 0) {
 		m0_sm_move(&op->op_sm, 0, M0_OS_LAUNCHED);
 	} else if (rc == M0TR_COB_LOOKUP_SKIPPED) {
-		/* This is M0_EO_GETATTR and op state is already
-		 * moved to LAUNCHED --> EXECUTED --> STABLE, so
+		/* This means meta-data lookup is skipped and op state is
+		 * already moved to LAUNCHED --> EXECUTED --> STABLE, so
 		 * skipped m0_sm_move() and resetting rc state to 0
 		 * */
 		(void)rc;
@@ -810,6 +810,8 @@ int m0_entity_create(struct m0_fid *pool,
 	struct m0_obj *obj;
 
 	M0_ENTRY();
+	if ( entity->en_flags & M0_EOF_META )
+		M0_LOG(M0_DEBUG,"EOF_META FLAG is set from application");
 
 	M0_PRE(entity != NULL);
 	M0_PRE(op != NULL);

--- a/motr/obj.c
+++ b/motr/obj.c
@@ -263,7 +263,7 @@ static void obj_namei_cb_launch(struct m0_op_common *oc)
 	rc = m0__obj_namei_send(oo);
 	if (rc == 0) {
 		m0_sm_move(&op->op_sm, 0, M0_OS_LAUNCHED);
-	} else if (rc == M0TR_COB_LOOKUP_SKIPPED) {
+	} else if (rc == MOTR_MDCOB_LOOKUP_SKIP) {
 		/* This means meta-data lookup is skipped and op state is
 		 * already moved to LAUNCHED --> EXECUTED --> STABLE, so
 		 * skipped m0_sm_move() and resetting rc state to 0
@@ -810,7 +810,7 @@ int m0_entity_create(struct m0_fid *pool,
 	struct m0_obj *obj;
 
 	M0_ENTRY();
-	if ( entity->en_flags & M0_EOF_META )
+	if (entity->en_flags & M0_ENF_META)
 		M0_LOG(M0_DEBUG,"EOF_META FLAG is set from application");
 
 	M0_PRE(entity != NULL);

--- a/motr/st/utils/cat.c
+++ b/motr/st/utils/cat.c
@@ -61,6 +61,7 @@ static void cat_usage(FILE *file, char *prog_name)
 				 "suffix b/k/m/g/K/M/G.\n%*c Ex: 1k=1024, "
 				 "1m=1024*1024, 1K=1000 1M=1000*1000.\n"
 "  -L, --layout-id      INT       Layout ID, Range: [1-14].\n"
+"  -v, --pver           FID       Pool version fid.\n"
 "  -e, --enable-locks             Enables acquiring and releasing RW locks "
 				 "before and after performing IO.\n"
 "  -b, --blocks-per-io  INT       Number of blocks per IO (>=0). \n%*c "
@@ -88,6 +89,8 @@ int main(int argc, char **argv)
 	m0_utility_args_init(argc, argv, &cat_param,
 			         &dix_conf, &conf, &cat_usage);
 
+	fprintf(stderr, "pver is : "FID_F "\n", FID_P(&cat_param.cup_pver));
+
 	rc = client_init(&conf, &container, &m0_instance);
 	if (rc < 0) {
 		fprintf(stderr, "init failed! rc = %d\n", rc);
@@ -101,7 +104,7 @@ int main(int argc, char **argv)
 		          cat_param.cup_block_size, cat_param.cup_block_count,
 			  cat_param.cup_offset,
 			  cat_param.cup_blks_per_io, cat_param.cup_take_locks,
-			  cat_param.flags);
+			  cat_param.flags, &cat_param.cup_pver);
 	if (rc < 0) {
 		fprintf(stderr, "m0_read failed! rc = %d\n", rc);
 	}

--- a/motr/st/utils/client.c
+++ b/motr/st/utils/client.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
 				     block_size, block_count, offset,
 				     blocks_per_io,
 				     params.cup_take_locks,
-				     0);
+				     0, NULL);
 		} else if (strcmp(arg, "write") == 0) {
 			GET_COMMON_ARG(arg, fname, saveptr, id,
 				       block_size, block_count,

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -240,7 +240,6 @@ static int create_object(struct m0_entity *entity)
 	struct m0_op_common *oc;
 	struct m0_op_obj    *oo;
 
-	entity->en_app_type = M0_OOF_MOTR_APP;
 	rc = m0_entity_create(NULL, entity, &ops[0]);
 	if (rc != 0)
 		return M0_ERR(rc);

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -502,13 +502,12 @@ int m0_read(struct m0_container *container,
 		goto get_error;
 
 	/* Setting pver here to read_pver received as parameter to this func.
-	 * Caller of this function is expected to pass pver of object tobe
+	 * Caller of this function is expected to pass pver of object to be
 	 * read, if he knows pver of object.
 	 * */
 	if (read_pver != NULL &&  m0_fid_is_set(read_pver)) {
 		obj.ob_attr.oa_pver = *read_pver;
-		M0_LOG(M0_DEBUG, "m0_read: obj->ob_attr.oa_pver is set to:"FID_F
-                       " To predent that, it is received from application",
+		M0_LOG(M0_DEBUG, "obj->ob_attr.oa_pver is set to:"FID_F,
 	               FID_P(&obj.ob_attr.oa_pver));
 	}
 

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -240,6 +240,7 @@ static int create_object(struct m0_entity *entity)
 	struct m0_op_common *oc;
 	struct m0_op_obj    *oo;
 
+	entity->en_app_type = M0_OOF_MOTR_APP;
 	rc = m0_entity_create(NULL, entity, &ops[0]);
 	if (rc != 0)
 		return M0_ERR(rc);
@@ -506,8 +507,7 @@ int m0_read(struct m0_container *container,
 	 * read, if he knows pver of object.
 	 * */
 	if (read_pver != NULL &&  m0_fid_is_set(read_pver)) {
-		obj.ob_attr.oa_pver.f_container = read_pver->f_container;
-		obj.ob_attr.oa_pver.f_key = read_pver->f_key;
+		obj.ob_attr.oa_pver = *read_pver;
 		M0_LOG(M0_DEBUG, "m0_read: obj->ob_attr.oa_pver is set to:"FID_F
                        " To predent that, it is received from application",
 	               FID_P(&obj.ob_attr.oa_pver));

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -237,6 +237,10 @@ static int create_object(struct m0_entity *entity)
 	int                  rc;
 	struct m0_op        *ops[1] = {NULL};
 
+	struct m0_obj       *obj;
+	struct m0_op_common *oc;
+	struct m0_op_obj    *oo;
+
 	rc = m0_entity_create(NULL, entity, &ops[0]);
 	if (rc != 0)
 		return M0_ERR(rc);
@@ -244,6 +248,12 @@ static int create_object(struct m0_entity *entity)
 	m0_op_launch(ops, 1);
 	rc = m0_op_wait(ops[0], M0_BITS(M0_OS_FAILED,
 					M0_OS_STABLE), M0_TIME_NEVER);
+	oc = M0_AMB(oc, ops[0], oc_op);
+	oo = M0_AMB(oo, oc, oo_oc);
+	obj = m0__obj_entity(oo->oo_oc.oc_op.op_entity);
+	M0_LOG(M0_DEBUG, "post create object, obj->ob_attr.oa_pver :"FID_F,
+	       FID_P(&obj->ob_attr.oa_pver));
+
 	if (rc == 0)
 		rc = m0_rc(ops[0]);
 
@@ -454,7 +464,7 @@ int m0_read(struct m0_container *container,
 	    struct m0_uint128 id, char *dest,
 	    uint32_t block_size, uint32_t block_count,
 	    uint64_t offset, int blks_per_io, bool take_locks,
-	    uint32_t flags)
+	    uint32_t flags, struct m0_fid *read_pver)
 {
 	int                           i;
 	int                           j;
@@ -491,6 +501,18 @@ int m0_read(struct m0_container *container,
 	rc = lock_ops->olo_read_lock_get_sync(&obj, &req);
 	if (rc != 0)
 		goto get_error;
+
+	/* Setting pver here to read_pver received as parameter to this func.
+	 * Caller of this function is expected to pass pver of object tobe
+	 * read, if he knows pver of object.
+	 * */
+	if (read_pver != NULL &&  m0_fid_is_set(read_pver)) {
+		obj.ob_attr.oa_pver.f_container = read_pver->f_container;
+		obj.ob_attr.oa_pver.f_key = read_pver->f_key;
+		M0_LOG(M0_DEBUG, "m0_read: obj->ob_attr.oa_pver is set to:"FID_F
+                       " To predent that, it is received from s3",
+	               FID_P(&obj.ob_attr.oa_pver));
+	}
 
 	rc = open_entity(&obj.ob_entity);
 	if (entity_sm_state(&obj) != M0_ES_OPEN || rc != 0)
@@ -929,6 +951,7 @@ int m0_utility_args_init(int argc, char **argv,
 				{"block-count",   required_argument, NULL, 'c'},
 				{"trunc-len",     required_argument, NULL, 't'},
 				{"layout-id",     required_argument, NULL, 'L'},
+				{"pver",          required_argument, NULL, 'v'},
 				{"n_obj",         required_argument, NULL, 'n'},
 				{"msg_size",      required_argument, NULL, 'S'},
 				{"min_queue",     required_argument, NULL, 'q'},
@@ -941,7 +964,7 @@ int m0_utility_args_init(int argc, char **argv,
 				{"no-hole",       no_argument,       NULL, 'N'},
 				{0,               0,                 0,     0 }};
 
-        while ((c = getopt_long(argc, argv, ":l:H:p:P:o:s:c:t:L:n:S:q:b:O:uerhN",
+        while ((c = getopt_long(argc, argv, ":l:H:p:P:o:s:c:t:L:v:n:S:q:b:O:uerhN",
 				l_opts, &option_index)) != -1)
 	{
 		switch (c) {
@@ -1035,6 +1058,12 @@ int m0_utility_args_init(int argc, char **argv,
 							"range: [1-14]\n", c);
 					utility_usage(stderr,
 						      basename(argv[0]));
+					exit(EXIT_FAILURE);
+				  }
+				  continue;
+			case 'v': if (m0_fid_sscanf(optarg,
+						&params->cup_pver) < 0) {
+					utility_usage(stderr, basename(argv[0]));
 					exit(EXIT_FAILURE);
 				  }
 				  continue;

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -236,7 +236,6 @@ static int create_object(struct m0_entity *entity)
 {
 	int                  rc;
 	struct m0_op        *ops[1] = {NULL};
-
 	struct m0_obj       *obj;
 	struct m0_op_common *oc;
 	struct m0_op_obj    *oo;
@@ -248,14 +247,14 @@ static int create_object(struct m0_entity *entity)
 	m0_op_launch(ops, 1);
 	rc = m0_op_wait(ops[0], M0_BITS(M0_OS_FAILED,
 					M0_OS_STABLE), M0_TIME_NEVER);
+	if (rc == 0)
+		rc = ops[0]->op_rc;
+
 	oc = M0_AMB(oc, ops[0], oc_op);
 	oo = M0_AMB(oo, oc, oo_oc);
 	obj = m0__obj_entity(oo->oo_oc.oc_op.op_entity);
 	M0_LOG(M0_DEBUG, "post create object, obj->ob_attr.oa_pver :"FID_F,
 	       FID_P(&obj->ob_attr.oa_pver));
-
-	if (rc == 0)
-		rc = m0_rc(ops[0]);
 
 	m0_op_fini(ops[0]);
 	m0_op_free(ops[0]);
@@ -510,7 +509,7 @@ int m0_read(struct m0_container *container,
 		obj.ob_attr.oa_pver.f_container = read_pver->f_container;
 		obj.ob_attr.oa_pver.f_key = read_pver->f_key;
 		M0_LOG(M0_DEBUG, "m0_read: obj->ob_attr.oa_pver is set to:"FID_F
-                       " To predent that, it is received from s3",
+                       " To predent that, it is received from application",
 	               FID_P(&obj.ob_attr.oa_pver));
 	}
 

--- a/motr/st/utils/helper.h
+++ b/motr/st/utils/helper.h
@@ -72,6 +72,7 @@ struct m0_utility_param {
 	char             *cup_file;
 	int               cup_blks_per_io;
 	bool              cup_update_mode;
+	struct m0_fid     cup_pver;
 	uint32_t          flags;
 };
 
@@ -122,7 +123,7 @@ int m0_write(struct m0_container *container,
 int m0_read(struct m0_container *container,
 	    struct m0_uint128 id, char *dest, uint32_t block_size,
 	    uint32_t block_count, uint64_t offset, int blks_per_io,
-	    bool take_locks, uint32_t flags);
+	    bool take_locks, uint32_t flags, struct m0_fid *read_pver);
 
 int m0_truncate(struct m0_container *container,
 		struct m0_uint128 id, uint32_t block_size,

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -59,6 +59,9 @@ addb_rec_dirs=`ls -d $ADDB_DIR`
 if [ -n "$ADDB_DIR" ]; then
     addb_rec_dirs="$addb_rec_dirs $ADDB_DIR"
 fi
+if [ -z "$ADDB_RECORD_DIR" ]; then
+   ADDB_RECORD_DIR="/var/motr/m0d-*"
+fi
 
 while getopts ":n:" option; do
     case "${option}" in

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh
@@ -59,9 +59,6 @@ addb_rec_dirs=`ls -d $ADDB_DIR`
 if [ -n "$ADDB_DIR" ]; then
     addb_rec_dirs="$addb_rec_dirs $ADDB_DIR"
 fi
-if [ -z "$ADDB_RECORD_DIR" ]; then
-   ADDB_RECORD_DIR="/var/motr/m0d-*"
-fi
 
 while getopts ":n:" option; do
     case "${option}" in


### PR DESCRIPTION
* During Read and Write(update) operation we do cob lookup to retrieve
  pver from server, but if we could get pver from s3 itself while trying to
  read object we can avoid cob lookup.

* Added required changes for the same, While creating object pver and LID will
  be stored into object attributes (obj->ob_attr.oa_pver) and the same will be
  returned by s3 while they try to read the object.

* Tried to simulate behavior on Motr side by setting pver (what is received in
  create object) into m0_read() before proceeding for object read, These changes
  from helper.c and debug logs will be removed from final patch.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>