### PR TITLE
EOS-19810: avoidance of internal dix layout index lookups

### DIFF
--- a/motr/client.c
+++ b/motr/client.c
@@ -264,6 +264,14 @@ m0__obj_instance(const struct m0_obj *obj)
 	return m0__entity_instance(&obj->ob_entity);
 }
 
+M0_INTERNAL struct m0_client *
+m0__idx_instance(const struct m0_idx *idx)
+{
+	M0_PRE(idx != NULL);
+
+	return m0__entity_instance(&idx->in_entity);
+}
+
 /**
  * Pick a locality: Motr and the new locality interface(chore) now uses TLS to
  * store data and these data are set when a "motr" thread is created.

--- a/motr/client.h
+++ b/motr/client.h
@@ -751,6 +751,20 @@ struct m0_client_layout {
 };
 
 /**
+ * Index attributes.
+ * 
+ * This is supplied by an application and return by the implementation
+ * when an index is created.
+ *
+ */
+struct m0_idx_attr {
+	/** DIX pool layout type. */
+	uint32_t      idx_layout_type;
+	/** DIX pool version type. */
+	struct m0_fid idx_pver;
+};
+
+/**
  * Index is an ordered key-value store.
  *
  * A record is a key-value pair. A new record can be inserted in an index,
@@ -768,7 +782,8 @@ struct m0_client_layout {
  *   m0_cas_index_fid_type type.
  */
 struct m0_idx {
-	struct m0_entity in_entity;
+	struct m0_entity   in_entity;
+	struct m0_idx_attr in_attr;
 };
 
 #define	M0_COMPOSITE_EXTENT_INF (0xffffffffffffffff)

--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -33,6 +33,8 @@
 
 #define OP_OBJ2CODE(op_obj) op_obj->oo_oc.oc_op.op_code
 
+#define OP_IDX2CODE(op_idx) op_idx->oi_oc.oc_op.op_code
+
 #define MOCK
 #define CLIENT_FOR_M0T1FS
 
@@ -941,6 +943,15 @@ M0_INTERNAL int m0__io_ref_get(struct m0_client *m0c);
 M0_INTERNAL void m0__io_ref_put(struct m0_client *m0c);
 M0_INTERNAL struct m0_file *m0_client_fop_to_file(struct m0_fop *fop);
 M0_INTERNAL bool entity_id_is_valid(const struct m0_uint128 *id);
+
+/**
+ * Returns the m0_client instance, found from the provided index.
+ *
+ * @param idx The index to find the instance for.
+ * @return A pointer to the m0_client instance.
+ */
+M0_INTERNAL struct m0_client *
+m0__idx_instance(const struct m0_idx *idx);
 
 /** @} end of client group */
 

--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -547,8 +547,20 @@ static void cas_next_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 static void dix_build(const struct m0_op_idx *oi,
 		      struct m0_dix          *out)
 {
+	unsigned int   opcode = OP_IDX2CODE(oi);
+	struct m0_idx *idx = oi->oi_idx;
+
 	M0_SET0(out);
 	out->dd_fid = *OI_IFID(oi);
+	/* Pool version and layout type which are passed by consumers like S3 */
+	if (M0_IN(opcode, (M0_IC_GET, M0_IC_PUT, M0_IC_DEL, M0_IC_NEXT))) {
+		if (idx->in_attr.idx_layout_type == DIX_LTYPE_DESCR) {
+			M0_LOG(M0_DEBUG, "Opcode: %u, DIX pool version:"FID_F"",
+			       opcode, FID_P(&idx->in_attr.idx_pver));
+			out->dd_layout.dl_type = DIX_LTYPE_DESCR;
+			out->dd_layout.u.dl_desc.ld_pver = idx->in_attr.idx_pver;
+		}
+	}
 }
 
 static void cas_req_init(struct dix_req   *req,

--- a/motr/obj.c
+++ b/motr/obj.c
@@ -741,6 +741,8 @@ static int entity_namei_op(struct m0_entity *entity,
 		break;
 	case M0_ET_IDX:
 		rc = m0_idx_op_namei(entity, op, opcode);
+		if (rc != 0)
+			goto error;
 		break;
 	default:
 		M0_IMPOSSIBLE("Entity type not yet implemented.");

--- a/pool/pool.c
+++ b/pool/pool.c
@@ -670,6 +670,40 @@ m0_pool_version_get(struct m0_pools_common  *pc,
 	return M0_RC(rc);
 }
 
+static int dix_pool_version_get_locked(struct m0_pools_common  *pc,
+                                       struct m0_pool_version **pv)
+{
+	struct m0_pool         *pool;
+
+	M0_ENTRY();
+	M0_PRE(m0_mutex_is_locked(&pc->pc_mutex));
+
+	if (pv == NULL)
+		return M0_ERR(-EINVAL);
+
+	m0_tl_for(pools, &pc->pc_pools, pool) {
+		if (is_dix_pool(pc, pool)) {
+			*pv = m0_pool_clean_pver_find(pool);
+			if (*pv != NULL)
+				return M0_RC(0);
+		}
+	} m0_tl_endfor;
+	return M0_ERR(-ENOENT);
+}
+
+M0_INTERNAL int
+m0_dix_pool_version_get(struct m0_pools_common  *pc,
+                        struct m0_pool_version **pv)
+{
+	int rc;
+
+	M0_ENTRY();
+	m0_mutex_lock(&pc->pc_mutex);
+	rc = dix_pool_version_get_locked(pc, pv);
+	m0_mutex_unlock(&pc->pc_mutex);
+	return M0_RC(rc);
+}
+
 static int _nodes_count(struct m0_conf_pver *pver, uint32_t *nodes)
 {
 	struct m0_conf_diter  it;

--- a/pool/pool.h
+++ b/pool/pool.h
@@ -369,6 +369,9 @@ m0_pools_common_service_ctx_find(const struct m0_pools_common *pc,
 M0_INTERNAL void
 m0_pools_common_service_ctx_connect_sync(struct m0_pools_common *pc);
 
+M0_INTERNAL int m0_dix_pool_version_get(struct m0_pools_common  *pc,
+					struct m0_pool_version **pv);
+
 /**
  * pool node. Data structure representing a node in a pool.
  *


### PR DESCRIPTION
Added idx_pool_version_get() internal API to get index pool version
and layout type. It will be called when m0_entity_create() API is
triggered from consumers like s3, m0kv. It is applicable for create
index operation.

Added required changes to support pver and layout type which are
passed by S3. It is applicable for PUT, GET, NEXT and DEL KV operations
in md-path.

Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>