### PR TITLE
EOS-20955: Motr panic during write operation.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,7 +185,7 @@ motr_libmotr_la_CPPFLAGS  = -DM0_TARGET='libmotr' $(AM_CPPFLAGS)
 motr_libmotr_la_LDFLAGS   = -version-info @LT_VERSION@ -pthread $(AM_LDFLAGS)
 motr_libmotr_la_LIBADD    = @MATH_LIBS@ @PTHREAD_LIBS@ @AIO_LIBS@ @RT_LIBS@ \
                             @YAML_LIBS@ @PROFILER_LIBS@ @UUID_LIBS@ @GALOIS_LIBS@ \
-                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@ @ISAL_LIBS@
+                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@ @ISAL_LIBS@ @OPENSSL_LIBS@
 
 # install directory for public libmotr headers
 motr_includedir             = $(includedir)/motr

--- a/configure.ac
+++ b/configure.ac
@@ -626,6 +626,11 @@ MOTR_SEARCH_LIBS([pthread_create], [c pthread], [PTHREAD_LIBS],
 )
 AC_SUBST([PTHREAD_LIBS])
 
+MOTR_SEARCH_LIBS([MD5_Init], [c crypto], [OPENSSL_LIBS],
+        [MD5_Init cannot be found! Try to install openssl.]
+)
+AC_SUBST([OPENSSL_LIBS])
+
 # check for aio library (io_submit(3) & co.)
 MOTR_SEARCH_LIBS([io_getevents], [aio c], [AIO_LIBS],
         [io_getevents cannot be found! Try to install libaio-devel.]
@@ -662,6 +667,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h malloc.h memory.h netdb.h \
                   sys/socket.h sys/time.h unistd.h])
 
 AC_CHECK_HEADERS([pthread.h], [], [AC_MSG_ERROR([pthread.h cannot be found!])])
+AC_CHECK_HEADERS([openssl/md5.h], [], [AC_MSG_ERROR([md5.h cannot be found!])])
 AC_CHECK_HEADERS([isa-l.h],   [
 				# check for isa library
 				MOTR_SEARCH_LIBS([ec_encode_data], [c isal], [ISAL_LIBS],
@@ -1069,6 +1075,7 @@ echo "GALOIS_LIBS    :  \"$GALOIS_LIBS\""
 echo "YAML_LIBS      :  \"$YAML_LIBS\""
 echo "UUID_LIBS      :  \"$UUID_LIBS\""
 echo "ISAL_LIBS      :  \"$ISAL_LIBS\""
+echo "OPENSSL_LIBS   :  \"$OPENSSL_LIBS\""
 echo ""
 echo "Gcc            :  \"$BUILD_GCC\""
 AS_IF([test x$with_lustre != xno],[

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -90,6 +90,8 @@ BuildRequires:  perl-YAML-LibYAML
 BuildRequires:  kernel-devel = %{kernel_ver_requires}
 BuildRequires:  %{lustre_devel}
 BuildRequires:  libuuid-devel
+BuildRequires:  openssl
+BuildRequires:  openssl-devel
 BuildRequires:  binutils-devel
 %if %{rhel} <= 7
 BuildRequires:  python36-ply
@@ -114,6 +116,8 @@ Requires:       kernel = %{kernel_ver_requires}
 Requires:       %{lustre}
 Requires:       libaio
 Requires:       libyaml
+#Supported openssl versions -- CentOS 7 its 1.0.2k, RHEL8 its 1.1.1
+Requires:       openssl
 Requires:       gdb
 Requires:       genders
 Requires:       sysvinit-tools

--- a/motr/client.c
+++ b/motr/client.c
@@ -867,6 +867,7 @@ M0_INTERNAL int m0_calculate_md5_inc_context(
 	if (flag & M0_PI_CALC_UNIT_ZERO) {
 		memset(pi, 0, sizeof(struct m0_md5_inc_context_pi));
 		pi->hdr.pi_type = M0_PI_TYPE_MD5_INC_CONTEXT;
+		pi->hdr.pi_size = (uint8_t)sizeof(struct m0_md5_inc_context_pi);
 		rc = MD5_Init((MD5_CTX *)&pi->prev_context);
 		if (rc != 1) {
 			return M0_ERR_INFO(rc, "MD5_Init failed.");

--- a/motr/client.c
+++ b/motr/client.c
@@ -865,6 +865,8 @@ M0_INTERNAL int m0_calculate_md5_inc_context(
 
 	/* This call is for first data unit, need to initialize prev_context */
 	if (flag & M0_PI_CALC_UNIT_ZERO) {
+		memset(pi, 0, sizeof(struct m0_md5_inc_context_pi));
+		pi->hdr.pi_type = M0_PI_TYPE_MD5_INC_CONTEXT;
 		rc = MD5_Init((MD5_CTX *)&pi->prev_context);
 		if (rc != 1) {
 			return M0_ERR_INFO(rc, "MD5_Init failed.");

--- a/motr/client.c
+++ b/motr/client.c
@@ -1,6 +1,6 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2020-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_CLIENT
 #include "lib/trace.h"
 #include "lib/finject.h"
+
 /**
  * Bob definitions
  */
@@ -842,84 +843,116 @@ M0_INTERNAL int m0_op_init(struct m0_op *op,
 	return M0_RC(0);
 }
 
-M0_INTERNAL int m0_calculate_md5_inc_digest(
-		struct m0_md5_inc_digest_pi *pi,
+#ifndef __KERNEL__
+M0_INTERNAL int m0_calculate_md5_inc_context(
+		struct m0_md5_inc_context_pi *pi,
 		struct m0_pi_seed *seed,
 		struct m0_bufvec *bvec,
 		enum m0_pi_calc_flag flag,
-		unsigned char *curr_digest,
+		unsigned char *curr_context,
 		unsigned char *pi_value_without_seed)
 {
+	MD5_CTX context;
+	int i, rc;
+
 	M0_ENTRY();
 
 	M0_PRE(pi != NULL);
-	M0_PRE(curr_digest != NULL);
+	M0_PRE(curr_context != NULL);
 	M0_PRE(bvec != NULL);
 	M0_PRE(bvec->ov_vec.v_count != NULL);
 	M0_PRE(bvec->ov_buf != NULL);
 
-	/* Following code block should be removed */
-	/* sending dummy values to S3 */
-#if 1
-#define PI_DIGEST_LENGTH 92
-#define PI_VALUE_LENGTH 16
+	/* This call is for first data unit, need to initialize prev_context */
 	if (flag & M0_PI_CALC_UNIT_ZERO) {
-		 memset(&pi->prev_digest, '0', PI_DIGEST_LENGTH);
-	}
-	memset(&pi->pi_value, 'A', PI_VALUE_LENGTH);
-	memset(curr_digest, '1', PI_DIGEST_LENGTH);
-	if (pi_value_without_seed) {
-		memset(pi_value_without_seed, 'B', PI_VALUE_LENGTH);
-	}
-#endif
-
-	/* Uncomment following code once motr has integration for MD5 */
-#if 0
-
-	/* This call is for first data unit, need to initialize prev_digest*/
-	if (flag & M0_PI_CALC_UNIT_ZERO) {
-		MD5_Init(&pi->prev_digest);
+		rc = MD5_Init((MD5_CTX *)&pi->prev_context);
+		if (rc != 1) {
+			return M0_ERR_INFO(rc, "MD5_Init failed.");
+		}
 	}
 
-	/* memcpy, so that we do not change the prev_digest */
-	memcpy(curr_digest, &pi->prev_digest, sizeof(MD5_CTX));
+	/* memcpy, so that we do not change the prev_context */
+	memcpy(curr_context, &pi->prev_context, sizeof(MD5_CTX));
 
-	/* get the curr digest i by updating it*/
+
+	/* get the curr context i by updating it*/
 	for (i = 0; i < bvec->ov_vec.v_nr; i++) {
-		MD5_Update(curr_digest, bvec->ov_buf[i], bvec->ov_vec.v_count[i]);
+		rc = MD5_Update((MD5_CTX *)curr_context, bvec->ov_buf[i],
+				bvec->ov_vec.v_count[i]);
+		if (rc != 1) {
+			return M0_ERR_INFO(rc, "MD5_Update failed. curr_context=%p, "
+					"bvec->ov_buf[%d]=%p, bvec->ov_vec.v_count[%u]=%u",
+					curr_context, i, bvec->ov_buf[i], i,
+					(uint32_t)bvec->ov_vec.v_count[i]);
+		}
 	}
 
-	/* if caller want checksum without seed and with seed, in this case
-	 * 'pi_value_without_seed' will be used to send wihout seed checksum.
+	/* If caller wants checksum without seed and with seed, caller needs to
+	 * pass 'pi_value_without_seed'. pi_value will be used to return with
+	 * seed checksum. 'pi_value_without_seed' will be used to return non
+	 * seeded checksum.
 	 */
-	if (pi_value_without_seed && (flag & M0_PI_CALC_FINAL)) {
-		unsigned char digest[sizeof(MD5_CTX)];
-		memcpy(&digest, curr_digest, sizeof(MD5_CTX));
-
+	if (pi_value_without_seed != NULL) {
 		/* 
-		 * NOTE: MD5_final() changes the digest itself and curr_digest
+		 * NOTE: MD5_final() changes the context itself and curr_context
 		 * should not be finalised, thus copy it and use it for MD5_final
 		 */
+		memcpy((void *)&context, (void *)curr_context, sizeof(MD5_CTX));
 
-		MD5_Final(pi_value_without_seed, digest);
+		rc = MD5_Final(pi_value_without_seed, &context);
+		if (rc != 1) {
+			return M0_ERR_INFO(rc, "MD5_Final failed"
+					"pi_value_without_seed=%p"
+					"curr_context=%p",
+					pi_value_without_seed, curr_context);
+		}
 	}
 
-	/* if seed is passed, memcpy and update the digest calculated so far.
+	/* if seed is passed, memcpy and update the context calculated so far.
 	 * calculate checksum with seed, set the pi_value with seeded checksum.
-	 * NOTE: curr_digest will always have digest without seed.
+	 * If seed is not passed than memcpy context and calculate checksum
+	 * without seed, set the pi_value with unseeded checksum.
+	 * NOTE: curr_context will always have context without seed.
 	 */
-	if (seed) {
-		unsigned char seed_digest[sizeof(MD5_CTX)];
-		memcpy(&seed_digest, curr_digest, sizeof(MD5_CTX));
+	memcpy((void *)&context, (void *)curr_context, sizeof(MD5_CTX));
 
-		MD5_Update(&seed_digest, &seed, sizeof(struct m0_pi_seed));
-		MD5_Final(pi->pi_value, &seed_digest);
+	if (seed != NULL) {
+
+		/*
+		 * seed_str have string represention for 3 uint64_t(8 bytes)
+		 * range for uint64_t is 0 to 18,446,744,073,709,551,615 at
+		 * max 20 chars per var, for three var it will be 3*20, +1 '\0'.
+		 * seed_str needs to be 61 bytes, round off and taking 64 bytes.
+		 */
+		char seed_str[64] = {'\0'};
+		snprintf(seed_str, sizeof(seed_str), "%"PRIx64"%"PRIx64"%"PRIx64,
+				seed->obj_id.f_container, seed->obj_id.f_key,
+				seed->data_unit_offset);
+		rc = MD5_Update(&context, (unsigned char *)seed_str,
+				sizeof(seed_str));
+		if (rc != 1) {
+
+			return M0_ERR_INFO(rc, "MD5_Update fail curr_context=%p"
+					"f_container %"PRIx64"f_key %"PRIx64
+					"data_unit_offset %"PRIx64"seed_str %s",
+					curr_context, seed->obj_id.f_container,
+					seed->obj_id.f_key,
+					seed->data_unit_offset,
+					(char *)seed_str);
+		}
 	}
 
-#endif
+	if (!(flag & M0_PI_SKIP_CALC_FINAL)) {
+		rc = MD5_Final(pi->pi_value, &context);
+		if (rc != 1) {
+			return M0_ERR_INFO(rc, "MD5_Final fail curr_context=%p",
+					curr_context);
+		}
+	}
 
 	return  M0_RC(0);
 }
+#endif
 
 void m0_op_fini(struct m0_op *op)
 {
@@ -1023,20 +1056,22 @@ int m0_client_calculate_pi(struct m0_generic_pi *pi,
 		struct m0_pi_seed *seed,
 		struct m0_bufvec *bvec,
 		enum m0_pi_calc_flag flag,
-		unsigned char *curr_digest,
+		unsigned char *curr_context,
 		unsigned char *pi_value_without_seed)
 {
 	M0_ENTRY();
 
-	switch(pi->hdr.pi_type)
-	{
-		case M0_PI_TYPE_MD5_INC_DIGEST:
-		{
-			struct m0_md5_inc_digest_pi *md5_digest_pi = 
-				(struct m0_md5_inc_digest_pi *) pi;
+	switch(pi->hdr.pi_type) {
 
-			m0_calculate_md5_inc_digest(md5_digest_pi, seed, bvec, flag,
-					curr_digest, pi_value_without_seed);
+		case M0_PI_TYPE_MD5_INC_CONTEXT:
+		{
+#ifndef __KERNEL__
+			struct m0_md5_inc_context_pi *md5_context_pi = 
+				(struct m0_md5_inc_context_pi *) pi;
+			m0_calculate_md5_inc_context(md5_context_pi, seed, bvec,
+					flag, curr_context,
+					pi_value_without_seed);
+#endif
 		}
 	}
 	return M0_RC(0);

--- a/motr/client.c
+++ b/motr/client.c
@@ -842,6 +842,85 @@ M0_INTERNAL int m0_op_init(struct m0_op *op,
 	return M0_RC(0);
 }
 
+M0_INTERNAL int m0_calculate_md5_inc_digest(
+		struct m0_md5_inc_digest_pi *pi,
+		struct m0_pi_seed *seed,
+		struct m0_bufvec *bvec,
+		enum m0_pi_calc_flag flag,
+		unsigned char *curr_digest,
+		unsigned char *pi_value_without_seed)
+{
+	M0_ENTRY();
+
+	M0_PRE(pi != NULL);
+	M0_PRE(curr_digest != NULL);
+	M0_PRE(bvec != NULL);
+	M0_PRE(bvec->ov_vec.v_count != NULL);
+	M0_PRE(bvec->ov_buf != NULL);
+
+	/* Following code block should be removed */
+	/* sending dummy values to S3 */
+#if 1
+#define PI_DIGEST_LENGTH 92
+#define PI_VALUE_LENGTH 16
+	if (flag & M0_PI_CALC_UNIT_ZERO) {
+		 memset(&pi->prev_digest, '0', PI_DIGEST_LENGTH);
+	}
+	memset(&pi->pi_value, 'A', PI_VALUE_LENGTH);
+	memset(curr_digest, '1', PI_DIGEST_LENGTH);
+	if (pi_value_without_seed) {
+		memset(pi_value_without_seed, 'B', PI_VALUE_LENGTH);
+	}
+#endif
+
+	/* Uncomment following code once motr has integration for MD5 */
+#if 0
+
+	/* This call is for first data unit, need to initialize prev_digest*/
+	if (flag & M0_PI_CALC_UNIT_ZERO) {
+		MD5_Init(&pi->prev_digest);
+	}
+
+	/* memcpy, so that we do not change the prev_digest */
+	memcpy(curr_digest, &pi->prev_digest, sizeof(MD5_CTX));
+
+	/* get the curr digest i by updating it*/
+	for (i = 0; i < bvec->ov_vec.v_nr; i++) {
+		MD5_Update(curr_digest, bvec->ov_buf[i], bvec->ov_vec.v_count[i]);
+	}
+
+	/* if caller want checksum without seed and with seed, in this case
+	 * 'pi_value_without_seed' will be used to send wihout seed checksum.
+	 */
+	if (pi_value_without_seed && (flag & M0_PI_CALC_FINAL)) {
+		unsigned char digest[sizeof(MD5_CTX)];
+		memcpy(&digest, curr_digest, sizeof(MD5_CTX));
+
+		/* 
+		 * NOTE: MD5_final() changes the digest itself and curr_digest
+		 * should not be finalised, thus copy it and use it for MD5_final
+		 */
+
+		MD5_Final(pi_value_without_seed, digest);
+	}
+
+	/* if seed is passed, memcpy and update the digest calculated so far.
+	 * calculate checksum with seed, set the pi_value with seeded checksum.
+	 * NOTE: curr_digest will always have digest without seed.
+	 */
+	if (seed) {
+		unsigned char seed_digest[sizeof(MD5_CTX)];
+		memcpy(&seed_digest, curr_digest, sizeof(MD5_CTX));
+
+		MD5_Update(&seed_digest, &seed, sizeof(struct m0_pi_seed));
+		MD5_Final(pi->pi_value, &seed_digest);
+	}
+
+#endif
+
+	return  M0_RC(0);
+}
+
 void m0_op_fini(struct m0_op *op)
 {
 	struct m0_op_common        *oc;
@@ -939,6 +1018,31 @@ int32_t m0_rc(const struct m0_op *op)
 	return M0_RC(op->op_rc);
 }
 M0_EXPORTED(m0_rc);
+
+int m0_client_calculate_pi(struct m0_generic_pi *pi,
+		struct m0_pi_seed *seed,
+		struct m0_bufvec *bvec,
+		enum m0_pi_calc_flag flag,
+		unsigned char *curr_digest,
+		unsigned char *pi_value_without_seed)
+{
+	M0_ENTRY();
+
+	switch(pi->hdr.pi_type)
+	{
+		case M0_PI_TYPE_MD5_INC_DIGEST:
+		{
+			struct m0_md5_inc_digest_pi *md5_digest_pi = 
+				(struct m0_md5_inc_digest_pi *) pi;
+
+			m0_calculate_md5_inc_digest(md5_digest_pi, seed, bvec, flag,
+					curr_digest, pi_value_without_seed);
+		}
+	}
+	return M0_RC(0);
+}
+
+M0_EXPORTED(m0_client_calculate_pi);
 
 #undef M0_TRACE_SUBSYSTEM
 

--- a/motr/client.h
+++ b/motr/client.h
@@ -1,6 +1,6 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2016-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2016-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@
 #include "fid/fid.h"
 #include "lib/cookie.h"
 #include "xcode/xcode_attr.h"
-
+#ifndef __KERNEL__
+#include <openssl/md5.h>
+#endif /* __KERNEL__ */
 /**
  * @defgroup client
  *
@@ -929,7 +931,7 @@ struct m0_config {
 enum
 {
 	M0_PI_TYPE_MD5,
-	M0_PI_TYPE_MD5_INC_DIGEST,
+	M0_PI_TYPE_MD5_INC_CONTEXT,
 	M0_PI_TYPE_CRC,
 	M0_PI_TYPE_MAX
 };
@@ -938,8 +940,8 @@ enum m0_pi_calc_flag {
 
 	/* PI calculation for data unit 0 */
 	M0_PI_CALC_UNIT_ZERO = 1 << 0,
-	/* PI final value to be calculated */
-	M0_PI_CALC_FINAL = 1 << 1
+	/* Skip PI final value calculation */
+	M0_PI_SKIP_CALC_FINAL = 1 << 1
 	
 };
 
@@ -954,33 +956,32 @@ struct m0_pi_hdr {
 
 struct m0_md5_pi {
 
-#define PI_VALUE_LENGTH 16
-
 	/* header for protection info */
 	struct m0_pi_hdr hdr;
+#ifndef __KERNEL__
 	/* protection value computed for the current data*/
-	unsigned char pi_value[PI_VALUE_LENGTH];
+	unsigned char pi_value[MD5_DIGEST_LENGTH];
 	/* structure should be 32 byte aligned */
-	char pad[M0_CALC_PAD(sizeof(struct m0_pi_hdr)+ PI_VALUE_LENGTH, 32)];
+	char pad[M0_CALC_PAD(sizeof(struct m0_pi_hdr)+ MD5_DIGEST_LENGTH, 32)];
+#endif
 };
 
-struct m0_md5_inc_digest_pi {
-
-#define PI_DIGEST_LENGTH 92
-#define PI_VALUE_LENGTH 16
+struct m0_md5_inc_context_pi {
 
 	/* header for protection info */
 	struct m0_pi_hdr hdr;
-	/*digest of previous data unit, required for checksum computation */
-	unsigned char prev_digest[PI_DIGEST_LENGTH];
+#ifndef __KERNEL__
+	/*context of previous data unit, required for checksum computation */
+	unsigned char prev_context[sizeof(MD5_CTX)];
 	/* protection value computed for the current data unit.
 	 * If seed is not provided then this checksum is
 	 * calculated without seed.
 	 */
-	unsigned char pi_value[PI_VALUE_LENGTH];
+	unsigned char pi_value[MD5_DIGEST_LENGTH];
 	/* structure should be 32 byte aligned */
-	char pad[M0_CALC_PAD(sizeof(struct m0_pi_hdr)+PI_VALUE_LENGTH+
-			PI_VALUE_LENGTH, 32)];
+	char pad[M0_CALC_PAD(sizeof(struct m0_pi_hdr)+ sizeof(MD5_CTX)+
+			MD5_DIGEST_LENGTH, 32)];
+#endif
 };
 
 struct m0_generic_pi {
@@ -1867,11 +1868,11 @@ void m0_client_layout_free(struct m0_client_layout *layout);
  *
  * @param[IN/OUT] pi  Caller will pass Generic pi struct, which will be typecasted to
  *                    specific PI type struct. API will calculate the checksum and set
- *                    pi_value of PI type struct. In case of digest, caller will send
- *                    data unit N-1 unit's digest via prev_digest field in PI type struct.
- *                    This api will calculate unit N's digest and set value in curr_digest.
- *                    IN values - pi_type, pi_size, prev_digest
- *                    OUT values - pi_value, prev_digest for first data unit. 
+ *                    pi_value of PI type struct. In case of context, caller will send
+ *                    data unit N-1 unit's context via prev_context field in PI type struct.
+ *                    This api will calculate unit N's context and set value in curr_context.
+ *                    IN values - pi_type, pi_size, prev_context
+ *                    OUT values - pi_value, prev_context for first data unit. 
  * @param[IN] seed seed value (obj_id+data_unit_offset) required to calculate
  *                 the checksum. If this pointer is NULL that means either 
  *                 this checksum calculation is meant for KV or user does
@@ -1881,9 +1882,9 @@ void m0_client_layout_free(struct m0_client_layout *layout);
  *                      this set of vectors will make one data unit.
  * @param[IN] flag If flag is M0_PI_CALC_UNIT_ZERO, it means this api is called for 
  *                 first data unit and init functionality should be invoked such as MD5_Init.
- * @param[OUT] curr_digest digest of data unit N, will be required to calculate checksum for
+ * @param[OUT] curr_context context of data unit N, will be required to calculate checksum for
  *                         next data unit, N+1. This api will calculate and set value for this field.
- *                         NOTE: curr_digest always have unseeded and non finalised digest value 
+ *                         NOTE: curr_context always have unseeded and non finalised context value 
  *                         and sending this parameter is mandatory.
  * @param[OUT] pi_value_without_seed Caller may need checksum value without seed and with seed.
  *                                   With seed checksum is set in pi_value of PI type struct.
@@ -1891,20 +1892,11 @@ void m0_client_layout_free(struct m0_client_layout *layout);
  *                                   Caller has to allocate memory for this filed.
  */
 
-/*
- * Following dummy values are sent to S3 right now
- * curr_digest is set to '0 if flag M0_PI_CALC_UNIT_ZERO is on.
- * pi_value is set to 'A'
- * curr_digest is set to '1'
- * pi_value_without_seed is set to 'B'
- */
-
-
 int m0_client_calculate_pi(struct m0_generic_pi *pi,
 		struct m0_pi_seed *seed,
 		struct m0_bufvec *bvec,
 		enum m0_pi_calc_flag flag,
-		unsigned char *curr_digest,
+		unsigned char *curr_context,
 		unsigned char *pi_value_without_seed);
 
 //** @} end of client group */

--- a/motr/client.h
+++ b/motr/client.h
@@ -951,9 +951,9 @@ M0_BASSERT(M0_PI_TYPE_MAX <= 8);
 
 struct m0_pi_hdr {
 	/* type of protection algorithm being used */
-	uint8_t pi_type : 3;
+	uint8_t pi_type;
 	/*size of PI Structure in multiple of  32 bytes*/
-	uint8_t pi_size : 5;
+	uint8_t pi_size;
 };
 
 struct m0_md5_pi {

--- a/motr/client.h
+++ b/motr/client.h
@@ -938,6 +938,8 @@ enum
 
 enum m0_pi_calc_flag {
 
+	/* NO PI FLAG */
+	M0_PI_NO_FLAG = 0,
 	/* PI calculation for data unit 0 */
 	M0_PI_CALC_UNIT_ZERO = 1 << 0,
 	/* Skip PI final value calculation */
@@ -1879,7 +1881,7 @@ void m0_client_layout_free(struct m0_client_layout *layout);
  *                 not want seeding.
  *                 NOTE: seed is always NULL, non-null value sent at the last chunk of motr unit
  * @param[IN] m0_bufvec Set of buffers for which checksum is computed. Normally
- *                      this set of vectors will make one data unit.
+ *                      this set of vectors will make one data unit. It can be NULL as well.
  * @param[IN] flag If flag is M0_PI_CALC_UNIT_ZERO, it means this api is called for 
  *                 first data unit and init functionality should be invoked such as MD5_Init.
  * @param[OUT] curr_context context of data unit N, will be required to calculate checksum for

--- a/motr/client.h
+++ b/motr/client.h
@@ -520,6 +520,14 @@
  * @{
  */
 
+/*
+ * Macro calculates the size of padding required in a struct
+ * for byte alignment
+ * size - size of all structure members
+ * alignment - power of two, byte alignment
+ */
+#define M0_CALC_PAD(size, alignment) ( size%alignment ?(size/alignment + 1 ) * alignment - size : 0)
+
 /**
  * Operation codes for entity, object and index.
  */
@@ -915,6 +923,78 @@ struct m0_config {
  	 * ADDB size
  	 */
 	m0_bcount_t mc_addb_size;
+};
+
+/* Constants for protection info type, max types supported is 8 */
+enum
+{
+	M0_PI_TYPE_MD5,
+	M0_PI_TYPE_MD5_INC_DIGEST,
+	M0_PI_TYPE_CRC,
+	M0_PI_TYPE_MAX
+};
+
+enum m0_pi_calc_flag {
+
+	/* PI calculation for data unit 0 */
+	M0_PI_CALC_UNIT_ZERO = 1 << 0,
+	/* PI final value to be calculated */
+	M0_PI_CALC_FINAL = 1 << 1
+	
+};
+
+M0_BASSERT(M0_PI_TYPE_MAX <= 8);
+
+struct m0_pi_hdr {
+	/* type of protection algorithm being used */
+	uint8_t pi_type : 3;
+	/*size of PI Structure in multiple of  32 bytes*/
+	uint8_t pi_size : 5;
+};
+
+struct m0_md5_pi {
+
+#define PI_VALUE_LENGTH 16
+
+	/* header for protection info */
+	struct m0_pi_hdr hdr;
+	/* protection value computed for the current data*/
+	unsigned char pi_value[PI_VALUE_LENGTH];
+	/* structure should be 32 byte aligned */
+	char pad[M0_CALC_PAD(sizeof(struct m0_pi_hdr)+ PI_VALUE_LENGTH, 32)];
+};
+
+struct m0_md5_inc_digest_pi {
+
+#define PI_DIGEST_LENGTH 92
+#define PI_VALUE_LENGTH 16
+
+	/* header for protection info */
+	struct m0_pi_hdr hdr;
+	/*digest of previous data unit, required for checksum computation */
+	unsigned char prev_digest[PI_DIGEST_LENGTH];
+	/* protection value computed for the current data unit.
+	 * If seed is not provided then this checksum is
+	 * calculated without seed.
+	 */
+	unsigned char pi_value[PI_VALUE_LENGTH];
+	/* structure should be 32 byte aligned */
+	char pad[M0_CALC_PAD(sizeof(struct m0_pi_hdr)+PI_VALUE_LENGTH+
+			PI_VALUE_LENGTH, 32)];
+};
+
+struct m0_generic_pi {
+	/* header for protection info */
+	struct m0_pi_hdr hdr;
+	/*pointer to access specific pi structure fields*/
+	void *t_pi;
+};
+
+/* seed values for calculating checksum */
+struct m0_pi_seed {
+	struct m0_fid obj_id;
+	/* offset within motr object */
+	m0_bindex_t data_unit_offset;
 };
 
 /** The identifier of the root of realm hierarchy. */
@@ -1776,10 +1856,56 @@ int m0_client_layout_capture(struct m0_client_layout *layout,
 		      struct m0_obj *obj,
 		      struct m0_client_layout **out);
 
+
 /* Allocate/free in-memory layout data struct for an object. */
 struct m0_client_layout*
 m0_client_layout_alloc(enum m0_client_layout_type type);
 void m0_client_layout_free(struct m0_client_layout *layout);
+
+/**
+ * Calculate checksum/protection info for data/KV
+ *
+ * @param[IN/OUT] pi  Caller will pass Generic pi struct, which will be typecasted to
+ *                    specific PI type struct. API will calculate the checksum and set
+ *                    pi_value of PI type struct. In case of digest, caller will send
+ *                    data unit N-1 unit's digest via prev_digest field in PI type struct.
+ *                    This api will calculate unit N's digest and set value in curr_digest.
+ *                    IN values - pi_type, pi_size, prev_digest
+ *                    OUT values - pi_value, prev_digest for first data unit. 
+ * @param[IN] seed seed value (obj_id+data_unit_offset) required to calculate
+ *                 the checksum. If this pointer is NULL that means either 
+ *                 this checksum calculation is meant for KV or user does
+ *                 not want seeding.
+ *                 NOTE: seed is always NULL, non-null value sent at the last chunk of motr unit
+ * @param[IN] m0_bufvec Set of buffers for which checksum is computed. Normally
+ *                      this set of vectors will make one data unit.
+ * @param[IN] flag If flag is M0_PI_CALC_UNIT_ZERO, it means this api is called for 
+ *                 first data unit and init functionality should be invoked such as MD5_Init.
+ * @param[OUT] curr_digest digest of data unit N, will be required to calculate checksum for
+ *                         next data unit, N+1. This api will calculate and set value for this field.
+ *                         NOTE: curr_digest always have unseeded and non finalised digest value 
+ *                         and sending this parameter is mandatory.
+ * @param[OUT] pi_value_without_seed Caller may need checksum value without seed and with seed.
+ *                                   With seed checksum is set in pi_value of PI type struct.
+ *                                   Without seed checksum is set in this field.
+ *                                   Caller has to allocate memory for this filed.
+ */
+
+/*
+ * Following dummy values are sent to S3 right now
+ * curr_digest is set to '0 if flag M0_PI_CALC_UNIT_ZERO is on.
+ * pi_value is set to 'A'
+ * curr_digest is set to '1'
+ * pi_value_without_seed is set to 'B'
+ */
+
+
+int m0_client_calculate_pi(struct m0_generic_pi *pi,
+		struct m0_pi_seed *seed,
+		struct m0_bufvec *bvec,
+		enum m0_pi_calc_flag flag,
+		unsigned char *curr_digest,
+		unsigned char *pi_value_without_seed);
 
 //** @} end of client group */
 

--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -953,6 +953,35 @@ M0_INTERNAL bool entity_id_is_valid(const struct m0_uint128 *id);
 M0_INTERNAL struct m0_client *
 m0__idx_instance(const struct m0_idx *idx);
 
+/**
+ * Calculate checksum/protection info for data/KV
+ *
+ * @param pi  pi struct m0_md5_inc_digest_pi
+ *            This function will calculate the checksum and set
+ *            pi_value field of struct m0_md5_inc_digest_pi.
+ * @param seed seed value (obj_id+data_unit_offset) required to calculate
+ *             the checksum. If this pointer is NULL that means either
+ *             this checksum calculation is meant for KV or user does
+ *             not want seeding.
+ * @param m0_bufvec - Set of buffers for which checksum is computed.
+ * @param flag if flag is M0_PI_CALC_UNIT_ZERO, it means this api is called for
+ *             first data unit and MD5_Init should be invoked.
+ * @param[out] curr_digest digest of data unit N, will be required to calculate checksum for
+ *                         next data unit, N+1. Curre_digest is calculated and set in this func.
+ * @param[out] pi_value_without_seed - Caller may need checksum value without seed and with seed.
+ *                                     With seed checksum is set in pi_value of PI type struct.
+ *                                     Without seed checksum is set in this field.
+ */
+
+M0_INTERNAL int m0_calculate_md5_inc_digest(
+		struct m0_md5_inc_digest_pi *pi,
+		struct m0_pi_seed *seed,
+		struct m0_bufvec *bvec,
+		enum m0_pi_calc_flag flag,
+		unsigned char *curr_digest,
+		unsigned char *pi_value_without_seed);
+
+
 /** @} end of client group */
 
 #endif /* __MOTR_CLIENT_INTERNAL_H__ */

--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -1,6 +1,6 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2016-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2016-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -956,9 +956,9 @@ m0__idx_instance(const struct m0_idx *idx);
 /**
  * Calculate checksum/protection info for data/KV
  *
- * @param pi  pi struct m0_md5_inc_digest_pi
+ * @param pi  pi struct m0_md5_inc_context_pi
  *            This function will calculate the checksum and set
- *            pi_value field of struct m0_md5_inc_digest_pi.
+ *            pi_value field of struct m0_md5_inc_context_pi.
  * @param seed seed value (obj_id+data_unit_offset) required to calculate
  *             the checksum. If this pointer is NULL that means either
  *             this checksum calculation is meant for KV or user does
@@ -966,19 +966,19 @@ m0__idx_instance(const struct m0_idx *idx);
  * @param m0_bufvec - Set of buffers for which checksum is computed.
  * @param flag if flag is M0_PI_CALC_UNIT_ZERO, it means this api is called for
  *             first data unit and MD5_Init should be invoked.
- * @param[out] curr_digest digest of data unit N, will be required to calculate checksum for
- *                         next data unit, N+1. Curre_digest is calculated and set in this func.
+ * @param[out] curr_context context of data unit N, will be required to calculate checksum for
+ *                         next data unit, N+1. Curre_context is calculated and set in this func.
  * @param[out] pi_value_without_seed - Caller may need checksum value without seed and with seed.
  *                                     With seed checksum is set in pi_value of PI type struct.
  *                                     Without seed checksum is set in this field.
  */
 
-M0_INTERNAL int m0_calculate_md5_inc_digest(
-		struct m0_md5_inc_digest_pi *pi,
+M0_INTERNAL int m0_calculate_md5_inc_context(
+		struct m0_md5_inc_context_pi *pi,
 		struct m0_pi_seed *seed,
 		struct m0_bufvec *bvec,
 		enum m0_pi_calc_flag flag,
-		unsigned char *curr_digest,
+		unsigned char *curr_context,
 		unsigned char *pi_value_without_seed);
 
 

--- a/motr/motr-pub.api
+++ b/motr/motr-pub.api
@@ -94,6 +94,7 @@ m0_idx_fini
 m0_idx_op
 m0_op_kick
 m0_rc
+m0_client_calculate_pi
 m0_obj_write_lock_get
 m0_obj_write_lock_get_sync
 m0_obj_read_lock_get

--- a/motr/ut/Makefile.sub
+++ b/motr/ut/Makefile.sub
@@ -12,6 +12,7 @@ ut_libmotr_ut_la_SOURCES += motr/ut/cs_ut_main.c rm/st/wlock_helper.c \
                             motr/ut/sync.c \
                             motr/ut/layout.c \
                             motr/ut/client.h \
-                            motr/st/mt/mt_fom.c
+                            motr/st/mt/mt_fom.c \
+                            motr/ut/protection_info_checks.c
 
 CONFXC_FILES += motr/ut/dix_conf.xc

--- a/motr/ut/protection_info_checks.c
+++ b/motr/ut/protection_info_checks.c
@@ -222,14 +222,14 @@ static void ut_test_pi_api_case_one_two(void)
 		}
 		else if (j == DATA_UNIT_COUNT - 1) {
 			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
-					&seed, &user_data[j],
-					0, curr_context[j], final_sum);
+					&seed, &user_data[j], M0_PI_NO_FLAG,
+					curr_context[j], final_sum);
 			M0_UT_ASSERT(rc == 0);
 		}
 		else {
 			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
-					&seed, &user_data[j],
-					0, curr_context[j], NULL);
+					&seed, &user_data[j], M0_PI_NO_FLAG,
+					curr_context[j], NULL);
 			M0_UT_ASSERT(rc == 0);
 		}
 
@@ -280,13 +280,13 @@ static void ut_test_pi_api_case_third(void)
 		}
 		else if (j == DATA_UNIT_COUNT - 1) {
 			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
-					&seed, &user_data[j], 0,
+					&seed, &user_data[j], M0_PI_NO_FLAG,
 					curr_context[j], final_sum);
 			M0_UT_ASSERT(rc == 0);
 		}
 		else {
 			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
-					NULL, &user_data[j], 0,
+					NULL, &user_data[j], M0_PI_NO_FLAG,
 					curr_context[j], NULL);
 			M0_UT_ASSERT(rc == 0);
 		}

--- a/motr/ut/protection_info_checks.c
+++ b/motr/ut/protection_info_checks.c
@@ -1,0 +1,331 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#ifndef __KERNEL__
+#include <openssl/md5.h>
+#endif /* __KERNEL__ */
+
+#include "ut/ut.h"
+#include "motr/client.h"
+#include "motr/client_internal.h"
+#include "motr/ut/client.h"
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_CLIENT
+#include "lib/trace.h"          /* M0_LOG */
+
+struct m0_ut_suite ut_suite_pi;
+
+enum {
+	BUFFER_SIZE = 4096,
+	SEGS_NR     = 16,
+
+	BIG_BUFFER_SIZE = 4096*16,
+	BIG_SEGS_NR = 10
+};
+
+#define DATA_UNIT_COUNT 10
+#define OBJ_CONTAINER 0x123
+#define OBJ_KEY 0x456
+
+struct m0_bufvec *user_data;
+unsigned char *curr_context[DATA_UNIT_COUNT];
+unsigned char *seeded_sum[DATA_UNIT_COUNT];
+unsigned char *final_sum;
+
+struct m0_bufvec *big_user_data;
+unsigned char *big_curr_context;
+unsigned char *big_final_sum;
+
+M0_INTERNAL int pi_init(void)
+{
+#ifndef __KERNEL__
+	ut_shuffle_test_order(&ut_suite_pi);
+#endif
+
+	int i, j, rc;
+	// allocate and populate buffers
+
+	M0_ALLOC_ARR(user_data, DATA_UNIT_COUNT);
+	M0_UT_ASSERT(user_data != NULL);
+
+	for (j = 0; j < DATA_UNIT_COUNT; j++) {
+		rc = m0_bufvec_alloc(&user_data[j], SEGS_NR, BUFFER_SIZE);
+		M0_UT_ASSERT(rc == 0);
+		for (i = 0; i < user_data[j].ov_vec.v_nr; ++i) {
+			memset(user_data[j].ov_buf[i], 'a' + j, BUFFER_SIZE);
+		}
+
+		M0_ALLOC_ARR(curr_context[j], sizeof(MD5_CTX));
+		M0_UT_ASSERT(curr_context[j] != NULL);
+		M0_ALLOC_ARR(seeded_sum[j], MD5_DIGEST_LENGTH);
+		M0_UT_ASSERT(seeded_sum[j] != NULL);
+	}
+
+	M0_ALLOC_ARR(final_sum, MD5_DIGEST_LENGTH);
+	M0_UT_ASSERT(final_sum != NULL);
+
+	M0_ALLOC_ARR(big_user_data, 1);
+	M0_UT_ASSERT(big_user_data != NULL);
+	rc = m0_bufvec_alloc(big_user_data, BIG_SEGS_NR, BIG_BUFFER_SIZE);
+	M0_UT_ASSERT(rc == 0);
+	for (i = 0; i < big_user_data->ov_vec.v_nr; ++i) {
+		memset(big_user_data->ov_buf[i], 'a' + i, BIG_BUFFER_SIZE);
+	}
+
+	M0_ALLOC_ARR(big_curr_context, sizeof(MD5_CTX));
+	M0_UT_ASSERT(big_curr_context != NULL);
+
+	M0_ALLOC_ARR(big_final_sum, MD5_DIGEST_LENGTH);
+	M0_UT_ASSERT(big_final_sum != NULL);
+
+	return 0;
+}
+
+M0_INTERNAL int pi_fini(void)
+{
+	int j;
+
+	for (j = 0; j < DATA_UNIT_COUNT; j++) {
+		m0_bufvec_free(&user_data[j]);
+		m0_free(seeded_sum[j]);
+		m0_free(curr_context[j]);
+	}
+
+	m0_free(user_data);
+	m0_free(final_sum);
+	m0_free(big_curr_context);
+	m0_free(big_final_sum);
+	m0_bufvec_free(big_user_data);
+	m0_free(big_user_data);
+	return 0;
+}
+
+void verify_case_one_two(void)
+{
+	int i, j, rc;
+	MD5_CTX curr_ctx;
+	MD5_CTX tmp_ctx;
+	char seed_str[64] = {'\0'};
+	struct m0_pi_seed seed;
+	unsigned char *seed_sum;
+	unsigned char *unseed_final_sum;
+
+	M0_ALLOC_ARR(seed_sum, MD5_DIGEST_LENGTH);
+	M0_UT_ASSERT(seed_sum != NULL);
+	M0_ALLOC_ARR(unseed_final_sum, MD5_DIGEST_LENGTH);
+	M0_UT_ASSERT(unseed_final_sum != NULL);
+
+	rc = MD5_Init(&curr_ctx);
+	M0_UT_ASSERT(rc == 1);
+
+	for (j = 0; j < DATA_UNIT_COUNT; j++)
+	{
+		for (i = 0; i < user_data[j].ov_vec.v_nr; i++) {
+			rc = MD5_Update(&curr_ctx, user_data[j].ov_buf[i],
+					user_data[j].ov_vec.v_count[i]);
+			M0_UT_ASSERT(rc == 1);
+		}
+
+		M0_UT_ASSERT(memcmp((MD5_CTX *)curr_context[j], &curr_ctx,
+					sizeof(MD5_CTX)) == 0);
+
+		if (j == DATA_UNIT_COUNT - 1 ) {
+			rc = MD5_Final(unseed_final_sum, &curr_ctx);
+			M0_UT_ASSERT(rc == 1);
+			M0_UT_ASSERT(memcmp(final_sum, unseed_final_sum,
+						MD5_DIGEST_LENGTH) == 0);
+		}
+	}
+
+	m0_fid_set(&seed.obj_id, OBJ_CONTAINER, OBJ_KEY);
+	for (j = 0; j < DATA_UNIT_COUNT; j++)
+	{
+		memcpy((void *)&tmp_ctx,(void *)curr_context[j],sizeof(MD5_CTX));
+		seed.data_unit_offset = j*SEGS_NR*BUFFER_SIZE;
+		snprintf(seed_str,sizeof(seed_str),"%"PRIx64"%"PRIx64"%"PRIx64,
+				seed.obj_id.f_container, seed.obj_id.f_key,
+				seed.data_unit_offset);
+
+		rc = MD5_Update(&tmp_ctx, (unsigned char *)seed_str,
+				sizeof(seed_str));
+		M0_UT_ASSERT(rc == 1);
+		rc = MD5_Final(seed_sum, &tmp_ctx);
+		M0_UT_ASSERT(rc == 1);
+		M0_UT_ASSERT(memcmp(seeded_sum[j], seed_sum,
+					MD5_DIGEST_LENGTH) == 0);
+	}
+
+	M0_UT_ASSERT(memcmp(final_sum, big_final_sum,
+				MD5_DIGEST_LENGTH) == 0);
+
+	m0_free(seed_sum);
+	m0_free(unseed_final_sum);
+}
+
+/*
+ * CASE1:
+ * Calculate seeded checksums and non seeded contexts via API
+ * for multilple data units one by one. Calculate unseeded checksum
+ * for last data unit.
+ * Verification :  Calculate seeded checksums and non seeded contexts
+ * via UT code verify_case_one_two() for multilple data units one by one.
+ * Calculate unseeded checksum for last data unit.
+ * Compare seeded checksums and non seeded contexts and final unseeded
+ * checksum obtained via API and UT. API and UT calculations should match.
+ *
+ * CASE2:
+ * step 1: Pass all the data units as one chunk to API with no seed and compute
+ * unseeded final checksum.
+ * step 2: Calculate seeded checksums and non seeded contexts via API
+ * for multilple data units one by one. Calculate unseeded checksum
+ * for last data unit. (Already done by case 1)
+ * Verification : Unseeded checksum from step1 and step2 should match.
+ */
+static void ut_test_pi_api_case_one_two(void)
+{
+
+	int j, rc;
+	struct m0_md5_inc_context_pi pi;
+	struct m0_pi_seed seed;
+
+	m0_fid_set(&seed.obj_id, OBJ_CONTAINER, OBJ_KEY);
+
+	memset(&pi, 0, sizeof(struct m0_md5_inc_context_pi));
+	pi.hdr.pi_type = M0_PI_TYPE_MD5_INC_CONTEXT;
+
+	for (j = 0; j < DATA_UNIT_COUNT; j++) {
+
+		seed.data_unit_offset = j*SEGS_NR*BUFFER_SIZE;
+		if (j == 0) {
+			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
+					&seed, &user_data[j], M0_PI_CALC_UNIT_ZERO,
+					curr_context[j], NULL);
+			M0_UT_ASSERT(rc == 0);
+		}
+		else if (j == DATA_UNIT_COUNT - 1) {
+			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
+					&seed, &user_data[j],
+					0, curr_context[j], final_sum);
+			M0_UT_ASSERT(rc == 0);
+		}
+		else {
+			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
+					&seed, &user_data[j],
+					0, curr_context[j], NULL);
+			M0_UT_ASSERT(rc == 0);
+		}
+
+		memcpy(pi.prev_context, curr_context[j], sizeof(MD5_CTX));
+		memcpy(seeded_sum[j], pi.pi_value, MD5_DIGEST_LENGTH);
+	}
+
+	memset(&pi, 0, sizeof(struct m0_md5_inc_context_pi));
+	pi.hdr.pi_type = M0_PI_TYPE_MD5_INC_CONTEXT;
+	rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi, NULL,
+			big_user_data, M0_PI_CALC_UNIT_ZERO,
+			big_curr_context, big_final_sum);
+	M0_UT_ASSERT(rc == 0);
+
+	verify_case_one_two();
+}
+
+
+/* CASE 3:
+ * STEP1: Call API for different data units one by one. Seed should be passed
+ * for only last data unit which is some non-zero offset.
+ * STEP2 : call API one time with all data units as one chunk
+ * with the same seed as used in step1.
+ * Verification: seeded checksum (pi_value) from both the steps should match.
+ */
+static void ut_test_pi_api_case_third(void)
+{
+
+	int j, rc;
+	struct m0_md5_inc_context_pi pi;
+	struct m0_pi_seed seed;
+	unsigned char seeded_final_chunks_value[MD5_DIGEST_LENGTH];
+
+	m0_fid_set(&seed.obj_id, OBJ_CONTAINER, OBJ_KEY);
+	seed.data_unit_offset = (DATA_UNIT_COUNT-1)*SEGS_NR*BUFFER_SIZE;
+
+	memset(&pi, 0, sizeof(struct m0_md5_inc_context_pi));
+	pi.hdr.pi_type = M0_PI_TYPE_MD5_INC_CONTEXT;
+
+	/* STEP 1 */
+	for (j = 0; j < DATA_UNIT_COUNT; j++) {
+
+		if (j == 0) {
+			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
+					NULL, &user_data[j], M0_PI_CALC_UNIT_ZERO,
+					curr_context[j], NULL);
+			M0_UT_ASSERT(rc == 0);
+		}
+		else if (j == DATA_UNIT_COUNT - 1) {
+			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
+					&seed, &user_data[j], 0,
+					curr_context[j], final_sum);
+			M0_UT_ASSERT(rc == 0);
+		}
+		else {
+			rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
+					NULL, &user_data[j], 0,
+					curr_context[j], NULL);
+			M0_UT_ASSERT(rc == 0);
+		}
+
+		memcpy(pi.prev_context, curr_context[j], sizeof(MD5_CTX));
+		memcpy(seeded_sum[j], pi.pi_value, MD5_DIGEST_LENGTH);
+	}
+
+	memcpy(&seeded_final_chunks_value, pi.pi_value, MD5_DIGEST_LENGTH);
+
+	/* STEP 2 */
+	memset(&pi, 0, sizeof(struct m0_md5_inc_context_pi));
+	pi.hdr.pi_type = M0_PI_TYPE_MD5_INC_CONTEXT;
+	rc = m0_client_calculate_pi((struct m0_generic_pi *)&pi,
+			&seed, big_user_data, M0_PI_CALC_UNIT_ZERO,
+			big_curr_context, big_final_sum);
+	M0_UT_ASSERT(rc == 0);
+
+	/* VERIFICATION */
+	M0_UT_ASSERT(memcmp(&seeded_final_chunks_value, pi.pi_value,
+				MD5_DIGEST_LENGTH) == 0);
+	M0_UT_ASSERT(memcmp(final_sum, big_final_sum, MD5_DIGEST_LENGTH) == 0);
+
+}
+
+
+struct m0_ut_suite ut_suite_pi = {
+	.ts_name = "pi_ut",
+	.ts_init = pi_init,
+	.ts_fini = pi_fini,
+	.ts_tests = {
+
+		/* Initialising client. */
+		{ "m0_pi_checks_case_one_two", &ut_test_pi_api_case_one_two},
+		{ "m0_pi_checks_case_third", &ut_test_pi_api_case_third},
+		{ NULL, NULL },
+	}
+};
+
+#undef M0_TRACE_SUBSYSTEM
+
+

--- a/scripts/provisioning/roles/motr-build/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-build/vars/RedHat.yml
@@ -51,6 +51,8 @@ motr_build_deps_pkgs:
   - systemd-devel
   - libedit-devel
   - yasm
+  - openssl
+  - openssl-devel
 
 motr_build_deps_python3_pkgs:
   - python36

--- a/scripts/provisioning/roles/motr-runtime/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-runtime/vars/RedHat.yml
@@ -39,3 +39,4 @@ motr_runtime_deps_pkgs:
   - rubygem-net-ssh
   - sysvinit-tools
   - libedit
+  - openssl

--- a/ut/m0ut.c
+++ b/ut/m0ut.c
@@ -1,6 +1,6 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2013-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,6 +172,7 @@ extern struct m0_ut_suite xcode_bufvec_fop_ut;
 extern struct m0_ut_suite xcode_ff2c_ut;
 extern struct m0_ut_suite xcode_ut;
 extern struct m0_ut_suite sns_flock_ut;
+extern struct m0_ut_suite ut_suite_pi;
 
 static void tests_add(struct m0_ut_module *m)
 {
@@ -309,6 +310,7 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &xcode_bufvec_fop_ut, true);
 	m0_ut_add(m, &xcode_ff2c_ut, true);
 	m0_ut_add(m, &xcode_ut, true);
+	m0_ut_add(m, &ut_suite_pi, true);
 
 	/* These tests have redirection of messages. */
 	m0_ut_add(m, &console_ut, true);


### PR DESCRIPTION
EOS-20955: Motr panic during write operation.
Problem:
There is a situation in which S3 code can send
NULL data to m0_client_calculate_pi. There are checks and
asserts in motr code which fails as of today.
Solution:
Update the checks in motr code and allow
callers to pass NULL buffer vec in m0_client_calculate_pi.

Testing
Code compiled and newly written UT passed.
Tried sending NULL buf vec and it worked.

Signed-off-by: Shipra Gupta <shipra.gupta@seagate.com>