### PR TITLE
WIP: EOS-20762: copy s3 buffer checksum to motr server

### DIFF
--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1736,7 +1736,9 @@ static int io_launch(struct m0_fom *fom)
 	 */
 	index -= m0_is_write_fop(fop) ?
 		netbufs_tlist_length(&fom_obj->fcrw_netbuf_list) : 0;
-
+	if (m0_is_write_fop(fop)) {
+			m0_bufs_print(&rwfop->crw_di_data_cksum, "YJC_CKSUM: rw_fop->crw_di_data_cksum");
+	}
 	m0_tl_for(netbufs, &fom_obj->fcrw_netbuf_list, nb) {
 		struct m0_indexvec     *mem_ivec;
 		struct m0_stob_io_desc *stio_desc;
@@ -1774,9 +1776,8 @@ static int io_launch(struct m0_fom *fom)
 			uint32_t di_size = m0_di_size_get(file, ivec_count);
 			uint32_t curr_pos = m0_di_size_get(file,
 						fom_obj->fcrw_curr_size);
-
-			struct   m0_bufs *bufs;
 			di_buf = &rwfop->crw_di_data;
+
 			if (di_buf != NULL) {
 				struct m0_buf buf = M0_BUF_INIT(di_size,
 						di_buf->b_addr + curr_pos);
@@ -1787,10 +1788,8 @@ static int io_launch(struct m0_fom *fom)
 					  mem_ivec, &nb->nb_buffer,
 					  &cksum_data));
 			}
-			bufs = &rwfop->crw_di_data_cksum;
 			//YJC_TODO: concated cksum would be passed from client, replace m0_bufs with m0_buf
 			//YJC_TODO: m0_bufs_print only for debug, needs to be removed
-			m0_bufs_print(bufs, "YJC_CKSUM: rw_fop->crw_di_data_cksum");
 		}
 		stio->si_opcode = m0_is_write_fop(fop) ? SIO_WRITE : SIO_READ;
 

--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1737,7 +1737,7 @@ static int io_launch(struct m0_fom *fom)
 	index -= m0_is_write_fop(fop) ?
 		netbufs_tlist_length(&fom_obj->fcrw_netbuf_list) : 0;
 	if (m0_is_write_fop(fop)) {
-			m0_bufs_print(&rwfop->crw_di_data_cksum, "YJC_CKSUM: rw_fop->crw_di_data_cksum");
+		M0_LOG(M0_DEBUG, "YJC_SRV:"FID_F "  %p %s baddr = %p nob= %"PRIu64, FID_P(&rwfop->crw_fid), rwfop, (char *)rwfop->crw_di_data_cksum.b_addr, rwfop->crw_di_data_cksum.b_addr, rwfop->crw_di_data_cksum.b_nob);
 	}
 	m0_tl_for(netbufs, &fom_obj->fcrw_netbuf_list, nb) {
 		struct m0_indexvec     *mem_ivec;
@@ -1788,8 +1788,6 @@ static int io_launch(struct m0_fom *fom)
 					  mem_ivec, &nb->nb_buffer,
 					  &cksum_data));
 			}
-			//YJC_TODO: concated cksum would be passed from client, replace m0_bufs with m0_buf
-			//YJC_TODO: m0_bufs_print only for debug, needs to be removed
 		}
 		stio->si_opcode = m0_is_write_fop(fop) ? SIO_WRITE : SIO_READ;
 

--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1775,6 +1775,7 @@ static int io_launch(struct m0_fom *fom)
 			uint32_t curr_pos = m0_di_size_get(file,
 						fom_obj->fcrw_curr_size);
 
+			struct   m0_bufs *bufs;
 			di_buf = &rwfop->crw_di_data;
 			if (di_buf != NULL) {
 				struct m0_buf buf = M0_BUF_INIT(di_size,
@@ -1786,6 +1787,10 @@ static int io_launch(struct m0_fom *fom)
 					  mem_ivec, &nb->nb_buffer,
 					  &cksum_data));
 			}
+			bufs = &rwfop->crw_di_data_cksum;
+			//YJC_TODO: concated cksum would be passed from client, replace m0_bufs with m0_buf
+			//YJC_TODO: m0_bufs_print only for debug, needs to be removed
+			m0_bufs_print(bufs, "YJC_CKSUM: rw_fop->crw_di_data_cksum");
 		}
 		stio->si_opcode = m0_is_write_fop(fop) ? SIO_WRITE : SIO_READ;
 

--- a/ioservice/io_fops.h
+++ b/ioservice/io_fops.h
@@ -405,7 +405,7 @@ struct m0_fop_cob_rw {
 	uint64_t                  crw_flags;
 	/** Checksum and tag values for the input data blocks. */
 	struct m0_buf		  crw_di_data;
-	struct m0_bufs	   	  crw_di_data_cksum;
+	struct m0_buf	   	  crw_di_data_cksum;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 /**

--- a/ioservice/io_fops.h
+++ b/ioservice/io_fops.h
@@ -405,6 +405,7 @@ struct m0_fop_cob_rw {
 	uint64_t                  crw_flags;
 	/** Checksum and tag values for the input data blocks. */
 	struct m0_buf		  crw_di_data;
+	struct m0_bufs	   	  crw_di_data_cksum;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 /**

--- a/lib/buf.h
+++ b/lib/buf.h
@@ -75,6 +75,21 @@ struct m0_bufs {
 #define BUF_F    "[%p,%llu]"
 #define BUF_P(p) (p)->b_addr, (unsigned long long)(p)->b_nob
 
+/*
+ * Print all elements in m0_bufs
+ */
+#define m0_bufs_print(bufs, msg) \
+do { \
+	uint32_t i;\
+	for (i = 0; i < (bufs)->ab_count; ++i) { \
+		struct m0_buf *buf = &(bufs)->ab_elems[i]; \
+		if (buf->b_nob > 0) { \
+			M0_LOG(M0_DEBUG, msg " buf[%d]: b_nob = %"PRIu64 "b_addr = %s", \
+				i, buf->b_nob, (char *)buf->b_addr); \
+		} \
+	} \
+}while(0)
+
 /** Initialises struct m0_buf. */
 M0_INTERNAL void m0_buf_init(struct m0_buf *buf, void *data, uint32_t nob);
 

--- a/lib/buf.h
+++ b/lib/buf.h
@@ -81,13 +81,28 @@ struct m0_bufs {
 #define m0_bufs_print(bufs, msg) \
 do { \
 	uint32_t i;\
-	for (i = 0; i < (bufs)->ab_count; ++i) { \
+	uint32_t count=0; \
+	uint32_t idx = 0; \
+	for (i = 0; i < (bufs)->ab_count; i++) { \
+		M0_ASSERT_EX(count + (bufs)->ab_elems[i].b_nob >= count); \
+		count += (bufs)->ab_elems[i].b_nob; \
+	} \
+	M0_ASSERT(count != 0); \
+	do { char arr[count + 1]; \
+	for (i = 0, idx = 0; i < (bufs)->ab_count; ++i) { \
 		struct m0_buf *buf = &(bufs)->ab_elems[i]; \
 		if (buf->b_nob > 0) { \
-			M0_LOG(M0_DEBUG, msg " buf[%d]: b_nob = %"PRIu64 "b_addr = %s", \
-				i, buf->b_nob, (char *)buf->b_addr); \
+			char str[buf->b_nob + 10]; \
+			int len = (buf->b_nob) - 1; \
+			memcpy(arr + idx, buf->b_addr, len); \
+			snprintf(str, buf->b_nob, "%s", (char *)buf->b_addr); \
+			M0_LOG(M0_DEBUG, "YJC_TEST1: %s", (char *)str); \
+			idx += len; \
 		} \
 	} \
+	M0_LOG(M0_DEBUG, msg " buf[%d]: b_nob = %"PRIu32 " b_addr = %s", \
+		(bufs)->ab_count, count, (char *)arr); \
+        }while(0); \
 }while(0)
 
 /** Initialises struct m0_buf. */

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -208,6 +208,21 @@ M0_INTERNAL int m0_bufvec_extend(struct m0_bufvec *bufvec,
 				 uint32_t num_segs);
 
 /**
+ * Prints all vector in bufvec
+ */
+#define m0_bufvec_print(buf, msg) \
+do { \
+	uint32_t i;\
+	struct m0_vec *vec = &(buf)->ov_vec; \
+	for (i = 0; i < vec->v_nr; ++i) { \
+		if (vec->v_count[i] > 0) { \
+			M0_LOG(M0_DEBUG, msg " count[%d] = %"PRIu64 "ov buf = %s", \
+				i, vec->v_count[i], (char *)(buf)->ov_buf[i]); \
+		} \
+	} \
+}while(0)
+
+/**
  * Merges the source bufvec to the destination bufvec.
  * Assumes that all segments are of equal size.
  * Does not allocate bufvec->ov_buf, but does pointer manipulation

--- a/motr/io.c
+++ b/motr/io.c
@@ -729,7 +729,7 @@ int m0_obj_op(struct m0_obj       *obj,
 	struct m0_io_args          io_args;
 	enum m0_client_layout_type type;
 
-	M0_ENTRY();
+	M0_ENTRY("YJC: obj_id: " U128X_F, U128_P(&obj->ob_entity.en_id));
 	M0_PRE(obj != NULL);
 	M0_PRE(op != NULL);
 	M0_PRE(ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE))));

--- a/motr/io.c
+++ b/motr/io.c
@@ -729,7 +729,9 @@ int m0_obj_op(struct m0_obj       *obj,
 	struct m0_io_args          io_args;
 	enum m0_client_layout_type type;
 
-	M0_ENTRY("YJC: obj_id: " U128X_F, U128_P(&obj->ob_entity.en_id));
+	M0_ENTRY("YJC: obj_id: " U128X_F "opcode = %s", U128_P(&obj->ob_entity.en_id),
+		 opcode == M0_OC_READ ? "read" : opcode == M0_OC_WRITE ? "write" :  \
+		 opcode == M0_OC_FREE ? "free" : "Not known");
 	M0_PRE(obj != NULL);
 	M0_PRE(op != NULL);
 	M0_PRE(ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE))));

--- a/motr/io.h
+++ b/motr/io.h
@@ -221,6 +221,15 @@ M0_INTERNAL uint64_t target_offset(uint64_t                  frame,
 				   struct m0_pdclust_layout *play,
 				   m0_bindex_t               gob_offset);
 /**
+ * Calculates the offset in the cksum object based on the global offset.
+ *
+ * @param play The Parity layout for the global object
+ * @param gob_offset Offset in global object.
+ * @return The cksum:object offset.
+ */
+M0_INTERNAL uint32_t di_cksum_offset(struct m0_pdclust_layout *play,
+				   m0_bindex_t               gob_offset);
+/**
  * Calculates the group index, given a data index and the block size.
  *
  * @param index The data index.

--- a/motr/pg.h
+++ b/motr/pg.h
@@ -803,6 +803,7 @@ struct target_ioreq {
 	 */
 	struct m0_bufvec               ti_bufvec;
 	struct m0_bufvec               ti_auxbufvec;
+	struct m0_bufvec               ti_attrbufvec;
 
 	/**
 	 * Degraded mode read/write IO vector.

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -113,7 +113,6 @@ static int alloc_vecs(struct m0_indexvec *ext, struct m0_bufvec *data,
 	 * and initialises the bufvec for us.
 	 */
 
-	fprintf(stderr, "YJC: allocating data and att for %d blocks of size %d\n", block_count, block_size);
 	//block_count = block_size /  lid_size;
 	rc = m0_bufvec_alloc(data, block_count, block_size);
 	if (rc != 0) {
@@ -137,13 +136,11 @@ static int write_dummy_hash_data(struct m0_uint128 id, struct m0_bufvec *attr)
        int len;
 
        nr_blocks = attr->ov_vec.v_nr;
-       fprintf(stderr, "YJC: attr buf cnt = %d\n", nr_blocks);
        for (i = 0; i < nr_blocks; ++i) {
 		sprintf(str, U128X_F"seg%d", U128_P(&id), i);
 		len = strlen(str);
 		memcpy(attr->ov_buf[i], str, len);
-		attr->ov_vec.v_count[i] = len + 1;
-	        fprintf(stderr, "YJC_CKSUM: attr[%d] = %s len = %d\n", i, (char *)attr->ov_buf[i], len);
+		attr->ov_vec.v_count[i] = len;
        }
        return i;
 }
@@ -443,6 +440,7 @@ int m0_write(struct m0_container *container, char *src,
 			  blks_per_io:block_count;
 		if (bcount < blks_per_io) {
 			cleanup_vecs(&data, &attr, &ext);
+			fprintf(stderr, "YJC: MOTR_APP allocating data and attr for %d blocks of size %d\n", bcount, block_size);
 			rc = alloc_vecs(&ext, &data, &attr, bcount,
 					block_size);
 			if (rc != 0)
@@ -454,8 +452,6 @@ int m0_write(struct m0_container *container, char *src,
 		/* Read data from source file. */
 		rc = read_data_from_file(fp, &data);
 		M0_ASSERT(rc == bcount);
-		fprintf(stderr, "YJC: writing dummy hash bcount = %d\n",
-		        bcount);
 		write_dummy_hash_data(id, &attr);
 
 		/* Copy data to the object*/

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -129,18 +129,21 @@ static int alloc_vecs(struct m0_indexvec *ext, struct m0_bufvec *data,
 	return rc;
 }
 
-static int write_dummy_hash_data(struct m0_bufvec *attr)
+static int write_dummy_hash_data(struct m0_uint128 id, struct m0_bufvec *attr)
 {
        int i;
        int nr_blocks;
+       char str[128];
+       int len;
 
        nr_blocks = attr->ov_vec.v_nr;
        fprintf(stderr, "YJC: attr buf cnt = %d\n", nr_blocks);
        for (i = 0; i < nr_blocks; ++i) {
-		sprintf(attr->ov_buf[i], "%s_seg%d", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-					       i);
-		attr->ov_vec.v_count[i] = ATTR_SIZE;
-	        fprintf(stderr, "YJC_CKSUM: attr[%d] = %s \n", i, (char *)attr->ov_buf[i]);
+		sprintf(str, U128X_F"seg%d", U128_P(&id), i);
+		len = strlen(str);
+		memcpy(attr->ov_buf[i], str, len);
+		attr->ov_vec.v_count[i] = len + 1;
+	        fprintf(stderr, "YJC_CKSUM: attr[%d] = %s len = %d\n", i, (char *)attr->ov_buf[i], len);
        }
        return i;
 }
@@ -453,7 +456,7 @@ int m0_write(struct m0_container *container, char *src,
 		M0_ASSERT(rc == bcount);
 		fprintf(stderr, "YJC: writing dummy hash bcount = %d\n",
 		        bcount);
-		write_dummy_hash_data(&attr);
+		write_dummy_hash_data(id, &attr);
 
 		/* Copy data to the object*/
 		rc = write_data_to_object(&obj, &ext, &data, &attr);

--- a/motr/utils.c
+++ b/motr/utils.c
@@ -136,6 +136,13 @@ M0_INTERNAL uint64_t target_offset(uint64_t                  frame,
 		(gob_offset % layout_unit_size(play));
 }
 
+M0_INTERNAL uint32_t di_cksum_offset(struct m0_pdclust_layout *play,
+				   m0_bindex_t               gob_offset)
+{
+	M0_PRE(play != NULL);
+	return (gob_offset / layout_unit_size(play));
+}
+
 M0_INTERNAL uint64_t group_id(m0_bindex_t index, m0_bcount_t dtsize)
 {
 	/* XXX add any PRE()? => update UTs */


### PR DESCRIPTION
- copy checksum values passed from s3 in attr variable to motr buffers
- send checksum fops to io service

Ex:
S3:<seg0><seg1><seg2><seg3><seg0><seg1><seg2><seg3>
iofop1:
mo_buf {
b_nob = sizeof(b_addr)
b_addr = <seg0><seg3><seg4><seg7>
}

iofop2:
mo_buf {
b_nob = sizeof(b_addr)
b_addr = <seg1><seg2><seg5><seg6>
}

Signed-off-by: Yeshpal Jain <yeshpal.jain@seagate.com>