### PR TITLE
EOS-19916 dtm0: improve m0traces instrumentation

### DIFF
--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -137,10 +137,13 @@ function expected_trace_lines_num()
 function traces_dump()
 {
     local fid
+    local out
 
     for i in ${!M0D_PIDS[@]} ; do
         fid=$(echo "${M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
-        $MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/m0trace.${M0D_PIDS[i]}" > m0trace_"${fid}".dump
+        out="m0trace_${fid}.dump"
+        _info "Dumping ${out}..."
+        $MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/m0trace.${M0D_PIDS[i]}" > "${out}"
     done
 }
 

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -134,6 +134,16 @@ function expected_trace_lines_num()
     return 0
 }
 
+function traces_dump()
+{
+    local fid
+
+    for i in ${!M0D_PIDS[@]} ; do
+        fid=$(echo "${M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
+        $MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/m0trace.${M0D_PIDS[i]}" > m0trace_"${fid}".dump
+    done
+}
+
 function processes_status_check()
 {
     local rc=0
@@ -203,7 +213,10 @@ function main()
     wait $cli_pid
 
     stop_cluster
-    
+
+    _info "Dumping traces..."
+    traces_dump
+
     _info "Checking processes exit status..."
     processes_status_check || {
         _err "TEST STATUS: FAIL"

--- a/lib/trace.h
+++ b/lib/trace.h
@@ -171,10 +171,10 @@
 #define M0_ENTRY(...) M0_LOG(M0_CALL, "> " __VA_ARGS__)
 #define M0_LEAVE(...) M0_LOG(M0_CALL, "< " __VA_ARGS__)
 
-#define M0_MEAS(fmt, ...) ({				\
-	m0_time_t __meas_time = m0_time_now();		\
-	M0_LOG(M0_DEBUG, "[MEAS] %"PRIu64" " fmt,	\
-	       (uint64_t)__meas_time, __VA_ARGS__);	\
+#define M0_MEAS(fmt, ...) ({					\
+	m0_time_t __meas_time = m0_time_now();			\
+	M0_LOG(M0_DEBUG, "[MEAS] { time: %"PRIu64", " fmt " }",	\
+	       (uint64_t)__meas_time, __VA_ARGS__);		\
 })
 
 #define M0_RC(rc) ({                        \

--- a/lib/trace.h
+++ b/lib/trace.h
@@ -173,8 +173,8 @@
 
 #define M0_MEAS(fmt, ...) ({				\
 	m0_time_t __meas_time = m0_time_now();		\
-	M0_LOG(M0_DEBUG, "[MEAS] " fmt " time: "TIME_F,	\
-	       __VA_ARGS__, TIME_P(__meas_time));	\
+	M0_LOG(M0_DEBUG, "[MEAS] %"PRIu64" " fmt,	\
+	       (uint64_t)__meas_time, __VA_ARGS__);	\
 })
 
 #define M0_RC(rc) ({                        \

--- a/rpc/conn.c
+++ b/rpc/conn.c
@@ -327,7 +327,7 @@ M0_INTERNAL int m0_rpc_conn_init(struct m0_rpc_conn      *conn,
 		m0_sm_state_trace_enable(&conn->c_sm);
 		m0_rpc_machine_add_conn(machine, conn);
 		M0_LOG(M0_INFO, "%p INITIALISED \n", conn);
-		M0_MEAS("conn-sm-to-uuid sm_id: %"PRIu64" uuid: "U128X_F,
+		M0_MEAS("conn-sm-to-uuid sm_id: %"PRIu64", uuid: \""U128D_F"\"",
 			conn->c_sm.sm_id, U128_P(&conn->c_uuid));
 	}
 
@@ -549,7 +549,7 @@ M0_INTERNAL int m0_rpc_rcv_conn_init(struct m0_rpc_conn *conn,
 		m0_sm_state_trace_enable(&conn->c_sm);
 		m0_rpc_machine_add_conn(machine, conn);
 		M0_LOG(M0_INFO, "%p INITIALISED \n", conn);
-		M0_MEAS("conn-uuid-to-sm uuid: "U128X_F" sm_id: %"PRIu64,
+		M0_MEAS("conn-uuid-to-sm uuid: \""U128D_F"\", sm_id: %"PRIu64,
 			U128_P(&conn->c_uuid), conn->c_sm.sm_id);
 	}
 

--- a/rpc/conn.c
+++ b/rpc/conn.c
@@ -327,8 +327,9 @@ M0_INTERNAL int m0_rpc_conn_init(struct m0_rpc_conn      *conn,
 		m0_sm_state_trace_enable(&conn->c_sm);
 		m0_rpc_machine_add_conn(machine, conn);
 		M0_LOG(M0_INFO, "%p INITIALISED \n", conn);
-		M0_MEAS("conn-sm-to-uuid sm_id: %"PRIu64", uuid: \""U128D_F"\"",
-			conn->c_sm.sm_id, U128_P(&conn->c_uuid));
+		M0_MEAS("name: conn-sm-to-uuid, sm_id: %"PRIu64
+			", uuid: \""U128D_F"\"", conn->c_sm.sm_id,
+			U128_P(&conn->c_uuid));
 	}
 
 	M0_POST(ergo(rc == 0, m0_rpc_conn_invariant(conn) &&
@@ -549,8 +550,9 @@ M0_INTERNAL int m0_rpc_rcv_conn_init(struct m0_rpc_conn *conn,
 		m0_sm_state_trace_enable(&conn->c_sm);
 		m0_rpc_machine_add_conn(machine, conn);
 		M0_LOG(M0_INFO, "%p INITIALISED \n", conn);
-		M0_MEAS("conn-uuid-to-sm uuid: \""U128D_F"\", sm_id: %"PRIu64,
-			U128_P(&conn->c_uuid), conn->c_sm.sm_id);
+		M0_MEAS("name: conn-uuid-to-sm, uuid: \""U128D_F"\""
+			", sm_id: %"PRIu64, U128_P(&conn->c_uuid),
+			conn->c_sm.sm_id);
 	}
 
 	M0_POST(ergo(rc == 0, m0_rpc_conn_invariant(conn) &&
@@ -737,11 +739,6 @@ M0_INTERNAL void m0_rpc_conn_add_session(struct m0_rpc_conn *conn,
 		if (watch->mw_session_added != NULL)
 			watch->mw_session_added(watch, session);
 	} m0_tl_endfor;
-#if 0
-	M0_MEAS("conn-to-session conn_uuid: "U128X_F" conn_sm_id: %"
-		PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
-		conn->c_sm.sm_id, session->s_sm.sm_id);
-#endif
 }
 
 M0_INTERNAL void m0_rpc_conn_remove_session(struct m0_rpc_session *session)

--- a/rpc/session.c
+++ b/rpc/session.c
@@ -453,7 +453,8 @@ M0_INTERNAL int m0_rpc_session_establish(struct m0_rpc_session *session,
 	}
 	m0_fop_put(fop);
 
-	M0_MEAS("conn-to-session conn_sm_id: %"PRIu64", session_sm_id: %"PRIu64,
+	M0_MEAS("name: conn-to-session, conn_sm_id: %"PRIu64
+		", session_sm_id: %"PRIu64,
 		conn->c_sm.sm_id, session->s_sm.sm_id);
 
 	M0_POST(ergo(rc != 0, session_state(session) == M0_RPC_SESSION_FAILED));

--- a/rpc/session.c
+++ b/rpc/session.c
@@ -453,8 +453,7 @@ M0_INTERNAL int m0_rpc_session_establish(struct m0_rpc_session *session,
 	}
 	m0_fop_put(fop);
 
-	M0_MEAS("conn-to-session conn_uuid: "U128X_F" conn_sm_id: %"
-		PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
+	M0_MEAS("conn-to-session conn_sm_id: %"PRIu64", session_sm_id: %"PRIu64,
 		conn->c_sm.sm_id, session->s_sm.sm_id);
 
 	M0_POST(ergo(rc != 0, session_state(session) == M0_RPC_SESSION_FAILED));
@@ -537,10 +536,6 @@ M0_INTERNAL void m0_rpc_session_establish_reply_received(struct m0_rpc_item
 		    reply->rser_sender_id != SENDER_ID_INVALID) {
 			session->s_session_id = session_id;
 			session_state_set(session, M0_RPC_SESSION_IDLE);
-			M0_MEAS("sm-to-session conn_uuid: "U128X_F
-				" session_id: %" PRIu64" session_sm_id: %"PRIu64,
-				U128_P(&session->s_conn->c_uuid),
-				session->s_session_id, session->s_sm.sm_id);
 		} else {
 			rc = M0_ERR(-EPROTO);
 		}

--- a/rpc/session_foms.c
+++ b/rpc/session_foms.c
@@ -403,7 +403,7 @@ M0_INTERNAL int m0_rpc_fom_session_establish_tick(struct m0_fom *fom)
 		session_state_set(session, M0_RPC_SESSION_IDLE);
 		reply->rser_session_id = session->s_session_id;
 
-		M0_MEAS("conn-to-session conn_sm_id: %"PRIu64
+		M0_MEAS("name: conn-to-session, conn_sm_id: %"PRIu64
 			", session_sm_id: %"PRIu64,
 			conn->c_sm.sm_id, session->s_sm.sm_id);
 	}

--- a/rpc/session_foms.c
+++ b/rpc/session_foms.c
@@ -403,13 +403,9 @@ M0_INTERNAL int m0_rpc_fom_session_establish_tick(struct m0_fom *fom)
 		session_state_set(session, M0_RPC_SESSION_IDLE);
 		reply->rser_session_id = session->s_session_id;
 
-		M0_MEAS("conn-to-session conn_uuid: "U128X_F" conn_sm_id: %"
-			PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
+		M0_MEAS("conn-to-session conn_sm_id: %"PRIu64
+			", session_sm_id: %"PRIu64,
 			conn->c_sm.sm_id, session->s_sm.sm_id);
-
-		M0_MEAS("session-to-sm conn_uuid: "U128X_F" session_id: %"
-			PRIu64" session_sm_id: %"PRIu64, U128_P(&conn->c_uuid),
-			session->s_session_id, session->s_sm.sm_id);
 	}
 	m0_rpc_machine_unlock(machine);
 

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -387,7 +387,7 @@ M0_INTERNAL void m0_sm_state_trace_enable(struct m0_sm *mach)
 
 	mach->sm_state_trace_off = false;
 
-	M0_MEAS("state-trace-enable [%s] sm_id: %"PRIu64
+	M0_MEAS("conf_name: \"%s\", sm_id: %"PRIu64
 		", state: %s", mach->sm_conf->scf_name,
 		m0_sm_id_get(mach), sd->sd_name);
 }
@@ -448,7 +448,7 @@ static void state_set(struct m0_sm *mach, int state, int32_t rc)
 			sd->sd_ex(mach);
 
 		if (!mach->sm_state_trace_off) {
-			M0_MEAS("state-set [%s] sm_id: %"PRIu64
+			M0_MEAS("conf_name: \"%s\", sm_id: %"PRIu64
 				", from: %s, to: %s", mach->sm_conf->scf_name,
 				m0_sm_id_get(mach), sd->sd_name,
 				state_get(mach, state)->sd_name);

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -387,8 +387,8 @@ M0_INTERNAL void m0_sm_state_trace_enable(struct m0_sm *mach)
 
 	mach->sm_state_trace_off = false;
 
-	M0_MEAS("state-trace-enable name: \"%s\" sm_id: %"PRIu64
-		" state: %s", mach->sm_conf->scf_name,
+	M0_MEAS("state-trace-enable [%s] sm_id: %"PRIu64
+		", state: %s", mach->sm_conf->scf_name,
 		m0_sm_id_get(mach), sd->sd_name);
 }
 
@@ -448,8 +448,8 @@ static void state_set(struct m0_sm *mach, int state, int32_t rc)
 			sd->sd_ex(mach);
 
 		if (!mach->sm_state_trace_off) {
-			M0_MEAS("state-set name: \"%s\" sm_id: %"PRIu64
-				" from: %s to: %s", mach->sm_conf->scf_name,
+			M0_MEAS("state-set [%s] sm_id: %"PRIu64
+				", from: %s, to: %s", mach->sm_conf->scf_name,
 				m0_sm_id_get(mach), sd->sd_name,
 				state_get(mach, state)->sd_name);
 		}


### PR DESCRIPTION
Improved m0traces instrumentation related to states logging,
connections and sessions relation.

Also added dumping of m0traces at the end of all2all test.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>