### PR TITLE
EOS-17288: Return error code from parity math functions

### DIFF
--- a/m0t1fs/linux_kernel/file.c
+++ b/m0t1fs/linux_kernel/file.c
@@ -1602,7 +1602,7 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 
 				rc = m0_parity_math_diff(parity_math(map->pi_ioreq),
 							 old, dbufs, pbufs, col);
-				if (rc != 0){
+				if (rc != 0) {
 					m0_free(old);
 					goto last;
 				}

--- a/m0t1fs/linux_kernel/file.c
+++ b/m0t1fs/linux_kernel/file.c
@@ -1505,7 +1505,7 @@ last:
 
 static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 {
-	int                       rc;
+	int                       rc = 0;
 	uint32_t                  row;
 	uint32_t                  col;
 	struct m0_buf            *dbufs;
@@ -1529,8 +1529,6 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 	    || map->pi_rtype == PIR_READREST) {
 
 		unsigned long zpage;
-
-		rc = 0;
 
 		zpage = get_zeroed_page(GFP_KERNEL);
 		if (zpage == 0) {
@@ -1558,10 +1556,8 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 				break;
 		}
 		free_page(zpage);
-
 		if (rc != 0)
 			goto last;
-
 		M0_LOG(M0_DEBUG, "[%p] Parity recalculated for %s",
 		       map->pi_ioreq,
 		       map->pi_rtype == PIR_READREST ? "read-rest" :

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -1160,7 +1160,7 @@ static int pargrp_iomap_readrest(struct pargrp_iomap *map)
  */
 static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 {
-	int                       rc;
+	int                       rc = 0;
 	uint32_t                  row;
 	uint32_t                  col;
 	struct m0_buf            *dbufs;
@@ -1200,8 +1200,6 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 	    || map->pi_rtype == PIR_READREST) {
 		void *zpage;
 
-		rc = 0;
-
 		zpage = m0_alloc_aligned(1ULL<<obj->ob_attr.oa_bshift,
 					  M0_NETBUF_SHIFT);
 		if (zpage == 0) {
@@ -1231,10 +1229,8 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 
 		m0_free_aligned(zpage, 1ULL<<obj->ob_attr.oa_bshift,
 				M0_NETBUF_SHIFT);
-
 		if (rc != 0)
 			goto last;
-
 		M0_LOG(M0_DEBUG, "Parity recalculated for %s",
 		       map->pi_rtype == PIR_READREST ? "read-rest" :
 		       "aligned write");

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -1200,6 +1200,8 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 	    || map->pi_rtype == PIR_READREST) {
 		void *zpage;
 
+		rc = 0;
+
 		zpage = m0_alloc_aligned(1ULL<<obj->ob_attr.oa_bshift,
 					  M0_NETBUF_SHIFT);
 		if (zpage == 0) {
@@ -1221,13 +1223,18 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 				pbufs[col] = map->pi_paritybufs[row][col]->
 					     db_buf;
 
-			m0_parity_math_calculate(parity_math(map->pi_ioo),
-						 dbufs, pbufs);
+			rc = m0_parity_math_calculate(parity_math(map->pi_ioo),
+						      dbufs, pbufs);
+			if (rc != 0)
+				break;
 		}
 
-		rc = 0;
 		m0_free_aligned(zpage, 1ULL<<obj->ob_attr.oa_bshift,
 				M0_NETBUF_SHIFT);
+
+		if (rc != 0)
+			goto last;
+
 		M0_LOG(M0_DEBUG, "Parity recalculated for %s",
 		       map->pi_rtype == PIR_READREST ? "read-rest" :
 		       "aligned write");
@@ -1267,13 +1274,15 @@ static int pargrp_iomap_parity_recalc(struct pargrp_iomap *map)
 
 				dbufs[col] = map->pi_databufs[row][col]->db_buf;
 				old[col] = map->pi_databufs[row][col]->db_auxbuf;
-				m0_parity_math_diff(parity_math(map->pi_ioo),
-						    old, dbufs, pbufs, col);
+				rc = m0_parity_math_diff(parity_math(map->pi_ioo),
+							 old, dbufs, pbufs, col);
+				if (rc != 0) {
+					m0_free(old);
+					goto last;
+				}
 			}
-
 		}
 		m0_free(old);
-		rc = 0;
 	}
 last:
 	m0_free(dbufs);
@@ -2018,8 +2027,10 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 			parity[col].b_nob  = pagesize;
 		}
 
-		m0_parity_math_recover(parity_math(ioo), data,
-				       parity, &failed, M0_LA_INVERSE);
+		rc = m0_parity_math_recover(parity_math(ioo), data,
+					    parity, &failed, M0_LA_INVERSE);
+		if (rc != 0)
+			goto end;
 	}
 
 #if !ISAL_ENCODE_ENABLED
@@ -2250,8 +2261,10 @@ static int pargrp_iomap_parity_verify(struct pargrp_iomap *map)
 		}
 
 		/* generate parity into new buf */
-		m0_parity_math_calculate(parity_math(map->pi_ioo),
-					 dbufs, pbufs);
+		rc = m0_parity_math_calculate(parity_math(map->pi_ioo),
+					      dbufs, pbufs);
+		if (rc != 0)
+			goto last;
 
 		/* verify the parity */
 		for (col = 0; col < layout_k(play); ++col) {

--- a/sns/cm/repair/xform.c
+++ b/sns/cm/repair/xform.c
@@ -135,12 +135,14 @@ static void cp_rs_recover(struct m0_cm_cp *src_cp, uint32_t failed_index)
 	struct m0_net_buffer       *nbuf_head;
 	struct m0_sns_cm_repair_ag *rag = sag2repairag(ag2snsag(src_cp->c_ag));
 	enum m0_sns_ir_block_type   bt;
+	int                         ret;
 
 	nbuf_head = cp_data_buf_tlist_head(&src_cp->c_buffers);
 	scp = cp2snscp(src_cp);
 	bt = scp->sc_is_local ? M0_SI_BLOCK_LOCAL : M0_SI_BLOCK_REMOTE;
-	m0_sns_ir_recover(&rag->rag_ir, &nbuf_head->nb_buffer,
-			  &src_cp->c_xform_cp_indices, failed_index, bt);
+	ret = m0_sns_ir_recover(&rag->rag_ir, &nbuf_head->nb_buffer,
+				&src_cp->c_xform_cp_indices, failed_index, bt);
+	M0_POST(ret == 0);
 }
 
 /** Merges the source bitmap to the destination bitmap. */

--- a/sns/cm/repair/xform.c
+++ b/sns/cm/repair/xform.c
@@ -129,7 +129,7 @@ static void cp_xor_recover(struct m0_cm_cp *dst_cp, struct m0_cm_cp *src_cp)
 	}
 }
 
-static void cp_rs_recover(struct m0_cm_cp *src_cp, uint32_t failed_index)
+static int cp_rs_recover(struct m0_cm_cp *src_cp, uint32_t failed_index)
 {
 	struct m0_sns_cm_cp        *scp;
 	struct m0_net_buffer       *nbuf_head;
@@ -142,7 +142,7 @@ static void cp_rs_recover(struct m0_cm_cp *src_cp, uint32_t failed_index)
 	bt = scp->sc_is_local ? M0_SI_BLOCK_LOCAL : M0_SI_BLOCK_REMOTE;
 	ret = m0_sns_ir_recover(&rag->rag_ir, &nbuf_head->nb_buffer,
 				&src_cp->c_xform_cp_indices, failed_index, bt);
-	M0_POST(ret == 0);
+	return M0_RC(ret);
 }
 
 /** Merges the source bitmap to the destination bitmap. */
@@ -279,7 +279,9 @@ M0_INTERNAL int m0_sns_cm_repair_cp_xform(struct m0_cm_cp *cp)
 		rc = m0_cm_cp_bufvec_merge(cp);
 		if (rc != 0)
 			goto out;
-		cp_rs_recover(cp, scp->sc_failed_idx);
+		rc = cp_rs_recover(cp, scp->sc_failed_idx);
+		if (rc != 0)
+			goto out;
 	}
 	/*
 	 * Local copy packets are merged with all the accumulators while the

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -45,72 +45,108 @@ enum {
 		(ret) = 0;							\
 })
 
+#define BLOCK_SIZE_ERR_INFO(msg, blksz, index, b_nob) ({	\
+	M0_ERR_INFO(-EINVAL, msg " block size mismatch. "	\
+		    "block_size = %u, " msg "[%u].b_nob=%u",	\
+		    (uint32_t)blksz, index, (uint32_t)b_nob);	\
+})
+
+#define FAIL_COUNT_ERR_INFO(f_count, limit, str) ({		\
+	M0_ERR_INFO(-EINVAL, "Invalid " str " value. "		\
+		    str " = %u. Expected value: "		\
+		    "0 < " str " <= %u", 			\
+		    (uint32_t)f_count, (uint32_t)limit);	\
+})
+
+#define VALUE_ERR_INFO(f_count, limit, str) ({			\
+	M0_ERR_INFO(-EINVAL, "Invalid " str " value. "		\
+		    str " = %u. Expected value: " str " < %u",	\
+		    (uint32_t)f_count, (uint32_t)limit);	\
+})
+
+#define BUF_ALLOC_ERR_INFO(ret, str, len) ({			\
+	M0_ERR_INFO(ret, "Failed to allocate memory for "	\
+		    str " buffer of length = %u",		\
+		    (uint32_t)len);				\
+})
+
+#define MAT_INIT_ERR_INFO(ret, str, row, col) ({		\
+	M0_ERR_INFO(ret, "failed to initialize %ux%u "		\
+	 	    str " matrix.", (uint32_t)row,		\
+		    (uint32_t)col);				\
+})
+
+#define MATVEC_INIT_ERR_INFO(ret, str, size) ({			\
+	M0_ERR_INFO(ret, "failed to initialize " str " matrix "	\
+		    "vector of size=%u", (uint32_t)size);	\
+})
+
 /* Forward declarations */
-static void xor_calculate(struct m0_parity_math *math,
-                          const struct m0_buf *data,
-                          struct m0_buf *parity);
+static int xor_calculate(struct m0_parity_math *math,
+			 const struct m0_buf *data,
+			 struct m0_buf *parity);
 
 #if ISAL_ENCODE_ENABLED
-static void isal_encode(struct m0_parity_math *math,
-                        const struct m0_buf *data,
-                        struct m0_buf *parity);
+static int isal_encode(struct m0_parity_math *math,
+		       const struct m0_buf *data,
+		       struct m0_buf *parity);
 #else
-static void reed_solomon_encode(struct m0_parity_math *math,
-                                const struct m0_buf *data,
-                                struct m0_buf *parity);
+static int reed_solomon_encode(struct m0_parity_math *math,
+			       const struct m0_buf *data,
+			       struct m0_buf *parity);
 #endif /* ISAL_ENCODE_ENABLED */
 
-static void xor_diff(struct m0_parity_math *math,
+static int xor_diff(struct m0_parity_math *math,
+		    struct m0_buf         *old,
+		    struct m0_buf         *new,
+		    struct m0_buf         *parity,
+		    uint32_t               index);
+
+#if ISAL_ENCODE_ENABLED
+static int isal_diff(struct m0_parity_math *math,
 		     struct m0_buf         *old,
 		     struct m0_buf         *new,
 		     struct m0_buf         *parity,
 		     uint32_t               index);
 
-#if ISAL_ENCODE_ENABLED
-static void isal_diff(struct m0_parity_math *math,
-		      struct m0_buf         *old,
-		      struct m0_buf         *new,
-		      struct m0_buf         *parity,
-		      uint32_t               index);
-
 static bool parity_math_invariant(const struct m0_parity_math *math);
 #else
-static void reed_solomon_diff(struct m0_parity_math *math,
-		              struct m0_buf         *old,
-		              struct m0_buf         *new,
-		              struct m0_buf         *parity,
-		              uint32_t               index);
+static int reed_solomon_diff(struct m0_parity_math *math,
+			     struct m0_buf         *old,
+			     struct m0_buf         *new,
+			     struct m0_buf         *parity,
+			     uint32_t               index);
 #endif /* ISAL_ENCODE_ENABLED */
 
-static void xor_recover(struct m0_parity_math *math,
-                        struct m0_buf *data,
-                        struct m0_buf *parity,
-                        struct m0_buf *fails,
-			enum m0_parity_linsys_algo algo);
+static int xor_recover(struct m0_parity_math *math,
+		       struct m0_buf *data,
+		       struct m0_buf *parity,
+		       struct m0_buf *fails,
+		       enum m0_parity_linsys_algo algo);
 
 #if ISAL_ENCODE_ENABLED
-static void isal_recover(struct m0_parity_math *math,
-			 struct m0_buf *data,
-			 struct m0_buf *parity,
-			 struct m0_buf *fails,
-			 enum m0_parity_linsys_algo algo);
+static int isal_recover(struct m0_parity_math *math,
+			struct m0_buf *data,
+			struct m0_buf *parity,
+			struct m0_buf *fails,
+			enum m0_parity_linsys_algo algo);
 
 /**
  * This is wrapper function for Intel ISA API ec_encode_data_update().
- * @param[out] dest_buf - Array of coded output buffers i.e. struct m0_buf
- * @param[in]  src_buf  - Pointer to single input source (struct m0_buf) used to
- *                        update output parity.
- * @param[in]  vec_idx  - The vector index corresponding to the single
- *                        input source.
- * @param[in]  g_tbls   - Pointer to array of input tables generated from
- *                        coding coefficients in ec_init_tables().
- *                        Must be of size 32*data_nr*dest_nr
- * @param[in]  data_nr  - The number of data blocks for coding.
- * @param[in]  dest_nr  - The number of output blocks to concurrently
- *                        encode/decode.
- * @retval     0        - success otherwise failure
+ * @param[out] dest_bufs - Array of coded output buffers i.e. struct m0_buf
+ * @param[in]  src_buf   - Pointer to single input source (struct m0_buf) used
+ *                         to update output parity.
+ * @param[in]  vec_idx   - The vector index corresponding to the single
+ *                         input source.
+ * @param[in]  g_tbls    - Pointer to array of input tables generated from
+ *                         coding coefficients in ec_init_tables().
+ *                         Must be of size 32*data_nr*dest_nr
+ * @param[in]  data_nr   - The number of data blocks for coding.
+ * @param[in]  dest_nr   - The number of output blocks to concurrently
+ *                         encode/decode.
+ * @retval     0         - success otherwise failure
  */
-static int isal_encode_data_update(struct m0_buf *dest_buf, struct m0_buf *src_buf,
+static int isal_encode_data_update(struct m0_buf *dest_bufs, struct m0_buf *src_buf,
 				   uint32_t vec_idx, uint8_t *g_tbls,
 				   uint32_t data_nr, uint32_t dest_nr);
 
@@ -177,30 +213,30 @@ static bool fails_sort(uint8_t *fail, uint32_t unit_count,
 #endif /* ISAL_ENCODE_ENABLED */
 
 #if !ISAL_ENCODE_ENABLED
-static void reed_solomon_recover(struct m0_parity_math *math,
-                                 struct m0_buf *data,
-                                 struct m0_buf *parity,
-                                 struct m0_buf *fails,
-				 enum m0_parity_linsys_algo algo);
+static int reed_solomon_recover(struct m0_parity_math *math,
+				struct m0_buf *data,
+				struct m0_buf *parity,
+				struct m0_buf *fails,
+				enum m0_parity_linsys_algo algo);
 #endif /* !ISAL_ENCODE_ENABLED */
 
-static void fail_idx_xor_recover(struct m0_parity_math *math,
-				 struct m0_buf *data,
-				 struct m0_buf *parity,
-				 const uint32_t failure_index);
+static int fail_idx_xor_recover(struct m0_parity_math *math,
+				struct m0_buf *data,
+				struct m0_buf *parity,
+				const uint32_t failure_index);
 
 #if !ISAL_ENCODE_ENABLED
-static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
-					  struct m0_buf *data,
-					  struct m0_buf *parity,
-					  const uint32_t failure_index);
+static int fail_idx_reed_solomon_recover(struct m0_parity_math *math,
+					 struct m0_buf *data,
+					 struct m0_buf *parity,
+					 const uint32_t failure_index);
 #endif /* !ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
-static void fail_idx_isal_recover(struct m0_parity_math *math,
-				  struct m0_buf *data,
-				  struct m0_buf *parity,
-				  const uint32_t failure_index);
+static int fail_idx_isal_recover(struct m0_parity_math *math,
+				 struct m0_buf *data,
+				 struct m0_buf *parity,
+				 const uint32_t failure_index);
 
 /**
  * Generate decode matrix for incremental recovery using Intel ISA.
@@ -312,6 +348,7 @@ static void forward_rectification(struct m0_sns_ir *ir,
  */
 static void failed_data_blocks_xform(struct m0_sns_ir *ir);
 #endif /* !ISAL_ENCODE_ENABLED */
+
 static inline bool is_valid_block_idx(const  struct m0_sns_ir *ir,
 				      uint32_t block_idx);
 
@@ -352,9 +389,9 @@ static int isal_ir_init(struct m0_sns_ir *ir);
 static void isal_ir_fini(struct m0_sns_ir *ir);
 #endif /* ISAL_ENCODE_ENABLED */
 
-static void (*calculate[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
-						const struct m0_buf *data,
-						struct m0_buf *parity) = {
+static int (*calculate[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
+					       const struct m0_buf *data,
+					       struct m0_buf *parity) = {
 	[M0_PARITY_CAL_ALGO_XOR] = xor_calculate,
 #if ISAL_ENCODE_ENABLED
 	[M0_PARITY_CAL_ALGO_ISA] = isal_encode,
@@ -363,11 +400,11 @@ static void (*calculate[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
 #endif /* ISAL_ENCODE_ENABLED */
 };
 
-static void (*diff[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
-					   struct m0_buf         *old,
-					   struct m0_buf         *new,
-					   struct m0_buf         *parity,
-					   uint32_t               index) = {
+static int (*diff[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
+					  struct m0_buf         *old,
+					  struct m0_buf         *new,
+					  struct m0_buf         *parity,
+					  uint32_t               index) = {
 	[M0_PARITY_CAL_ALGO_XOR]          = xor_diff,
 #if ISAL_ENCODE_ENABLED
 	[M0_PARITY_CAL_ALGO_ISA] = isal_diff,
@@ -376,11 +413,11 @@ static void (*diff[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
 #endif /* ISAL_ENCODE_ENABLED */
 };
 
-static void (*recover[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
-					      struct m0_buf *data,
-					      struct m0_buf *parity,
-					      struct m0_buf *fails,
-					      enum m0_parity_linsys_algo algo) = {
+static int (*recover[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
+					     struct m0_buf *data,
+					     struct m0_buf *parity,
+					     struct m0_buf *fails,
+					     enum m0_parity_linsys_algo algo) = {
 	[M0_PARITY_CAL_ALGO_XOR] = xor_recover,
 #if ISAL_ENCODE_ENABLED
 	[M0_PARITY_CAL_ALGO_ISA] = isal_recover,
@@ -389,10 +426,10 @@ static void (*recover[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
 #endif /* ISAL_ENCODE_ENABLED */
 };
 
-static void (*fidx_recover[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
-						   struct m0_buf *data,
-						   struct m0_buf *parity,
-						   const uint32_t fidx) = {
+static int (*fidx_recover[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
+						  struct m0_buf *data,
+						  struct m0_buf *parity,
+						  const uint32_t fidx) = {
 	[M0_PARITY_CAL_ALGO_XOR] = fail_idx_xor_recover,
 #if ISAL_ENCODE_ENABLED
 	[M0_PARITY_CAL_ALGO_ISA] = fail_idx_isal_recover,
@@ -447,7 +484,8 @@ static int vandmat_init(struct m0_matrix *m, uint32_t data_count,
 
 	ret = m0_matrix_init(m, mat_width, mat_height);
 	if (ret < 0)
-		return ret;
+		return MAT_INIT_ERR_INFO(ret, "vandermonde", mat_height,
+					 mat_width);
 
 	for (y = 0; y < mat_height; ++y)
 		for (x = 0; x < mat_width; ++x)
@@ -488,8 +526,12 @@ static int vandmat_norm(struct m0_matrix *m)
 				m0_matrix_cols_operate(m, x, y, gsub, 0, gmul,
                                             *m0_matrix_elem_get(m, x, y), gsub);
 
-		/* Assert if units are not configured properly. */
-		M0_ASSERT(check_row_is_id(m, y));
+		/* Check if units are configured properly. */
+		if (check_row_is_id(m, y) == false)
+			return M0_ERR_INFO(-EINVAL, "Units are not configured "
+					   "properly. row=%u of matrix=%p is "
+					   "not part of identity matrix",
+					   y, m);
 	}
 
 	return 0;
@@ -505,19 +547,18 @@ static bool parity_math_invariant(const struct m0_parity_math *math)
 		_0C(math->pmi_data_count <= SNS_PARITY_MATH_DATA_BLOCKS_MAX);
 }
 
-static int isal_encode_data_update(struct m0_buf *dest_buf, struct m0_buf *src_buf,
+static int isal_encode_data_update(struct m0_buf *dest_bufs, struct m0_buf *src_buf,
 				   uint32_t vec_idx, uint8_t *g_tbls,
 				   uint32_t data_nr, uint32_t dest_nr)
 {
 	uint32_t i;
 	uint32_t block_size;
-	int	 ret = 0;
 
-	M0_ENTRY("dest_buf=%p, src_buf=%p, vec_idx=%u, "
+	M0_ENTRY("dest_bufs=%p, src_buf=%p, vec_idx=%u, "
 		 "g_tbls=%p, data_nr=%u, dest_nr=%u",
-		 dest_buf, src_buf, vec_idx, g_tbls, data_nr, dest_nr);
+		 dest_bufs, src_buf, vec_idx, g_tbls, data_nr, dest_nr);
 
-	M0_PRE(dest_buf != NULL);
+	M0_PRE(dest_bufs != NULL);
 	M0_PRE(src_buf != NULL);
 	M0_PRE(g_tbls != NULL);
 
@@ -526,21 +567,16 @@ static int isal_encode_data_update(struct m0_buf *dest_buf, struct m0_buf *src_b
 	block_size = (uint32_t)src_buf->b_nob;
 
 	for (i = 0; i < dest_nr; ++i) {
-		if (block_size != dest_buf[i].b_nob) {
-			ret = M0_ERR_INFO(-EINVAL, "dest block size mismatch. "
-					  "block_size = %u, "
-					  "dest_buf[%u].b_nob=%u",
-					  block_size, i,
-					  (uint32_t)dest_buf[i].b_nob);
-			return M0_RC(ret);
-		}
-		dest_frags[i] = (uint8_t *)dest_buf[i].b_addr;
+		if (block_size != dest_bufs[i].b_nob)
+			return BLOCK_SIZE_ERR_INFO("dest_bufs", block_size, i,
+						   dest_bufs[i].b_nob);
+		dest_frags[i] = (uint8_t *)dest_bufs[i].b_addr;
 	}
 
 	ec_encode_data_update(block_size, data_nr, dest_nr, vec_idx,
 			      g_tbls, (uint8_t *)src_buf->b_addr, dest_frags);
 
-	return M0_RC(ret);
+	return M0_RC(0);
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
@@ -632,33 +668,49 @@ M0_INTERNAL int m0_parity_math_init(struct m0_parity_math *math,
 
 	ret = m0_matrix_init(&math->pmi_vandmat_parity_slice,
 			     data_count, parity_count);
-	if (ret < 0)
+	if (ret < 0) {
+		ret = MAT_INIT_ERR_INFO(ret, "vandermonde parity slice",
+					parity_count, data_count);
 		goto handle_error;
+	}
 
 	m0_matrix_submatrix_get(&math->pmi_vandmat,
 				&math->pmi_vandmat_parity_slice, 0,
 				data_count);
 
 	ret = m0_matvec_init(&math->pmi_data, data_count);
-	if (ret < 0)
+	if (ret < 0) {
+		ret = MATVEC_INIT_ERR_INFO(ret, "data", data_count);
 		goto handle_error;
+	}
 
 	ret = m0_matvec_init(&math->pmi_parity, parity_count);
-	if (ret < 0)
+	if (ret < 0) {
+		ret = MATVEC_INIT_ERR_INFO(ret, "parity", parity_count);
 		goto handle_error;
+	}
 
 	ret = m0_matvec_init(&math->pmi_sys_vec, math->pmi_data.mv_size);
-	if (ret < 0)
+	if (ret < 0) {
+		ret = MATVEC_INIT_ERR_INFO(ret, "sys_vec",
+					   math->pmi_data.mv_size);
 		goto handle_error;
+	}
 
 	ret = m0_matvec_init(&math->pmi_sys_res, math->pmi_data.mv_size);
-	if (ret < 0)
+	if (ret < 0) {
+		ret = MATVEC_INIT_ERR_INFO(ret, "sys_res",
+					   math->pmi_data.mv_size);
 		goto handle_error;
+	}
 
 	ret = m0_matrix_init(&math->pmi_sys_mat, math->pmi_data.mv_size,
 			     math->pmi_data.mv_size);
-	if (ret < 0)
+	if (ret < 0) {
+		ret = MAT_INIT_ERR_INFO(ret, "sys_mat", math->pmi_data.mv_size,
+					math->pmi_data.mv_size);
 		goto handle_error;
+	}
 #endif /* ISAL_ENCODE_ENABLED */
 
 	return M0_RC(ret);
@@ -668,18 +720,23 @@ M0_INTERNAL int m0_parity_math_init(struct m0_parity_math *math,
 	return M0_RC(ret);
 }
 
-static void xor_calculate(struct m0_parity_math *math,
-			  const struct m0_buf *data,
-			  struct m0_buf *parity)
+static int xor_calculate(struct m0_parity_math *math,
+			 const struct m0_buf *data,
+			 struct m0_buf *parity)
 {
-        uint32_t          ei; /* block element index. */
-        uint32_t          ui; /* unit index. */
-        uint32_t          block_size = data[0].b_nob;
+	uint32_t	  ei; /* block element index. */
+	uint32_t	  ui; /* unit index. */
+	uint32_t	  block_size = data[0].b_nob;
 	m0_parity_elem_t  pe;
 
-	M0_PRE(block_size == parity[0].b_nob);
+	if (block_size != parity[0].b_nob)
+		return BLOCK_SIZE_ERR_INFO("parity", block_size, 0,
+					   parity[0].b_nob);
+
 	for (ui = 1; ui < math->pmi_data_count; ++ui)
-		M0_PRE(block_size == data[ui].b_nob);
+		if (block_size != data[ui].b_nob)
+			return BLOCK_SIZE_ERR_INFO("data", block_size, ui,
+						   data[ui].b_nob);
 
 	for (ei = 0; ei < block_size; ++ei) {
 		pe = 0;
@@ -689,14 +746,15 @@ static void xor_calculate(struct m0_parity_math *math,
 		((uint8_t*)parity[0].b_addr)[ei] = pe;
 	}
 
+	return M0_RC(0);
 }
 
 #if ISAL_ENCODE_ENABLED
-static void isal_diff(struct m0_parity_math *math,
-		      struct m0_buf         *old,
-		      struct m0_buf         *new,
-		      struct m0_buf         *parity,
-		      uint32_t               index)
+static int isal_diff(struct m0_parity_math *math,
+		     struct m0_buf         *old,
+		     struct m0_buf         *new,
+		     struct m0_buf         *parity,
+		     uint32_t               index)
 {
 	struct m0_buf	diff_data_buf;
 	uint8_t	       *diff_data = NULL;
@@ -713,7 +771,13 @@ static void isal_diff(struct m0_parity_math *math,
 	M0_PRE(new    != NULL);
 	M0_PRE(parity != NULL);
 	M0_PRE(index  <  math->pmi_data_count);
-	M0_PRE(old[index].b_nob == new[index].b_nob);
+
+	if (old[index].b_nob != new[index].b_nob)
+		return M0_ERR_INFO(-EINVAL, "Data block size mismatch. "
+				   "Index=%u, Old data block size=%u, "
+				   "New data block size=%u", index,
+				   (uint32_t)old[index].b_nob,
+				   (uint32_t)new[index].b_nob);
 
 	block_size = new[index].b_nob;
 
@@ -728,7 +792,7 @@ static void isal_diff(struct m0_parity_math *math,
 
 	ALLOC_ARR_INFO(diff_data, block_size, "differential data block", ret);
 	if (diff_data == NULL)
-		goto fini;
+		return ret;
 
 	m0_buf_init(&diff_data_buf, diff_data, block_size);
 
@@ -739,30 +803,27 @@ static void isal_diff(struct m0_parity_math *math,
 			((uint_fast32_t *)new[index].b_addr)[i];
 
 	/* Update differential parity */
-	isal_encode_data_update(parity, &diff_data_buf, index,
-				math->pmi_encode_tbls, math->pmi_data_count,
-				math->pmi_parity_count);
+	ret = isal_encode_data_update(parity, &diff_data_buf, index,
+				      math->pmi_encode_tbls,
+				      math->pmi_data_count,
+				      math->pmi_parity_count);
 
-fini:
 	m0_free(diff_data);
-
-	/* TODO: Return error code instead of assert */
-	M0_ASSERT(ret == 0);
-
-	M0_LEAVE();
+	return M0_RC(ret);
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
 #if !ISAL_ENCODE_ENABLED
-static void reed_solomon_diff(struct m0_parity_math *math,
-			      struct m0_buf         *old,
-			      struct m0_buf         *new,
-			      struct m0_buf         *parity,
-			      uint32_t               index)
+static int reed_solomon_diff(struct m0_parity_math *math,
+			     struct m0_buf         *old,
+			     struct m0_buf         *new,
+			     struct m0_buf         *parity,
+			     uint32_t               index)
 {
 	struct m0_matrix *mat;
-	uint32_t          ei;
-	uint32_t          ui;
+	uint32_t	  ei;
+	uint32_t	  ui;
+	uint32_t	  pi;
 	uint8_t		  diff_data;
 	m0_parity_elem_t  mat_elem;
 
@@ -771,9 +832,18 @@ static void reed_solomon_diff(struct m0_parity_math *math,
 	M0_PRE(new    != NULL);
 	M0_PRE(parity != NULL);
 	M0_PRE(index  <  math->pmi_data_count);
-	M0_PRE(old[index].b_nob == new[index].b_nob);
-	M0_PRE(m0_forall(i, math->pmi_parity_count,
-		         new[index].b_nob == parity[i].b_nob));
+
+	if (old[index].b_nob != new[index].b_nob)
+		return M0_ERR_INFO(-EINVAL, "Data block size mismatch. "
+				   "Index=%u, Old data block size=%u, "
+				   "New data block size=%u", index,
+				   (uint32_t)old[index].b_nob,
+				   (uint32_t)new[index].b_nob);
+
+	for (pi = 0; pi < math->pmi_parity_count; ++pi)
+		if (new[index].b_nob != parity[pi].b_nob)
+			return BLOCK_SIZE_ERR_INFO("parity", new[index].b_nob, pi,
+						   parity[pi].b_nob);
 
 	mat = &math->pmi_vandmat_parity_slice;
 	for (ui = 0; ui < math->pmi_parity_count; ++ui) {
@@ -785,14 +855,16 @@ static void reed_solomon_diff(struct m0_parity_math *math,
 				gmul(diff_data, mat_elem);
 		}
 	}
+
+	return M0_RC(0);
 }
 #endif /* !ISAL_ENCODE_ENABLED */
 
-static void xor_diff(struct m0_parity_math *math,
-		     struct m0_buf         *old,
-		     struct m0_buf         *new,
-		     struct m0_buf         *parity,
-		     uint32_t               index)
+static int xor_diff(struct m0_parity_math *math,
+		    struct m0_buf         *old,
+		    struct m0_buf         *new,
+		    struct m0_buf         *parity,
+		    uint32_t               index)
 {
 	uint32_t ei;
 
@@ -801,20 +873,31 @@ static void xor_diff(struct m0_parity_math *math,
 	M0_PRE(new    != NULL);
 	M0_PRE(parity != NULL);
 	M0_PRE(index  <  math->pmi_data_count);
-	M0_PRE(old[index].b_nob == new[index].b_nob);
-	M0_PRE(new[index].b_nob == parity[0].b_nob);
+
+	if (old[index].b_nob != new[index].b_nob)
+		return M0_ERR_INFO(-EINVAL, "Data block size mismatch. "
+				   "Index=%u, Old data block size=%u, "
+				   "New data block size=%u", index,
+				   (uint32_t)old[index].b_nob,
+				   (uint32_t)new[index].b_nob);
+
+	if (new[index].b_nob != parity[0].b_nob)
+		return BLOCK_SIZE_ERR_INFO("parity", new[index].b_nob, 0,
+					   parity[0].b_nob);
 
 	for (ei = 0; ei < new[index].b_nob; ++ei) {
 		((uint8_t*)parity[0].b_addr)[ei] ^=
 			((uint8_t *)old[index].b_addr)[ei] ^
 			((uint8_t *)new[index].b_addr)[ei];
 	}
+
+	return M0_RC(0);
 }
 
 #if !ISAL_ENCODE_ENABLED
-static void reed_solomon_encode(struct m0_parity_math *math,
-				const struct m0_buf *data,
-				struct m0_buf *parity)
+static int reed_solomon_encode(struct m0_parity_math *math,
+			       const struct m0_buf *data,
+			       struct m0_buf *parity)
 {
 #define PARITY_MATH_REGION_ENABLE 0
 
@@ -826,12 +909,15 @@ static void reed_solomon_encode(struct m0_parity_math *math,
 	m0_parity_elem_t  mat_elem;
 	uint32_t	  block_size = data[0].b_nob;
 
-
 	for (di = 1; di < math->pmi_data_count; ++di)
-		M0_ASSERT(block_size == data[di].b_nob);
+		if (block_size != data[di].b_nob)
+			return BLOCK_SIZE_ERR_INFO("data", block_size, di,
+						   data[di].b_nob);
 
 	for (pi = 0; pi < math->pmi_parity_count; ++pi)
-		M0_ASSERT(block_size == parity[pi].b_nob);
+		if (block_size != parity[pi].b_nob)
+			return BLOCK_SIZE_ERR_INFO("parity", block_size, pi,
+						   parity[pi].b_nob);
 
 	for (pi = 0; pi < math->pmi_parity_count; ++pi) {
 		for (di = 0; di < math->pmi_data_count; ++di) {
@@ -867,17 +953,18 @@ static void reed_solomon_encode(struct m0_parity_math *math,
 	}
 
 #undef PARITY_MATH_REGION_ENABLE
+
+	return M0_RC(0);
 }
 #endif /* !ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
-static void isal_encode(struct m0_parity_math *math,
-			const struct m0_buf *data,
-			struct m0_buf *parity)
+static int isal_encode(struct m0_parity_math *math,
+		       const struct m0_buf *data,
+		       struct m0_buf *parity)
 {
 	uint32_t  i;
 	uint32_t  block_size;
-	int	  ret = 0;
 
 	M0_ENTRY();
 
@@ -892,22 +979,16 @@ static void isal_encode(struct m0_parity_math *math,
 
 	frags_in[0] = (uint8_t *)data[0].b_addr;
 	for (i = 1; i < math->pmi_data_count; ++i) {
-		if (block_size != data[i].b_nob) {
-			ret = M0_ERR_INFO(-EINVAL, "data block size mismatch. "
-					  "block_size = %u, data[%u].b_nob=%u",
-					  block_size, i, (uint32_t)data[i].b_nob);
-			goto fini;
-		}
+		if (block_size != data[i].b_nob)
+			return BLOCK_SIZE_ERR_INFO("data", block_size, i,
+						   data[i].b_nob);
 		frags_in[i] = (uint8_t *)data[i].b_addr;
 	}
 
 	for (i = 0; i < math->pmi_parity_count; ++i) {
-		if (block_size != parity[i].b_nob) {
-			ret = M0_ERR_INFO(-EINVAL, "parity block size mismatch. "
-					  "block_size = %u, parity[%u].b_nob=%u",
-					  block_size, i, (uint32_t)parity[i].b_nob);
-			goto fini;
-		}
+		if (block_size != parity[i].b_nob)
+			return BLOCK_SIZE_ERR_INFO("parity", block_size, i,
+						   parity[i].b_nob);
 		frags_out[i] = (uint8_t *)parity[i].b_addr;
 	}
 
@@ -915,42 +996,44 @@ static void isal_encode(struct m0_parity_math *math,
 	ec_encode_data(block_size, math->pmi_data_count, math->pmi_parity_count,
 		       math->pmi_encode_tbls, frags_in, frags_out);
 
-fini:
-	/* TODO: Return error code instead of assert */
-	M0_ASSERT(ret == 0);
-
-	M0_LEAVE();
+	return M0_RC(0);
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
-M0_INTERNAL void m0_parity_math_calculate(struct m0_parity_math *math,
-					  struct m0_buf *data,
-					  struct m0_buf *parity)
+M0_INTERNAL int m0_parity_math_calculate(struct m0_parity_math *math,
+					 struct m0_buf *data,
+					 struct m0_buf *parity)
 {
+	int	rc;
+
 	M0_ENTRY();
-	(*calculate[math->pmi_parity_algo])(math, data, parity);
-	M0_LEAVE();
+	rc = (*calculate[math->pmi_parity_algo])(math, data, parity);
+	return M0_RC(rc);
 }
 
-M0_INTERNAL void m0_parity_math_diff(struct m0_parity_math *math,
-				     struct m0_buf *old,
-				     struct m0_buf *new,
-				     struct m0_buf *parity, uint32_t index)
+M0_INTERNAL int m0_parity_math_diff(struct m0_parity_math *math,
+				    struct m0_buf *old,
+				    struct m0_buf *new,
+				    struct m0_buf *parity, uint32_t index)
 {
+	int	rc;
+
 	M0_ENTRY();
-	(*diff[math->pmi_parity_algo])(math, old, new, parity, index);
-	M0_LEAVE();
+	rc = (*diff[math->pmi_parity_algo])(math, old, new, parity, index);
+	return M0_RC(rc);
 }
 
-M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
-				       struct m0_buf *data,
-				       struct m0_buf *parity,
-				       uint32_t data_ind_changed)
+M0_INTERNAL int m0_parity_math_refine(struct m0_parity_math *math,
+				      struct m0_buf *data,
+				      struct m0_buf *parity,
+				      uint32_t data_ind_changed)
 {
+	int rc;
+
 	M0_ENTRY();
 	/* for simplicity: */
-	m0_parity_math_calculate(math, data, parity);
-	M0_LEAVE();
+	rc = m0_parity_math_calculate(math, data, parity);
+	return M0_RC(rc);
 }
 
 /* Counts number of failed blocks. */
@@ -968,8 +1051,8 @@ static uint32_t fails_count(uint8_t *fail, uint32_t unit_count)
 #if !ISAL_ENCODE_ENABLED
 /* Fills 'mat' and 'vec' with data passed to recovery algorithm. */
 static void recovery_vec_fill(struct m0_parity_math *math,
-			       uint8_t *fail, uint32_t unit_count, /* in. */
-			       struct m0_matvec *vec) /* out. */
+			      uint8_t *fail, uint32_t unit_count, /* in. */
+			      struct m0_matvec *vec) /* out. */
 {
 	uint32_t f;
 	uint32_t y = 0;
@@ -989,9 +1072,7 @@ static void recovery_vec_fill(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* !ISAL_ENCODE_ENABLED */
 
-#if !ISAL_ENCODE_ENABLED
 /* Fills 'mat' with data passed to recovery algorithm. */
 static void recovery_mat_fill(struct m0_parity_math *math,
 			      uint8_t *fail, uint32_t unit_count, /* in. */
@@ -1011,9 +1092,7 @@ static void recovery_mat_fill(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* !ISAL_ENCODE_ENABLED */
 
-#if !ISAL_ENCODE_ENABLED
 /* Updates internal structures of 'math' with recovered data. */
 static void parity_math_recover(struct m0_parity_math *math,
 				uint8_t *fail, uint32_t unit_count,
@@ -1038,9 +1117,7 @@ static void parity_math_recover(struct m0_parity_math *math,
 		}
 	}
 }
-#endif /* !ISAL_ENCODE_ENABLED */
 
-#if !ISAL_ENCODE_ENABLED
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 					uint8_t *fail)
 {
@@ -1054,20 +1131,18 @@ M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 
 	return rc == 0 ? M0_RC(0) : M0_ERR(rc);
 }
-#endif /* !ISAL_ENCODE_ENABLED */
 
-#if !ISAL_ENCODE_ENABLED
 M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math)
 {
 	m0_matrix_fini(&math->pmi_recov_mat);
 }
 #endif /* !ISAL_ENCODE_ENABLED */
 
-static void xor_recover(struct m0_parity_math *math,
-			struct m0_buf *data,
-			struct m0_buf *parity,
-			struct m0_buf *fails,
-			enum m0_parity_linsys_algo algo)
+static int xor_recover(struct m0_parity_math *math,
+		       struct m0_buf *data,
+		       struct m0_buf *parity,
+		       struct m0_buf *fails,
+		       enum m0_parity_linsys_algo algo)
 {
 	uint32_t          ei; /* block element index. */
 	uint32_t          ui; /* unit index. */
@@ -1082,30 +1157,40 @@ static void xor_recover(struct m0_parity_math *math,
 	fail = (uint8_t*) fails->b_addr;
 	fail_count = fails_count(fail, unit_count);
 
-	M0_PRE(fail_count == 1);
-	M0_PRE(fail_count <= math->pmi_parity_count);
-	M0_PRE(block_size == parity[0].b_nob);
+	if ((fail_count != 1) || (fail_count > math->pmi_parity_count))
+		return FAIL_COUNT_ERR_INFO(fail_count, math->pmi_parity_count,
+					   "fail_count");
+
+	if (block_size != parity[0].b_nob)
+		return BLOCK_SIZE_ERR_INFO("parity", block_size, 0,
+					   parity[0].b_nob);
 
 	for (ui = 1; ui < math->pmi_data_count; ++ui)
-		M0_PRE(block_size == data[ui].b_nob);
+		if (block_size != data[ui].b_nob)
+			return BLOCK_SIZE_ERR_INFO("data", block_size, ui,
+						   data[ui].b_nob);
 
 	for (ei = 0; ei < block_size; ++ei) {
 		pe = 0;
-                for (ui = 0; ui < math->pmi_data_count; ++ui) {
+		for (ui = 0; ui < math->pmi_data_count; ++ui) {
 			if (fail[ui] != 1)
 				pe ^= (m0_parity_elem_t)((uint8_t*)
 				       data[ui].b_addr)[ei];
 			else
 				fail_index = ui;
-                }
+		}
 		/* Now ui points to parity block, test if it was failed. */
 		if (fail[ui] != 1) {
-			M0_ASSERT(fail_index != BAD_FAIL_INDEX);
+			if (fail_index == BAD_FAIL_INDEX)
+				return M0_ERR_INFO(-EINVAL,
+						   "fail_index = BAD_FAIL_INDEX");
 			((uint8_t*)data[fail_index].b_addr)[ei] = pe ^
 				((uint8_t*)parity[0].b_addr)[ei];
 		} else /* Parity was lost, so recover it. */
 			((uint8_t*)parity[0].b_addr)[ei] = pe;
-        }
+	}
+
+	return M0_RC(0);
 }
 
 #if ISAL_ENCODE_ENABLED
@@ -1260,11 +1345,11 @@ static bool fails_sort(uint8_t *fail, uint32_t unit_count,
 	return M0_RC(true);
 }
 
-static void isal_recover(struct m0_parity_math *math,
-			 struct m0_buf *data,
-			 struct m0_buf *parity,
-			 struct m0_buf *fails,
-			 enum m0_parity_linsys_algo algo)
+static int isal_recover(struct m0_parity_math *math,
+			struct m0_buf *data,
+			struct m0_buf *parity,
+			struct m0_buf *fails,
+			enum m0_parity_linsys_algo algo)
 {
 	struct m0_buf failed_idx_buf = M0_BUF_INIT0;
 	struct m0_buf alive_idx_buf = M0_BUF_INIT0;
@@ -1291,45 +1376,32 @@ static void isal_recover(struct m0_parity_math *math,
 
 	fail_count = fails_count(fail, unit_count);
 
-	if ((fail_count == 0) || (fail_count > math->pmi_parity_count)) {
-		ret = M0_ERR_INFO(-EINVAL, "Invalid fail count value. "
-				  "fail_count = %u. Expected value "
-				  "0 < fail_count <= %u", fail_count,
-				  math->pmi_parity_count);
-		goto fini;
-	}
+	if ((fail_count == 0) || (fail_count > math->pmi_parity_count))
+		return FAIL_COUNT_ERR_INFO(fail_count, math->pmi_parity_count,
+					   "fail_count");
 
 	/* Validate block size for data buffers */
-	for (i = 1; i < math->pmi_data_count; ++i) {
-		if (block_size != data[i].b_nob) {
-			ret = M0_ERR_INFO(-EINVAL, "data block size mismatch. "
-					  "block_size = %u, data[%u].b_nob=%u",
-					  block_size, i, (uint32_t)data[i].b_nob);
-			goto fini;
-		}
-	}
+	for (i = 1; i < math->pmi_data_count; ++i)
+		if (block_size != data[i].b_nob)
+			return BLOCK_SIZE_ERR_INFO("data", block_size, i,
+						   data[i].b_nob);
 
 	/* Validate block size for parity buffers */
-	for (i = 0; i < math->pmi_parity_count; ++i) {
-		if (block_size != parity[i].b_nob) {
-			ret = M0_ERR_INFO(-EINVAL, "parity block size mismatch. "
-					  "block_size = %u, parity[%u].b_nob=%u",
-					  block_size, i, (uint32_t)parity[i].b_nob);
-			goto fini;
-		}
-	}
+	for (i = 0; i < math->pmi_parity_count; ++i)
+		if (block_size != parity[i].b_nob)
+			return BLOCK_SIZE_ERR_INFO("parity", block_size, i,
+						   parity[i].b_nob);
 
 	ret = m0_buf_alloc(&failed_idx_buf, math->pmi_parity_count);
 	if (ret != 0) {
-		ret = M0_ERR_INFO(ret, "failed to allocate memory for "
-				  "array of failed ids");
+		ret = BUF_ALLOC_ERR_INFO(ret, "failed index",
+					 math->pmi_parity_count);
 		goto fini;
 	}
 
 	ret = m0_buf_alloc(&alive_idx_buf, unit_count);
 	if (ret != 0) {
-		ret = M0_ERR_INFO(ret, "failed to allocate memory for "
-				  "array of alive ids");
+		ret = BUF_ALLOC_ERR_INFO(ret, "alive index", unit_count);
 		goto fini;
 	}
 
@@ -1376,19 +1448,16 @@ fini:
 	m0_buf_free(&failed_idx_buf);
 	m0_buf_free(&alive_idx_buf);
 
-	/* TODO: Return error code instead of assert */
-	M0_ASSERT(ret == 0);
-
-	M0_LEAVE();
+	return M0_RC(ret);
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
 #if !ISAL_ENCODE_ENABLED
-static void reed_solomon_recover(struct m0_parity_math *math,
-				 struct m0_buf *data,
-				 struct m0_buf *parity,
-				 struct m0_buf *fails,
-				 enum m0_parity_linsys_algo algo)
+static int reed_solomon_recover(struct m0_parity_math *math,
+				struct m0_buf *data,
+				struct m0_buf *parity,
+				struct m0_buf *fails,
+				enum m0_parity_linsys_algo algo)
 {
 	uint32_t ei; /* block element index. */
 	uint32_t ui; /* unit index. */
@@ -1400,14 +1469,21 @@ static void reed_solomon_recover(struct m0_parity_math *math,
 	fail = (uint8_t*) fails->b_addr;
 	fail_count = fails_count(fail, unit_count);
 
-	M0_ASSERT(fail_count > 0);
-	M0_ASSERT(fail_count <= math->pmi_parity_count);
+	if ((fail_count == 0) || (fail_count > math->pmi_parity_count))
+		return FAIL_COUNT_ERR_INFO(fail_count, math->pmi_parity_count,
+					   "fail_count");
 
+	/* Validate block size for data buffers */
 	for (ui = 1; ui < math->pmi_data_count; ++ui)
-		M0_ASSERT(block_size == data[ui].b_nob);
+		if (block_size != data[ui].b_nob)
+			return BLOCK_SIZE_ERR_INFO("data", block_size, ui,
+						   data[ui].b_nob);
 
+	/* Validate block size for parity buffers */
 	for (ui = 0; ui < math->pmi_parity_count; ++ui)
-		M0_ASSERT(block_size == parity[ui].b_nob);
+		if (block_size != parity[ui].b_nob)
+			return BLOCK_SIZE_ERR_INFO("parity", block_size, ui,
+						   parity[ui].b_nob);
 
 	for (ei = 0; ei < block_size; ++ei) {
 		struct m0_matvec *recovered = &math->pmi_sys_res;
@@ -1431,24 +1507,28 @@ static void reed_solomon_recover(struct m0_parity_math *math,
 				*m0_matvec_elem_get(recovered, ui);
 		}
 	}
+
+	return M0_RC(0);
 }
 #endif /* !ISAL_ENCODE_ENABLED */
 
-M0_INTERNAL void m0_parity_math_recover(struct m0_parity_math *math,
-					struct m0_buf *data,
-					struct m0_buf *parity,
-					struct m0_buf *fails,
-					enum m0_parity_linsys_algo algo)
+M0_INTERNAL int m0_parity_math_recover(struct m0_parity_math *math,
+				       struct m0_buf *data,
+				       struct m0_buf *parity,
+				       struct m0_buf *fails,
+				       enum m0_parity_linsys_algo algo)
 {
+	int	rc;
+
 	M0_ENTRY();
-	(*recover[math->pmi_parity_algo])(math, data, parity, fails, algo);
-	M0_LEAVE();
+	rc = (*recover[math->pmi_parity_algo])(math, data, parity, fails, algo);
+	return M0_RC(rc);
 }
 
-static void fail_idx_xor_recover(struct m0_parity_math *math,
-				 struct m0_buf *data,
-				 struct m0_buf *parity,
-				 const uint32_t failure_index)
+static int fail_idx_xor_recover(struct m0_parity_math *math,
+				struct m0_buf *data,
+				struct m0_buf *parity,
+				const uint32_t failure_index)
 {
         uint32_t          ei; /* block element index. */
         uint32_t          ui; /* unit index. */
@@ -1456,13 +1536,18 @@ static void fail_idx_xor_recover(struct m0_parity_math *math,
         uint32_t          block_size = data[0].b_nob;
         m0_parity_elem_t  pe;
 
-	M0_PRE(block_size == parity[0].b_nob);
+	if (block_size != parity[0].b_nob)
+		return BLOCK_SIZE_ERR_INFO("parity", block_size, 0,
+					   parity[0].b_nob);
 
-        unit_count = math->pmi_data_count + math->pmi_parity_count;
-        M0_ASSERT(failure_index < unit_count);
+	unit_count = math->pmi_data_count + math->pmi_parity_count;
+	if (failure_index >= unit_count)
+		return VALUE_ERR_INFO(failure_index, unit_count, "failure_index");
 
 	for (ui = 1; ui < math->pmi_data_count; ++ui)
-		M0_ASSERT(block_size == data[ui].b_nob);
+		if (block_size != data[ui].b_nob)
+			return BLOCK_SIZE_ERR_INFO("data", block_size, ui,
+						   data[ui].b_nob);
 
         for (ei = 0; ei < block_size; ++ei) {
                 pe = 0;
@@ -1478,23 +1563,25 @@ static void fail_idx_xor_recover(struct m0_parity_math *math,
                         ((uint8_t*)parity[0].b_addr)[ei] = pe;
         }
 
+	return M0_RC(0);
 }
 
 #if !ISAL_ENCODE_ENABLED
 /** @todo Iterative reed-solomon decode to be implemented. */
-static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
-					  struct m0_buf *data,
-					  struct m0_buf *parity,
-					  const uint32_t failure_index)
+static int fail_idx_reed_solomon_recover(struct m0_parity_math *math,
+					 struct m0_buf *data,
+					 struct m0_buf *parity,
+					 const uint32_t failure_index)
 {
+	return M0_RC(0);
 }
 #endif /* !ISAL_ENCODE_ENABLED */
 
 #if ISAL_ENCODE_ENABLED
-static void fail_idx_isal_recover(struct m0_parity_math *math,
-				  struct m0_buf *data,
-				  struct m0_buf *parity,
-				  const uint32_t failure_index)
+static int fail_idx_isal_recover(struct m0_parity_math *math,
+				 struct m0_buf *data,
+				 struct m0_buf *parity,
+				 const uint32_t failure_index)
 {
 	M0_ERR_INFO(-ENOSYS, "Recover using failed index is not implemented "
 		    "for Intel ISA");
@@ -1502,14 +1589,16 @@ static void fail_idx_isal_recover(struct m0_parity_math *math,
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
-M0_INTERNAL void m0_parity_math_fail_index_recover(struct m0_parity_math *math,
-						   struct m0_buf *data,
-						   struct m0_buf *parity,
-						   const uint32_t fidx)
+M0_INTERNAL int m0_parity_math_fail_index_recover(struct m0_parity_math *math,
+						  struct m0_buf *data,
+						  struct m0_buf *parity,
+						  const uint32_t fidx)
 {
+	int	rc;
+
 	M0_ENTRY();
-	(*fidx_recover[math->pmi_parity_algo])(math, data, parity, fidx);
-	M0_LEAVE();
+	rc = (*fidx_recover[math->pmi_parity_algo])(math, data, parity, fidx);
+	return M0_RC(rc);
 }
 
 M0_INTERNAL void m0_parity_math_buffer_xor(struct m0_buf *dest,
@@ -1679,7 +1768,8 @@ M0_INTERNAL int m0_sns_ir_mat_compute(struct m0_sns_ir *ir)
 		}
 		ret = data_recov_mat_construct(ir);
 		if (ret != 0)
-			return ret;
+			return M0_ERR_INFO(ret, "failed to construct recovery "
+					   "matrix");
 	}
 
 	for (j = 0, i = 0; j < total_blocks_nr; ++j) {
@@ -1697,11 +1787,11 @@ M0_INTERNAL int m0_sns_ir_mat_compute(struct m0_sns_ir *ir)
 
 	ret = ir_gen_decode_matrix(ir);
 	if (ret != 0)
-		return M0_RC(ret);
+		return M0_ERR_INFO(ret, "failed to generate decode matrix");
 
-	for (i = 0; i < ir->si_failed_nr; i++) {
+	for (i = 0; i < ir->si_failed_nr; i++)
 		dependency_bitmap_prepare(&blocks[ir->si_failed_idx[i]], ir);
-	}
+
 #endif /* !ISAL_ENCODE_ENABLED */
 	return M0_RC(ret);
 }
@@ -1726,10 +1816,9 @@ static int ir_gen_decode_matrix(struct m0_sns_ir *ir)
 				       &alive_idx_buf,
 				       ir->si_encode_matrix,
 				       ir->si_decode_tbls);
-	if (ret != 0) {
-		ret = M0_ERR_INFO(ret, "failed to generate recovery "
-				  "coefficient tables");
-	}
+	if (ret != 0)
+		return M0_ERR_INFO(ret, "failed to generate recovery "
+				   "coefficient tables");
 
 	return M0_RC(ret);
 }
@@ -1749,21 +1838,37 @@ static int data_recov_mat_construct(struct m0_sns_ir *ir)
 
 	ret = m0_matrix_init(&encode_mat, ir->si_data_nr,
 			     ir->si_data_nr);
-	if (ret != 0)
+	if (ret != 0) {
+		ret = MAT_INIT_ERR_INFO(ret, "encode", ir->si_data_nr,
+					ir->si_data_nr);
 		goto fini;
+	}
+
 	submatrix_construct(&ir->si_vandmat, ir->si_blocks,
 			    M0_SI_BLOCK_ALIVE, &encode_mat);
+
 	ret = m0_matrix_init(&encode_mat_inverse, encode_mat.m_width,
 			     encode_mat.m_height);
-	if (ret != 0)
+	if (ret != 0) {
+		ret = MAT_INIT_ERR_INFO(ret, "inverse of encode",
+					encode_mat.m_height, encode_mat.m_width);
 		goto fini;
+	}
+
 	ret = m0_matrix_invert(&encode_mat, &encode_mat_inverse);
-	if (ret != 0)
+	if (ret != 0) {
+		ret = M0_ERR_INFO(ret, "failed to invert encode matrix.");
 		goto fini;
+	}
+
 	ret = m0_matrix_init(&ir->si_data_recovery_mat, ir->si_data_nr,
 			     ir->si_failed_data_nr);
-	if (ret != 0)
+	if (ret != 0) {
+		ret = MAT_INIT_ERR_INFO(ret, "data recovery",
+					ir->si_failed_data_nr, ir->si_data_nr);
 		goto fini;
+	}
+
 	submatrix_construct(&encode_mat_inverse, ir->si_blocks,
 			    M0_SI_BLOCK_FAILED, &ir->si_data_recovery_mat);
 fini:
@@ -1824,7 +1929,7 @@ static void dependency_bitmap_prepare(struct m0_sns_ir_block *f_block,
 #else /* ISAL_ENCODE_ENABLED */
 	for (i = 0; i < ir->si_data_nr; ++i)
 		m0_bitmap_set(&f_block->sib_bitmap, ir->si_alive_idx[i], true);
-#endif /* ISAL_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 }
 
 #if !ISAL_ENCODE_ENABLED
@@ -1855,7 +1960,7 @@ M0_INTERNAL void m0_sns_ir_fini(struct m0_sns_ir *ir)
 	m0_matrix_fini(&ir->si_data_recovery_mat);
 #else /* ISAL_ENCODE_ENABLED */
 	isal_ir_fini(ir);
-#endif /* ISAL_ENCODE_ENABLED */
+#endif /* !ISAL_ENCODE_ENABLED */
 	m0_free(ir->si_blocks);
 	M0_LEAVE();
 }
@@ -1936,8 +2041,7 @@ static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block)
 	for (i = 0; i < ir->si_failed_nr; i++) {
 		ret = m0_buf_alloc(&f_bufs[i], length);
 		if (ret != 0){
-			ret = M0_ERR_INFO(ret, "Failed to allocate buffer %d "
-					"of length = %u", i, length);
+			ret = BUF_ALLOC_ERR_INFO(ret, "failure", length);
 			goto exit;
 		}
 		/* Save address of m0_bufvec for failed block */
@@ -1969,8 +2073,7 @@ static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block)
 	/* Allocate buffer for alive block */
 	ret = m0_buf_alloc(&alive_buf, length);
 	if (ret != 0){
-		ret = M0_ERR_INFO(ret, "Failed to allocate buffer of "
-				  "length = %u", length);
+		ret = BUF_ALLOC_ERR_INFO(ret, "alive", length);
 		goto exit;
 	}
 
@@ -1982,10 +2085,16 @@ static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block)
 		goto exit;
 	}
 
-	isal_encode_data_update(f_bufs, &alive_buf, curr_idx,
-				ir->si_decode_tbls, ir->si_data_nr,
-				ir->si_failed_nr);
-
+	/* Recover the data */
+	ret = isal_encode_data_update(f_bufs, &alive_buf, curr_idx,
+				      ir->si_decode_tbls, ir->si_data_nr,
+				      ir->si_failed_nr);
+	if (ret != 0) {
+		ret = M0_ERR_INFO(ret, "Failed to recover data using "
+				  "index=%u, data count=%u and failed count=%u ",
+				  curr_idx, ir->si_data_nr, ir->si_failed_nr);
+		goto exit;
+	}
 
 	/* Copy recovered data back to buffer vector. */
 	ret = buf_to_bufvec_copy(failed_bufvecs, f_bufs, ir->si_failed_nr);
@@ -2003,11 +2112,11 @@ exit:
 }
 #endif /* ISAL_ENCODE_ENABLED */
 
-M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
-				   struct m0_bufvec *bufvec,
-				   const struct m0_bitmap *bitmap,
-				   uint32_t failed_index,
-				   enum m0_sns_ir_block_type block_type)
+M0_INTERNAL int m0_sns_ir_recover(struct m0_sns_ir *ir,
+				  struct m0_bufvec *bufvec,
+				  const struct m0_bitmap *bitmap,
+				  uint32_t failed_index,
+				  enum m0_sns_ir_block_type block_type)
 {
 #if !ISAL_ENCODE_ENABLED
 	uint32_t		j;
@@ -2016,6 +2125,7 @@ M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
 	size_t		        b_set_nr;
 	struct m0_sns_ir_block *blocks;
 	struct m0_sns_ir_block *alive_block;
+	int			ret = 0;
 
 	M0_ENTRY("ir=%p, bufvec=%p, bitmap=%p, failed_index=%u, block_type=%u",
 		 ir, bufvec, bitmap, failed_index, block_type);
@@ -2036,7 +2146,9 @@ M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
 				break;
 		}
 	}
-	M0_ASSERT(is_valid_block_idx(ir, block_idx));
+
+	if (is_valid_block_idx(ir, block_idx) == false)
+		return VALUE_ERR_INFO(block_idx, ir_blocks_count(ir), "block_idx");
 
 	blocks = ir->si_blocks;
 
@@ -2049,7 +2161,10 @@ M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
 		alive_block = &blocks[block_idx];
 		alive_block->sib_addr = bufvec;
 #if ISAL_ENCODE_ENABLED
-		M0_ASSERT(ir_recover(ir, alive_block) == 0);
+		ret = ir_recover(ir, alive_block);
+		if (ret != 0)
+			return 	M0_ERR_INFO(ret,
+					    "Incremental recovery failed.");
 #else
 		for (j = 0; j < ir_blocks_count(ir); ++j)
 			if (ir->si_blocks[j].sib_status == M0_SI_BLOCK_FAILED) {
@@ -2081,7 +2196,7 @@ M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
 		break;
 	}
 
-	M0_LEAVE();
+	return M0_RC(ret);
 }
 
 #if !ISAL_ENCODE_ENABLED

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -724,9 +724,9 @@ static int xor_calculate(struct m0_parity_math *math,
 			 const struct m0_buf *data,
 			 struct m0_buf *parity)
 {
-	uint32_t	  ei; /* block element index. */
-	uint32_t	  ui; /* unit index. */
-	uint32_t	  block_size = data[0].b_nob;
+	uint32_t          ei; /* block element index. */
+	uint32_t          ui; /* unit index. */
+	uint32_t          block_size = data[0].b_nob;
 	m0_parity_elem_t  pe;
 
 	if (block_size != parity[0].b_nob)

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -188,7 +188,7 @@ M0_INTERNAL int m0_parity_math_init(struct m0_parity_math *math,
 				    uint32_t data_count, uint32_t parity_count);
 
 /**
-   Deinitializaton of parity math algorithms.
+   Deinitialization of parity math algorithms.
    Frees all memory blocks allocated by m0_parity_math_init().
  */
 M0_INTERNAL void m0_parity_math_fini(struct m0_parity_math *math);
@@ -200,9 +200,9 @@ M0_INTERNAL void m0_parity_math_fini(struct m0_parity_math *math);
                         b_nob elements.
    @pre m0_parity_math_init() succeeded.
  */
-M0_INTERNAL void m0_parity_math_calculate(struct m0_parity_math *math,
-					  struct m0_buf *data,
-					  struct m0_buf *parity);
+M0_INTERNAL int m0_parity_math_calculate(struct m0_parity_math *math,
+					 struct m0_buf *data,
+					 struct m0_buf *parity);
 
 /**
  * Calculates parity in a differential manner.
@@ -214,10 +214,10 @@ M0_INTERNAL void m0_parity_math_calculate(struct m0_parity_math *math,
  * @param index   Index of data unit in parity group for which old and new
  * versions are sent.
  */
-M0_INTERNAL void m0_parity_math_diff(struct m0_parity_math *math,
-				     struct m0_buf *old_ver,
-				     struct m0_buf *new_ver,
-				     struct m0_buf *parity, uint32_t index);
+M0_INTERNAL int m0_parity_math_diff(struct m0_parity_math *math,
+				    struct m0_buf *old_ver,
+				    struct m0_buf *new_ver,
+				    struct m0_buf *parity, uint32_t index);
 
 /**
  * Parity block refinement iff one data word of one data unit had changed.
@@ -228,10 +228,10 @@ M0_INTERNAL void m0_parity_math_diff(struct m0_parity_math *math,
  * @param[in]  data_ind_changed - index of data unit recently changed.
  * @pre m0_parity_math_init() succeeded.
  */
-M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
-				       struct m0_buf *data,
-				       struct m0_buf *parity,
-				       uint32_t data_ind_changed);
+M0_INTERNAL int m0_parity_math_refine(struct m0_parity_math *math,
+				      struct m0_buf *data,
+				      struct m0_buf *parity,
+				      uint32_t data_ind_changed);
 
 #if !ISAL_ENCODE_ENABLED
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
@@ -254,13 +254,13 @@ M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math);
  *                         parityblock with given index is treated as broken.
  * @param[in]     algo   - algorithm for recovery of data in case reed solomon
  *                         encoding is used.
- * @pre m0_parity_math_init() succeded.
+ * @pre m0_parity_math_init() succeeded.
  */
-M0_INTERNAL void m0_parity_math_recover(struct m0_parity_math *math,
-					struct m0_buf *data,
-					struct m0_buf *parity,
-					struct m0_buf *fail,
-					enum m0_parity_linsys_algo algo);
+M0_INTERNAL int m0_parity_math_recover(struct m0_parity_math *math,
+				       struct m0_buf *data,
+				       struct m0_buf *parity,
+				       struct m0_buf *fail,
+				       enum m0_parity_linsys_algo algo);
 
 /**
  * Recovers data or parity units partially or fully depending on the parity
@@ -269,13 +269,13 @@ M0_INTERNAL void m0_parity_math_recover(struct m0_parity_math *math,
  * @param data - data block, treated as uint8_t block with b_nob elements.
  * @param parity - parity block, treated as uint8_t block with b_nob elements.
  * @param failure_index - Index of the failed block.
-   @pre m0_parity_math_init() succeded.
+   @pre m0_parity_math_init() succeeded.
  */
-M0_INTERNAL void m0_parity_math_fail_index_recover(struct m0_parity_math *math,
-						   struct m0_buf *data,
-						   struct m0_buf *parity,
-						   const uint32_t
-						   failure_index);
+M0_INTERNAL int m0_parity_math_fail_index_recover(struct m0_parity_math *math,
+						  struct m0_buf *data,
+						  struct m0_buf *parity,
+						  const uint32_t
+						  failure_index);
 
 /**
  * XORs the source and destination buffers and stores the output in destination
@@ -562,16 +562,16 @@ M0_INTERNAL int m0_sns_ir_mat_compute(struct m0_sns_ir *ir);
  *			    on a node or coming from a remote node. All remote
  *			    blocks are assumed to be transformed.
  */
-M0_INTERNAL void m0_sns_ir_recover(struct m0_sns_ir *ir,
-				   struct m0_bufvec *bufvec,
-				   const struct m0_bitmap *bitmap,
-				   uint32_t failed_indexi,
-				   enum m0_sns_ir_block_type block_type);
+M0_INTERNAL int m0_sns_ir_recover(struct m0_sns_ir *ir,
+				  struct m0_bufvec *bufvec,
+				  const struct m0_bitmap *bitmap,
+				  uint32_t failed_index,
+				  enum m0_sns_ir_block_type block_type);
 /**
  * When failures include both data and parity blocks, this function uses
  * local copy of recovered (partially or fully) data-block for recovering
  * failed parity block. On any node, this function can be triggered only once
- * per parity group. Subsequent triggers will result into a no-operaiton.
+ * per parity group. Subsequent triggers will result into a no-operation.
  * @param ir holds information relevant for recovery
  */
 //M0_INTERNAL void m0_sns_ir_local_xform(struct m0_sns_ir *ir);

--- a/sns/ut/parity_math_mt_ub.c
+++ b/sns/ut/parity_math_mt_ub.c
@@ -198,12 +198,14 @@ void tb_thread(struct tb_cfg *cfg)
 		m0_buf_init(&parity_buf[i], cfg->tc_parity[i], buff_size);
 
 
-	m0_parity_math_calculate(&math, data_buf, parity_buf);
+	ret = m0_parity_math_calculate(&math, data_buf, parity_buf);
+	M0_UT_ASSERT(ret == 0);
 
 	m0_buf_init(&fail_buf, cfg->tc_fail, fail_count);
 	unit_spoil(cfg);
 
-	m0_parity_math_recover(&math, data_buf, parity_buf, &fail_buf, 0);
+	ret = m0_parity_math_recover(&math, data_buf, parity_buf, &fail_buf, 0);
+	M0_UT_ASSERT(ret == 0);
 
 	unit_compare(cfg);
 

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -322,6 +322,7 @@ static void test_recovery(const enum m0_parity_cal_algo algo,
 	struct m0_buf         parity_buf[DATA_UNIT_COUNT_MAX];
 	struct m0_buf         fail_buf;
 	struct m0_parity_math *math;
+	int		      ret;
 
 	M0_ALLOC_PTR(math);
 	M0_UT_ASSERT(math != NULL);
@@ -329,8 +330,8 @@ static void test_recovery(const enum m0_parity_cal_algo algo,
 	while (config_generate(&data_count, &parity_count, &buff_size, algo)) {
 		fail_count = data_count + parity_count;
 
-		M0_UT_ASSERT(m0_parity_math_init(math, data_count,
-					         parity_count) == 0);
+		ret = m0_parity_math_init(math, data_count, parity_count);
+		M0_UT_ASSERT(ret == 0);
 
 		for (i = 0; i < data_count; ++i) {
 			m0_buf_init(&data_buf[i], data[i], buff_size);
@@ -339,17 +340,22 @@ static void test_recovery(const enum m0_parity_cal_algo algo,
 
 		m0_buf_init(&fail_buf, fail, buff_size);
 
-		m0_parity_math_calculate(math, data_buf, parity_buf);
+		ret = m0_parity_math_calculate(math, data_buf, parity_buf);
+		M0_UT_ASSERT(ret == 0);
 
 		unit_spoil(buff_size, fail_count, data_count);
 
-		if (rt == FAIL_INDEX)
-			m0_parity_math_fail_index_recover(math, data_buf,
-							  parity_buf,
-							  fail_index_xor);
-		else if (rt == FAIL_VECTOR)
-			m0_parity_math_recover(math, data_buf, parity_buf,
-					       &fail_buf, 0);
+		if (rt == FAIL_INDEX) {
+			ret = m0_parity_math_fail_index_recover(math, data_buf,
+								parity_buf,
+								fail_index_xor);
+			M0_UT_ASSERT(ret == 0);
+		}
+		else if (rt == FAIL_VECTOR) {
+			ret = m0_parity_math_recover(math, data_buf, parity_buf,
+						     &fail_buf, 0);
+			M0_UT_ASSERT(ret == 0);
+		}
 
 		m0_parity_math_fini(math);
 
@@ -376,6 +382,7 @@ static void test_rs_fv_rand_recover(void)
 	struct m0_buf         parity_buf[DATA_UNIT_COUNT_MAX];
 	struct m0_buf         fail_buf;
 	struct m0_parity_math math;
+	int		      ret;
 
 	duc = DATA_UNIT_COUNT_MAX;
 	puc = PARITY_UNIT_COUNT_MAX;
@@ -384,8 +391,8 @@ static void test_rs_fv_rand_recover(void)
 	while (rand_rs_config_generate(&data_count, &parity_count, &buff_size)) {
 		fail_count = data_count + parity_count;
 
-		M0_UT_ASSERT(m0_parity_math_init(&math, data_count,
-					         parity_count) == 0);
+		ret = m0_parity_math_init(&math, data_count, parity_count);
+		M0_UT_ASSERT(ret == 0);
 
 		for (i = 0; i < data_count; ++i) {
 			m0_buf_init(&data_buf[i], data[i], buff_size);
@@ -394,12 +401,14 @@ static void test_rs_fv_rand_recover(void)
 
 		m0_buf_init(&fail_buf, fail, buff_size);
 
-		m0_parity_math_calculate(&math, data_buf, parity_buf);
+		ret = m0_parity_math_calculate(&math, data_buf, parity_buf);
+		M0_UT_ASSERT(ret == 0);
 
 		unit_spoil(buff_size, fail_count, data_count);
 
-		m0_parity_math_recover(&math, data_buf, parity_buf,
-				       &fail_buf, 0);
+		ret = m0_parity_math_recover(&math, data_buf, parity_buf,
+					     &fail_buf, 0);
+		M0_UT_ASSERT(ret == 0);
 
 		m0_parity_math_fini(&math);
 
@@ -503,14 +512,16 @@ static void test_parity_math_diff(uint32_t parity_cnt)
 		m0_buf_init(&p_new[i], arr, UNIT_BUFF_SIZE);
 	}
 
-	m0_parity_math_calculate(&math, data_buf_old, p_old);
-	m0_parity_math_calculate(&math, data_buf_new, p_new);
+	ret = m0_parity_math_calculate(&math, data_buf_old, p_old);
+	M0_UT_ASSERT(ret == 0);
+	ret = m0_parity_math_calculate(&math, data_buf_new, p_new);
+	M0_UT_ASSERT(ret == 0);
 
 	for (i = 0; i < DATA_UNIT_COUNT; ++i) {
 		if (i % 2)
-			m0_parity_math_diff(&math, data_buf_old,
-					    data_buf_new,
-					    p_old, i);
+			M0_UT_ASSERT(m0_parity_math_diff(&math, data_buf_old,
+							 data_buf_new,
+					    		 p_old, i) == 0);
 	}
 
 	for(i = 0; i < parity_cnt; ++i) {
@@ -768,7 +779,7 @@ static void parity_calculate(struct m0_parity_math *math, struct m0_bufvec *x,
 	buf_initialize(p_ser, math->pmi_parity_count, num_seg * seg_size);
 	buf_initialize(x_ser, math->pmi_data_count, num_seg * seg_size);
 	bufvec_buf(x, x_ser, math->pmi_data_count, true);
-	m0_parity_math_calculate(math, x_ser, p_ser);
+	M0_UT_ASSERT(m0_parity_math_calculate(math, x_ser, p_ser) == 0);
 	bufvec_buf(p, p_ser, math->pmi_parity_count, false);
 
 	buf_free(x_ser, math->pmi_data_count);
@@ -1135,18 +1146,20 @@ static void sns_ir_nodes_recover(struct sns_ir_node *node, uint32_t node_nr,
 				      true);
 			alive_idx = node[i].sin_alive[j];
 			if (alive_idx < ir.si_data_nr) {
-				m0_sns_ir_recover(&node[i].sin_ir,
-						  &x[alive_idx],
-						  &alive_bitmap, 0,
-						  M0_SI_BLOCK_LOCAL);
+				ret = m0_sns_ir_recover(&node[i].sin_ir,
+							&x[alive_idx],
+							&alive_bitmap, 0,
+						  	M0_SI_BLOCK_LOCAL);
+				M0_UT_ASSERT(ret == 0);
 			}
 			else if (alive_idx >= ir.si_data_nr &&
 				 alive_idx < ir.si_data_nr + ir.si_parity_nr) {
-				m0_sns_ir_recover(&node[i].sin_ir,
-						  &p[alive_idx -
-						  ir.si_data_nr],
-						  &alive_bitmap, 0,
-						  M0_SI_BLOCK_LOCAL);
+				ret = m0_sns_ir_recover(&node[i].sin_ir,
+							&p[alive_idx -
+							ir.si_data_nr],
+							&alive_bitmap, 0,
+							M0_SI_BLOCK_LOCAL);
+				M0_UT_ASSERT(ret == 0);
 			}
 			for (k = 0; k < total_failures; ++k) {
 				m0_bitmap_set(&node[i].sin_bitmap[k],
@@ -1182,10 +1195,11 @@ static void sns_ir_nodes_gather(struct sns_ir_node *node, uint32_t node_nr,
 	/* Add remote blocks */
 	for (i = 1; i < node_nr - 2; ++i) {
 		for (k = 0; k < total_failures; ++k) {
-			m0_sns_ir_recover(&node[0].sin_ir,
-					  &node[i].sin_recov_arr[k],
-					  &node[i].sin_bitmap[k],
-					  failed_arr[k], M0_SI_BLOCK_REMOTE);
+			ret = m0_sns_ir_recover(&node[0].sin_ir,
+						&node[i].sin_recov_arr[k],
+						&node[i].sin_bitmap[k],
+						failed_arr[k], M0_SI_BLOCK_REMOTE);
+			M0_UT_ASSERT(ret == 0);
 		}
 	}
 
@@ -1195,18 +1209,20 @@ static void sns_ir_nodes_gather(struct sns_ir_node *node, uint32_t node_nr,
 				      true);
 			alive_idx = node[0].sin_alive[j];
 			if (alive_idx < ir.si_data_nr) {
-				m0_sns_ir_recover(&node[0].sin_ir,
-						  &x[alive_idx],
-						  &alive_bitmap, 0,
-						  M0_SI_BLOCK_LOCAL);
+				ret = m0_sns_ir_recover(&node[0].sin_ir,
+							&x[alive_idx],
+							&alive_bitmap, 0,
+							M0_SI_BLOCK_LOCAL);
+				M0_UT_ASSERT(ret == 0);
 			}
 			else if (alive_idx >= ir.si_data_nr &&
 				 alive_idx < ir.si_data_nr + ir.si_parity_nr) {
-				m0_sns_ir_recover(&node[0].sin_ir,
-						  &p[alive_idx -
-						  ir.si_data_nr],
-						  &alive_bitmap, 0,
-						  M0_SI_BLOCK_LOCAL);
+				ret = m0_sns_ir_recover(&node[0].sin_ir,
+							&p[alive_idx -
+							ir.si_data_nr],
+							&alive_bitmap, 0,
+							M0_SI_BLOCK_LOCAL);
+				M0_UT_ASSERT(ret == 0);
 			}
 			for (k = 0; k < total_failures; ++k) {
 				m0_bitmap_set(&node[0].sin_bitmap[k],
@@ -1218,10 +1234,11 @@ static void sns_ir_nodes_gather(struct sns_ir_node *node, uint32_t node_nr,
 	/* Add remote blocks */
 	for (i = node_nr - 2; i < node_nr; ++i) {
 		for (k = 0; k < total_failures; ++k) {
-			m0_sns_ir_recover(&node[0].sin_ir,
-					  &node[i].sin_recov_arr[k],
-					  &node[i].sin_bitmap[k],
-					  failed_arr[k], M0_SI_BLOCK_REMOTE);
+			ret = m0_sns_ir_recover(&node[0].sin_ir,
+						&node[i].sin_recov_arr[k],
+						&node[i].sin_bitmap[k],
+						failed_arr[k], M0_SI_BLOCK_REMOTE);
+			M0_UT_ASSERT(ret == 0);
 		}
 	}
 	m0_bitmap_fini(&alive_bitmap);
@@ -1482,11 +1499,14 @@ void parity_math_tb(void)
 
 		m0_buf_init(&fail_buf, fail, buff_size);
 
-		m0_parity_math_calculate(math, data_buf, parity_buf);
+		ret = m0_parity_math_calculate(math, data_buf, parity_buf);
+		M0_ASSERT(ret == 0);
 
 		unit_spoil(buff_size, fail_count, data_count);
 
-		m0_parity_math_recover(math, data_buf, parity_buf, &fail_buf, 0);
+		ret = m0_parity_math_recover(math, data_buf, parity_buf,
+					     &fail_buf, 0);
+		M0_UT_ASSERT(ret == 0);
 
 		m0_parity_math_fini(math);
 	}

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -518,10 +518,11 @@ static void test_parity_math_diff(uint32_t parity_cnt)
 	M0_UT_ASSERT(ret == 0);
 
 	for (i = 0; i < DATA_UNIT_COUNT; ++i) {
-		if (i % 2)
-			M0_UT_ASSERT(m0_parity_math_diff(&math, data_buf_old,
-							 data_buf_new,
-					    		 p_old, i) == 0);
+		if (i % 2) {
+			ret = m0_parity_math_diff(&math, data_buf_old,
+						  data_buf_new, p_old, i);
+			M0_UT_ASSERT(ret == 0);
+		}
 	}
 
 	for(i = 0; i < parity_cnt; ++i) {
@@ -770,6 +771,7 @@ static void parity_calculate(struct m0_parity_math *math, struct m0_bufvec *x,
 {
 	struct m0_buf *x_ser;
 	struct m0_buf *p_ser;
+	int	       ret;
 
 	M0_ALLOC_ARR(x_ser, math->pmi_data_count);
 	M0_UT_ASSERT(x_ser != NULL);
@@ -779,7 +781,8 @@ static void parity_calculate(struct m0_parity_math *math, struct m0_bufvec *x,
 	buf_initialize(p_ser, math->pmi_parity_count, num_seg * seg_size);
 	buf_initialize(x_ser, math->pmi_data_count, num_seg * seg_size);
 	bufvec_buf(x, x_ser, math->pmi_data_count, true);
-	M0_UT_ASSERT(m0_parity_math_calculate(math, x_ser, p_ser) == 0);
+	ret = m0_parity_math_calculate(math, x_ser, p_ser);
+	M0_UT_ASSERT(ret == 0);
 	bufvec_buf(p, p_ser, math->pmi_parity_count, false);
 
 	buf_free(x_ser, math->pmi_data_count);


### PR DESCRIPTION
- Updated functions m0_parity_math_calculate(), m0_parity_math_diff(),
  m0_parity_math_recover(), m0_parity_math_fail_index_recover() and
  m0_sns_ir_recover() to return error code in case of failures.
- Updated the callers of these functions to handle the returned error
  codes.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>