### PR TITLE
Eos 21067 Reverting change from commit id fb19a7 which caused btree truncate failures in some cases.

### DIFF
--- a/be/btree.c
+++ b/be/btree.c
@@ -1256,17 +1256,16 @@ static void btree_truncate(struct m0_be_btree *btree, struct m0_be_tx *tx,
 			 * node->bt_child_arr[node->bt_num_active_key]
 			 * leaf node
 			 */
-			if (i > 0 && limit > 0) {
+			if (i > 0)
 				btree_pair_release(btree, tx,
 						&parent->bt_kv_arr[i-1]);
 
+			if (limit > 0)
 				limit--;
-				parent->bt_num_active_key--;
-			}
-
 			if (i == 0)
 				parent->bt_isleaf = true;
-
+			else
+				parent->bt_num_active_key--;
 			if (parent == btree->bb_root &&
 			    parent->bt_num_active_key == 0) {
 				/*

--- a/be/btree.c
+++ b/be/btree.c
@@ -1205,7 +1205,7 @@ static void btree_truncate(struct m0_be_btree *btree, struct m0_be_tx *tx,
 {
 	struct m0_be_bnode *node;
 	struct m0_be_bnode *parent;
-	int                 i;
+	unsigned int        i;
 
 	/* Add one more reserve for non-leaf node. */
 	if (limit > 1)

--- a/be/ut/btree.c
+++ b/be/ut/btree.c
@@ -610,6 +610,7 @@ static void truncate_tree(struct m0_be_btree *tree)
 	struct m0_buf           key;
 	char                    k[INSERT_KSIZE];
 	int                     rc;
+	int                     i;
 
 	M0_ENTRY();
 
@@ -627,8 +628,12 @@ static void truncate_tree(struct m0_be_btree *tree)
 	rc = m0_be_tx_open_sync(tx);
 	M0_UT_ASSERT(rc == 0);
 	btree_dbg_print(tree);
-	M0_BE_OP_SYNC_WITH(op, m0_be_btree_truncate(tree, tx,
-							op, INSERT_COUNT));
+	M0_ASSERT(INSERT_COUNT % 5 == 0);
+	for (i = 0; i < INSERT_COUNT; i+=5) {
+		M0_SET0(op);
+		M0_BE_OP_SYNC_WITH(op, m0_be_btree_truncate(tree, tx,
+							    op, 5));
+	}
 	M0_UT_ASSERT(m0_be_btree_is_empty(tree));
 	M0_BE_FREE_PTR_SYNC(tree, seg, tx);
 	m0_be_tx_close_sync(tx); /* Make things persistent. */


### PR DESCRIPTION
Reverting change from commit id fb19a784b900a73dfdb9fec45659b6c8b282644b which caused the btree truncate to fail in cases when the truncate record count would align with any of the btree node KV counts.
Changed the btree ut to catch similar conditions during truncate operation.
Added -m option to beck tool which will map the BE segment in the memory and wait in a while(1) loop if this option is provided. This is useful during debugging of core dumps.