### PR TITLE
lib/coroutine: Added coroutine operations used for FOM syncronization

### DIFF
--- a/lib/coroutine.c
+++ b/lib/coroutine.c
@@ -30,6 +30,8 @@
 #include "lib/trace.h"
 #include "lib/coroutine.h"
 #include "lib/memory.h"
+#include "fop/fom.h"
+
 
 static int locals_alloc_init(struct m0_co_locals_allocator *alloc)
 {
@@ -139,6 +141,105 @@ M0_INTERNAL int m0_co_context_init(struct m0_co_context *context)
 M0_INTERNAL void m0_co_context_fini(struct m0_co_context *context)
 {
 	locals_alloc_fini(&context->mc_alloc);
+}
+
+enum m0_co_op_state {
+	COR_INVALID,
+	COR_INIT,
+	COR_ACTIVE,
+	COR_DONE,
+};
+
+static struct m0_sm_state_descr co_states[] = {
+	[COR_INIT] = {
+		.sd_flags   = M0_SDF_INITIAL,
+		.sd_name    = "COR_INIT",
+		.sd_allowed = M0_BITS(COR_ACTIVE),
+	},
+	[COR_ACTIVE] = {
+		.sd_flags   = 0,
+		.sd_name    = "COR_ACTIVE",
+		.sd_allowed = M0_BITS(COR_DONE),
+	},
+	[COR_DONE] = {
+		.sd_flags   = M0_SDF_TERMINAL,
+		.sd_name    = "COR_DONE",
+		.sd_allowed = 0,
+	},
+};
+
+static struct m0_sm_trans_descr co_trans[] = {
+	{ "started",   COR_INIT,   COR_ACTIVE },
+	{ "completed", COR_ACTIVE, COR_DONE   },
+};
+
+M0_INTERNAL struct m0_sm_conf co_states_conf = {
+	.scf_name      = "m0_co_op::co_sm",
+	.scf_nr_states = ARRAY_SIZE(co_states),
+	.scf_state     = co_states,
+	.scf_trans_nr  = ARRAY_SIZE(co_trans),
+	.scf_trans     = co_trans
+};
+
+M0_INTERNAL void m0_co_op_init(struct m0_co_op *op)
+{
+	M0_PRE_EX(M0_IS0(op));
+	m0_sm_group_init(&op->co_sm_group);
+	m0_sm_init(&op->co_sm, &co_states_conf, COR_INIT,
+		   &op->co_sm_group);
+}
+
+M0_INTERNAL void m0_co_op_fini(struct m0_co_op *op)
+{
+	m0_sm_group_lock(&op->co_sm_group);
+	M0_PRE(M0_IN(op->co_sm.sm_state, (COR_INIT, COR_DONE)));
+
+	if (op->co_sm.sm_state == COR_INIT) {
+		m0_sm_state_set(&op->co_sm, COR_ACTIVE);
+		m0_sm_state_set(&op->co_sm, COR_DONE);
+	}
+	m0_sm_fini(&op->co_sm);
+	m0_sm_group_unlock(&op->co_sm_group);
+	M0_SET0(op);
+}
+
+M0_INTERNAL void m0_co_op_reset(struct m0_co_op *op)
+{
+	m0_co_op_fini(op);
+	m0_co_op_init(op);
+}
+
+M0_INTERNAL void m0_co_op_active(struct m0_co_op *op)
+{
+	m0_sm_group_lock(&op->co_sm_group);
+	m0_sm_state_set(&op->co_sm, COR_ACTIVE);
+	m0_sm_group_unlock(&op->co_sm_group);
+}
+
+M0_INTERNAL void m0_co_op_done(struct m0_co_op *op)
+{
+	m0_sm_group_lock(&op->co_sm_group);
+	m0_sm_state_set(&op->co_sm, COR_DONE);
+	m0_sm_group_unlock(&op->co_sm_group);
+}
+
+M0_INTERNAL int m0_co_op_tick_ret(struct m0_co_op *op,
+				  struct m0_fom   *fom,
+				  int              next_state)
+{
+	enum m0_fom_phase_outcome ret = M0_FSO_AGAIN;
+
+	m0_sm_group_lock(&op->co_sm_group);
+	M0_PRE(M0_IN(op->co_sm.sm_state, (COR_ACTIVE, COR_DONE)));
+
+	if (op->co_sm.sm_state == COR_ACTIVE) {
+		ret = M0_FSO_WAIT;
+		m0_fom_wait_on(fom, &op->co_sm.sm_chan, &fom->fo_cb);
+	}
+	m0_sm_group_unlock(&op->co_sm_group);
+
+	m0_fom_phase_set(fom, next_state);
+	return ret;
 }
 
 #undef M0_TRACE_SUBSYSTEM

--- a/lib/coroutine.h
+++ b/lib/coroutine.h
@@ -270,6 +270,26 @@ M0_INTERNAL void m0_co_context_locals_alloc(struct m0_co_context *context,
 					    uint64_t size);
 M0_INTERNAL void m0_co_context_locals_free(struct m0_co_context *context);
 
+#include "sm/sm.h"         /* m0_sm_group */
+
+struct m0_fom;
+struct m0_co_op {
+	struct m0_sm       co_sm;
+	/* MOTR-787: get rid of explicit locking here, use locality lock! */
+	struct m0_sm_group co_sm_group;
+};
+
+M0_INTERNAL void m0_co_op_init(struct m0_co_op *op);
+M0_INTERNAL void m0_co_op_fini(struct m0_co_op *op);
+
+M0_INTERNAL void m0_co_op_reset(struct m0_co_op *op);
+M0_INTERNAL void m0_co_op_active(struct m0_co_op *op);
+M0_INTERNAL void m0_co_op_done(struct m0_co_op *op);
+
+/* Don't introduce co_op_wait()! co_op intended to be used inside foms. */
+M0_INTERNAL int m0_co_op_tick_ret(struct m0_co_op *op,
+				  struct m0_fom   *fom,
+				  int              next_state);
 
 /** @} end of Coroutine group */
 #endif /* __MOTR_LIB_COROUTINE_H__ */

--- a/lib/ut/Makefile.sub
+++ b/lib/ut/Makefile.sub
@@ -8,6 +8,7 @@ ut_libmotr_ut_la_SOURCES += lib/ut/main.c \
                             lib/ut/cookie.c \
                             lib/ut/combinations.c \
                             lib/ut/coroutine.c \
+                            lib/ut/coroutine2.c \
                             lib/ut/finject.c \
                             lib/ut/fold.c \
                             lib/ut/getopts.c \

--- a/lib/ut/coroutine2.c
+++ b/lib/ut/coroutine2.c
@@ -1,0 +1,240 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2017-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_UT
+#include "lib/trace.h"
+#include "lib/coroutine.h"
+#include "lib/string.h"
+#include "ut/ut.h"
+#include "be/op.h"
+#include "reqh/reqh.h"		/* m0_reqh_fop_handle */
+#include "fop/fom.h"		/* m0_fom_phase_set */
+#include "fop/fom_generic.h"	/* M0_FOPH_FINISH */
+#include "fop/fom_simple.h"
+
+#define F M0_CO_FRAME_DATA
+
+extern struct m0_reqh *m0_ut__reqh_init(void);
+extern        void     m0_ut__reqh_fini(void);
+
+enum coroutine2_state {
+	C2_INIT   = M0_FOM_PHASE_INIT,
+	C2_FINISH = M0_FOM_PHASE_FINISH,
+	C2_NR,
+};
+
+static struct m0_sm_state_descr coroutine2_states[C2_NR] = {
+#define _S(name, flags, allowed)      \
+	[name] = {                    \
+		.sd_flags   = flags,  \
+		.sd_name    = #name,  \
+		.sd_allowed = allowed \
+	}
+
+	_S(C2_INIT,   M0_SDF_INITIAL, M0_BITS(C2_INIT, C2_FINISH)),
+	_S(C2_FINISH, M0_SDF_TERMINAL, 0),
+#undef _S
+};
+
+static struct m0_sm_conf coroutine2_conf = {
+	.scf_name      = "coroutine2_states",
+	.scf_nr_states = ARRAY_SIZE(coroutine2_states),
+	.scf_state     = coroutine2_states,
+};
+
+struct test_tree {
+	int insert;
+	int delete;
+};
+
+static void crud(struct m0_co_context *context,
+		 struct test_tree *tree, int k, int v);
+static void insert(struct m0_co_context *context,
+		   struct test_tree *tree, int k, int v);
+static void delete(struct m0_co_context *context,
+		   struct test_tree *tree, int k);
+
+static struct m0_semaphore ready;
+static struct m0_semaphore insert1;
+static struct m0_semaphore insert2;
+static struct m0_semaphore delete1;
+static struct m0_semaphore delete2;
+
+static struct m0_fom_simple simple_fom;
+static struct m0_co_context fom_context = {};
+static struct test_tree     fom_tree = {};
+static struct m0_co_op      fom_op = {};
+
+
+static void coroutine_fom_run(void)
+{
+	m0_semaphore_down(&insert1);
+	m0_co_op_done(&fom_op);
+
+	m0_semaphore_down(&insert2);
+	m0_co_op_done(&fom_op);
+
+	m0_semaphore_down(&delete1);
+	m0_co_op_done(&fom_op);
+
+	m0_semaphore_down(&delete2);
+	m0_co_op_done(&fom_op);
+
+	m0_semaphore_down(&ready);
+}
+
+static int coroutine_fom_tick(struct m0_fom *fom, int *x, int *__unused)
+{
+	int key = 1;
+	int val = 2;
+	int rc;
+
+	m0_co_op_reset(&fom_op);
+
+	M0_CO_START(&fom_context);
+	crud(&fom_context, &fom_tree, key, val);
+	rc = M0_CO_END(&fom_context);
+
+	if (rc == -EAGAIN)
+		return m0_co_op_tick_ret(&fom_op, fom, m0_fom_phase(fom));
+
+	m0_semaphore_up(&ready);
+	return -1;
+}
+
+static void crud(struct m0_co_context *context,
+		struct test_tree *tree, int k, int v)
+{
+	M0_CO_REENTER(context);
+
+	M0_LOG(M0_DEBUG, "tree=%p tree.delete=%d, tree.insert=%d k=%d",
+	       tree, tree->delete, tree->insert, k);
+
+	M0_CO_FUN(context, insert(context, tree, k, v));
+
+	M0_CO_FUN(context, delete(context, tree, k));
+
+	M0_UT_ASSERT(tree->delete + tree->insert == 4);
+}
+
+static void insert(struct m0_co_context *context,
+		   struct test_tree *tree, int k, int v)
+{
+	M0_CO_REENTER(context,
+		      int         rc;
+		      char        c;
+		      long long   i;
+		);
+	F(rc) = 0;
+	F(i) = 0x5011D57A7E;
+	F(c) = '8';
+
+	M0_LOG(M0_DEBUG, "tree=%p tree.delete=%d, tree.insert=%d k=%d v=%d",
+	       tree, tree->delete, tree->insert, k, v);
+
+	M0_LOG(M0_DEBUG, "yield");
+	tree->insert++;
+	m0_co_op_active(&fom_op);
+	m0_semaphore_up(&insert1);
+	M0_CO_YIELD(context);
+
+	M0_LOG(M0_DEBUG, "yield");
+	tree->insert++;
+	m0_co_op_active(&fom_op);
+	m0_semaphore_up(&insert2);
+	M0_CO_YIELD(context);
+}
+
+static void delete(struct m0_co_context *context,
+		   struct test_tree *tree, int k)
+{
+	M0_CO_REENTER(context);
+
+	M0_LOG(M0_DEBUG, "tree=%p tree.delete=%d, tree.insert=%d",
+	       tree, tree->delete, tree->insert);
+
+	M0_LOG(M0_DEBUG, "yield");
+	tree->delete++;
+	m0_co_op_active(&fom_op);
+	m0_semaphore_up(&delete1);
+	M0_CO_YIELD(context);
+
+	M0_LOG(M0_DEBUG, "yield");
+	tree->delete++;
+	m0_co_op_active(&fom_op);
+	m0_semaphore_up(&delete2);
+	M0_CO_YIELD(context);
+}
+
+static void test_run(void)
+{
+	struct m0_reqh *reqh = m0_ut__reqh_init();
+	(void) reqh;
+
+	M0_SET0(&simple_fom);
+	M0_FOM_SIMPLE_POST(&simple_fom, reqh, &coroutine2_conf,
+			   &coroutine_fom_tick, NULL, NULL, 1);
+	coroutine_fom_run();
+	m0_ut__reqh_fini();
+}
+
+void m0_test_coroutine2(void)
+{
+	int rc;
+
+	m0_semaphore_init(&ready, 0);
+
+	m0_semaphore_init(&insert1, 0);
+	m0_semaphore_init(&insert2, 0);
+	m0_semaphore_init(&delete1, 0);
+	m0_semaphore_init(&delete2, 0);
+
+	m0_co_op_init(&fom_op);
+
+	rc = m0_co_context_init(&fom_context);
+	M0_UT_ASSERT(rc == 0);
+
+
+	test_run();
+
+	m0_co_context_fini(&fom_context);
+	m0_co_op_fini(&fom_op);
+
+	m0_semaphore_init(&delete2, 0);
+	m0_semaphore_init(&delete1, 0);
+	m0_semaphore_init(&insert2, 0);
+	m0_semaphore_init(&insert1, 0);
+
+	m0_semaphore_init(&ready, 0);
+}
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/lib/ut/locality.c
+++ b/lib/ut/locality.c
@@ -64,7 +64,7 @@ static void fom_simple_svc_start(void)
 	M0_POST(m0_reqh_service_invariant(service));
 }
 
-static void _reqh_init(void)
+struct m0_reqh *m0_ut__reqh_init(void)
 {
 	int result;
 
@@ -78,9 +78,10 @@ static void _reqh_init(void)
 	M0_UT_ASSERT(result == 0);
 	m0_reqh_start(&reqh);
 	fom_simple_svc_start();
+	return &reqh;
 }
 
-static void _reqh_fini(void)
+void m0_ut__reqh_fini(void)
 {
 	m0_reqh_shutdown(&reqh);
 	m0_reqh_services_terminate(&reqh);
@@ -209,7 +210,7 @@ void test_locality(void)
 	int                  nr;
 
 	m0_mutex_init(&lock);
-	_reqh_init();
+	m0_ut__reqh_init();
 	for (i = 0; i < ARRAY_SIZE(sem); ++i) {
 		m0_semaphore_init(&sem[i], 0);
 		ast[i].sa_cb = &_cb0;
@@ -270,7 +271,7 @@ void test_locality(void)
 	for (i = 0; i < ARRAY_SIZE(sem); ++i)
 		m0_semaphore_fini(&sem[i]);
 	m0_bitmap_fini(&online);
-	_reqh_fini();
+	m0_ut__reqh_fini();
 	m0_mutex_fini(&lock);
 }
 M0_EXPORTED(test_locality);
@@ -394,7 +395,7 @@ void test_locality_chore(void)
 	M0_UT_ASSERT(result == -ENOSYS);
 	m0_locality_data_free(key0);
 	has0 = false;
-	_reqh_init();
+	m0_ut__reqh_init();
 	ops.co_enter = &enter;
 	entered = left = ticked = 0;
 	M0_SET0(&chore);
@@ -410,7 +411,7 @@ void test_locality_chore(void)
 	m0_fi_enable_once("m0_alloc", "keep_quiet");
 	result = m0_locality_data_alloc(1ULL << 60, NULL, NULL, NULL);
 	M0_UT_ASSERT(result == -ENOMEM);
-	_reqh_fini();
+	m0_ut__reqh_fini();
 	m0_locality_data_free(key);
 	m0_mutex_fini(&lock);
 }

--- a/lib/ut/main.c
+++ b/lib/ut/main.c
@@ -59,6 +59,7 @@ extern void m0_ut_lib_thread_pool_test(void);
 extern void test_combinations(void);
 extern void test_hash_fnc(void);
 extern void m0_test_coroutine(void);
+extern void m0_test_coroutine2(void);
 
 struct m0_ut_suite libm0_ut = {
 	.ts_name = "libm0-ut",
@@ -100,6 +101,7 @@ struct m0_ut_suite libm0_ut = {
 		{ "combinations",     test_combinations  },
 		{ "hash-fnc",         test_hash_fnc,     "Leonid" },
 		{ "coroutine",        m0_test_coroutine, "Anatoliy" },
+		{ "coroutine2",       m0_test_coroutine2,"Anatoliy" },
 		{ NULL,               NULL               }
 	}
 };


### PR DESCRIPTION
Added corresponding unittest coroutine2.c

Signed-off-by: Anatoliy Bilenko <anatoliy.bilenko@seagte.com>