### PR TITLE
go: add vi settings to the sources

### DIFF
--- a/bindings/go/mcp/mcp.go
+++ b/bindings/go/mcp/mcp.go
@@ -137,3 +137,5 @@ func main() {
     // might suffer. A tip from https://github.com/golang/go/issues/16474)
     io.CopyBuffer(struct{ io.Writer }{writer}, reader, buf)
 }
+
+// vi: sw=4 ts=4 expandtab ai

--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -667,3 +667,5 @@ func (mio *Mio) Seek(offset int64, whence int) (int64, error) {
 
     return int64(mio.off), nil
 }
+
+// vi: sw=4 ts=4 expandtab ai

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -192,3 +192,5 @@ func (mkv *Mkv) Delete(key []byte) error {
     _, err := mkv.doIdxOp(C.M0_IC_DEL, key, nil, false)
     return err
 }
+
+// vi: sw=4 ts=4 expandtab ai

--- a/bindings/go/mkv/mkv.go
+++ b/bindings/go/mkv/mkv.go
@@ -93,3 +93,5 @@ func main() {
         }
     }
 }
+
+// vi: sw=4 ts=4 expandtab ai


### PR DESCRIPTION
Add Vi settings to the Golang-source code files at the bottom.