### PR TITLE
go/mkv: fix build with go-1.17

### DIFF
--- a/bindings/go/mkv/mkv.go
+++ b/bindings/go/mkv/mkv.go
@@ -27,7 +27,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "../mio"
+    "motr/mio"
 )
 
 func usage() {


### PR DESCRIPTION
Import mio as a module. See commit 09ff618 also.

Closes #762.