### PR TITLE
utils: add pool selection feature to m0crate

### DIFF
--- a/motr/m0crate/crate_client.h
+++ b/motr/m0crate/crate_client.h
@@ -165,7 +165,7 @@ struct m0_workload_io {
 	 * can run several IO operations concurrently.)
 	 */
 	uint32_t          cwi_bcount_per_op;
-	uint32_t          cwi_pool_id;
+	struct m0_fid     cwi_pool_id;
 	uint64_t          cwi_io_size;
 	uint64_t          cwi_ops_done[CR_OPS_NR];
 	uint32_t          cwi_max_nr_ops;

--- a/motr/m0crate/crate_io.c
+++ b/motr/m0crate/crate_io.c
@@ -343,7 +343,6 @@ int cr_namei_create(struct m0_workload_io *cwi,
 		    int                    obj_idx,
 		    int                    op_index)
 {
-	printf("TESTSTSTS %" PRIu64 "\n", (&cwi->cwi_pool_id)->f_container);	
 	return m0_entity_create(&cwi->cwi_pool_id, &obj->ob_entity,
 			        &cti->cti_ops[free_slot]);
 }

--- a/motr/m0crate/crate_io.c
+++ b/motr/m0crate/crate_io.c
@@ -343,7 +343,8 @@ int cr_namei_create(struct m0_workload_io *cwi,
 		    int                    obj_idx,
 		    int                    op_index)
 {
-	return m0_entity_create(NULL, &obj->ob_entity,
+	printf("TESTSTSTS %" PRIu64 "\n", (&cwi->cwi_pool_id)->f_container);	
+	return m0_entity_create(&cwi->cwi_pool_id, &obj->ob_entity,
 			        &cti->cti_ops[free_slot]);
 }
 

--- a/motr/m0crate/parser.c
+++ b/motr/m0crate/parser.c
@@ -55,6 +55,7 @@ enum config_key_val {
 	ADDB_INIT,
 	ADDB_SIZE,
 	LOG_LEVEL,
+	POOL_FID,
 	/*
 	 * All parameters below are workload-specific,
 	 * anything else should be added above this point.
@@ -127,6 +128,7 @@ struct key_lookup_table lookuptable[] = {
 	{"MAX_RSIZE", MAX_VALUE_SIZE},
 	{"GET", GET},
 	{"PUT", PUT},
+	{"POOL_FID", POOL_FID},
 	{"NEXT", NEXT},
 	{"DEL", DEL},
 	{"NXRECORDS", NXRECORDS},
@@ -553,6 +555,13 @@ int copy_value(struct workload *load, int max_workload, int *index,
 			cw = workload_io(w);
 			cw->cwi_random_io = atoi(value);
 			break;
+		case POOL_FID:
+			w = &load[*index];
+                        cw = workload_io(w);
+                        if (0 != m0_fid_sscanf(value, &cw->cwi_pool_id)) {
+                                parser_emit_error("Unable to parse fid: %s", value);
+                        }
+                        break;
 		case OPCODE:
 			w = &load[*index];
 			cw = workload_io(w);


### PR DESCRIPTION
Signed-off-by: Patrick Hession \<patrick.hession@seagate.com>

Add pool selection feature to m0crate

You can now select the pool you wish to use with m0crate in the yaml configuration file