### PR TITLE
Update Quick-Start-Guide.rst

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -149,7 +149,14 @@ Troubleshooting
 Build the documentation
 =======================
 
-To create Motr documentation files, in Motr folder run::
+To create Motr documentation files, make sure you first install ``latex`` and ``ghostscript``::
+
+    sudo yum install doxygen
+    sudo yum install texlive-pdftex texlive-latex-bin texlive-texconfig* texlive-latex* texlive-metafont* texlive-cmap* texlive-ec texlive-fncychap* texlive-pdftex-def texlive-fancyhdr* texlive-titlesec* texlive-multirow texlive-framed* texlive-wrapfig* texlive-parskip* texlive-caption texlive-ifluatex* texlive-collection-fontsrecommended texlive-collection-latexrecommended
+    sudo yum install ghostscript
+
+
+Then in Motr folder run::
 
     make doc
 


### PR DESCRIPTION
Add prerequisites for running "make doc". 
Latex and ghostscript are required.
Otherwise will get errors. See #775 

Signed-off-by: Meng Wang <mengwanguc@gmail.com>