### PR TITLE
EOS-21946 ioservice: avoid using unitialized BE tx

### DIFF
--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1974,6 +1974,7 @@ static int io_sync(struct m0_fom *fom)
 	struct m0_be_tx         *tx   = m0_fom_tx(fom);
 
 	if ((fobj->fcrw_flags & M0_IO_FLAG_SYNC) &&
+	    fom->fo_tx.tx_state != M0_DTX_INVALID &&
 	    m0_be_tx_state(tx) < M0_BTS_LOGGED) {
 		M0_LOG(M0_DEBUG, "fom wait for tx to be logged");
 		m0_fom_wait_on(fom, &tx->t_sm.sm_chan, &fom->fo_cb);


### PR DESCRIPTION
The code doesn't handle the case when failure happens before BE tx is
initialised. The issue was caught with zero-copy-finish -> failure state
transition in 47motr-tests-user-kernel and 28motr-sys-kvs-test tests.

The patch that added the code in the first place has
similar code in another place, but I haven't seen a failure there.

Signed-off-by: Maksym Medvied <maksym.medvied@seagate.com>