### PR TITLE
Degraded read is failing for partially spanned parity groups 

### DIFF
--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -930,8 +930,14 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 		rw_fop->crw_fid = ti->ti_fid;
 		rw_fop->crw_pver = ioo->ioo_pver;
 		rw_fop->crw_index = ti->ti_obj;
-		if (ioo->ioo_flags & M0_OOF_NOHOLE)
-			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
+		/* @todo In case of partially spanned units in a parity group,
+		 * degraded read expects zero-filled units from server side.
+		 * No hole case needs to be handled, which was added during
+		 * data recovery, as some extents may be corrupted. With DI
+		 * enabled this can be handled in R2.
+		 * if (ioo->ioo_flags & M0_OOF_NOHOLE)
+		 * 		rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
+		 */
 		if (ioo->ioo_flags & M0_OOF_SYNC)
 			rw_fop->crw_flags |= M0_IO_FLAG_SYNC;
 		io_attr = m0_io_attr(ioo);

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -930,14 +930,13 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 		rw_fop->crw_fid = ti->ti_fid;
 		rw_fop->crw_pver = ioo->ioo_pver;
 		rw_fop->crw_index = ti->ti_obj;
-		/* @todo In case of partially spanned units in a parity group,
+		/* In case of partially spanned units in a parity group,
 		 * degraded read expects zero-filled units from server side.
-		 * No hole case needs to be handled, which was added during
-		 * data recovery, as some extents may be corrupted. With DI
-		 * enabled this can be handled in R2.
-		 * if (ioo->ioo_flags & M0_OOF_NOHOLE)
-		 * 		rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
 		 */
+		if (ioreq_sm_state(ioo) != IRS_DEGRADED_READING &&
+		    ioo->ioo_flags & M0_OOF_NOHOLE)
+			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
+
 		if (ioo->ioo_flags & M0_OOF_SYNC)
 			rw_fop->crw_flags |= M0_IO_FLAG_SYNC;
 		io_attr = m0_io_attr(ioo);

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -1347,11 +1347,12 @@ static int nw_xfer_io_distribute(struct nw_xfer_request *xfer)
 			if (rc != 0)
 				goto err;
 
-			if (op_code == M0_OC_WRITE && do_cobs)
-				m0_bitmap_set(&units_spanned, unit, true);
-
 			ti->ti_ops->tio_seg_add(ti, &src, &tgt, r_ext.e_start,
 						m0_ext_length(&r_ext), iomap);
+			if (op_code == M0_OC_WRITE && do_cobs &&
+			    ti->ti_req_type == TI_READ_WRITE)
+				m0_bitmap_set(&units_spanned, unit, true);
+
 		}
 
 		M0_ASSERT(ergo(M0_IN(op_code, (M0_OC_READ, M0_OC_WRITE)),

--- a/motr/io_req_fop.c
+++ b/motr/io_req_fop.c
@@ -171,7 +171,7 @@ static void io_bottom_half(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	M0_LOG(M0_DEBUG, "[%p] item %p[%u], reply received = %d, "
 			 "sns state = %d", ioo, req_item,
 			 req_item->ri_type->rit_opcode, rc, ioo->ioo_sns_state);
-
+	actual_bytes = rw_reply->rwr_count;
 	rc = gen_rep->gr_rc;
 	rc = rc ?: rw_reply->rwr_rc;
 	irfop->irf_reply_rc = rc;

--- a/motr/st/utils/motr_dgmode_io_st.sh
+++ b/motr/st/utils/motr_dgmode_io_st.sh
@@ -34,9 +34,9 @@ m0t1fs_dir="$motr_st_util_dir/../../../m0t1fs/linux_kernel/st"
 . $motr_st_util_dir/motr_local_conf.sh
 . $motr_st_util_dir/motr_st_inc.sh
 
-N=3
-K=3
-S=3
+N=6
+K=2
+S=0
 P=15
 stride=32
 BLOCKSIZE=""
@@ -69,8 +69,8 @@ main()
 	dest_file="$MOTR_TEST_DIR/motr_dest"
 	rc=0
 
-	BLOCKSIZE=4096
-	BLOCKCOUNT=25
+	BLOCKSIZE=16384 #4096
+	BLOCKCOUNT=3
 	echo "dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of=$src_file"
 	dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of=$src_file \
               2> $MOTR_TEST_LOGFILE || {

--- a/motr/st/utils/motr_st_inc.sh
+++ b/motr/st/utils/motr_st_inc.sh
@@ -229,7 +229,7 @@ io_conduct()
                           -p '$MOTR_PROF_OPT' -P '$MOTR_PROC_FID' \
                           -o $source"
 		cmd_exec="${motr_st_util_dir}/m0cat"
-		cmd_args="$cmd_args -s $BLOCKSIZE -c $BLOCKCOUNT"
+		cmd_args="$cmd_args -s $BLOCKSIZE -c $BLOCKCOUNT -L 3"
 
 		if [[ $verify == "true" ]]; then
 			cmd_args+=" -r"
@@ -241,7 +241,7 @@ io_conduct()
                           -p '$MOTR_PROF_OPT' -P '$MOTR_PROC_FID' \
                           -o $dest $source"
 		cmd_exec="${motr_st_util_dir}/m0cp"
-		cmd_args="$cmd_args -s $BLOCKSIZE -c $BLOCKCOUNT"
+		cmd_args="$cmd_args -s $BLOCKSIZE -c $BLOCKCOUNT -L 3"
 
 		if [ $verify == "true" ]
 		then

--- a/pool/pool.c
+++ b/pool/pool.c
@@ -726,7 +726,7 @@ static int _nodes_count(struct m0_conf_pver *pver, uint32_t *nodes)
 	 */
 	while ((rc = m0_conf_diter_next_sync(&it, obj_is_enclosurev)) ==
 		M0_CONF_DIRNEXT) {
-		/* We filter only controllerv objects. */
+		/* We filter only enclosurev objects. */
 		M0_CNT_INC(nr_nodes);
 	}
 


### PR DESCRIPTION
Degraded read for partially spanned parity groups is failing due to cobs are not created
and iofops are returning -ENOENT.

Updated the unit spanned logic to create cobs for all the units which are not spanned
by checking PA_WRITE flag, which was set during iomap creation.

Updated Dgmod ST with unit sizes larger than PAGE_SIZE, in which this case can be
reproduced.