### PR TITLE
Update Quick-Start-Guide.rst

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -12,8 +12,8 @@ The prerequisite that is necessary to install the Motr component is mentioned be
 
 - **Ansible** is needed::
 
-    sudo yum install epel-release # Install EPEL yum repo
-    sudo yum install ansible
+    sudo yum install -y epel-release # Install EPEL yum repo
+    sudo yum install -y ansible
 
 Get the Sources
 ===============


### PR DESCRIPTION
Add `-y` when installing `epel-release` and `ansible` using yum.

These two `yum install` commands are put together in the same code block. If users copy the two lines together and paste them in the shell, shell will ask this when installing `epel-release`:
```
Installing:
 epel-release                         noarch                         7-11                          extras                          15 k
Total download size: 15 k
Installed size: 24 k
Is this ok [y/d/N]:
```
And shell will automatically treat `sudo yum install ansible` as the answer to `Is this ok [y/d/N]`.

In this case, shell won't run `sudo yum install ansible` as a command, as it's treated as an answer to `Is this ok [y/d/N]`.

To avoid this problem, it's better if we add option `-y` when running `yum install`.

Signed-off-by: Meng Wang mengwanguc@gmail.com