### PR TITLE
Update Quick-Start-Guide.rst

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -117,7 +117,7 @@ Troubleshooting
 - If the pip installation fails while installing build dependencies,
   run the following commands::
 
-    python -m pip uninstall pip setuptools
+    sudo python -m pip uninstall pip setuptools
     sudo scripts/install-build-deps
 
 - If an installation failure occurs due to the dependency of ``pip3`` ,


### PR DESCRIPTION
need to be root user in order to run `python -m pip uninstall pip setuptools`. Otherwise will get permission errors.

Signed-off-by: Meng Wang mengwanguc@gmail.com