### PR TITLE
Update Quick-Start-Guide.rst

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -31,7 +31,7 @@ Build
 
 2. Check the Lustre network interface configuration::
 
-    vi /etc/modprobe.d/lnet.conf
+    sudo vi /etc/modprobe.d/lnet.conf
 
    Use ``ip a`` command to get a list of network interfaces.
    Then modify ``lnet.conf`` to use one of the listed network interfaces.
@@ -117,7 +117,7 @@ Troubleshooting
 - If the pip installation fails while installing build dependencies,
   run the following commands::
 
-    python -m pip uninstall pip setuptools
+    sudo python -m pip uninstall pip setuptools
     sudo scripts/install-build-deps
 
 - If an installation failure occurs due to the dependency of ``pip3`` ,


### PR DESCRIPTION
Need to be root user when modifying `/etc/modprobe.d/lnet.conf` and running `python -m pip uninstall pip setuptools`.
Otherwise permission errors will happen

Signed-off-by: Meng Wang <mengwanguc@gmail.com>