### PR TITLE
Fix btree-ut:multi_thread_single_tree_kv_op.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -6402,7 +6402,7 @@ static void btree_ut_kv_oper_thread_handler(struct btree_ut_thread_info *ti)
 			del_key = (r % 2 == 0) ?
 						del_key + ti->ti_key_incr :
 						del_key - ti->ti_key_incr;
-			keys_found_count--;
+			keys_put_count--;
 		}
 
 		key_iter_start = key_last + ti->ti_key_incr;

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -6222,9 +6222,13 @@ static void btree_ut_kv_oper_thread_handler(struct btree_ut_thread_info *ti)
 		key_first = key_iter_start;
 		if (ti->ti_random_bursts) {
 			random_r(&ti->ti_random_buf, &r);
-			key_last = (r % (key_end - key_first)) + key_first;
-			key_last = (key_last / ti->ti_key_incr) * ti->ti_key_incr
-				   + ti->ti_key_first;
+			if (key_first == key_end)
+				key_last = key_end;
+			else
+				key_last = (r % (key_end - key_first)) +
+					   key_first;
+			key_last = (key_last / ti->ti_key_incr) *
+				   ti->ti_key_incr + ti->ti_key_first;
 		} else
 			key_last = key_end;
 


### PR DESCRIPTION
- Fixed the ut to pass correct key for get_key operation.
- Modified assert to handle multi-thread sceanrio
- Modified key counts for delete operation

Signed-off-by: Nikhil Kumar Birgade <nikhil.birgade@seagate.com>