### PR TITLE
EOS-22127 fdmi/fol_fdmi_src: don't post fdmi record if src dock fom is not running

### DIFF
--- a/fdmi/source_dock_fom.c
+++ b/fdmi/source_dock_fom.c
@@ -196,6 +196,7 @@ m0_fdmi__src_dock_fom_start(struct m0_fdmi_src_dock *src_dock,
 	int                    rc;
 
 	M0_ENTRY();
+	M0_PRE(!src_dock->fsdc_started);
 
 	m0_semaphore_init(&sd_fom->fsf_shutdown, 0);
 	rpc_mach = m0_reqh_rpc_mach_tlist_head(&reqh->rh_rpc_machines);
@@ -224,6 +225,7 @@ m0_fdmi__src_dock_fom_start(struct m0_fdmi_src_dock *src_dock,
 	pending_fops_tlist_init(&sd_fom->fsf_pending_fops);
 	m0_fom_init(fom, &fdmi_sd_fom_type, &fdmi_sd_fom_ops, NULL, NULL, reqh);
 	m0_fom_queue(fom);
+	src_dock->fsdc_started = true;
 	return M0_RC(0);
 }
 
@@ -269,6 +271,8 @@ M0_INTERNAL void
 m0_fdmi__src_dock_fom_stop(struct m0_fdmi_src_dock *src_dock)
 {
 	M0_ENTRY();
+	M0_PRE(src_dock->fsdc_started);
+	src_dock->fsdc_started = false;
 
 	/* Wake up FOM, so it can stop itself */
 	m0_fdmi__src_dock_fom_wakeup(&src_dock->fsdc_sd_fom);

--- a/fdmi/ut/fol_ut.c
+++ b/fdmi/ut/fol_ut.c
@@ -192,6 +192,7 @@ static void fdmi_fol_test_ops(enum ffs_ut_test_op test_op)
 	/* get ops */
 	dock = m0_fdmi_src_dock_get();
 	M0_UT_ASSERT(dock != NULL);
+	dock->fsdc_started = true;
 	src_ctx = m0_fdmi__src_ctx_get(M0_FDMI_REC_TYPE_FOL);
 	M0_UT_ASSERT(src_ctx != NULL);
 	src_reg = &src_ctx->fsc_src;
@@ -354,6 +355,8 @@ static void fdmi_fol_test_ops(enum ffs_ut_test_op test_op)
 
 	/* system fini */
 	m0_be_ut_backend_fini(&ut_be);
+
+	dock->fsdc_started = false;
 
 	M0_LEAVE();
 }


### PR DESCRIPTION
There is a finalisation order bug that could be reproduced by adding
M0_IMPOSSIBLE() instead of return in this patch and then running

scripts/m0 run-ut -n 10000 -t m0d-ut:cs-single-service

The bug is about finalising FDMI src dock fom and then posting FDMI
record. There is no src dock fom running to consume the record at this
point, and BE tx reference is not released unless src dock fom releases
it. This leads to a situation when UT gets stuck (it will panic with
M0_IMPOSSIBLE and it just gets stuck without this patch).

The patch prints an M0_ERROR message and discards the record. It's not
the right way to handle FDMI records because they may get lost with this
approach, but it's the best short term fix.

The right fix would be to fix reqh service finalisation order in the way
that any code that may post FDMI record would be finalised before FDMI
service.

Signed-off-by: Maksym Medvied <maksym.medvied@seagate.com>