### PR TITLE
Update go/mio README.md

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -60,7 +60,7 @@ cd motr/bindings/go/mcp && go build && go install
 ```
 
 The binary will be installed to your `GOBIN` directory
-(check with `go env GOBIN`).
+(check with `go env GOBIN` or `echo $(go env GOPATH)/bin`).
 
 See the usage example at this discussion thread -
 https://github.com/Seagate/cortx-motr/discussions/285.


### PR DESCRIPTION
I'm using go 1.15.5 on CenOS 7.8.2003.
My `go env GOBIN` doesn't show any output.
My `go env GOPATH` points to `/home/cc/go` and I can find the `mcp` binary installed in `GOPATH/bin`.

Therefore update the README to help users locate their binary.

A similar issue was reported in #682

-----
[View rendered bindings/go/README.md](https://github.com/mengwanguc/cortx-motr/blob/patch-10/bindings/go/README.md)