### PR TITLE
EOS-21221: Fix deadlock at P_LOCKALL state.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3549,16 +3549,13 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 		if (!path_check(oi, tree, &bop->bo_rec.r_key.k_cookie)) {
 			oi->i_trial++;
 			if (oi->i_trial >= MAX_TRIALS) {
-				if (bop->bo_flags & BOF_LOCKALL) {
-					lock_op_unlock(bop->bo_arbor->t_desc);
-					return fail(bop, -ETOOMANYREFS);
-				} else {
-					bop->bo_flags |= BOF_LOCKALL;
-					lock_op_unlock(tree);
-					return m0_sm_op_sub(&bop->bo_op,
-							    P_CLEANUP,
-							    P_LOCKALL);
-				}
+				M0_ASSERT_INFO((bop->bo_flags & BOF_LOCKALL) ==
+					       0, "Put record failure in tree"
+					       "lock mode");
+				bop->bo_flags |= BOF_LOCKALL;
+				lock_op_unlock(tree);
+				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
+						    P_LOCKALL);
 			}
 			if (oi->i_height != tree->t_height) {
 				/* If height has changed. */
@@ -4201,16 +4198,13 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 		if (!path_check(oi, tree, &bop->bo_rec.r_key.k_cookie)) {
 			oi->i_trial++;
 			if (oi->i_trial >= MAX_TRIALS) {
-				if (bop->bo_flags & BOF_LOCKALL) {
-					lock_op_unlock(bop->bo_arbor->t_desc);
-					return fail(bop, -ETOOMANYREFS);
-				} else {
-					bop->bo_flags |= BOF_LOCKALL;
-					lock_op_unlock(tree);
-					return m0_sm_op_sub(&bop->bo_op,
-							    P_CLEANUP,
-							    P_LOCKALL);
-				}
+				M0_ASSERT_INFO((bop->bo_flags & BOF_LOCKALL) ==
+					       0, "Get record failure in tree"
+					       "lock mode");
+				bop->bo_flags |= BOF_LOCKALL;
+				lock_op_unlock(tree);
+				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
+						    P_LOCKALL);
 			}
 			if (oi->i_height != tree->t_height) {
 				/* If height has changed. */
@@ -4512,16 +4506,13 @@ int64_t btree_iter_kv_tick(struct m0_sm_op *smop)
 		    !sibling_node_check(oi)) {
 			oi->i_trial++;
 			if (oi->i_trial >= MAX_TRIALS) {
-				if (bop->bo_flags & BOF_LOCKALL) {
-					lock_op_unlock(tree);
-					return fail(bop, -ETOOMANYREFS);
-				} else {
-					bop->bo_flags |= BOF_LOCKALL;
-					lock_op_unlock(tree);
-					return m0_sm_op_sub(&bop->bo_op,
-							    P_CLEANUP,
-							    P_LOCKALL);
-				}
+				M0_ASSERT_INFO((bop->bo_flags & BOF_LOCKALL) ==
+					       0, "Iterator failure in tree"
+					       "lock mode");
+				bop->bo_flags |= BOF_LOCKALL;
+				lock_op_unlock(tree);
+				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
+						    P_LOCKALL);
 			}
 			if (oi->i_height != tree->t_height) {
 				lock_op_unlock(tree);
@@ -4921,16 +4912,13 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 		    !child_node_check(oi)) {
 			oi->i_trial++;
 			if (oi->i_trial >= MAX_TRIALS) {
-				if (bop->bo_flags & BOF_LOCKALL) {
-					lock_op_unlock(tree);
-					return fail(bop, -ETOOMANYREFS);
-				} else {
-					bop->bo_flags |= BOF_LOCKALL;
-					lock_op_unlock(tree);
-					return m0_sm_op_sub(&bop->bo_op,
-							    P_CLEANUP,
-							    P_LOCKALL);
-				}
+				M0_ASSERT_INFO((bop->bo_flags & BOF_LOCKALL) ==
+					       0, "Delete record failure in"
+					       "tree lock mode");
+				bop->bo_flags |= BOF_LOCKALL;
+				lock_op_unlock(tree);
+				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
+						    P_LOCKALL);
 			}
 			if (oi->i_height != tree->t_height) {
 				/* If height has changed. */

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -4492,13 +4492,11 @@ int64_t btree_iter_kv_tick(struct m0_sm_op *smop)
 				if (!node_isvalid(lev->l_node)) {
 					node_unlock(lev->l_node);
 					node_op_fini(&oi->i_nop);
-					bop->bo_flags |= BOF_LOCKALL;
 					return m0_sm_op_sub(&bop->bo_op,
 							    P_CLEANUP, P_SETUP);
 				}
 				if (lev->l_seq != lev->l_node->n_seq) {
 					node_unlock(lev->l_node);
-					bop->bo_flags |= BOF_LOCKALL;
 					return m0_sm_op_sub(&bop->bo_op,
 							    P_CLEANUP, P_SETUP);
 				}

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3448,8 +3448,11 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL)
+		if (oi->i_level == NULL) {
+			if (lock_acquired)
+				lock_op_unlock(tree);
 			return fail(bop, M0_ERR(-ENOMEM));
+		}
 		bop->bo_i->i_key_found = false;
 		/** Fall through to P_DOWN. */
 	case P_DOWN:
@@ -3577,7 +3580,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 				/* If height has changed. */
 				lock_op_unlock(tree);
 				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
-				                    P_SETUP);
+						    P_SETUP);
 			} else {
 				/* If height is same, put back all the nodes. */
 				lock_op_unlock(tree);
@@ -4152,8 +4155,11 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL)
+		if (oi->i_level == NULL) {
+			if (lock_acquired)
+				lock_op_unlock(tree);
 			return fail(bop, M0_ERR(-ENOMEM));
+		}
 		/** Fall through to P_DOWN. */
 	case P_DOWN:
 		oi->i_used = 0;
@@ -4344,8 +4350,11 @@ int64_t btree_iter_kv_tick(struct m0_sm_op *smop)
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL)
+		if (oi->i_level == NULL) {
+			if (lock_acquired)
+				lock_op_unlock(tree);
 			return fail(bop, M0_ERR(-ENOMEM));
+		}
 		/** Fall through to P_DOWN. */
 	case P_DOWN:
 		oi->i_used  = 0;
@@ -4871,8 +4880,11 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL)
+		if (oi->i_level == NULL) {
+			if (lock_acquired)
+				lock_op_unlock(tree);
 			return fail(bop, M0_ERR(-ENOMEM));
+		}
 		bop->bo_i->i_key_found = false;
 		/** Fall through to P_DOWN. */
 	case P_DOWN:

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3429,12 +3429,12 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 		if (cookie_is_valid(tree, &bop->bo_rec.r_key.k_cookie) &&
 		    !node_isoverflow(oi->i_cookie_node))
 			return P_LOCK;
-		/** Fall through if cookie is invalid or node overflow. */
+		else
+			return P_SETUP;
 	case P_LOCKALL:
-		if (bop->bo_flags & BOF_LOCKALL)
-			return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
-					    bop->bo_arbor->t_desc, P_SETUP);
-		/** Fall through if LOCKALL flag is not set. */
+		M0_ASSERT(bop->bo_flags & BOF_LOCKALL);
+		return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
+				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);
@@ -3664,7 +3664,7 @@ static struct m0_sm_state_descr btree_states[P_NR] = {
 	[P_COOKIE] = {
 		.sd_flags   = 0,
 		.sd_name    = "P_COOKIE",
-		.sd_allowed = M0_BITS(P_LOCK),
+		.sd_allowed = M0_BITS(P_LOCK, P_SETUP),
 	},
 	[P_SETUP] = {
 		.sd_flags   = 0,
@@ -3759,6 +3759,7 @@ static struct m0_sm_trans_descr btree_trans[] = {
 	{ "kvop-init-cookie", P_INIT, P_COOKIE },
 	{ "kvop-init", P_INIT, P_SETUP },
 	{ "kvop-cookie-valid", P_COOKIE, P_LOCK },
+	{ "kvop-cookie-invalid", P_COOKIE, P_SETUP },
 	{ "kvop-setup-failed", P_SETUP, P_CLEANUP },
 	{ "kvop-setup-down-fallthrough", P_SETUP, P_NEXTDOWN },
 	{ "kvop-lockall", P_LOCKALL, P_SETUP },
@@ -4118,12 +4119,12 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 	case P_COOKIE:
 		if (cookie_is_valid(tree, &bop->bo_rec.r_key.k_cookie))
 			return P_LOCK;
-		/** Fall through if cookie is invalid. */
+		else
+			return P_SETUP;
 	case P_LOCKALL:
-		if (bop->bo_flags & BOF_LOCKALL)
-			return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
-				            bop->bo_arbor->t_desc, P_SETUP);
-		/** Fall through if LOCKALL flag is not set. */
+		M0_ASSERT(bop->bo_flags & BOF_LOCKALL);
+		return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
+				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);
@@ -4302,12 +4303,12 @@ int64_t btree_iter_kv_tick(struct m0_sm_op *smop)
 	case P_COOKIE:
 		if (cookie_is_valid(tree, &bop->bo_rec.r_key.k_cookie))
 			return P_LOCK;
-		/** Fall through if cookie is valid. */
+		else
+			return P_SETUP;
 	case P_LOCKALL:
-		if (bop->bo_flags & BOF_LOCKALL)
-			return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
-				            bop->bo_arbor->t_desc, P_SETUP);
-		/** Fall through if LOCKALL flag is not set. */
+		M0_ASSERT(bop->bo_flags & BOF_LOCKALL);
+		return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
+				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);
@@ -4804,12 +4805,12 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 		if (cookie_is_valid(tree, &bop->bo_rec.r_key.k_cookie) &&
 		    !node_isunderflow(oi->i_cookie_node, true))
 			return P_LOCK;
-		/** Fall though if node is invalid or node underflow. */
+		else
+			return P_SETUP;
 	case P_LOCKALL:
-		if (bop->bo_flags & BOF_LOCKALL)
-			return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
-					    bop->bo_arbor->t_desc, P_SETUP);
-		/** Fall through if LOCKALL flag is not set. */
+		M0_ASSERT(bop->bo_flags & BOF_LOCKALL);
+		return lock_op_init(&bop->bo_op, &bop->bo_i->i_nop,
+				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
 		level_alloc(oi, oi->i_height);


### PR DESCRIPTION
Issue: A thread was waiting to take tree lock at P_LOCKALL. In the meantime
another thread took lock, inserted records and changed height of the tree.
When thread one took tree lock, it found height is changed and returned to next
state without unlocking the tree.
Fix: Changed the P_LOCKALL and P_SETUP order for lockall case.

Signed-off-by: Nikhil Kumar Birgade <nikhil.birgade@seagate.com>