### PR TITLE
go/mkv: add check for index fid format

### DIFF
--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -45,12 +45,19 @@ type Mkv struct {
     idx    *C.struct_m0_idx
 }
 
+func uint128_to_fid(u C.struct_m0_uint128) (f C.struct_m0_fid) {
+    f.f_container = u.u_hi
+    f.f_key       = u.u_lo
+    return f
+}
+
 func (mkv *Mkv) idxNew(id string) (err error) {
     mkv.idxID, err = ScanID(id)
     if err != nil {
         return err
     }
-    if (mkv.idxID.u_hi >> 56) != 0x78 {
+    fid := uint128_to_fid(mkv.idxID)
+    if C.m0_fid_tget(&fid) != C.m0_dix_fid_type.ft_id {
         return fmt.Errorf("index fid must start with 0x78 in MSByte" +
                           ", for example: 0x7800000000000123:0x...")
     }

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -45,7 +45,7 @@ type Mkv struct {
     idx    *C.struct_m0_idx
 }
 
-func uint128_to_fid(u C.struct_m0_uint128) (f C.struct_m0_fid) {
+func uint128fid(u C.struct_m0_uint128) (f C.struct_m0_fid) {
     f.f_container = u.u_hi
     f.f_key       = u.u_lo
     return f
@@ -56,7 +56,7 @@ func (mkv *Mkv) idxNew(id string) (err error) {
     if err != nil {
         return err
     }
-    fid := uint128_to_fid(mkv.idxID)
+    fid := uint128fid(mkv.idxID)
     if C.m0_fid_tget(&fid) != C.m0_dix_fid_type.ft_id {
         return fmt.Errorf("index fid must start with 0x%x in MSByte" +
                           ", for example: 0x%x00000000000123:0x...",

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -58,8 +58,9 @@ func (mkv *Mkv) idxNew(id string) (err error) {
     }
     fid := uint128_to_fid(mkv.idxID)
     if C.m0_fid_tget(&fid) != C.m0_dix_fid_type.ft_id {
-        return fmt.Errorf("index fid must start with 0x78 in MSByte" +
-                          ", for example: 0x7800000000000123:0x...")
+        return fmt.Errorf("index fid must start with 0x%x in MSByte" +
+                          ", for example: 0x%x00000000000123:0x...",
+                          C.m0_dix_fid_type.ft_id, C.m0_dix_fid_type.ft_id)
     }
     mkv.idx = (*C.struct_m0_idx)(C.calloc(1, C.sizeof_struct_m0_idx))
     return nil

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -50,6 +50,10 @@ func (mkv *Mkv) idxNew(id string) (err error) {
     if err != nil {
         return err
     }
+    if (mkv.idxID.u_hi >> 56) != 0x78 {
+        return fmt.Errorf("index fid must start with 0x78 in MSByte" +
+                          ", for example: 0x7800000000000123:0x...")
+    }
     mkv.idx = (*C.struct_m0_idx)(C.calloc(1, C.sizeof_struct_m0_idx))
     return nil
 }


### PR DESCRIPTION
Check index fid provided by user to make sure it starts with `0x78`.

This should help to avoid issues like https://github.com/Seagate/cortx-motr/issues/826.