### PR TITLE
Initial code for BE segment support in new btree.

### DIFF
--- a/be/alloc.h
+++ b/be/alloc.h
@@ -135,12 +135,12 @@ struct m0_be_allocator {
 	 * Entire segment except m0_be_seg_hdr is used as a memory
 	 * for allocations.
 	 */
-	struct m0_be_seg	      *ba_seg;
+	struct m0_be_seg              *ba_seg;
 	/**
 	 * Lock protects allocator lists and allocator chunks
 	 * (but not allocated memory).
 	 */
-	struct m0_mutex		       ba_lock;
+	struct m0_mutex                ba_lock;
 	/** Internal allocator data. It is stored inside the segment. */
 	struct m0_be_allocator_header *ba_h[M0_BAP_NR];
 };
@@ -319,8 +319,8 @@ M0_INTERNAL void m0_be_alloc_stats_capture(struct m0_be_allocator *a,
  * It is a wrapper around m0_be_alloc().
  * @see m0_be_alloc(), M0_ALLOC_ARR().
  */
-#define M0_BE_ALLOC_ARR(arr, nr, seg, tx, op)				\
-		m0_be_alloc(m0_be_seg_allocator(seg), (tx), (op),	\
+#define M0_BE_ALLOC_ARR(arr, nr, seg, tx, op)                           \
+		m0_be_alloc(m0_be_seg_allocator(seg), (tx), (op),       \
 			    (void **)&(arr), (nr) * sizeof((arr)[0]))
 
 /**
@@ -329,48 +329,69 @@ M0_INTERNAL void m0_be_alloc_stats_capture(struct m0_be_allocator *a,
  * It is a wrapper around m0_be_alloc().
  * @see m0_be_alloc(), M0_ALLOC_PTR(), M0_BE_ALLOC_ARR().
  */
-#define M0_BE_ALLOC_PTR(ptr, seg, tx, op)				\
+#define M0_BE_ALLOC_PTR(ptr, seg, tx, op)                               \
 		M0_BE_ALLOC_ARR((ptr), 1, (seg), (tx), (op))
 
-#define M0_BE_ALLOC_ARR_SYNC(arr, nr, seg, tx)				\
-		M0_BE_OP_SYNC(__op,					\
-			      M0_BE_ALLOC_ARR((arr), (nr), (seg), (tx), &__op))
+#define M0_BE_ALLOC_ARR_SYNC(arr, nr, seg, tx)                          \
+		M0_BE_OP_SYNC(__op,                                     \
+			      M0_BE_ALLOC_ARR((arr), (nr), (seg), (tx), \
+			      &__op))
 
-#define M0_BE_ALLOC_PTR_SYNC(ptr, seg, tx)				\
-		M0_BE_OP_SYNC(__op, M0_BE_ALLOC_PTR((ptr), (seg), (tx), &__op))
+#define M0_BE_ALLOC_PTR_SYNC(ptr, seg, tx)                              \
+		M0_BE_OP_SYNC(__op, M0_BE_ALLOC_PTR((ptr), (seg), (tx), \
+		&__op))
 
-#define M0_BE_FREE_PTR(ptr, seg, tx, op)				\
+#define M0_BE_FREE_PTR(ptr, seg, tx, op)                                \
 		m0_be_free(m0_be_seg_allocator(seg), (tx), (op), (ptr))
 
-#define M0_BE_FREE_PTR_SYNC(ptr, seg, tx)				\
-		M0_BE_OP_SYNC(__op, M0_BE_FREE_PTR((ptr), (seg), (tx), &__op))
+#define M0_BE_FREE_PTR_SYNC(ptr, seg, tx)                               \
+		M0_BE_OP_SYNC(__op,                                     \
+			      M0_BE_FREE_PTR((ptr), (seg), (tx), &__op))
 
-#define M0_BE_ALLOC_BUF(buf, seg, tx, op)				\
-		m0_be_alloc(m0_be_seg_allocator(seg), (tx), (op),	\
+#define M0_BE_ALLOC_BUF(buf, seg, tx, op)                               \
+		m0_be_alloc(m0_be_seg_allocator(seg), (tx), (op),       \
 			    &(buf)->b_addr, (buf)->b_nob)
 
-#define M0_BE_ALLOC_BUF_SYNC(buf, seg, tx)				\
-		M0_BE_OP_SYNC(__op, M0_BE_ALLOC_BUF((buf), (seg), (tx), &__op))
+#define M0_BE_ALLOC_ALIGN_BUF(buf, shift, seg, tx, op)                  \
+		m0_be_alloc_aligned(m0_be_seg_allocator(seg), (tx),     \
+				    (op), &(buf)->b_addr, (buf)->b_nob, \
+				    shift, M0_BITS(M0_BAP_NORMAL))
 
-#define M0_BE_ALLOC_CREDIT_PTR(ptr, seg, accum)				\
-		m0_be_allocator_credit(m0_be_seg_allocator(seg),	\
-				       M0_BAO_ALLOC, sizeof *(ptr), 0, (accum))
+#define M0_BE_ALLOC_BUF_SYNC(buf, seg, tx)                              \
+		M0_BE_OP_SYNC(__op, M0_BE_ALLOC_BUF((buf), (seg),       \
+						    (tx), &__op))
 
-#define M0_BE_FREE_CREDIT_PTR(ptr, seg, accum)				\
-		m0_be_allocator_credit(m0_be_seg_allocator(seg),	\
-				       M0_BAO_FREE, sizeof *(ptr), 0, (accum))
+#define M0_BE_ALLOC_ALIGN_BUF_SYNC(buf, shift, seg, tx)                 \
+		M0_BE_OP_SYNC(__op,                                     \
+			      M0_BE_ALLOC_ALIGN_BUF((buf), (shift),     \
+						    (seg), (tx), &__op))
 
-#define M0_BE_ALLOC_CREDIT_ARR(arr, nr, seg, accum)				\
-		m0_be_allocator_credit(m0_be_seg_allocator(seg),	\
-				       M0_BAO_ALLOC, (nr) * sizeof((arr)[0]), 0, (accum))
+#define M0_BE_ALLOC_CREDIT_PTR(ptr, seg, accum)                         \
+		m0_be_allocator_credit(m0_be_seg_allocator(seg),        \
+				       M0_BAO_ALLOC, sizeof *(ptr),     \
+				       0, (accum))
 
-#define M0_BE_FREE_CREDIT_ARR(arr, nr, seg, accum)				\
-		m0_be_allocator_credit(m0_be_seg_allocator(seg),	\
-				       M0_BAO_FREE, (nr) * sizeof((arr)[0]), 0, (accum))
+#define M0_BE_FREE_CREDIT_PTR(ptr, seg, accum)                          \
+		m0_be_allocator_credit(m0_be_seg_allocator(seg),        \
+				       M0_BAO_FREE, sizeof *(ptr),      \
+				       0, (accum))
 
-#define M0_BE_ALLOC_CREDIT_BUF(buf, seg, accum)				\
-		m0_be_allocator_credit(m0_be_seg_allocator(seg),	\
-				       M0_BAO_ALLOC, (buf)->b_nob, 0, (accum))
+#define M0_BE_ALLOC_CREDIT_ARR(arr, nr, seg, accum)                     \
+		m0_be_allocator_credit(m0_be_seg_allocator(seg),        \
+				       M0_BAO_ALLOC,                    \
+				       (nr) * sizeof((arr)[0]),         \
+				       0, (accum))
+
+#define M0_BE_FREE_CREDIT_ARR(arr, nr, seg, accum)                      \
+		m0_be_allocator_credit(m0_be_seg_allocator(seg),        \
+				       M0_BAO_FREE,                     \
+				       (nr) * sizeof((arr)[0]),         \
+				       0, (accum))
+
+#define M0_BE_ALLOC_CREDIT_BUF(buf, seg, accum)                         \
+		m0_be_allocator_credit(m0_be_seg_allocator(seg),        \
+				       M0_BAO_ALLOC, (buf)->b_nob, 0,   \
+				       (accum))
 
 
 /** @} end of be group */

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -560,12 +560,15 @@
 #include "lib/tlist.h"     /** m0_tl */
 #include "lib/time.h"      /** m0_time_t */
 
+#include "be/ut/helper.h"  /** m0_be_ut_backend_init() */
+
 #ifndef __KERNEL__
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
 #endif
 
+#define AVOID_BE_SEGMENT    1
 /**
  *  --------------------------------------------
  *  Section START - BTree Structure and Operations
@@ -621,6 +624,71 @@ enum {
 	MAX_TRIALS               = 3,
 	INTERNAL_NODE_VALUE_SIZE = sizeof(void *),
 };
+
+#define M0_BTREE_TX_CAPTURE(tx, seg, ptr, size)                              \
+			   m0_be_tx_capture(tx, &M0_BE_REG(seg, size, ptr))
+
+#if AVOID_BE_SEGMENT
+
+#undef M0_BTREE_TX_CAPTURE
+#define M0_BTREE_TX_CAPTURE(tx, seg, ptr, size)                              \
+	({                                                                   \
+		typeof(size) __size = (size);                                \
+		(tx) = (tx);                                                 \
+		(seg) = (seg);                                               \
+		(ptr) = (ptr);                                               \
+		(__size) = (__size);                                         \
+	})
+
+#undef M0_BE_ALLOC_ALIGN_BUF_SYNC
+#define M0_BE_ALLOC_ALIGN_BUF_SYNC(buf, shift, seg, tx)                      \
+		(buf)->b_addr = m0_alloc_aligned((buf)->b_nob, shift)
+
+#undef M0_BE_ALLOC_CREDIT_BUF
+#define M0_BE_ALLOC_CREDIT_BUF(buf, seg, cred)                               \
+	do { *(buf) = *(buf); (seg) = (seg); *(cred) = *(cred); } while (0)
+
+#define m0_be_ut_tx_init(tx, ut_be)                                          \
+	do { } while (0)
+
+#define m0_be_tx_init(tx,tid,dom,sm_group,persistent,discarded,filler,datum) \
+	do { } while (0)
+
+#define m0_be_tx_prep(tx,credit)                                             \
+	do { } while (0)
+
+#define m0_be_tx_open_sync(tx)  (0)
+
+#define m0_be_tx_open(tx)                                                    \
+	do { } while (0)
+
+#define m0_be_tx_capture(tx,req)                                             \
+	do { } while (0)
+
+#define m0_be_tx_close_sync(tx)                                              \
+	do { } while (0)
+
+#define m0_be_tx_close(tx)                                                   \
+	do { } while (0)
+
+#define m0_be_tx_fini(tx)                                                    \
+	do { } while (0)
+
+#define m0_be_ut_seg_reload(ut_seg)                                          \
+	do { } while (0)
+
+#define m0_be_ut_backend_init(ut_be)                                         \
+	do { } while (0)
+
+#define m0_be_ut_seg_init(ut_seg, ut_be, size)                               \
+	do { } while (0)
+
+#define m0_be_ut_seg_fini(ut_seg)                                            \
+	do { } while (0)
+
+#define m0_be_ut_backend_fini(ut_be)                                         \
+	do { } while (0)
+#endif
 
 #if 0
 static int fail(struct m0_btree_op *bop, int rc)
@@ -809,6 +877,7 @@ struct td {
 	struct nd                  *t_root;
 	int                         t_height;
 	int                         t_ref;
+	struct m0_be_seg           *t_seg; /** Segment hosting tree nodes. */
 
 	/**
 	 * Start time is basically used in tree close to calculate certain time-
@@ -858,10 +927,11 @@ struct node_type {
 
 	/** Initializes newly allocated node */
 	void (*nt_init)(const struct segaddr *addr, int shift, int ksize,
-			int vsize, uint32_t ntype, struct m0_be_tx *tx);
+			int vsize, uint32_t ntype, struct m0_be_seg *seg,
+			struct m0_be_tx *tx);
 
 	/** Cleanup of the node if any before deallocation */
-	void (*nt_fini)(const struct nd *node);
+	void (*nt_fini)(const struct nd *node, struct m0_be_tx *tx);
 
 	/** Returns count of keys in the node */
 	int  (*nt_count)(const struct nd *node);
@@ -922,7 +992,7 @@ struct node_type {
 	 *  Node changes related to last record have completed; any post
 	 *  processing related to the record needs to be done in this function.
 	 */
-	void (*nt_done) (struct slot *slot, struct m0_be_tx *tx, bool modified);
+	void (*nt_done)(struct slot *slot, struct m0_be_tx *tx, bool modified);
 
 	/** Makes space in the node for inserting new entry at specific index */
 	void (*nt_make) (struct slot *slot, struct m0_be_tx *tx);
@@ -962,11 +1032,15 @@ struct node_type {
 
 	/** Does minimal (or basic) validation */
 	bool (*nt_isvalid)(const struct segaddr *addr);
+
 	/** Saves opaque data. */
 	void (*nt_opaque_set)(const struct segaddr *addr, void *opaque);
 
 	/** Gets opaque data. */
 	void* (*nt_opaque_get)(const struct segaddr *addr);
+
+	/** Captures node data in segment */
+	void (*nt_capture)(struct slot *slot, struct m0_be_tx *tx);
 
 	/** Gets key size from segment. */
 	/* uint16_t (*nt_ksize_get)(const struct segaddr *addr); */
@@ -1088,8 +1162,10 @@ struct slot {
 
 static int64_t tree_get   (struct node_op *op, struct segaddr *addr, int nxt);
 #ifndef __KERNEL__
+#if 0
 static int64_t tree_create(struct node_op *op, struct m0_btree_type *tt,
 			   int rootshift, struct m0_be_tx *tx, int nxt);
+#endif
 static int64_t tree_delete(struct node_op *op, struct td *tree,
 			   struct m0_be_tx *tx, int nxt);
 #endif
@@ -1107,7 +1183,7 @@ static void       node_put  (struct node_op *op, struct nd *node,
 static struct nd *node_try  (struct td *tree, struct segaddr *addr);
 #endif
 
-static int64_t    node_alloc(struct node_op *op, struct td *tree, int size,
+static int64_t    node_alloc(struct node_op *op, struct td *tree, int shift,
 			     const struct node_type *nt, int ksize, int vsize,
 			     struct m0_be_tx *tx, int nxt);
 static int64_t    node_free(struct node_op *op, struct nd *node,
@@ -1117,7 +1193,8 @@ static void node_op_fini(struct node_op *op);
 #endif
 #ifndef __KERNEL__
 static void node_init(struct segaddr *addr, int ksize, int vsize,
-		      const struct node_type *nt, struct m0_be_tx *tx);
+		      const struct node_type *nt, struct m0_be_seg *seg,
+		      struct m0_be_tx *tx);
 #endif
 #if 0
 static bool node_verify(const struct nd *node);
@@ -1143,8 +1220,8 @@ static void node_key  (struct slot *slot);
 static void node_child(struct slot *slot, struct segaddr *addr);
 #endif
 static bool node_isfit(struct slot *slot);
-static void node_done (struct slot *slot, struct m0_be_tx *tx, bool modified);
-static void node_make (struct slot *slot, struct m0_be_tx *tx);
+static void node_done(struct slot *slot, struct m0_be_tx *tx, bool modified);
+static void node_make(struct slot *slot, struct m0_be_tx *tx);
 
 #ifndef __KERNEL__
 static bool node_find (struct slot *slot, const struct m0_btree_key *key);
@@ -1161,10 +1238,11 @@ static void node_refcnt_update(struct nd *node, bool increment);
 #ifndef __KERNEL__
 static void node_set_level  (const struct nd *node, uint8_t new_level,
 			     struct m0_be_tx *tx);
-static void node_move (struct nd *src, struct nd *tgt,
-		       enum dir dir, int nr, struct m0_be_tx *tx);
+static void node_move (struct nd *src, struct nd *tgt, enum dir dir, int nr,
+		       struct m0_be_tx *tx);
 #endif
 
+static void node_capture(struct slot *slot, struct m0_be_tx *tx);
 /**
  * Common node header.
  *
@@ -1287,9 +1365,11 @@ M0_TL_DESCR_DEFINE(ndlist, "node descr list", static, struct nd,
 M0_TL_DEFINE(ndlist, static, struct nd);
 
 static void node_init(struct segaddr *addr, int ksize, int vsize,
-		      const struct node_type *nt, struct m0_be_tx *tx)
+		      const struct node_type *nt, struct m0_be_seg *seg,
+		      struct m0_be_tx *tx)
 {
-	nt->nt_init(addr, segaddr_shift(addr), ksize, vsize, nt->nt_id, tx);
+	nt->nt_init(addr, segaddr_shift(addr), ksize, vsize, nt->nt_id, seg,
+		    tx);
 }
 
 static bool node_invariant(const struct nd *node)
@@ -1478,13 +1558,18 @@ static void node_set_level(const struct nd *node, uint8_t new_level,
 	node->n_type->nt_set_level(node, new_level, tx);
 }
 
-static void node_move(struct nd *src, struct nd *tgt,
-		      enum dir dir, int nr, struct m0_be_tx *tx)
+static void node_move(struct nd *src, struct nd *tgt, enum dir dir, int nr,
+		      struct m0_be_tx *tx)
 {
 	M0_PRE(node_invariant(src));
 	M0_PRE(node_invariant(tgt));
 	M0_IN(dir,(D_LEFT, D_RIGHT));
 	tgt->n_type->nt_move(src, tgt, dir, nr, tx);
+}
+
+static void node_capture(struct slot *slot, struct m0_be_tx *tx)
+{
+	slot->s_node->n_type->nt_capture(slot, tx);
 }
 
 static void node_lock(struct nd *node)
@@ -1696,10 +1781,12 @@ static void tree_type_unregister(const struct m0_btree_type *tt)
 struct seg_ops {
 	int64_t    (*so_tree_get)(struct node_op *op,
 			          struct segaddr *addr, int nxt);
+#if 0
 	int64_t    (*so_tree_create)(struct node_op *op,
 	                             struct m0_btree_type *tt,
 				     int rootshift, struct m0_be_tx *tx,
 				     int nxt);
+#endif
 	int64_t    (*so_tree_delete)(struct node_op *op, struct td *tree,
 				     struct m0_be_tx *tx, int nxt);
 	void       (*so_tree_put)(struct td *tree);
@@ -1734,6 +1821,7 @@ static int64_t tree_get(struct node_op *op, struct segaddr *addr, int nxt)
 
 #ifndef __KERNEL__
 
+#if 0
 /**
  * Creates a tree with an empty root node.
  *
@@ -1750,6 +1838,7 @@ static int64_t tree_create(struct node_op *op, struct m0_btree_type *tt,
 {
 	return segops->so_tree_create(op, tt, rootshift, tx, nxt);
 }
+#endif
 
 /**
  * Deletes an existing tree.
@@ -1942,7 +2031,7 @@ static void node_put(struct node_op *op, struct nd *node, struct m0_be_tx *tx)
 			m0_rwlock_fini(&node->n_lock);
 			op->no_addr = node->n_addr;
 			shift = node->n_type->nt_shift(node);
-			node->n_type->nt_fini(node);
+			node->n_type->nt_fini(node, tx);
 			m0_free(node);
 			m0_rwlock_write_unlock(&list_lock);
 			m0_free_aligned(segaddr_addr(&op->no_addr),
@@ -1967,7 +2056,7 @@ static struct nd *node_try(struct td *tree, struct segaddr *addr){
  *
  * @param op indicates node allocate operation.
  * @param tree points to the tree this node will be a part-of.
- * @param size is a power-of-2 size of this node.
+ * @param shift is a power-of-2 size of this node.
  * @param nt points to the node type
  * @param ksize is the size of key (if constant) if not this contains '0'.
  * @param vsize is the size of value (if constant) if not this contains '0'.
@@ -1976,25 +2065,28 @@ static struct nd *node_try(struct td *tree, struct segaddr *addr){
  *
  * @return int64_t
  */
-static int64_t node_alloc(struct node_op *op, struct td *tree, int size,
+static int64_t node_alloc(struct node_op *op, struct td *tree, int shift,
 			  const struct node_type *nt, int ksize, int vsize,
 			  struct m0_be_tx *tx, int nxt)
 {
 	int            nxt_state = nxt;
 	void          *area;
-	int            actual_size = 1ULL << size;
+	int            size = 1ULL << shift;
+	struct m0_buf  buf;
 
 	M0_PRE(op->no_opc == NOP_ALLOC);
-	M0_PRE(node_shift_is_valid(size));
+	M0_PRE(node_shift_is_valid(shift));
 
-	area = m0_alloc_aligned(actual_size, size);
+	buf = M0_BUF_INIT(size, NULL);
+	M0_BE_ALLOC_ALIGN_BUF_SYNC(&buf, shift, tree->t_seg, tx);
+	area = buf.b_addr;
 
 	M0_ASSERT(area != NULL);
 
-	op->no_addr = segaddr_build(area, size);
+	op->no_addr = segaddr_build(area, shift);
 	op->no_tree = tree;
 
-	node_init(&op->no_addr, ksize, vsize, nt, tx);
+	node_init(&op->no_addr, ksize, vsize, nt, tree->t_seg, tx);
 
 	nxt_state = node_get(op, tree, &op->no_addr, nxt_state);
 
@@ -2014,7 +2106,7 @@ static int64_t node_free(struct node_op *op, struct nd *node,
 		ndlist_tlink_del_fini(node);
 		m0_rwlock_fini(&node->n_lock);
 		op->no_addr = node->n_addr;
-		node->n_type->nt_fini(node);
+		node->n_type->nt_fini(node, tx);
 		m0_free(node);
 		m0_rwlock_write_unlock(&list_lock);
 		m0_free_aligned(segaddr_addr(&op->no_addr), 1ULL << shift,
@@ -2115,6 +2207,7 @@ static int64_t mem_tree_get(struct node_op *op, struct segaddr *addr, int nxt)
 	return nxt;
 }
 
+#if 0
 static int64_t mem_tree_create(struct node_op *op, struct m0_btree_type *tt,
 			       int rootshift, struct m0_be_tx *tx, int nxt)
 {
@@ -2128,7 +2221,7 @@ static int64_t mem_tree_create(struct node_op *op, struct m0_btree_type *tt,
 	tree_get(op, NULL, nxt);
 
 	tree = op->no_tree;
-	node_alloc(op, tree, rootshift, &fixed_format, 8, 8, NULL, nxt);
+	node_alloc(op, tree, rootshift, &fixed_format, 8, 8, tx, nxt);
 
 	m0_rwlock_write_lock(&tree->t_lock);
 	tree->t_root = op->no_node;
@@ -2137,6 +2230,7 @@ static int64_t mem_tree_create(struct node_op *op, struct m0_btree_type *tt,
 
 	return nxt;
 }
+#endif
 
 static int64_t mem_tree_delete(struct node_op *op, struct td *tree,
 			       struct m0_be_tx *tx, int nxt)
@@ -2180,7 +2274,7 @@ static void mem_tree_put(struct td *tree)
 
 static const struct seg_ops mem_seg_ops = {
 	.so_tree_get     = &mem_tree_get,
-	.so_tree_create  = &mem_tree_create,
+	/* .so_tree_create  = &mem_tree_create, */
 	.so_tree_delete  = &mem_tree_delete,
 	.so_tree_put     = &mem_tree_put,
 };
@@ -2216,8 +2310,8 @@ enum m0_be_bnode_format_version {
 };
 
 static void ff_init(const struct segaddr *addr, int shift, int ksize, int vsize,
-		    uint32_t ntype, struct m0_be_tx *tx);
-static void ff_fini(const struct nd *node);
+		    uint32_t ntype, struct m0_be_seg *seg, struct m0_be_tx *tx);
+static void ff_fini(const struct nd *node, struct m0_be_tx *tx);
 static int  ff_count(const struct nd *node);
 static int  ff_count_rec(const struct nd *node);
 static int  ff_space(const struct nd *node);
@@ -2247,6 +2341,7 @@ static bool ff_invariant(const struct nd *node);
 static bool ff_verify(const struct nd *node);
 static void ff_opaque_set(const struct segaddr *addr, void *opaque);
 static void *ff_opaque_get(const struct segaddr *addr);
+static void ff_capture(struct slot *slot, struct m0_be_tx *tx);
 /* uint16_t ff_ksize_get(const struct segaddr *addr); */
 /* uint16_t ff_valsize_get(const struct segaddr *addr);  */
 
@@ -2287,6 +2382,7 @@ static const struct node_type fixed_format = {
 	.nt_verify          = ff_verify,
 	.nt_opaque_set      = ff_opaque_set,
 	.nt_opaque_get      = ff_opaque_get,
+	.nt_capture         = ff_capture,
 	/* .nt_ksize_get    = ff_ksize_get, */
 	/* .nt_valsize_get  = ff_valsize_get, */
 };
@@ -2384,7 +2480,7 @@ static bool segaddr_header_isvalid(const struct segaddr *addr)
 }
 
 static void ff_init(const struct segaddr *addr, int shift, int ksize, int vsize,
-		    uint32_t ntype, struct m0_be_tx *tx)
+		    uint32_t ntype, struct m0_be_seg *seg, struct m0_be_tx *tx)
 {
 	struct ff_head *h   = segaddr_addr(addr);
 
@@ -2396,6 +2492,7 @@ static void ff_init(const struct segaddr *addr, int shift, int ksize, int vsize,
 	h->ff_ksize           = ksize;
 	h->ff_vsize           = vsize;
 	h->ff_seg.h_node_type = ntype;
+	h->ff_opaque          = NULL;
 
 	m0_format_header_pack(&h->ff_fmt, &(struct m0_format_tag){
 		.ot_version       = M0_BE_BNODE_FORMAT_VERSION,
@@ -2405,14 +2502,13 @@ static void ff_init(const struct segaddr *addr, int shift, int ksize, int vsize,
 	m0_format_footer_update(h);
 
 	/**
-	 * ToDo: We need to capture the changes occuring in the header using
-	 * m0_be_tx_capture().
-	 * Capture only those fields where there is any updation instead of the
-	 * whole header.
+	 * This is the only time we capture the opaque data of the header. No
+	 * other place should the opaque data get captured and written to BE
+	 * segment.
 	 */
 }
 
-static void ff_fini(const struct nd *node)
+static void ff_fini(const struct nd *node, struct m0_be_tx *tx)
 {
 	struct ff_head *h = ff_data(node);
 
@@ -2545,16 +2641,8 @@ static void ff_make(struct slot *slot, struct m0_be_tx *tx)
 	M0_PRE(ff_rec_is_valid(slot));
 	M0_PRE(ff_isfit(slot));
 	memmove(start + rsize, start, rsize * (h->ff_used - slot->s_idx));
-	/**
-	 * ToDo: We need to capture the changes occuring in the memory whose
-	 * address starts from "start + rsize" and has its respective size using
-	 * m0_be_tx_capture().
-	 */
 	h->ff_used++;
-	/**
-	 * ToDo: We need to capture the changes occuring in the header's ff_used
-	 * field using m0_be_tx_capture().
-	 */
+	/** Capture these changes in ff_capture.*/
 }
 
 static bool ff_find(struct slot *slot, const struct m0_btree_key *find_key)
@@ -2603,7 +2691,9 @@ static bool ff_find(struct slot *slot, const struct m0_btree_key *find_key)
 static void ff_fix(const struct nd *node, struct m0_be_tx *tx)
 {
 	struct ff_head *h = ff_data(node);
+
 	m0_format_footer_update(h);
+	/** Capture changes in ff_capture */
 }
 
 static void ff_cut(const struct nd *node, int idx, int size,
@@ -2614,23 +2704,15 @@ static void ff_cut(const struct nd *node, int idx, int size,
 
 static void ff_del(const struct nd *node, int idx, struct m0_be_tx *tx)
 {
-	struct ff_head *h     = ff_data(node);
-	int             rsize = h->ff_ksize + h->ff_vsize;
-	void           *start = ff_key(node, idx);
+	struct ff_head   *h     = ff_data(node);
+	int               rsize = h->ff_ksize + h->ff_vsize;
+	void             *start = ff_key(node, idx);
 
 	M0_PRE(idx < h->ff_used);
 	M0_PRE(h->ff_used > 0);
 	memmove(start, start + rsize, rsize * (h->ff_used - idx - 1));
-	/**
-	 * ToDo: We need to capture the changes occuring in the memory whose
-	 * address starts from "start" and has its respective size using
-	 * m0_be_tx_capture().
-	 */
 	h->ff_used--;
-	/**
-	 * ToDo: We need to capture the changes occuring in the header's ff_used
-	 * field using m0_be_tx_capture().
-	 */
+	/** Capture changes in ff_capture */
 }
 
 static void ff_set_level(const struct nd *node, uint8_t new_level,
@@ -2639,16 +2721,14 @@ static void ff_set_level(const struct nd *node, uint8_t new_level,
 	struct ff_head *h = ff_data(node);
 
 	h->ff_level = new_level;
-	/**
-	 * ToDo: We need to capture the changes occuring in the node-header's
-	 * ff_level field using m0_be_tx_capture().
-	 */
+	/** Capture these changes in ff_capture.*/
 }
 
 static void ff_opaque_set(const struct  segaddr *addr, void *opaque)
 {
 	struct ff_head *h = segaddr_addr(addr);
 	h->ff_opaque = opaque;
+	/** This change should NEVER be captured.*/
 }
 
 static void *ff_opaque_get(const struct segaddr *addr)
@@ -2738,19 +2818,34 @@ static void generic_move(struct nd *src, struct nd *tgt,
 	node_fix(src, tx);
 	node_seq_cnt_update(tgt);
 	node_fix(tgt, tx);
-
-	/**
-	 * ToDo: We need to capture the changes occuring in the "src" node
-	 * using m0_be_tx_capture().
-	 * Only the modified memory from the node needs to be updated.
-	 */
-
-	/**
-	 * ToDo: We need to capture the changes occuring in the "tgt" node
-	 * using m0_be_tx_capture().
-	 * Only the modified memory from the node needs to be updated.
-	 */
 }
+
+static void ff_capture(struct slot *slot, struct m0_be_tx *tx)
+{
+	struct ff_head   *h     = ff_data(slot->s_node);
+	int               rsize  = h->ff_ksize + h->ff_vsize;
+	void             *start = ff_key(slot->s_node, slot->s_idx);
+	struct m0_be_seg *seg   = slot->s_node->n_tree->t_seg;
+	m0_bcount_t       hsize = sizeof(*h) - sizeof(h->ff_opaque);
+ 
+	/**
+	 *  Capture starting from the location where new record may have been
+	 *  added or deleted. Capture till the last record. If the deleted
+	 *  record was at the end then no records need to be captured only the
+	 *  header modifications need to be persisted.
+	 */
+	if (h->ff_used > slot->s_idx)
+		M0_BTREE_TX_CAPTURE(tx, seg, start, rsize * (h->ff_used - slot->s_idx));
+	else if (h->ff_opaque == NULL)
+		/**
+		 *  This will happen when the node is initialized in which case
+		 *  we want to capture the opaque pointer.
+		 */
+		hsize += sizeof(h->ff_opaque);
+
+	M0_BTREE_TX_CAPTURE(tx, seg, h, hsize);
+}
+
 #define COPY_RECORD(tgt, src)                                                  \
 	({                                                                     \
 		struct m0_btree_rec *__tgt_rec = (tgt);                        \
@@ -2987,8 +3082,7 @@ static int64_t btree_put_root_split_handle(struct m0_btree_op *bop,
 	node_set_level(oi->i_extra_node, curr_max_level, bop->bo_tx);
 	node_set_level(lev->l_node, curr_max_level + 1, bop->bo_tx);
 
-	node_move(lev->l_node, oi->i_extra_node, D_RIGHT, NR_MAX,
-		  bop->bo_tx);
+	node_move(lev->l_node, oi->i_extra_node, D_RIGHT, NR_MAX, bop->bo_tx);
 	M0_ASSERT(node_count_rec(lev->l_node) == 0);
 	oi->i_extra_node->n_skip_rec_count_check = false;
 
@@ -3061,8 +3155,8 @@ static int64_t btree_put_root_split_handle(struct m0_btree_op *bop,
  */
 static void btree_put_split_and_find(struct nd *allocated_node,
 				     struct nd *current_node,
-				     struct m0_btree_rec *rec,
-				     struct slot *tgt, struct m0_be_tx *tx)
+				     struct m0_btree_rec *rec, struct slot *tgt,
+				     struct m0_be_seg *seg, struct m0_be_tx *tx)
 {
 	struct slot              right_slot;
 	struct slot              left_slot;
@@ -3160,8 +3254,8 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 	node_lock(lev->l_alloc);
 	node_lock(lev->l_node);
 
-	btree_put_split_and_find(lev->l_alloc, lev->l_node,
-				 &bop->bo_rec, &tgt, bop->bo_tx);
+	btree_put_split_and_find(lev->l_alloc, lev->l_node, &bop->bo_rec, &tgt,
+				 bop->bo_seg, bop->bo_tx);
 	tgt.s_rec = bop->bo_rec;
 	node_make (&tgt, bop->bo_tx);
 	tgt.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
@@ -3233,7 +3327,7 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 		node_lock(lev->l_node);
 
 		btree_put_split_and_find(lev->l_alloc, lev->l_node, &new_rec,
-					 &tgt, bop->bo_tx);
+					 &tgt, bop->bo_seg, bop->bo_tx);
 		tgt.s_rec = new_rec;
 		node_make(&tgt, bop->bo_tx);
 		tgt.s_rec = REC_INIT(&p_key_1, &ksize_1, &p_val_1, &vsize_1);
@@ -3275,7 +3369,6 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 	struct m0_btree_oimpl *oi             = bop->bo_i;
 	bool                   lock_acquired  = bop->bo_flags & BOF_LOCKALL;
 	struct level          *lev;
-
 
 	switch (bop->bo_op.o_sm.sm_state) {
 	case P_INIT:
@@ -3818,14 +3911,15 @@ int64_t btree_create_tree_tick(struct m0_sm_op *smop)
 
 		oi->i_nop.no_addr = segaddr_build(data->addr, calc_shift(data->
 							      num_bytes));
-		node_init(&oi->i_nop.no_addr, k_size, v_size, data->nt,
-			  bop->bo_tx);
+		node_init(&oi->i_nop.no_addr, k_size, v_size,
+			  data->nt, bop->bo_seg, bop->bo_tx);
 
 		return tree_get(&oi->i_nop, &oi->i_nop.no_addr, P_ACT);
 
 	case P_ACT:
 		oi->i_nop.no_node->n_type = data->nt;
 		oi->i_nop.no_tree->t_type = data->bt;
+		oi->i_nop.no_tree->t_seg  = bop->bo_seg;
 
 		bop->bo_arbor->t_desc           = oi->i_nop.no_tree;
 		bop->bo_arbor->t_type           = data->bt;
@@ -5115,21 +5209,25 @@ void m0_btree_close(struct m0_btree *arbor, struct m0_btree_op *bop)
 
 void m0_btree_create(void *addr, int nob, const struct m0_btree_type *bt,
 		     const struct node_type *nt, struct m0_btree_op *bop,
-		     struct m0_be_tx *tx)
+		     struct m0_be_seg *seg, struct m0_be_tx *tx)
 {
 	bop->b_data.addr        = addr;
 	bop->b_data.num_bytes   = nob;
 	bop->b_data.bt          = bt;
 	bop->b_data.nt          = nt;
+	bop->bo_tx              = tx;
+	bop->bo_seg             = seg;
 
 	m0_sm_op_init(&bop->bo_op, &btree_create_tree_tick, &bop->bo_op_exec,
 		      &btree_conf, &bop->bo_sm_group);
 }
 
-void m0_btree_destroy(struct m0_btree *arbor, struct m0_btree_op *bop)
+void m0_btree_destroy(struct m0_btree *arbor, struct m0_btree_op *bop,
+		      struct m0_be_tx *tx)
 {
-	bop->bo_arbor   = arbor;
-	bop->bo_tx      = NULL;
+	bop->bo_arbor = arbor;
+	bop->bo_tx    = tx;
+	bop->bo_seg   = arbor->t_desc->t_seg;
 
 	m0_sm_op_init(&bop->bo_op, &btree_destroy_tree_tick, &bop->bo_op_exec,
 		      &btree_conf, &bop->bo_sm_group);
@@ -5139,12 +5237,14 @@ void m0_btree_get(struct m0_btree *arbor, const struct m0_btree_key *key,
 		  const struct m0_btree_cb *cb, uint64_t flags,
 		  struct m0_btree_op *bop)
 {
-	bop->bo_opc = M0_BO_GET;
-	bop->bo_arbor = arbor;
+	bop->bo_opc       = M0_BO_GET;
+	bop->bo_arbor     = arbor;
 	bop->bo_rec.r_key = *key;
-	bop->bo_flags = flags;
-	bop->bo_cb = *cb;
-	bop->bo_i = NULL;
+	bop->bo_flags     = flags;
+	bop->bo_cb        = *cb;
+	bop->bo_tx        = NULL;
+	bop->bo_seg       = NULL;
+	bop->bo_i         = NULL;
 	m0_sm_op_init(&bop->bo_op, &btree_get_kv_tick, &bop->bo_op_exec,
 		      &btree_conf, &bop->bo_sm_group);
 }
@@ -5155,12 +5255,14 @@ void m0_btree_iter(struct m0_btree *arbor, const struct m0_btree_key *key,
 {
 	M0_PRE(flags & BOF_NEXT || flags & BOF_PREV);
 
-	bop->bo_opc = M0_BO_ITER;
-	bop->bo_arbor = arbor;
+	bop->bo_opc       = M0_BO_ITER;
+	bop->bo_arbor     = arbor;
 	bop->bo_rec.r_key = *key;
-	bop->bo_flags = flags;
-	bop->bo_cb = *cb;
-	bop->bo_i = NULL;
+	bop->bo_flags     = flags;
+	bop->bo_cb        = *cb;
+	bop->bo_tx        = NULL;
+	bop->bo_seg       = NULL;
+	bop->bo_i         = NULL;
 	m0_sm_op_init(&bop->bo_op, &btree_iter_kv_tick, &bop->bo_op_exec,
 		      &btree_conf, &bop->bo_sm_group);
 }
@@ -5175,6 +5277,7 @@ void m0_btree_put(struct m0_btree *arbor, const struct m0_btree_rec *rec,
 	bop->bo_cb     = *cb;
 	bop->bo_tx     = tx;
 	bop->bo_flags  = flags;
+	bop->bo_seg    = arbor->t_desc->t_seg;
 	bop->bo_i      = NULL;
 
 	m0_sm_op_init(&bop->bo_op, &btree_put_kv_tick, &bop->bo_op_exec,
@@ -5191,6 +5294,7 @@ void m0_btree_del(struct m0_btree *arbor, const struct m0_btree_key *key,
 	bop->bo_cb        = *cb;
 	bop->bo_tx        = tx;
 	bop->bo_flags     = flags;
+	bop->bo_seg       = arbor->t_desc->t_seg;
 	bop->bo_i         = NULL;
 
 	m0_sm_op_init(&bop->bo_op, &btree_del_kv_tick, &bop->bo_op_exec,
@@ -5213,37 +5317,11 @@ void m0_btree_del(struct m0_btree *arbor, const struct m0_btree_key *key,
  * is not intuitive or maintainable.
  */
 
-#define m0_be_tx_init(tx,tid,dom,sm_group,persistent,discarded,filler,datum) \
-	do {                                                                 \
-	                                                                     \
-	} while (0)
+static struct m0_be_ut_backend *ut_be;
+static struct m0_be_ut_seg     *ut_seg;
+static struct m0_be_seg        *seg;
+static bool                     btree_ut_initialised = false;
 
-#define m0_be_tx_prep(tx,credit)                                             \
-	do {                                                                 \
-                                                                             \
-	} while (0)
-
-#define m0_be_tx_open(tx)                                                    \
-	do {                                                                 \
-                                                                             \
-	} while (0)
-
-#define m0_be_tx_capture(tx,req)                                             \
-	do {                                                                 \
-                                                                             \
-	} while (0)
-
-#define m0_be_tx_close(tx)                                                   \
-	do {                                                                 \
-                                                                             \
-	} while (0)
-
-#define m0_be_tx_fini(tx)                                                    \
-	do {                                                                 \
-                                                                             \
-	} while (0)
-
-static bool btree_ut_initialised = false;
 static void btree_ut_init(void)
 {
 	if (!btree_ut_initialised) {
@@ -5269,7 +5347,7 @@ static void ut_node_create_delete(void)
 	struct node_op          op;
 	struct node_op          op1;
 	struct node_op          op2;
-	struct m0_btree_type    tt;
+	/* struct m0_btree_type    tt; */
 	struct td              *tree;
 	struct td              *tree_clone;
 	struct nd              *node1;
@@ -5286,7 +5364,7 @@ static void ut_node_create_delete(void)
 
 	// Create a Fixed-Format tree.
 	op.no_opc = NOP_ALLOC;
-	tree_create(&op, &tt, 10, NULL, 0);
+	/* tree_create(&op, &tt, 10, NULL, 0); */
 
 	tree = op.no_tree;
 
@@ -5341,6 +5419,7 @@ static bool add_rec(struct nd *node,
 	void                *p_key;
 	m0_bcount_t          vsize;
 	void                *p_val;
+	struct m0_be_tx     *tx = NULL;
 
 	/**
 	 * To add a record if space is available in the node to hold a new
@@ -5382,6 +5461,7 @@ static bool add_rec(struct nd *node,
 	*((uint64_t *)p_key) = key;
 	*((uint64_t *)p_val) = val;
 
+	node_capture(&slot, tx);
 	return true;
 }
 
@@ -5494,7 +5574,7 @@ static void ut_node_add_del_rec(void)
 {
 	struct node_op          op;
 	struct node_op          op1;
-	struct m0_btree_type    tt;
+	/* struct m0_btree_type    tt; */
 	struct td              *tree;
 	struct nd              *node1;
 	const struct node_type *nt      = &fixed_format;
@@ -5508,7 +5588,7 @@ static void ut_node_add_del_rec(void)
 	M0_ENTRY();
 
 	time(&curr_time);
-	printf("\nUsing seed %lu", curr_time);
+	M0_LOG(M0_INFO, "Using seed %lu", curr_time);
 	srand(curr_time);
 
 	run_loop = 50000;
@@ -5518,7 +5598,7 @@ static void ut_node_add_del_rec(void)
 	M0_SET0(&op);
 
 	op.no_opc = NOP_ALLOC;
-	tree_create(&op, &tt, 10, NULL, 0);
+	/* tree_create(&op, &tt, 10, NULL, 0); */
 
 	tree = op.no_tree;
 
@@ -5555,7 +5635,6 @@ static void ut_node_add_del_rec(void)
 		}
 	}
 
-	printf("\n");
 	op1.no_opc = NOP_FREE;
 	node_free(&op1, node1, NULL, 0);
 
@@ -5580,8 +5659,9 @@ static void ut_basic_tree_oper(void)
 	struct m0_btree_type    btree_type = {  .tt_id = M0_BT_UT_KV_OPS,
 						.ksize = 8,
 						.vsize = 8, };
-	struct m0_be_tx        *tx = NULL;
-	struct m0_btree_op      b_op = {};
+	struct m0_be_tx        *tx         = NULL;
+	struct m0_be_seg       *seg        = NULL;
+	struct m0_btree_op      b_op       = {};
 	void                   *temp_node;
 	const struct node_type *nt = &fixed_format;
 	int                     rc;
@@ -5604,7 +5684,7 @@ static void ut_basic_tree_oper(void)
 	btree = m0_alloc(sizeof *btree);
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_create(temp_node, 1024,
 							     &btree_type, nt,
-							     &b_op, tx));
+							     &b_op, seg, tx));
 	M0_ASSERT(rc == 0);
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(b_op.bo_arbor,
@@ -5622,7 +5702,7 @@ static void ut_basic_tree_oper(void)
 	if (b_op.bo_arbor->t_desc->t_ref > 0) {
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					      m0_btree_destroy(b_op.bo_arbor,
-							       &b_op));
+							       &b_op, tx));
 		M0_ASSERT(rc == 0);
 	}
 	m0_free_aligned(temp_node, (1024 + sizeof(struct nd)), 10);
@@ -5659,7 +5739,7 @@ static void ut_basic_tree_oper(void)
 	temp_node = m0_alloc_aligned((1024 + sizeof(struct nd)), 10);
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_create(temp_node, 1024,
 							     &btree_type, nt,
-							     &b_op, tx));
+							     &b_op, seg, tx));
 	M0_ASSERT(rc == 0);
 	/** Close it */
 	/**
@@ -5699,7 +5779,7 @@ static void ut_basic_tree_oper(void)
 	if (b_op.bo_arbor->t_desc->t_ref > 0) {
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					      m0_btree_destroy(b_op.bo_arbor,
-							       &b_op));
+							       &b_op, tx));
 		M0_ASSERT(rc == 0);
 	}
 	m0_free_aligned(temp_node, (1024 + sizeof(struct nd)), 10);
@@ -5837,6 +5917,7 @@ static void ut_basic_kv_oper(void)
 					      .ksize = 8,
 					      .vsize = 8, };
 	struct m0_be_tx        *tx          = NULL;
+	struct m0_be_seg       *seg         = NULL;
 	struct m0_btree_op      b_op        = {};
 	struct m0_btree        *tree;
 	void                   *temp_node;
@@ -5851,7 +5932,7 @@ static void ut_basic_kv_oper(void)
 	M0_ENTRY();
 
 	time(&curr_time);
-	printf("\nUsing seed %lu", curr_time);
+	M0_LOG(M0_INFO, "Using seed %lu", curr_time);
 	srandom(curr_time);
 
 	/** Prepare transaction to capture tree operations. */
@@ -5872,7 +5953,7 @@ static void ut_basic_kv_oper(void)
 	temp_node = m0_alloc_aligned((1024 + sizeof(struct nd)), 10);
 	M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_create(temp_node, 1024,
 							&btree_type, nt,
-							&b_op, tx));
+							&b_op, seg, tx));
 
 	tree = b_op.bo_arbor;
 
@@ -5962,13 +6043,14 @@ static void ut_basic_kv_oper(void)
 
 	if (b_op.bo_arbor->t_desc->t_ref > 0) {
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
-					      m0_btree_destroy(tree, &b_op));
+					      m0_btree_destroy(tree, &b_op,
+							       tx));
 		M0_ASSERT(rc == 0);
 	}
 	btree_ut_fini();
 }
 
-
+#if (AVOID_BE_SEGMENT == 1)
 enum {
 	MIN_STREAM_CNT         = 5,
 	MAX_STREAM_CNT         = 20,
@@ -5982,7 +6064,21 @@ enum {
 	MAX_TREE_LOOPS         = 15000,
 	MAX_RECS_FOR_TREE_TEST = 100,
 };
+#else
+enum {
+	MIN_STREAM_CNT         = 5,
+	MAX_STREAM_CNT         = 10,
 
+	MIN_RECS_PER_STREAM    = 5,
+	MAX_RECS_PER_STREAM    = 512,
+
+	MAX_RECS_PER_THREAD    = 100000, /** Records count for each thread */
+
+	MIN_TREE_LOOPS         = 5000,
+	MAX_TREE_LOOPS         = 15000,
+	MAX_RECS_FOR_TREE_TEST = 100,
+};
+#endif
 
 /**
  * This unit test exercises the KV operations triggered by multiple streams.
@@ -5993,6 +6089,7 @@ static void ut_multi_stream_kv_oper(void)
 	int                     i;
 	time_t                  curr_time;
 	struct m0_btree_cb      ut_cb;
+	struct m0_be_tx_credit  cred;
 	struct m0_be_tx        *tx              = NULL;
 	struct m0_btree_op      b_op            = {};
 	uint32_t                stream_count    = 0;
@@ -6005,10 +6102,11 @@ static void ut_multi_stream_kv_oper(void)
 						  .vsize = btree_type.ksize*2,
 						  };
 	int                     rc;
+	struct m0_buf           buf;
 	M0_ENTRY();
 
 	time(&curr_time);
-	printf("\nUsing seed %lu", curr_time);
+	M0_LOG(M0_INFO, "Using seed %lu", curr_time);
 	srandom(curr_time);
 
 	stream_count = (random() % (MAX_STREAM_CNT - MIN_STREAM_CNT)) +
@@ -6018,9 +6116,6 @@ static void ut_multi_stream_kv_oper(void)
 			   (MAX_RECS_PER_STREAM - MIN_RECS_PER_STREAM)) +
 			    MIN_RECS_PER_STREAM;
 
-	/** Prepare transaction to capture tree operations. */
-	m0_be_tx_init(tx, 0, NULL, NULL, NULL, NULL, NULL, NULL);
-	m0_be_tx_prep(tx, NULL);
 	btree_ut_init();
 	/**
 	 *  Run valid scenario:
@@ -6030,14 +6125,36 @@ static void ut_multi_stream_kv_oper(void)
 	 *  4) Deletes all the records from the tree using multiple streams.
 	 *  5) Close the btree
 	 *  6) Destroy the btree
+	 *
+	 *  Capture each operation in a separate transaction.
 	 */
 
+	/** TBD - Replace the following line to call the credit calculator. */
+	cred = M0_BE_TX_CREDIT(20, 5 * (1 << 10));
+	buf = M0_BUF_INIT((1 << 10), NULL);
+	M0_BE_ALLOC_CREDIT_BUF(&buf, seg, &cred);
+
+	/** Allocate and prepare transaction to capture tree operations. */
+	M0_ALLOC_PTR(tx);
+	M0_ASSERT(tx != NULL);
+	m0_be_ut_tx_init(tx, ut_be);
+	m0_be_tx_prep(tx, &cred);
+	rc = m0_be_tx_open_sync(tx);
+	M0_ASSERT(rc == 0);
+
 	/** Create temp node space and use it as root node for btree */
-	temp_node = m0_alloc_aligned((1024 + sizeof(struct nd)), 10);
+	M0_BE_ALLOC_ALIGN_BUF_SYNC(&buf, 10, seg, tx);
+	temp_node = buf.b_addr;
 	M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_create(temp_node, 1024,
 							&btree_type, nt,
-							&b_op, tx));
+							&b_op, seg, tx));
+	m0_be_tx_close_sync(tx);
+	m0_be_tx_fini(tx);
+
 	tree = b_op.bo_arbor;
+
+	/** Dummy credit calculation for PUT operation. Replace when possible.*/
+	cred = M0_BE_TX_CREDIT(100, 200 * 1024);
 
 	for (i = 1; i <= recs_per_stream; i++) {
 		uint64_t             key;
@@ -6068,12 +6185,25 @@ static void ut_multi_stream_kv_oper(void)
 			ut_cb.c_act        = btree_kv_put_cb;
 			ut_cb.c_datum      = &put_data;
 
+			m0_be_ut_tx_init(tx, ut_be);
+			m0_be_tx_prep(tx, &cred);
+			rc = m0_be_tx_open_sync(tx);
+			M0_ASSERT(rc == 0);
+
 			M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
 						 m0_btree_put(tree, &rec,
 							      &ut_cb, 0,
 							      &kv_op, tx));
+			m0_be_tx_close_sync(tx);
+			m0_be_tx_fini(tx);
 		}
 	}
+
+	/**
+	 *  Close and Reopen the BE segment and confirm if the records are still
+	 *  present.
+	 */
+	m0_be_ut_seg_reload(ut_seg);
 
 	for (i = 1; i <= (recs_per_stream*stream_count); i++) {
 		uint64_t             key;
@@ -6111,21 +6241,24 @@ static void ut_multi_stream_kv_oper(void)
 						      &kv_op));
 	}
 
+	/** Dummy credit calculation for DEL operation. Replace when possible.*/
+	cred = M0_BE_TX_CREDIT(20, 100 * 1024);
+
 	for (i = 1; i <= recs_per_stream; i++) {
-		uint64_t             del_key;
-		struct m0_btree_key  del_key_in_tree;
-		void                *p_del_key    = &del_key;
-		m0_bcount_t          del_key_size = sizeof del_key;
-		struct cb_data       del_data;
-		uint32_t             stream_num;
+		uint64_t            del_key;
+		struct m0_btree_key del_key_in_tree;
+		void                *p_del_key      = &del_key;
+		m0_bcount_t         del_key_size    = sizeof del_key;
+		struct cb_data      del_data;
+		uint32_t            stream_num;
 
-		del_data = (struct cb_data) { .key = &del_key_in_tree,
-						 .value = NULL,
-						 .check_value = false,
-						};
+		del_data = (struct cb_data){.key = &del_key_in_tree,
+			.value = NULL,
+			.check_value = false,
+		};
 
-		del_key_in_tree.k_data =
-				M0_BUFVEC_INIT_BUF(&p_del_key, &del_key_size);
+		del_key_in_tree.k_data = M0_BUFVEC_INIT_BUF(&p_del_key,
+							    &del_key_size);
 
 		ut_cb.c_act   = btree_kv_del_cb;
 		ut_cb.c_datum = &del_data;
@@ -6134,11 +6267,18 @@ static void ut_multi_stream_kv_oper(void)
 			del_key = i + (stream_num * recs_per_stream);
 			del_key = m0_byteorder_cpu_to_be64(del_key);
 
+			m0_be_ut_tx_init(tx, ut_be);
+			m0_be_tx_prep(tx, &cred);
+			rc = m0_be_tx_open_sync(tx);
+			M0_ASSERT(rc == 0);
+
 			M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
 						 m0_btree_del(tree,
 							      &del_key_in_tree,
 							      &ut_cb, 0,
 							      &kv_op, tx));
+			m0_be_tx_close_sync(tx);
+			m0_be_tx_fini(tx);
 		}
 	}
 
@@ -6146,11 +6286,27 @@ static void ut_multi_stream_kv_oper(void)
 	M0_ASSERT(rc == 0);
 
 	if (b_op.bo_arbor->t_desc->t_ref > 0) {
-		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
-					      m0_btree_destroy(tree, &b_op));
+		/** TBD - Replace the following line to call the credit
+		 *  calculator. */
+		cred = M0_BE_TX_CREDIT(20, 5 * (1 << 10));
+		buf = M0_BUF_INIT((1 << 10), NULL);
+		M0_BE_ALLOC_CREDIT_BUF(&buf, seg, &cred);
+
+		m0_be_ut_tx_init(tx, ut_be);
+		m0_be_tx_prep(tx, &cred);
+		rc = m0_be_tx_open_sync(tx);
 		M0_ASSERT(rc == 0);
+
+		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					      m0_btree_destroy(tree, &b_op,
+							       tx));
+		M0_ASSERT(rc == 0);
+
+		m0_be_tx_close_sync(tx);
+		m0_be_tx_fini(tx);
 	}
 
+	m0_free0(&tx);
 	btree_ut_fini();
 }
 
@@ -6543,12 +6699,13 @@ static void btree_ut_num_threads_num_trees_kv_oper(uint32_t thread_count,
 	void                         *temp_node;
 	struct m0_btree_op            b_op         = {};
 	struct m0_be_tx              *tx           = NULL;
+	struct m0_be_seg             *seg          = NULL;
 	const struct node_type       *nt           = &fixed_format;
 	const uint32_t                ksize_to_use = sizeof(uint64_t);
 	struct m0_btree_type          btree_type   = {.tt_id = M0_BT_UT_KV_OPS,
-				         	     .ksize = ksize_to_use,
-				         	     .vsize = ksize_to_use*2,
-				         	    };
+						      .ksize = ksize_to_use,
+						      .vsize = ksize_to_use*2,
+						     };
 	uint16_t                     *cpuid_ptr;
 	uint16_t                      cpu_count;
 	size_t                        cpu_max;
@@ -6598,7 +6755,7 @@ static void btree_ut_num_threads_num_trees_kv_oper(uint32_t thread_count,
 		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					 m0_btree_create(temp_node, 1024,
 							 &btree_type, nt, &b_op,
-							 tx));
+							 seg, tx));
 
 		ut_trees[i] = b_op.bo_arbor;
 	}
@@ -6741,6 +6898,7 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 					     };
 	const struct node_type *nt         = &fixed_format;
 	struct m0_be_tx        *tx         = NULL;
+	struct m0_be_seg       *seg        = NULL;
 	int                     rc;
 
 	random_r(&ti->ti_random_buf, &loop_count);
@@ -6775,7 +6933,7 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					      m0_btree_create(temp_node, 1024,
 							      &btree_type, nt,
-							      &b_op, tx));
+							      &b_op, seg, tx));
 		M0_ASSERT(rc == 0);
 
 		tree = b_op.bo_arbor;
@@ -6847,7 +7005,8 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 		if (b_op.bo_arbor->t_desc->t_ref > 0) {
 			rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 						      m0_btree_destroy(tree,
-								       &b_op));
+								       &b_op,
+								       tx));
 			M0_ASSERT(rc == 0);
 		}
 	}
@@ -7318,6 +7477,38 @@ static void ut_put_del_operation(void)
 }
 #endif
 
+static int ut_btree_suite_init(void)
+{
+	M0_ENTRY();
+
+	M0_ALLOC_PTR(ut_be);
+	M0_ASSERT(ut_be != NULL);
+
+	M0_ALLOC_PTR(ut_seg);
+	M0_ASSERT(ut_seg != NULL);
+	/* Init BE */
+	m0_be_ut_backend_init(ut_be);
+	m0_be_ut_seg_init(ut_seg, ut_be, 1ULL << 24);
+	seg = ut_seg->bus_seg;
+
+	M0_LEAVE();
+	return 0;
+}
+
+static int ut_btree_suite_fini(void)
+{
+	M0_ENTRY();
+
+	m0_be_ut_seg_reload(ut_seg);
+	m0_be_ut_seg_fini(ut_seg);
+	m0_be_ut_backend_fini(ut_be);
+	m0_free(ut_seg);
+	m0_free(ut_be);
+
+	M0_LEAVE();
+	return 0;
+}
+
 struct m0_ut_suite btree_ut = {
 	.ts_name = "btree-ut",
 	.ts_yaml_config_string = "{ valgrind: { timeout: 3600 },"
@@ -7325,8 +7516,8 @@ struct m0_ut_suite btree_ut = {
 	"  exclude:  ["
 	"   "
 	"  ] }",
-	.ts_init = NULL,
-	.ts_fini = NULL,
+	.ts_init = ut_btree_suite_init,
+	.ts_fini = ut_btree_suite_fini,
 	.ts_tests = {
 		{"node_create_delete",              ut_node_create_delete},
 		{"node_add_del_rec",                ut_node_add_del_rec},

--- a/btree/btree.h
+++ b/btree/btree.h
@@ -193,11 +193,12 @@ void m0_btree_close(struct m0_btree *arbor, struct m0_btree_op *bop);
  * @param bop is consumed by the m0_btree_create for its operation. It contains
  *        the field bo_arbor which holds the tree pointer to be used by the
  *        caller after the call completes.
+ * @param seg points to the BE segment which will host the nodes of the tree.
  * @param tx pointer to the transaction struture to capture BE segment changes.
  */
 void m0_btree_create(void *addr, int nob, const struct m0_btree_type *bt,
 		     const struct node_type *nt, struct m0_btree_op *bop,
-		     struct m0_be_tx *tx);
+		     struct m0_be_seg *seg, struct m0_be_tx *tx);
 
 /**
  * Destroys the opened or created tree represented by arbor. Once the destroy
@@ -208,8 +209,10 @@ void m0_btree_create(void *addr, int nob, const struct m0_btree_type *bt,
  *
  * @param arbor is the btree which needs to be closed.
  * @param bop is consumed by the m0_btree_destroy for its operation.
+ * @param tx pointer to the transaction structure to capture BE segment changes.
  */
-void m0_btree_destroy(struct m0_btree *arbor, struct m0_btree_op *bop);
+void m0_btree_destroy(struct m0_btree *arbor, struct m0_btree_op *bop,
+		      struct m0_be_tx *tx);
 
 /**
  * Searches for the key/slant key provided as the search key. The callback

--- a/btree/internal.h
+++ b/btree/internal.h
@@ -44,6 +44,7 @@ struct m0_btree_op {
 	struct m0_btree_rec    bo_rec;
 	struct m0_btree_cb     bo_cb;
 	struct m0_be_tx       *bo_tx;
+	struct m0_be_seg      *bo_seg;
 	uint64_t               bo_flags;
 	struct m0_btree_oimpl *bo_i;
 	struct m0_btree_idata  b_data;


### PR DESCRIPTION
Initial code is added for persisting btree in BE segment. The code adds a
define AVOID_BE_SEGMENT which if enabled continues to create btree in volatile
memory. Currently this #define is turned ON since the code to capture the btree
changes is not present in the btree functions causing the ut's to crash.

Signed-off-by: Shashank Parulekar <shashank.parulekar@seagate.com>