### PR TITLE
Changes in P_ALLOC phase

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3618,8 +3618,9 @@ static struct m0_sm_state_descr btree_states[P_NR] = {
 	[P_NEXTDOWN] = {
 		.sd_flags   = 0,
 		.sd_name    = "P_NEXTDOWN",
-		.sd_allowed = M0_BITS(P_NEXTDOWN, P_ALLOC_REQUIRE, P_STORE_CHILD,
-				      P_CLEANUP, P_SETUP, P_LOCK, P_SIBLING),
+		.sd_allowed = M0_BITS(P_NEXTDOWN, P_ALLOC_REQUIRE,
+				      P_STORE_CHILD, P_SIBLING, P_CLEANUP,
+				      P_LOCK),
 	},
 	[P_SIBLING] = {
 		.sd_flags   = 0,
@@ -3711,7 +3712,6 @@ static struct m0_sm_trans_descr btree_trans[] = {
 	{ "get-nextdown-next", P_NEXTDOWN, P_LOCK },
 	{ "iter-nextdown-sibling", P_NEXTDOWN, P_SIBLING },
 	{ "kvop-nextdown-failed", P_NEXTDOWN, P_CLEANUP },
-	{ "kvop-nextdown-setup", P_NEXTDOWN, P_SETUP},
 	{ "iter-sibling-repeat", P_SIBLING, P_SIBLING },
 	{ "iter-sibling-next", P_SIBLING, P_LOCK },
 	{ "iter-sibling-failed", P_SIBLING, P_CLEANUP },

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3027,7 +3027,7 @@ static int64_t btree_put_alloc_phase(struct m0_btree_op *bop)
 			lock_op_unlock(tree);
 		return m0_sm_op_sub(&bop->bo_op, P_CLEANUP, P_SETUP);
 	}
-	
+
 	if (oi->i_pivot == 0) {
 		if ((oi->i_extra_node == NULL || lev->l_alloc == NULL)) {
 			/**
@@ -3565,7 +3565,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 			if (!node_isoverflow(lev->l_node)) {
 				if (oi->i_nop.no_node != NULL) {
 					oi->i_nop.no_opc = NOP_FREE;
-					node_free(&oi->i_nop, oi->i_nop.no_node, 
+					node_free(&oi->i_nop, oi->i_nop.no_node,
 						  bop->bo_tx, 0);
 				}
 				break;

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3380,7 +3380,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 				if (oi->i_key_found)
 					return P_LOCK;
 				/**
-				 * Initialized i_alloc_lev to level of leaf
+				 * Initialize i_alloc_lev to level of leaf
 				 * node.
 				 */
 				oi->i_alloc_lev = oi->i_used;
@@ -3393,10 +3393,10 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 	case P_ALLOC_REQUIRE:{
 		do {
 			lev = &oi->i_level[oi->i_alloc_lev];
-			if (!node_isvalid(lev->l_node)) {
+			if (!node_isvalid(lev->l_node))
 				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
 						    P_SETUP);
-			}
+
 			if (!node_isoverflow(lev->l_node))
 				break;
 			if (lev->l_alloc == NULL || (oi->i_alloc_lev == 0 &&
@@ -3410,7 +3410,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 				int shift = node_shift(lev->l_node);
 				oi->i_nop.no_opc = NOP_ALLOC;
 				return node_alloc(&oi->i_nop, tree,
-						  shift,lev->l_node->n_type,
+						  shift, lev->l_node->n_type,
 						  ksize, vsize, bop->bo_tx,
 						  P_ALLOC_STORE);
 
@@ -3452,7 +3452,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 							  bop->bo_tx,
 							  P_ALLOC_STORE);
 
-				} else if (oi->i_extra_node == NULL){
+				} else if (oi->i_extra_node == NULL) {
 					oi->i_extra_node = oi->i_nop.no_node;
 					return P_LOCK;
 				} else


### PR DESCRIPTION
Fixed bug in P_ALLOC phase:
Freeing node which is allocated and not stored or used.

some other changes:
using oi->pivot for P_ALLOC phase instead of oi->i_used to avoid resetting of oi->i_used
