### PR TITLE
EOS-22610 Increase timeout value for async connection

### DIFF
--- a/rpc/ut/link_ut.c
+++ b/rpc/ut/link_ut.c
@@ -38,8 +38,8 @@
 
 enum {
 	RLUT_MAX_RPCS_IN_FLIGHT = 10,
-	RLUT_CONN_TIMEOUT       = 4, /* seconds */
-	RLUT_SESS_TIMEOUT       = 2, /* seconds */
+	RLUT_CONN_TIMEOUT       = 40, /* seconds */
+	RLUT_SESS_TIMEOUT       = 20, /* seconds */
 };
 
 struct m0_clink clink;


### PR DESCRIPTION
This will give enough time for the async connection to complete before
timeout. Otherwise, the async connection will not succeed.
And then the UT will hung there waiting for the connection state to be
changed.

Signed-off-by: Hua Huang <hua.huang@seagate.com>