### PR TITLE
FDMI sample app

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -691,6 +691,16 @@ motr_examples_example2_LDADD    = $(top_builddir)/motr/libmotr.la
 include $(top_srcdir)/motr/examples/Makefile.sub
 
 #
+# fdmi/plugins/fdmi_sample_plugin --------------------- {{{2
+#
+
+noinst_PROGRAMS    += fdmi/plugins/fdmi_sample_plugin
+fdmi_plugins_fdmi_sample_plugin_CPPFLAGS  = -DM0_TARGET='fdmi_sample_plugin' $(AM_CPPFLAGS)
+fdmi_plugins_fdmi_sample_plugin_LDADD     = $(top_builddir)/motr/libmotr.la
+
+include $(top_srcdir)/fdmi/plugins/Makefile.sub
+
+#
 # motr/crate ----------------------------------------- {{{2
 #
 sbin_PROGRAMS                    += motr/m0crate/m0crate
@@ -839,15 +849,6 @@ console_m0console_LDADD     = $(top_builddir)/motr/libmotr.la
 sbin_PROGRAMS     += ha/m0ham
 ha_m0ham_CPPFLAGS  = -DM0_TARGET='m0ham' $(AM_CPPFLAGS)
 ha_m0ham_LDADD     = $(top_builddir)/motr/libmotr.la
-
-#
-# fdmi/plugins/fdmi_sample_plugin --------------------- {{{2
-#
-
-sbin_PROGRAMS     += fdmi/plugins/fdmi_sample_plugin
-sbin_SCRIPTS     += fdmi/plugins/fdmi_app
-fdmi_plugins_fdmi_sample_plugin_CPPFLAGS  = -DM0_TARGET='fdmi_sample_plugin' $(AM_CPPFLAGS)
-fdmi_plugins_fdmi_sample_plugin_LDADD     = $(top_builddir)/motr/libmotr.la
 
 #
 # pool/m0poolmach ------------------------------------- {{{2

--- a/Makefile.am
+++ b/Makefile.am
@@ -841,6 +841,15 @@ ha_m0ham_CPPFLAGS  = -DM0_TARGET='m0ham' $(AM_CPPFLAGS)
 ha_m0ham_LDADD     = $(top_builddir)/motr/libmotr.la
 
 #
+# fdmi/plugins/fdmi_sample_plugin --------------------- {{{2
+#
+
+sbin_PROGRAMS     += fdmi/plugins/fdmi_sample_plugin
+sbin_SCRIPTS     += fdmi/plugins/fdmi_app
+fdmi_plugins_fdmi_sample_plugin_CPPFLAGS  = -DM0_TARGET='fdmi_sample_plugin' $(AM_CPPFLAGS)
+fdmi_plugins_fdmi_sample_plugin_LDADD     = $(top_builddir)/motr/libmotr.la
+
+#
 # pool/m0poolmach ------------------------------------- {{{2
 #
 

--- a/fdmi/plugins/.gitignore
+++ b/fdmi/plugins/.gitignore
@@ -1,0 +1,1 @@
+fdmi_sample_plugin

--- a/fdmi/plugins/Makefile.sub
+++ b/fdmi/plugins/Makefile.sub
@@ -1,0 +1,2 @@
+fdmi_plugins_fdmi_sample_plugin_SOURCES = fdmi/plugins/fdmi_sample_plugin.c
+EXTRA_DIST	+= fdmi/plugins/fdmi_app

--- a/fdmi/plugins/debug.c
+++ b/fdmi/plugins/debug.c
@@ -1,0 +1,238 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#if 0
+M0_INTERNAL void m0_save_m0_xcode_type(int fd, char tab[], const struct m0_xcode_type *xf_type)
+{
+	if (xf_type == NULL)
+		return;
+	int buffer_len = 4096;
+	char buffer[buffer_len];
+	int i = 0;
+	sprintf(buffer, "%sstruct m0_xcode_type: %p { \n", tab,xf_type);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_aggr: %d\n", tab, xf_type->xct_aggr);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_name: %s\n", tab, xf_type->xct_name);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_ops: %p\n", tab, xf_type->xct_ops);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_atype: %d\n", tab, xf_type->xct_atype);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_flags: %d\n", tab, xf_type->xct_flags);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_decor: %p\n", tab, xf_type->xct_decor);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_sizeof: %d\n", tab, (int)xf_type->xct_sizeof);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_nr: %d\n", tab, (int)xf_type->xct_nr);
+	write(fd, buffer, strlen(buffer));
+
+	for  ( i = 0;i < (int)xf_type->xct_nr; i++) {
+		sprintf(buffer, "\t%sstruct m0_xcode_field: { \n", tab);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t%sxf_name: %s\n", tab, xf_type->xct_child[i].xf_name);
+		write(fd, buffer, strlen(buffer));
+
+		strcat(tab,"\t");
+		m0_save_m0_xcode_type(fd, tab, xf_type->xct_child[i].xf_type);
+
+		sprintf(buffer, "\t\t%sxf_tag: %lu\n", tab, xf_type->xct_child[i].xf_tag);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t%sxf_offset: %d\n", tab, xf_type->xct_child[i].xf_offset);
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t%s}\n", tab); //struct m0_xcode_field
+		write(fd, buffer, strlen(buffer));
+	}
+
+	sprintf(buffer, "%s}\n", tab); //struct m0_xcode_type
+	write(fd, buffer, strlen(buffer));
+
+}
+
+M0_INTERNAL void m0_save_m0_fol_rec(struct m0_fol_rec *rec, const char *prefix)
+{
+	char filename[32];
+	int buffer_len = 4096;
+	char buffer[buffer_len];
+	int fd = 0;
+	static int fc = 0;
+	sprintf(filename, "/tmp/fol_rec_%s_%p_%d", prefix, rec, fc);
+	M0_ENTRY("m0_save_m0_fol_rec fol rec=%p\n ", rec);
+	++fc;
+
+	//open the file
+	fd = open(filename, O_WRONLY | O_CREAT);
+
+	//using m0_fol_rec_to_str
+	//int len = m0_fol_rec_to_str(rec, buffer, buffer_len);
+	//write(fd, buffer, len);
+
+	//fill the buffer and write buffer
+	sprintf(buffer, "\nstruct m0_fol_rec {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\tm0_fol: %p\n", rec->fr_fol);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\tfr_tid: %lu\n", rec->fr_tid);
+	write(fd, buffer, strlen(buffer));
+
+	//struct m0_fol_rec_header
+	sprintf(buffer, "\tstruct m0_fol_rec_header {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\trh_frags_nr: %u\n", rec->fr_header.rh_frags_nr);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\trh_data_len: %u\n", rec->fr_header.rh_data_len);
+	write(fd, buffer, strlen(buffer));
+
+	//struct m0_update_id
+	sprintf(buffer, "\t\tstruct m0_update_id {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\t\tui_node: %u\n", rec->fr_header.rh_self.ui_node);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\t\tui_update: %lu\n", rec->fr_header.rh_self.ui_update);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\t\trh_magic: %lu\n", rec->fr_header.rh_magic);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\tfr_epoch: %p\n", rec->fr_epoch);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\tfr_sibling: %p\n", rec->fr_sibling);
+	write(fd, buffer, strlen(buffer));
+
+	//m0_fol_frag:rp_link to this list
+	struct m0_fol_frag     *frag;
+	sprintf(buffer, "\tstruct m0_tl {\n");
+	m0_tl_for(m0_rec_frag, &rec->fr_frags, frag) {
+		sprintf(buffer, "\t\tstruct m0_fol_frag {\n");
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t struct m0_fol_frag_ops = %p {\n", frag->rp_ops);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t struct m0_fol_frag_type : %p{\n", frag->rp_ops->rpo_type);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\trpt_index: %d\n", frag->rp_ops->rpo_type->rpt_index);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\trpt_name: %s\n", frag->rp_ops->rpo_type->rpt_name);
+		write(fd, buffer, strlen(buffer));
+
+		//const struct m0_xcode_type        *rpt_xt;
+		char tab[100] = "\t\t\t\t\t";
+		m0_save_m0_xcode_type(fd, tab, frag->rp_ops->rpo_type->rpt_xt);
+
+		sprintf(buffer, "\t\t\t\t}\n");//struct m0_fol_frag_ops
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t}\n");
+		write(fd, buffer, strlen(buffer));
+
+		struct m0_fop_fol_frag *fp_frag = frag->rp_data;
+		sprintf(buffer, "\t\t\tstruct m0_fop_fol_frag: %p{\n", fp_frag);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\tffrp_fop_code: %d\n", fp_frag->ffrp_fop_code);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\tffrp_rep_code: %d\n", fp_frag->ffrp_rep_code);
+		write(fd, buffer, strlen(buffer));
+		struct m0_xcode_obj obj = {
+			//.xo_type = m0_fop_fol_frag_xc,
+			.xo_type = m0_cas_op_xc,
+			.xo_ptr = fp_frag->ffrp_fop
+			//.xo_ptr = frag->rp_data
+		};
+		//m0_xcode_print(&obj, buffer, buffer_len);
+
+		struct m0_cas_op *cas_op = fp_frag->ffrp_fop;
+		M0_LOG(M0_DEBUG, "m0_save rec: %p cas_op=%p ", rec, cas_op);
+		sprintf(buffer, "\t\t\t\tstruct m0_cas_op: %p {\n", cas_op);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\t\tfid:"FID_F"\n", FID_P(&cas_op->cg_id.ci_fid));
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\t\t\tstruct m0_cas_recv: {\n");
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\t\tcr_nr: %lu\n", cas_op->cg_rec.cr_nr);
+		write(fd, buffer, strlen(buffer));
+		int i=0;
+		for (i = 0; i < cas_op->cg_rec.cr_nr; i++) {
+			sprintf(buffer, "\n\t\t\t\t\t\tcr_key: %lu bytes ", cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_nob);
+			write(fd, buffer, strlen(buffer));
+			write(fd, cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_addr,
+			      cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_nob);
+			sprintf(buffer, "\n\t\t\t\t\t\tcr_val: %lu bytes ", cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_nob);
+			write(fd, buffer, strlen(buffer));
+			write(fd, cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_addr,
+			      cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_nob);
+			M0_LOG(M0_DEBUG, "op = %p key: %lu value=%lu ", cas_op, cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_nob,
+			       cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_nob);
+		}
+		sprintf(buffer, "\n\t\t\t\t\t}\n"); //struct m0_cas_recv
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\t\t\t\tcg_flags: %d\n", cas_op->cg_flags);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t}\n"); //struct m0_cas_op
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\t}\n"); //struct m0_fop_fol_frag
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\trp_magic: %lu\n", frag->rp_magic);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\trp_flag: %d\n", frag->rp_flag);
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t}\n");
+		write(fd, buffer, strlen(buffer));
+
+	} m0_tl_endfor;
+	sprintf(buffer, "\t}\n");
+
+        //struct m0_fdmi_src_rec
+	sprintf(buffer, "\tstruct m0_fdmi_src_rec {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tfsr_magic: %lu\n",rec->fr_fdmi_rec.fsr_magic);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tstruct *m0_fdmi_src fsr_src =%p{\n",rec->fr_fdmi_rec.fsr_src);
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\t\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\t\tfsr_rec_id:"U128X_F"\n",U128_P(&rec->fr_fdmi_rec.fsr_rec_id));
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tfsr_matched: %d\n",rec->fr_fdmi_rec.fsr_matched);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tfsr_dryrun: %d\n",rec->fr_fdmi_rec.fsr_dryrun);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "}\n");
+	write(fd, buffer, strlen(buffer));
+
+	close(fd);
+	M0_LEAVE("fol rec ptr=%p\n", rec);
+}
+#endif
+

--- a/fdmi/plugins/debug.c
+++ b/fdmi/plugins/debug.c
@@ -19,13 +19,13 @@
  *
  */
 
-#if 0
+/*
 M0_INTERNAL void m0_save_m0_xcode_type(int fd, char tab[], const struct m0_xcode_type *xf_type)
 {
 	if (xf_type == NULL)
 		return;
 	int buffer_len = 4096;
-	char buffer[buffer_len];
+	char buffer[buffer_len] = {0};
 	int i = 0;
 	sprintf(buffer, "%sstruct m0_xcode_type: %p { \n", tab,xf_type);
 	write(fd, buffer, strlen(buffer));
@@ -66,14 +66,13 @@ M0_INTERNAL void m0_save_m0_xcode_type(int fd, char tab[], const struct m0_xcode
 
 	sprintf(buffer, "%s}\n", tab); //struct m0_xcode_type
 	write(fd, buffer, strlen(buffer));
-
 }
 
 M0_INTERNAL void m0_save_m0_fol_rec(struct m0_fol_rec *rec, const char *prefix)
 {
-	char filename[32];
+	char filename[32] = {0};
 	int buffer_len = 4096;
-	char buffer[buffer_len];
+	char buffer[buffer_len] = {0};
 	int fd = 0;
 	static int fc = 0;
 	sprintf(filename, "/tmp/fol_rec_%s_%p_%d", prefix, rec, fc);
@@ -82,6 +81,8 @@ M0_INTERNAL void m0_save_m0_fol_rec(struct m0_fol_rec *rec, const char *prefix)
 
 	//open the file
 	fd = open(filename, O_WRONLY | O_CREAT);
+	if (fd == -1)
+		return;
 
 	//using m0_fol_rec_to_str
 	//int len = m0_fol_rec_to_str(rec, buffer, buffer_len);
@@ -234,5 +235,5 @@ M0_INTERNAL void m0_save_m0_fol_rec(struct m0_fol_rec *rec, const char *prefix)
 	close(fd);
 	M0_LEAVE("fol rec ptr=%p\n", rec);
 }
-#endif
+*/
 

--- a/fdmi/plugins/fdmi_app
+++ b/fdmi/plugins/fdmi_app
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# This is the FDMI sample application. It serves as a hub for the FDMI
+# records delivered fdmi_sample_plugin C-program via stdout. To do so
+# it gathers the cluster configuration with 'hctl status' command,
+# forks fdmi_sample_plugin and waits for the FDMI events in JSON form.
+# The reason to use it is simply because it is much easier to parse data
+# and develop new features in python in compare to C.
+
+# For now it is just a demo that prints FDMI records to console, but
+# except this it can perform records de-dup and for example, replication
+# coordination by means of set of the replication python programs that
+# perform actual data move.
+
+import subprocess
+import signal
+import shlex
+import sys
+import json
+import codecs
+
+# Global cluster info including information required for running
+# fdmi_sample_plugin C-program.
+cluster_info = dict()
+
+# Global key-value cache used for records de-duplication. KV pairs
+# are available by the kv['cr_key']
+kv_records = dict()
+
+# Global list of fdmi_sample_plugin processes that this program
+# is communicating.
+processes = []
+
+
+def str_decode(encoded):
+    if encoded is None:
+        return None
+    if encoded == '0':
+        return encoded
+    return codecs.decode(encoded, 'hex')
+
+
+# Process the FDMI records in form of JSON and perform some useful actions
+# such as de-dup, logging and/or sending to the replicator program for data
+# move.
+def process_fdmi_record(kv_record):
+    kvs = json.loads(kv_record)
+    fid = str_decode(kvs.get('fid'))
+    if fid is None:
+        print('Invalid fid in kv_record {}'.format(kv_record), file=sys.stderr)
+        return
+    cr_key = str_decode(kvs.get('cr_key'))
+    if cr_key is None:
+        print('Invalid cr_key in kv_record {}'.format(kv_record), file=sys.stderr)
+        return
+    cr_val = str_decode(kvs.get('cr_val'))
+    if cr_val is None:
+        print('Invalid cr_val in kv_record {}'.format(kv_record), file=sys.stderr)
+        return
+    kv = {
+        'fid': fid,
+        'cr_key': cr_key,
+        'cr_val': cr_val
+    }
+
+    # Check de-dup records
+    kv_i = kv_records.get(cr_key)
+    if kv_i is not None and kv['cr_val'] != "0":
+        print('de-dup: {} {}'.format(kv_i, kv), file=sys.stderr)
+    elif kv['cr_val'] != "0":
+        print('new key-value: {}'.format(kv), file=sys.stderr)
+        kv_records['cr_key'] = kv
+
+
+# Handle SIGNT and SIGTERM. Stop the underlying processes and exit.
+def signal_handler(sig, frame):
+    print('CTRL + C pressed', file=sys.stderr)
+    print('Stopping all fdmi_sample_plugin processes...')
+    for p in processes:
+        p.send_signal(sig)
+        p.wait()
+    sys.exit(0)
+
+
+# Fork the process and capture its output
+def execute_command_and_get_output(cmd):
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            shell=True)
+    stdout, stderr = proc.communicate()
+    output_var = str(stdout, 'utf-8')
+    return output_var
+
+
+# fdmi_sample_plugin -l 192.168.52.53@tcp:12345:4:1 -h 192.168.52.53@tcp:12345:1:1
+# -p 0x7000000000000001:0x37 -f 0x7200000000000001:0x19 -g 0x6c00000000000001:0x81
+def get_plugin_cmd(args):
+    # fdmi_sample_plugin = "/path/to/cortx-motr/fdmi/plugins/fdmi_sample_plugin"
+    opts = " -l " + cluster_info['local_endpoint']
+    opts += " -h " + cluster_info['ha_endpoint']
+    opts += " -p " + cluster_info['profile_fid']
+    opts += " -f " + cluster_info['process_fid']
+    opts += " -g " + cluster_info['fdmi_filter_fid']
+    return args.plugin_path + opts
+
+
+# Gather the cluster info with 'hctl status --json' command, which is
+# need for running fdmi_sample_plugin. In case that --filter-id is omitted
+# then parse /etc/motr/confd.xc to find the filter-id for fdmi_sample_plugin
+def get_cluster_info(args):
+    info = dict()
+    cmd = '{} status --json'.format(args.hctl_path)
+    output = execute_command_and_get_output(cmd)
+    if output is None:
+        print('Failed to execute {}. Please make sure the path to '
+              '{} is correct'.format(cmd, args.hctl_path), file=sys.stderr)
+        return None
+    cluster_js = json.loads(output)
+    if cluster_js is None:
+        print('Failed to fetch cluster info.', file=sys.stderr)
+        return None
+
+    profiles = cluster_js.get('profiles')
+    if profiles is None or len(profiles) == 0:
+        print('Failed to fetch profiles from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+
+    profile_fid = str(profiles[0].get('fid'))
+    if profile_fid is None or len(profile_fid) == 0:
+        print('Failed to fetch profiles[0]/fid from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+    info['profile_fid'] = profile_fid
+
+    nodes_data = cluster_js.get('nodes')
+    if nodes_data is None or len(nodes_data) == 0:
+        print('Failed to fetch nodes from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+    services = nodes_data[0].get('svcs')
+    if services is None or len(services) == 0:
+        print('Failed to fetch nodes/svcs from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+
+    for svc in services:
+        if svc['name'] == 'hax':
+            ha_endpoint = str(svc.get('ep'))
+            if ha_endpoint is None or len(ha_endpoint) == 0:
+                print('Invalid nodes/svcs/hax/ep in cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+                return None
+            info['ha_endpoint'] = ha_endpoint
+
+        svc_name = str(svc.get('name'))
+        if svc_name is None or len(svc_name) == 0:
+            print('Invalid nodes/svcs/name in cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+            return None
+
+        # Always using the first m0client
+        if svc_name == 'm0_client':
+            local_endpoint = str(svc.get('ep'))
+            if local_endpoint is None or len(local_endpoint) == 0:
+                print('Invalid nodes/svcs/m0_client/ep in cluster info:\n{}'.format(cluster_js),
+                      file=sys.stderr)
+                return None
+            info['local_endpoint'] = local_endpoint
+
+            process_fid = str(svc.get('fid'))
+            if process_fid is None or len(process_fid) == 0:
+                print('Invalid nodes/svcs/m0_client/fid in cluster info:\n{}'.format(cluster_js),
+                      file=sys.stderr)
+                return None
+            info['process_fid'] = process_fid
+            break
+
+    if args.filter_id is None:
+        with open(args.config_path) as f:
+            for s in f.readlines():
+                # Example: ' {0x6c| ((^l|1:81), 2, ^l|1:81, "", ^n|1:3, ^v|1:66, [1: "Bucket-Name"],
+                # [1: "192.168.12.2@tcp:12345:4:1"])},'
+                if s.startswith(' {0x6c| ((^l|'):
+                    s = s[15:]
+                    s = s[:s.index(')')]
+                    fdmi_filter_fid = f"0x6c00000000000001:{int(s):#x}"
+                    info['fdmi_filter_fid'] = fdmi_filter_fid
+                    break
+    else:
+        info['fdmi_filter_fid'] = args.filter_id
+
+    if info.get('ha_endpoint') is None:
+        print('Failed to get Hare endpoint from the cluster info.', file=sys.stderr)
+        return None
+    if info.get('process_fid') is None:
+        print('Failed to get client process fid from the cluster info.', file=sys.stderr)
+        return None
+    if info.get('local_endpoint') is None:
+        print('Failed to get local client endpoint from the cluster info.', file=sys.stderr)
+        return None
+    if info.get('fdmi_filter_fid') is None:
+        print('Failed to get fdmi filter id from the cluster config.', file=sys.stderr)
+        return None
+
+    print('  {}'.format(info), file=sys.stderr)
+    return info
+
+
+# For the plugin C-program and wait for data on stdout.
+def listen_on_command(command):
+    global processes
+    p = subprocess.Popen(shlex.split(command), stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if p is None:
+        print('Failed to run {}'.format(command), file=sys.stderr)
+        return -1
+    processes.append(p)
+
+    print('Listening for FDMI events on:\n  {}'.format(command), file=sys.stderr)
+    while True:
+        output = p.stdout.readline()
+        if output is not None:
+            fid = "fid"
+            record = output.decode("utf-8")
+            if fid in record:
+                process_fdmi_record(record)
+
+        rc = p.poll()
+        if rc is not None:
+            print('Exiting because fdmi_sample_plugin exited with:', file=sys.stderr)
+            print('  error code = {}'.format(rc), file=sys.stderr)
+            _, error = p.communicate()
+            if error is not None:
+                error = error.decode('utf-8')
+            if error is not None and len(error) > 0:
+                print('  error text = {}'.format(error), file=sys.stderr)
+            break
+
+    return p.poll()
+
+
+def main(args):
+    global cluster_info
+    einval = 22
+
+    # Filter id is used by Motr FDMI subsystem for identifying the
+    # FDMI plugins, because there are possible more than one.
+    # If the --filter-id is omitted then this program is looking
+    # for the corrct filter id in /etc/motr/confd.xc config file.
+
+    # Example: ' {0x6c| ((^l|1:81), 2, ^l|1:81, "", ^n|1:3, ^v|1:66, [1: "Bucket-Name"],
+    # [1: "192.168.12.2@tcp:12345:4:1"])},'
+
+    # The fid we need is 0x6c00000000000001:0x81 in this particular example.
+    if args.config_path is None and args.filter_id is None:
+        print('Either --config-path or --filter-id is required.', file=sys.stderr)
+        sys.exit(einval)
+
+    print('Using the following settings:', file=sys.stderr)
+    print('  plugin-path = {}'.format(args.plugin_path), file=sys.stderr)
+    print('  hctl-path = {}'.format(args.hctl_path), file=sys.stderr)
+
+    config_path = args.config_path
+    if config_path is None:
+        config_path = 'using filter-id'
+    print('  config-path = {}'.format(config_path), file=sys.stderr)
+
+    filter_id = args.filter_id
+    if filter_id is None:
+        filter_id = 'using config-path'
+    print('  filter-id = {}'.format(filter_id), file=sys.stderr)
+
+    print('Register SIGINT signal handler', file=sys.stderr)
+    signal.signal(signal.SIGINT, signal_handler)
+
+    print('Cluster info:', file=sys.stderr)
+    cluster_info = get_cluster_info(args)
+    if cluster_info is None:
+        sys.exit(einval)
+
+    # Execute fdmi_sample_plugin with cluster info in loop and wait for
+    # the FDMI events in form of JSON metadata.
+    listen_on_command(get_plugin_cmd(args))
+
+
+if __name__ == '__main__':
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('-pp', '--plugin-path', required=False,
+                    help='path to fdmi_sample_plugin executable',
+                    type=str, default='./fdmi_sample_plugin')
+    ap.add_argument('-hp', '--hctl-path', required=False, help='path to hctl executable',
+                    type=str, default='hctl')
+    ap.add_argument('-cp', '--config-path', required=False, help='path to confd.xc file',
+                    type=str, default='/etc/motr/confd.xc')
+    ap.add_argument('-fi', '--filter-id', required=False, help='plugin filter id',
+                    type=str)
+    main(ap.parse_args())

--- a/fdmi/plugins/fdmi_sample_plugin.c
+++ b/fdmi/plugins/fdmi_sample_plugin.c
@@ -22,23 +22,14 @@
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_FDMI
 #include "lib/trace.h"
 
-#include "fid/fid.h"
 #include "motr/client.h"
+#include "fid/fid.h"
 #include "motr/client_internal.h"
 #include "lib/getopts.h"	/* M0_GETOPTS */
-#include "lib/trace.h"
 #include "fdmi/fdmi.h"
 #include "fdmi/plugin_dock.h"
 #include "fdmi/service.h"
 #include "reqh/reqh.h"
-#include "ut/ut.h"
-
-#include <unistd.h>
-#include <getopt.h>
-#include <errno.h>
-#include <stddef.h>             /* ptrdiff_t */
-#include <fcntl.h>
-#include <stdio.h>
 
 /**
  * Plugin sample conf params. Here _fsp means "fdmi sample plugin"

--- a/fdmi/plugins/fdmi_sample_plugin.c
+++ b/fdmi/plugins/fdmi_sample_plugin.c
@@ -215,10 +215,9 @@ static int fsp_args_parse(struct m0_fsp_params *params, int argc, char ** argv)
 		return M0_ERR(rc);
 
         /* All mandatory params must be defined. */
-        if (rc == 0 &&
-	    (params->spp_local_addr == NULL || params->spp_hare_addr == NULL ||
-	     params->spp_profile_fid == NULL || params->spp_process_fid == NULL ||
-	     params->spp_fdmi_plugin_fid_s == NULL)) {
+        if (params->spp_local_addr == NULL  || params->spp_hare_addr == NULL   ||
+	    params->spp_profile_fid == NULL || params->spp_process_fid == NULL ||
+	    params->spp_fdmi_plugin_fid_s == NULL) {
 		fsp_usage();
 		return M0_ERR(-EINVAL);
 	}

--- a/fdmi/plugins/fdmi_sample_plugin.c
+++ b/fdmi/plugins/fdmi_sample_plugin.c
@@ -1,0 +1,456 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_FDMI
+#include "lib/trace.h"
+
+#include "fid/fid.h"
+#include "motr/client.h"
+#include "motr/client_internal.h"
+#include "lib/getopts.h"	/* M0_GETOPTS */
+#include "lib/trace.h"
+#include "fdmi/fdmi.h"
+#include "fdmi/plugin_dock.h"
+#include "fdmi/service.h"
+#include "reqh/reqh.h"
+#include "ut/ut.h"
+
+#include <unistd.h>
+#include <getopt.h>
+#include <errno.h>
+#include <stddef.h>             /* ptrdiff_t */
+#include <fcntl.h>
+#include <stdio.h>
+
+/**
+ * Plugin sample conf params. Here _fsp means "fdmi sample plugin"
+ * and _spp - "sample plugin params".
+ */
+struct m0_fsp_params {
+	char          *spp_local_addr;
+	char          *spp_hare_addr;
+	char          *spp_profile_fid;
+	char          *spp_process_fid;
+	char          *spp_fdmi_plugin_fid_s;
+	struct m0_fid  spp_fdmi_plugin_fid;
+};
+
+/**
+ * This is the FDMI plugin program. Its purpose is to start the listener
+ * for the special type of the FDMI events and forward them to the fdmi_app
+ * wrapper written in python. The communication is done via stdout.
+ */
+
+/**
+ * Storage for the program run parameters passed from console or the wrapper
+ * application.
+ */
+struct m0_fsp_params fsp_params;
+
+/**
+ * The main loop semaphore. The main loop here is just sleeping most of
+ * the time and waiting for some stop signal (e.g ctrl+c) from the python
+ * fdmi_app that controls this plugin program.
+ *
+ * The main job is done in one of the Motr locality threads, that handles
+ * the fops with FDMI data and call the callback function installed by this
+ * program if the type of the plugin match is found.
+ */
+static struct m0_semaphore fsp_sem;
+
+/**
+ * This program is basically adding the new client to the cluster. To do so
+ * we need to specify the client endpoint and the address of the cluster
+ * configuration service. This structure is used for delivering this info
+ * to the Motr core.
+ */
+static struct m0_config	fsp_conf = {};
+
+/**
+ * Pointer to the initialized m0_client structure denoting our program
+ * functionality.
+ */
+static struct m0_client	*fsp_client = NULL;
+
+/* DIX service (client interface for kv storage) config. */
+static struct m0_idx_dix_config	fsp_dix_conf = {};
+
+/**
+ * The vector of the FDMI plugin callback operations. They are called by
+ * the Motr when the new FDMI event occurs.
+ */
+const struct m0_fdmi_pd_ops *fsp_pdo;
+
+/**
+ * The handle of the local FDMI service that we start. Its purpose is to
+ * receive the FDMI rpcs, find the local consumer (this program) and send
+ * forward them to the consumer plugin in the form of FDMI records.
+ */
+static struct m0_reqh_service *fsp_fdmi_service = NULL;
+
+/**
+ * Aux buffer, used for data parsing.
+ */
+#define MAX_LEN 8192
+static char buffer[MAX_LEN];
+
+
+static char *to_hex(void *addr, int len)
+{
+	int i, j;
+	if ((2 * len) > MAX_LEN) {
+		fprintf(stderr, "to_hex() failed with (2 * len) > MAX_LEN\n");
+		return NULL;
+	}
+	for(i = 0, j = 0; i < (2 * len) && j < len; ++j)
+		i += sprintf(buffer + i, "%02x", ((char *)addr)[j]);
+	buffer[2 * len - 2] = '\0';
+	return buffer;
+}
+
+static void dump_fol_rec_to_json(struct m0_fol_rec *rec)
+{
+	struct m0_fol_frag *frag;
+	int i;
+
+	m0_tl_for(m0_rec_frag, &rec->fr_frags, frag) {
+		struct m0_fop_fol_frag *fp_frag = frag->rp_data;
+		struct m0_cas_op *cas_op = fp_frag->ffrp_fop;
+		struct m0_cas_recv cg_rec = cas_op->cg_rec;
+		struct m0_cas_rec *cr_rec = cg_rec.cr_rec;
+
+		for (i = 0; i < cg_rec.cr_nr; i++) {
+			int len = 0;
+
+			m0_console_printf("{ ");
+
+			len = sizeof(struct m0_fid);
+			m0_console_printf("\"fid\": \"%s\", ",
+					  to_hex((void *)&cas_op->cg_id.ci_fid, len));
+
+			len = cr_rec[i].cr_key.u.ab_buf.b_nob;
+			m0_console_printf("\"cr_key\": \"%s\", ",
+					  to_hex(cr_rec[i].cr_key.u.ab_buf.b_addr, len));
+
+			len = cr_rec[i].cr_val.u.ab_buf.b_nob;
+			if (len > 0) {
+				m0_console_printf("\"cr_val\": \"%s\"",
+						  to_hex(cr_rec[i].cr_val.u.ab_buf.b_addr, len));
+			} else {
+				m0_console_printf("\"cr_val\": \"0\"");
+			}
+			m0_console_printf(" }\n");
+
+		}
+	} m0_tl_endfor;
+}
+
+static void fsp_usage(void)
+{
+	fprintf(stderr,
+		"Usage: fdmi_sample_plugin "
+		"-l local_addr -h ha_addr -p profile_fid -f process_fid "
+		"-g fdmi_plugin_fid\n"
+		"Use -? or -i for more verbose help on common arguments.\n"
+		"Usage example for common arguments: \n"
+		"fdmi_sample_plugin -l 192.168.52.53@tcp:12345:4:1 "
+		"-h 192.168.52.53@tcp:12345:1:1 "
+		"-p 0x7000000000000001:0x37 -f 0x7200000000000001:0x19"
+		"-g 0x6c00000000000001:0x51"
+		"\n");
+}
+
+/**
+ * @retval 0      Success.
+ * @retval -Exxx  Error.
+ */
+static int fsp_args_parse(struct m0_fsp_params *params, int argc, char ** argv)
+{
+	int rc = 0;
+
+	params->spp_local_addr 	= NULL;
+	params->spp_hare_addr   = NULL;
+	params->spp_profile_fid = NULL;
+	params->spp_process_fid = NULL;
+	params->spp_fdmi_plugin_fid_s = NULL;
+
+	rc = M0_GETOPTS("fdmi_sample_plugin", argc, argv,
+			M0_HELPARG('?'),
+			M0_VOIDARG('i', "more verbose help",
+				   LAMBDA(void, (void) {
+						   fsp_usage();
+						   exit(0);
+					   })),
+			M0_STRINGARG('l', "Local endpoint address",
+				     LAMBDA(void, (const char *string) {
+						     params->spp_local_addr = (char*)string;
+					     })),
+			M0_STRINGARG('h', "HA address",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_hare_addr = (char*)str;
+					     })),
+			M0_STRINGARG('f', "Process FID",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_process_fid = (char*)str;
+					     })),
+			M0_STRINGARG('p', "Profile options for client",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_profile_fid = (char*)str;
+					     })),
+			M0_STRINGARG('g', "FDMI plugin fid",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_fdmi_plugin_fid_s =
+							     (char*)str;
+					     })));
+	if (rc != 0)
+		return M0_ERR(rc);
+
+        /* All mandatory params must be defined. */
+        if (rc == 0 &&
+	    (params->spp_local_addr == NULL || params->spp_hare_addr == NULL ||
+	     params->spp_profile_fid == NULL || params->spp_process_fid == NULL ||
+	     params->spp_fdmi_plugin_fid_s == NULL)) {
+		fsp_usage();
+		return M0_ERR(-EINVAL);
+	}
+
+	rc = m0_fid_sscanf(params->spp_fdmi_plugin_fid_s, &params->spp_fdmi_plugin_fid);
+	if (rc != 0) {
+		rc = M0_ERR_INFO(rc, "Invalid FDMI plugin fid format: fid=%s",
+				 params->spp_fdmi_plugin_fid_s);
+	}
+
+	return rc;
+}
+
+/**
+ * Callback function called by the FDMI service to deliver the FDMI event
+ * to the plugin program.
+ */
+static int process_fdmi_record(struct m0_uint128 *rec_id,
+			       struct m0_buf fdmi_rec,
+		   	       struct m0_fid filter_id)
+{
+	struct m0_fol_rec fol_rec;
+	int               rc;
+
+	m0_fol_rec_init(&fol_rec, NULL);
+	rc = m0_fol_rec_decode(&fol_rec, &fdmi_rec);
+	if (rc != 0)
+		goto out;
+	dump_fol_rec_to_json(&fol_rec);
+out:
+	m0_fol_rec_fini(&fol_rec);
+	return rc;
+}
+
+static int fdmi_service_start(struct m0_client *m0c)
+{
+	struct m0_reqh *reqh = &m0c->m0c_reqh;
+	struct m0_reqh_service_type *stype;
+	bool start_service = false;
+	int rc = 0;
+
+	stype = m0_reqh_service_type_find("M0_CST_FDMI");
+	if (stype == NULL) {
+		M0_LOG(M0_ERROR, "FDMI service type is not found.");
+		return M0_ERR_INFO(-EINVAL, "Unknown reqh service type: M0_CST_FDMI");
+	}
+
+	fsp_fdmi_service = m0_reqh_service_find(stype, reqh);
+	if (fsp_fdmi_service == NULL) {
+		rc = m0_reqh_service_allocate(&fsp_fdmi_service, &m0_fdmi_service_type, NULL);
+		if (rc != 0)
+			return M0_RC_INFO(rc, "Failed to allocate FDMI service.");
+		m0_reqh_service_init(fsp_fdmi_service, reqh, NULL);
+		start_service = true;
+	}
+
+	if (start_service)
+        	rc = m0_reqh_service_start(fsp_fdmi_service);
+	return M0_RC(rc);
+}
+
+static void fdmi_service_stop(void)
+{
+	if (fsp_fdmi_service != NULL) {
+		m0_reqh_service_stop(fsp_fdmi_service);
+		fsp_fdmi_service = NULL;
+	}
+}
+
+static int init_fdmi_plugin(struct m0_fsp_params *params)
+{
+	const static struct m0_fdmi_plugin_ops pcb = {
+		.po_fdmi_rec = process_fdmi_record
+	};
+	const struct m0_fdmi_filter_desc fd;
+	int rc;
+
+	fsp_pdo = m0_fdmi_plugin_dock_api_get();
+
+	rc = fsp_pdo->fpo_register_filter(&params->spp_fdmi_plugin_fid, &fd, &pcb);
+	fprintf(stderr, "Plugin registration failed: rc=%d\n", rc);
+	if (rc != 0)
+		return rc;
+
+	fsp_pdo->fpo_enable_filters(true, &params->spp_fdmi_plugin_fid, 1);
+	return rc;
+}
+
+static void fini_fdmi_plugin(struct m0_fsp_params *params)
+{
+	fsp_pdo->fpo_enable_filters(false, &params->spp_fdmi_plugin_fid, 1);
+	fsp_pdo->fpo_deregister_plugin(&params->spp_fdmi_plugin_fid, 1);
+}
+
+static int fsp_init(struct m0_fsp_params *params)
+{
+	int rc;
+
+	fsp_conf.mc_local_addr            = params->spp_local_addr;
+	fsp_conf.mc_ha_addr               = params->spp_hare_addr;
+	fsp_conf.mc_profile               = params->spp_profile_fid;
+	fsp_conf.mc_process_fid           = params->spp_process_fid;
+	fsp_conf.mc_tm_recv_queue_min_len = M0_NET_TM_RECV_QUEUE_DEF_LEN;
+	fsp_conf.mc_max_rpc_msg_size      = M0_RPC_DEF_MAX_RPC_MSG_SIZE;
+	fsp_conf.mc_layout_id             = 1;
+	fsp_conf.mc_is_oostore            = 1;
+	fsp_conf.mc_is_read_verify        = 0;
+	fsp_conf.mc_idx_service_id        = M0_IDX_DIX;
+
+	fsp_dix_conf.kc_create_meta 	 = false;
+	fsp_conf.mc_idx_service_conf 	 = &fsp_dix_conf;
+
+	/* Client instance init */
+	rc = m0_client_init(&fsp_client, &fsp_conf, true);
+	if (rc != 0)
+		return rc;
+
+	M0_POST(fsp_client != NULL);
+
+	rc = fdmi_service_start(fsp_client);
+	if (rc != 0) {
+		m0_client_fini(fsp_client, true);
+		return rc;
+	}
+
+	rc = init_fdmi_plugin(params);
+	if (rc != 0) {
+		fdmi_service_stop();
+		m0_client_fini(fsp_client, true);
+	}
+	return rc;
+}
+
+static void fsp_fini(struct m0_fsp_params *params)
+{
+	fini_fdmi_plugin(params);
+
+	/* Client stops its services including FDMI */
+	m0_client_fini(fsp_client, true);
+}
+
+/*
+ * Signals handling
+ */
+static void fsp_sighandler(int signum)
+{
+	fprintf(stderr, "fdmi_sample_plugin interrupted by signal %d\n", signum);
+	m0_semaphore_up(&fsp_sem);
+
+        /* Restore default handlers. */
+	signal(SIGINT, SIG_DFL);
+	signal(SIGTERM, SIG_DFL);
+}
+
+static int fsp_sighandler_init(void)
+{
+	struct sigaction sa = { .sa_handler = fsp_sighandler };
+	int              rc;
+
+	sigemptyset(&sa.sa_mask);
+
+	/* Block these signals while the handler runs. */
+	sigaddset(&sa.sa_mask, SIGINT);
+	sigaddset(&sa.sa_mask, SIGTERM);
+
+	rc = sigaction(SIGINT, &sa, NULL) ?: sigaction(SIGTERM, &sa, NULL);
+	return rc == 0 ? 0 : M0_ERR(errno);
+}
+
+static void fsp_print_params(struct m0_fsp_params *params)
+{
+	fprintf(stderr,
+		"Starting params:\n"
+		"  local_ep: %s\n"
+		"  hare_ep : %s\n"
+		"  profile_fid : %s\n"
+		"  process_fid : %s\n"
+		"  plugin_fid  : %s\n",
+		params->spp_local_addr, params->spp_hare_addr,
+		params->spp_profile_fid, params->spp_process_fid,
+		params->spp_fdmi_plugin_fid_s);
+}
+
+int main(int argc, char **argv)
+{
+	int rc = 0;
+
+	if (argc == 1) {
+		fsp_usage();
+		exit(EXIT_FAILURE);
+	}
+
+	rc = fsp_args_parse(&fsp_params, argc, argv);
+	if (rc != 0) {
+		fprintf(stderr, "Args parse failed\n");
+		return M0_ERR(errno);
+	}
+
+	rc = m0_semaphore_init(&fsp_sem, 0);
+	if (rc != 0)
+		return M0_ERR(errno);
+
+	rc = fsp_init(&fsp_params);
+	if (rc != 0) {
+		rc = M0_ERR(errno);
+		goto fini_sem;
+	}
+
+	rc = fsp_sighandler_init();
+	if (rc != 0)
+		goto fini_fsp;
+
+        /* Main thread loop */
+	fsp_print_params(&fsp_params);
+	fprintf(stderr, "fdmi_sample_plugin waiting for signal...\n");
+	m0_semaphore_down(&fsp_sem);
+
+fini_fsp:
+	fsp_fini(&fsp_params);
+fini_sem:
+	m0_semaphore_fini(&fsp_sem);
+	return M0_RC(rc < 0 ? -rc : rc);
+}
+
+#undef M0_TRACE_SUBSYSTEM
+/** @} fdmi_sample_plugin */

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -41,6 +41,7 @@
 /m0rpcping-altogether
 /m0rwlock
 /m0stats
+/fdmi_sample_plugin
 /m0t1fs_*_test_helper
 /m0t1fs_io_file_pattern
 /m0t1fs_test


### PR DESCRIPTION
FDMI sample app.

 - python fdmi_app cleanup:
      * a standard arguments parsing
      * added possibility to pass fdmi_filter_id on start. If missed then config file is used
      * handling errors of forked c-program with showing error code and error message
      * cleanup with printfs - errors and messages go to stderr
      * checking for missed json fields
      * fixed python warnings and errors
 - c-program fdmi_sample_plugin cleanup:
      * fixed error handling and corrected mero client and service fini() in error cases
      * removed copy-pasted useless code
      * more info on what params are used for running
      * fixed printing errors to stdout. Now they go to stderr since the python wrapper parses stdout we better
        avoid printing debug and errors there
      * header file cleanup, moved static vars to the c file
      * fixed missed init for params->fdmi_plugin_fid_s
