### PR TITLE
net/lnet: fix compilation with gcc-9.3

### DIFF
--- a/mdservice/ut/lustre.c
+++ b/mdservice/ut/lustre.c
@@ -103,7 +103,7 @@ static uint16_t lustre_get_valid(uint16_t valid)
 static void lustre_copy_body(struct m0_fop_cob *body,
                              const struct m0_md_lustre_logrec *rec)
 {
-	struct m0_md_lustre_fid fid;
+        struct m0_md_lustre_fid fid;
 
         body->b_index = rec->cr_index;
         if (rec->cr_valid & M0_LA_SIZE)

--- a/mdservice/ut/lustre.c
+++ b/mdservice/ut/lustre.c
@@ -103,6 +103,8 @@ static uint16_t lustre_get_valid(uint16_t valid)
 static void lustre_copy_body(struct m0_fop_cob *body,
                              const struct m0_md_lustre_logrec *rec)
 {
+	struct m0_md_lustre_fid fid;
+
         body->b_index = rec->cr_index;
         if (rec->cr_valid & M0_LA_SIZE)
                 body->b_size = rec->cr_size;
@@ -129,8 +131,8 @@ static void lustre_copy_body(struct m0_fop_cob *body,
         body->b_version = rec->cr_version;
         body->b_flags = rec->cr_flags;
         body->b_valid = lustre_get_valid(rec->cr_valid);
-        lustre_copy_fid(&body->b_tfid, &rec->cr_tfid);
-        lustre_copy_fid(&body->b_pfid, &rec->cr_pfid);
+        fid = rec->cr_tfid; lustre_copy_fid(&body->b_tfid, &fid);
+        fid = rec->cr_pfid; lustre_copy_fid(&body->b_pfid, &fid);
 }
 
 static int lustre_create_fop(struct m0_fop *fop, void *data)

--- a/mdservice/ut/lustre.c
+++ b/mdservice/ut/lustre.c
@@ -131,8 +131,10 @@ static void lustre_copy_body(struct m0_fop_cob *body,
         body->b_version = rec->cr_version;
         body->b_flags = rec->cr_flags;
         body->b_valid = lustre_get_valid(rec->cr_valid);
-        fid = rec->cr_tfid; lustre_copy_fid(&body->b_tfid, &fid);
-        fid = rec->cr_pfid; lustre_copy_fid(&body->b_pfid, &fid);
+        fid = rec->cr_tfid;
+        lustre_copy_fid(&body->b_tfid, &fid);
+        fid = rec->cr_pfid;
+        lustre_copy_fid(&body->b_pfid, &fid);
 }
 
 static int lustre_create_fop(struct m0_fop *fop, void *data)

--- a/net/lnet/lnet_core.c
+++ b/net/lnet/lnet_core.c
@@ -391,6 +391,7 @@ int nlx_core_ep_addr_decode(struct nlx_core_domain *lcdom,
 	char *cp = strchr(ep_addr, ':');
 	char *endp;
 	size_t n = cp - ep_addr;
+	uint64_t nid;
 	int rc;
 
 	M0_ENTRY("ep_addr=%s", ep_addr);
@@ -399,9 +400,10 @@ int nlx_core_ep_addr_decode(struct nlx_core_domain *lcdom,
 		return M0_ERR(-EINVAL);
 	strncpy(nidstr, ep_addr, n);
 	nidstr[n] = 0;
-	rc = nlx_core_nidstr_decode(lcdom, nidstr, &cepa->cepa_nid);
+	rc = nlx_core_nidstr_decode(lcdom, nidstr, &nid);
 	if (rc != 0)
 		return M0_RC(rc);
+	cepa->cepa_nid = nid;
 	++cp;
 	cepa->cepa_pid = m0_strtou32(cp, &endp, 10);
 	if (*endp != ':')


### PR DESCRIPTION
When compiling with gcc-9.3:

    net/lnet/lnet_core.c:402:45: error: taking address of packed member of
    'struct nlx_core_ep_addr' may result in an unaligned pointer value
    [-Werror=address-of-packed-member]
      402 |  rc = nlx_core_nidstr_decode(lcdom, nidstr, &cepa->cepa_nid);
          |                                             ^~~~~~~~~~~~~~~
    cc1: all warnings being treated as errors

Solution: use local variable to get the nid value from nlx_core_nidstr_decode().