### PR TITLE
rm: fix compilation with gcc-7.3

### DIFF
--- a/rm/rm_fops.c
+++ b/rm/rm_fops.c
@@ -357,7 +357,7 @@ M0_INTERNAL int m0_rm_request_out(enum m0_rm_outgoing_type otype,
 				  struct m0_rm_credit     *credit,
 				  struct m0_rm_remote     *other)
 {
-	struct rm_out *outreq;
+	struct rm_out *outreq = NULL;
 	int            rc;
 
 	M0_ENTRY("sending request type: %d for incoming: %p credit value: %llu",


### PR DESCRIPTION
When compiling with gcc-7.3:

    In file included from motr/motr_altogether_user.c:344:0:
    rm/rm_fops.c: In function 'm0_rm_request_out':
    rm/rm_fops.c:205:5: error: 'outreq' may be used uninitialized in this function [-Werror=maybe-uninitialized]
      rc = fop_common_fill(outreq, in, credit, &cookie,
      ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    rm/rm_fops.c:360:17: note: 'outreq' was declared here
      struct rm_out *outreq;
                     ^~~~~~
    cc1: all warnings being treated as errors

Solution: initialise outreq variable at m0_rm_request_out().