### PR TITLE
Revert "isc: fix foms hashing by localities"

### DIFF
--- a/fop/fom.c
+++ b/fop/fom.c
@@ -630,8 +630,6 @@ M0_INTERNAL void m0_fom_queue(struct m0_fom *fom)
 
 	dom = m0_fom_dom();
 	loc_idx = fom->fo_ops->fo_home_locality(fom) % dom->fd_localities_nr;
-	M0_LOG(M0_DEBUG, "fom=%p locs_nr=%zu loc_idx=%zu", fom,
-	       dom->fd_localities_nr, loc_idx);
 	M0_ASSERT(loc_idx < dom->fd_localities_nr);
 	fom->fo_loc = dom->fd_localities[loc_idx];
 	fom->fo_loc_idx = loc_idx;

--- a/iscservice/isc.c
+++ b/iscservice/isc.c
@@ -94,14 +94,9 @@ struct m0_sm_state_descr isc_fom_phases[] = {
 
 static size_t fom_home_locality(const struct m0_fom *fom)
 {
-	struct m0_fop_isc *fi = m0_fop_data(fom->fo_fop);
-	size_t             hash;
+	struct m0_isc_comp_req *comp_req = M0_AMB(comp_req, fom, icr_fom);
 
-	M0_ENTRY("fom=%p cob="FID_F, fom, FID_P(&fi->fi_cob));
-	hash = m0_fid_hash(&fi->fi_cob);
-	M0_LEAVE("hash=%zx", hash);
-
-	return hash;
+	return m0_fid_hash(&comp_req->icr_comp_fid);
 }
 
 static struct m0_rpc_machine *fom_rmach(const struct m0_fom *fom)

--- a/iscservice/isc_fops.h
+++ b/iscservice/isc_fops.h
@@ -55,11 +55,10 @@ extern const struct m0_rpc_item_type m0_rpc_item_type_isc_rep;
 struct m0_fop_isc {
 	/** An identifier of the computation registered with the service. */
 	struct m0_fid        fi_comp_id;
-	/** A component object to perform the computation on. */
-	struct m0_fid        fi_cob;
 	/**
-	 * An array holding the relevant arguments for the computation,
-	 * like index vector for I/O on the cob.
+	 * An array holding the relevant arguments for the computation.
+	 * This might involve gfid, cob fid, and few other parameters
+	 * relevant to the required computation.
 	 */
 	struct m0_rpc_at_buf fi_args;
 	/**

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -276,34 +276,24 @@ M0_INTERNAL uint64_t m0_htable_size(const struct m0_htable *htable)
 	return len;
 }
 
-/*
- * Improved version of well-known djb2 hash-function.
- *
- * Here is an example of what it does with a big number
- * which changes only slightly from the beginning or end:
- *
- * hash 8aee7dc0513403da -> 612cbbc11beedeed
- * hash 7aee7dc0513403da -> 7f5a5f634d50c0ba
- * hash 7aee7dc0513403db -> af729f8afb4348f8
- */
-static uint64_t hash(void *buf, int n)
-{
-	uint64_t hash = 5381;
-	unsigned char *p;
-
-	for (p = buf; n-- > 0; p++) {
-		hash += ((unsigned long long)*p << 32) | *p;
-		hash *= 2971215073;
-		hash >>= 16;
-		hash *= 2971215073;
-	}
-
-	return hash;
-}
-
 M0_INTERNAL uint64_t m0_hash(uint64_t x)
 {
-	return hash(&x, sizeof(x));
+	uint64_t y;
+
+	y = x;
+	y <<= 18;
+	x -= y;
+	y <<= 33;
+	x -= y;
+	y <<= 3;
+	x += y;
+	y <<= 3;
+	x -= y;
+	y <<= 4;
+	x += y;
+	y <<= 2;
+
+	return x + y;
 }
 
 #undef M0_TRACE_SUBSYSTEM


### PR DESCRIPTION
Reverts Seagate/cortx-motr#808 which introduced too many test failures.