### PR TITLE
Changes in code to provide readability

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3214,8 +3214,8 @@ static void btree_put_split_and_find(struct nd *allocated_node,
 				     struct m0_btree_rec *rec,
 				     struct slot *tgt, struct m0_be_tx *tx)
 {
-	struct slot right_slot ;
-	struct slot left_slot;
+	struct slot              right_slot;
+	struct slot              left_slot;
 	struct m0_bufvec_cursor  cur_1;
 	struct m0_bufvec_cursor  cur_2;
 	int                      diff;


### PR DESCRIPTION
  
- Added MACROS: COPY_RECORD, COPY_VALUE, INIT_REC_WITH_KV_INFO
- Changing lev->l_seq = lev->l_node->n_seq to lev->l_seq = oi->i_nop.no_node->n_seq
    to avoid confusion

Signed-off-by: RadhaGulhane13 <radha.gulhane@seagate.com>