### PR TITLE
isc: improve parallelism of computations

### DIFF
--- a/iscservice/isc.c
+++ b/iscservice/isc.c
@@ -94,9 +94,10 @@ struct m0_sm_state_descr isc_fom_phases[] = {
 
 static size_t fom_home_locality(const struct m0_fom *fom)
 {
-	struct m0_isc_comp_req *comp_req = M0_AMB(comp_req, fom, icr_fom);
+	static int cnt = 0;
 
-	return m0_fid_hash(&comp_req->icr_comp_fid);
+	/* Distribute all reqs evenly among all available localities. */
+	return cnt++;
 }
 
 static struct m0_rpc_machine *fom_rmach(const struct m0_fom *fom)


### PR DESCRIPTION
Improve parallelism of computations by evenly distributing isc-foms among all the available localities.

Test results on my devvm with 4 CPUs:

1. Without the patch:
```
$ /usr/bin/time ./c0isc_demo max 123:12371 $((256*1024))
idx=8846249 val=32767.991000
1.21user 0.24system 0:10.57elapsed 13%CPU (0avgtext+0avgdata 126396maxresident)k
0inputs+32776outputs (2major+42331minor)pagefaults 0swaps
```

2. With the patch:
```
$ /usr/bin/time ./c0isc_demo max 123:12371 $((256*1024))
idx=8846249 val=32767.991000
1.26user 0.23system 0:06.39elapsed 23%CPU (0avgtext+0avgdata 126288maxresident)k
0inputs+32776outputs (2major+42426minor)pagefaults 0swaps
```