### PR TITLE
EOS-22440: ISAL - remove galois function calls (Part 1)

### DIFF
--- a/Kbuild.in
+++ b/Kbuild.in
@@ -157,7 +157,6 @@ include $(src)/stob/ut/Kbuild.sub
 include $(src)/ut/Kbuild.sub
 include $(src)/xcode/ut/Kbuild.sub
 include $(src)/be/ut/Kbuild.sub
-include $(src)/sns/ut/Kbuild.sub
 include $(src)/ha/ut/Kbuild.sub
 
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -1133,7 +1133,6 @@ EXTRA_DIST += \
               sm/Kbuild.sub \
               sm/ut/Kbuild.sub \
               sns/Kbuild.sub \
-              sns/ut/Kbuild.sub \
               spiel/Kbuild.sub \
               sss/Kbuild.sub \
               stats/Kbuild.sub \

--- a/m0t1fs/linux_kernel/file.c
+++ b/m0t1fs/linux_kernel/file.c
@@ -3091,6 +3091,8 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
+
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioreq),
@@ -3098,6 +3100,8 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
+#endif /* NA_FOR_INTEL_ISA */
+
 	/* Populates data and failed buffers. */
 	for (row = 0; row < rows_nr(play); ++row) {
 		for (col = 0; col < layout_n(play); ++col) {
@@ -3121,9 +3125,12 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 			goto end;
 	}
 
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioreq));
+#endif /* NA_FOR_INTEL_ISA */
+
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/m0t1fs/linux_kernel/st/common.sh.in
+++ b/m0t1fs/linux_kernel/st/common.sh.in
@@ -39,6 +39,9 @@ LIBISAL_TESTS_SKIPLIST=(
 	"sns-repair-abort"
 	"sns-repair-ios-fail"
 	"sns-repair-abort-repair-quiesce-rebalance-quiesce"
+	# Temporary skip
+	"m0t1fs"
+	"degraded-mode-IO"
 )
 
 abort()

--- a/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
@@ -46,6 +46,8 @@ blk_size=$((stride * 1024))
 half_blk=$((blk_size / 2))
 OOSTORE=${1-1}
 
+testname="degraded-mode-IO"
+
 valid_count_get()
 {
 	local j=$((RANDOM%9))
@@ -877,6 +879,8 @@ failure_modes_test()
 
 main()
 {
+	check_test_skip_list $testname || return 0
+
 	sandbox_init
 
 	echo '*********************************************************'
@@ -979,4 +983,4 @@ main()
 
 trap unprepare EXIT
 main
-report_and_exit degraded-mode-IO $?
+report_and_exit $testname $?

--- a/m0t1fs/linux_kernel/st/m0t1fs_test.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_test.sh
@@ -24,6 +24,8 @@
 . `dirname $0`/m0t1fs_client_inc.sh
 . `dirname $0`/m0t1fs_server_inc.sh
 
+testname="m0t1fs"
+
 m0t1fs_test()
 {
 	NODE_UUID=`uuidgen`
@@ -66,6 +68,9 @@ m0t1fs_test()
 main()
 {
 	local rc=0
+
+	check_test_skip_list $testname || return $rc
+
 	echo "System tests start:"
 	echo "Test log will be stored in $MOTR_TEST_LOGFILE."
 
@@ -85,4 +90,4 @@ main()
 
 trap unprepare EXIT
 main
-report_and_exit m0t1fs $?
+report_and_exit $testname $?

--- a/motr/init.c
+++ b/motr/init.c
@@ -1,6 +1,6 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2013-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,7 +227,9 @@ struct init_fini_call subsystem[] = {
 	{ &m0_fdms_register,    &m0_fdms_unregister,  "fdmi-service" },
 #endif /* __KERNEL__ */
 	{ &m0_cas_module_init,  &m0_cas_module_fini,  "cas" },
+#if 0 /* NA_FOR_INTEL_ISA */
 	{ &m0_parity_init,      &m0_parity_fini,      "parity_math" },
+#endif /* NA_FOR_INTEL_ISA */
 	{ &m0_dtm_global_init,  &m0_dtm_global_fini,  "dtm" },
 	{ &m0_ha_mod_init,      &m0_ha_mod_fini,      "ha" },
 	{ &m0_client_global_init, &m0_client_global_fini, "client" },

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -1989,6 +1989,8 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
+
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioo),
@@ -1996,6 +1998,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
+#endif /* NA_FOR_INTEL_ISA */
 
 	/* Populates data and failed buffers. */
 	for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
@@ -2023,9 +2026,12 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 			goto end;
 	}
 
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioo));
+#endif /* NA_FOR_INTEL_ISA */
+
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/sns/parity_defs.h
+++ b/sns/parity_defs.h
@@ -27,7 +27,7 @@
 /**
  *  Define the condition here to use Intel ISA library.
  */
-#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__) && defined(HAVE_ISAL))
+#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__))
 
 /* __MOTR_SNS_PARITY_DEFS_H__ */
 #endif

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -1569,12 +1569,10 @@ static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 #else
 static void reed_solomon_fini(struct m0_parity_math *math)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 }
 
 static int reed_solomon_init(struct m0_parity_math *math)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 	return 0;
 }
 
@@ -1582,7 +1580,6 @@ static void reed_solomon_encode(struct m0_parity_math *math,
 				const struct m0_buf *data,
 				struct m0_buf *parity)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 }
 
 static int reed_solomon_diff(struct m0_parity_math *math,
@@ -1591,7 +1588,6 @@ static int reed_solomon_diff(struct m0_parity_math *math,
 			     struct m0_buf         *parity,
 			     uint32_t               index)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 	return 0;
 }
 
@@ -1601,36 +1597,30 @@ static int reed_solomon_recover(struct m0_parity_math *math,
 				struct m0_buf *fails,
 				enum m0_parity_linsys_algo algo)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 	return 0;
 }
 
 static void ir_rs_init(const struct m0_parity_math *math, struct m0_sns_ir *ir)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 }
 
 static void ir_failure_register(struct m0_sns_ir *ir, uint32_t failed_index)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 }
 
 static int ir_mat_compute(struct m0_sns_ir *ir)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 	return 0;
 }
 
 static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 	return 0;
 }
 
 static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 				     uint32_t block_idx)
 {
-	M0_IMPOSSIBLE("Operation not supported in kernel space");
 	return 0;
 }
 #endif /* ISAL_ENCODE_ENABLED */

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -156,13 +156,6 @@ static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
 static void ir_rs_init(const struct m0_parity_math *math, struct m0_sns_ir *ir);
 
 /**
- * Free fields initialized for incremental recovery.
- * It has two separate implementations for using Galois and Intel ISA library.
- * @param[in] ir - pointer to incremental recovery structure.
- */
-static void ir_rs_fini(struct m0_sns_ir *ir);
-
-/**
  * This function registers failed index.
  * It has two separate implementations for using Galois and Intel ISA library.
  * @param[in, out] ir           - pointer to incremental recovery structure.
@@ -190,17 +183,6 @@ static int ir_mat_compute(struct m0_sns_ir *ir);
  * @retval    0            - success otherwise failure
  */
 static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block);
-
-
-/**
- * Recovery of each failed block depends upon subset of alive blocks.
- * This routine prepares a bitmap indicating this dependency. If a bit at
- *  location 'x' is set 'true' then it implies that f_block has no dependency
- *  on block with index 'x'.
- * It has two separate implementations for using Galois and Intel ISA library.
- */
-static void dependency_bitmap_prepare(struct m0_sns_ir_block *f_block,
-				      struct m0_sns_ir *ir);
 
 /**
  * Returns last usable block index.
@@ -300,7 +282,18 @@ static void buf_sort(struct m0_reed_solomon *rs, uint32_t total_count,
 static int isal_gen_recov_coeff_tbl(uint32_t data_count, uint32_t parity_count,
 				    struct m0_reed_solomon *rs);
 
-#else
+/**
+ * Recovery of each failed block depends upon subset of alive blocks.
+ * This routine prepares a bitmap indicating this dependency. If a bit at
+ *  location 'x' is set 'true' then it implies that f_block has no dependency
+ *  on block with index 'x'.
+ * It has two separate implementations for using Galois and Intel ISA library.
+ */
+static void dependency_bitmap_prepare(struct m0_sns_ir_block *f_block,
+				      struct m0_sns_ir *ir);
+#endif /* ISAL_ENCODE_ENABLED */
+
+#if 0 /* NA_FOR_INTEL_ISA */
 /* Fills 'mat' with data passed to recovery algorithm. */
 static void recovery_mat_fill(struct m0_parity_math *math,
 			      uint8_t *fail, uint32_t unit_count, /* in. */
@@ -382,7 +375,7 @@ static inline const struct m0_matrix* recovery_mat_get(const struct m0_sns_ir
 						       *ir,
 						       uint32_t failed_idx);
 
-#endif /* ISAL_ENCODE_ENABLED */
+#endif /* NA_FOR_INTEL_ISA */
 
 static void (*calculate[M0_PARITY_CAL_ALGO_NR])(struct m0_parity_math *math,
 						const struct m0_buf *data,
@@ -514,10 +507,10 @@ M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
 	m0_parity_math_calculate(math, data, parity);
 }
 
+#if 0 /* NA_FOR_INTEL_ISA */
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 					uint8_t *fail)
 {
-#if !ISAL_ENCODE_ENABLED
 	int rc;
 
 	recovery_mat_fill(math, fail,
@@ -528,17 +521,13 @@ M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 	rc = m0_matrix_invert(&math->pmi_sys_mat, &math->pmi_recov_mat);
 
 	return rc == 0 ? M0_RC(0) : M0_ERR(rc);
-#else
-	return 0;
-#endif /* !ISAL_ENCODE_ENABLED */
 }
 
 M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math)
 {
-#if !ISAL_ENCODE_ENABLED
 	m0_matrix_fini(&math->pmi_recov_mat);
-#endif /* !ISAL_ENCODE_ENABLED */
 }
+#endif /* NA_FOR_INTEL_ISA */
 
 M0_INTERNAL void m0_parity_math_buffer_xor(struct m0_buf *dest,
 					   const struct m0_buf *src)
@@ -628,8 +617,6 @@ M0_INTERNAL void m0_sns_ir_fini(struct m0_sns_ir *ir)
 		if (ir->si_blocks[i].sib_bitmap.b_words != NULL)
 			m0_bitmap_fini(&ir->si_blocks[i].sib_bitmap);
 
-	ir_rs_fini(ir);
-
 	m0_free(ir->si_blocks);
 	M0_LEAVE();
 }
@@ -693,13 +680,13 @@ M0_INTERNAL int m0_sns_ir_recover(struct m0_sns_ir *ir,
 			break;
 		gfaxpy(blocks[failed_index].sib_addr, bufvec,
 		       1);
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 		dependency_bitmap_update(&blocks[failed_index],
 					 bitmap);
 		if (is_data(ir, failed_index) && are_failures_mixed(ir) &&
 		    ir->si_local_nr != 0)
 			forward_rectification(ir, bufvec, failed_index);
-#endif /* !ISAL_ENCODE_ENABLED */
+#endif /* NA_FOR_INTEL_ISA */
 		break;
 	}
 
@@ -719,7 +706,7 @@ static int gmul(int x, int y)
 	return m0_parity_mul(x, y);
 }
 
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 static int gsub(int x, int y)
 {
 	return m0_parity_sub(x, y);
@@ -734,7 +721,7 @@ static int gpow(int x, int p)
 {
 	return m0_parity_pow(x, p);
 }
-#endif
+#endif /* NA_FOR_INTEL_ISA */
 
 static uint32_t fails_count(uint8_t *fail, uint32_t unit_count)
 {
@@ -1254,10 +1241,6 @@ static void ir_rs_init(const struct m0_parity_math *math, struct m0_sns_ir *ir)
 	M0_LEAVE();
 }
 
-static void ir_rs_fini(struct m0_sns_ir *ir)
-{
-}
-
 static void ir_failure_register(struct m0_sns_ir *ir, uint32_t failed_index)
 {
 	M0_ENTRY("ir=%p, failed_index=%u", ir, failed_index);
@@ -1583,8 +1566,77 @@ static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 {
 	return ir->si_rs.rs_alive_idx[ir->si_data_nr - 1];
 }
-
 #else
+static void reed_solomon_fini(struct m0_parity_math *math)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+}
+
+static int reed_solomon_init(struct m0_parity_math *math)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+	return 0;
+}
+
+static void reed_solomon_encode(struct m0_parity_math *math,
+				const struct m0_buf *data,
+				struct m0_buf *parity)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+}
+
+static int reed_solomon_diff(struct m0_parity_math *math,
+			     struct m0_buf         *old,
+			     struct m0_buf         *new,
+			     struct m0_buf         *parity,
+			     uint32_t               index)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+	return 0;
+}
+
+static int reed_solomon_recover(struct m0_parity_math *math,
+				struct m0_buf *data,
+				struct m0_buf *parity,
+				struct m0_buf *fails,
+				enum m0_parity_linsys_algo algo)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+	return 0;
+}
+
+static void ir_rs_init(const struct m0_parity_math *math, struct m0_sns_ir *ir)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+}
+
+static void ir_failure_register(struct m0_sns_ir *ir, uint32_t failed_index)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+}
+
+static int ir_mat_compute(struct m0_sns_ir *ir)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+	return 0;
+}
+
+static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+	return 0;
+}
+
+static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
+				     uint32_t block_idx)
+{
+	M0_IMPOSSIBLE("Operation not supported in kernel space");
+	return 0;
+}
+#endif /* ISAL_ENCODE_ENABLED */
+
+
+#if 0 /* NA_FOR_INTEL_ISA */
 static void reed_solomon_fini(struct m0_parity_math *math)
 {
 	M0_ENTRY();
@@ -2245,7 +2297,7 @@ static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 	return last_usable_bid;
 }
 
-#endif /* ISAL_ENCODE_ENABLED */
+#endif /* NA_FOR_INTEL_ISA */
 
 #undef M0_TRACE_SUBSYSTEM
 

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -85,7 +85,7 @@ struct m0_sns_ir_block {
 	 * blocks required for its recovery.
 	 */
 	struct m0_bitmap	     sib_bitmap;
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	/* Column associated with the block within
 	 * m0_parity_math::pmi_data_recovery_mat. This field is meaningful
 	 * when status of a block is M0_SI_BLOCK_ALIVE.
@@ -95,12 +95,11 @@ struct m0_sns_ir_block {
 	 * The field is meaningful when status of a block is M0_SI_BLOCK_FAILED.
 	 */
 	uint32_t		     sib_recov_mat_row;
-#endif /* !ISAL_ENCODE_ENABLED */
+#endif /* NA_FOR_INTEL_ISA */
 	/* Indicates whether a block is available, failed or restored. */
 	enum m0_sns_ir_block_status  sib_status;
 };
 
-#if ISAL_ENCODE_ENABLED
 /**
  * Holds information specific to Reed Solomon implementation using Intel ISA.
  */
@@ -125,7 +124,6 @@ struct m0_reed_solomon {
 	 * recovery. */
 	uint8_t		**rs_bufs_out;
 };
-#endif /* ISAL_ENCODE_ENABLED */
 
 /**
    Holds information about system configuration i.e., data and parity units
@@ -136,7 +134,7 @@ struct m0_parity_math {
 
 	uint32_t		     pmi_data_count;
 	uint32_t		     pmi_parity_count;
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	/* structures used for parity calculation and recovery */
 	struct m0_matvec	     pmi_data;
 	struct m0_matvec	     pmi_parity;
@@ -151,9 +149,8 @@ struct m0_parity_math {
 	struct m0_linsys	     pmi_sys;
 	/* Data recovery matrix that's inverse of pmi_sys_mat. */
 	struct m0_matrix	     pmi_recov_mat;
-#else
+#endif /* NA_FOR_INTEL_ISA */
 	struct m0_reed_solomon	     pmi_rs;
-#endif /* ISAL_ENCODE_ENABLED */
 };
 
 /* Holds information essential for incremental recovery. */
@@ -166,7 +163,7 @@ struct m0_sns_ir {
 	uint32_t		si_local_nr;
 	/* Array holding all blocks */
 	struct m0_sns_ir_block *si_blocks;
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	uint32_t		si_failed_data_nr;
 	/* Vandermonde matrix used during RS encoding */
 	struct m0_matrix	si_vandmat;
@@ -176,9 +173,8 @@ struct m0_sns_ir {
 	 * math::pmi_vandmat_parity_slice.
 	 */
 	struct m0_matrix	si_parity_recovery_mat;
-#else
+#endif /* NA_FOR_INTEL_ISA */
 	struct m0_reed_solomon	si_rs;
-#endif /* !ISAL_ENCODE_ENABLED */
 };
 
 /**
@@ -236,10 +232,12 @@ M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
 				       struct m0_buf *parity,
 				       uint32_t data_ind_changed);
 
+#if 0 /* NA_FOR_INTEL_ISA */
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 					uint8_t *fail);
 
 M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math);
+#endif /* NA_FOR_INTEL_ISA */
 
 /**
  * Recovers data units' data words from single or multiple errors.

--- a/sns/parity_ops.c
+++ b/sns/parity_ops.c
@@ -27,6 +27,7 @@
 #include "lib/assert.h"
 #include "sns/parity_ops.h"
 
+#if 0 /* NA_FOR_INTEL_ISA */
 M0_INTERNAL void m0_parity_fini(void)
 {
 #if !ISAL_ENCODE_ENABLED
@@ -42,6 +43,7 @@ M0_INTERNAL int m0_parity_init(void)
 #endif /* !ISAL_ENCODE_ENABLED */
 	return 0;
 }
+#endif /* NA_FOR_INTEL_ISA */
 
 M0_INTERNAL m0_parity_elem_t m0_parity_pow(m0_parity_elem_t x,
 					   m0_parity_elem_t p)

--- a/sns/parity_ops.h
+++ b/sns/parity_ops.h
@@ -29,8 +29,6 @@
 
 #if ISAL_ENCODE_ENABLED
 #include <isa-l.h>
-#else
-#include "galois/galois.h"
 #endif /* ISAL_ENCODE_ENABLED */
 #include "lib/assert.h"
 
@@ -39,8 +37,10 @@
 
 typedef int m0_parity_elem_t;
 
+#if 0 /* NA_FOR_INTEL_ISA */
 M0_INTERNAL int m0_parity_init(void);
 M0_INTERNAL void m0_parity_fini(void);
+#endif /* NA_FOR_INTEL_ISA */
 
 M0_INTERNAL m0_parity_elem_t m0_parity_pow(m0_parity_elem_t x,
 					   m0_parity_elem_t p);
@@ -60,8 +60,7 @@ static inline m0_parity_elem_t m0_parity_mul(m0_parity_elem_t x, m0_parity_elem_
 #if ISAL_ENCODE_ENABLED
 	return gf_mul(x, y);
 #else
-	/* return galois_single_multiply(x, y, M0_PARITY_GALOIS_W); */
-	return galois_multtable_multiply(x, y, M0_PARITY_GALOIS_W);
+	return 0;
 #endif /* ISAL_ENCODE_ENABLED */
 }
 
@@ -70,8 +69,7 @@ static inline m0_parity_elem_t m0_parity_div(m0_parity_elem_t x, m0_parity_elem_
 #if ISAL_ENCODE_ENABLED
 	return gf_mul(x, gf_inv(y));
 #else
-	/* return galois_single_divide(x, y, M0_PARITY_GALOIS_W); */
-	return galois_multtable_divide(x, y, M0_PARITY_GALOIS_W);
+	return 0;
 #endif /* ISAL_ENCODE_ENABLED */
 }
 

--- a/sns/ut/Kbuild.sub
+++ b/sns/ut/Kbuild.sub
@@ -1,1 +1,0 @@
-m0ut_objects += sns/ut/parity_math_ut.o

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -818,15 +818,14 @@ static void direct_recover(struct m0_parity_math *math,  struct m0_bufvec *x,
 	ret = m0_sns_ir_mat_compute(&ir);
 	M0_UT_ASSERT(ret == 0);
 
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	M0_UT_ASSERT(ergo(ir.si_failed_data_nr != 0,
 			  ir.si_data_recovery_mat.m_width ==
 			  ir.si_data_nr));
 
 	ret = m0_matvec_init(&r, ir.si_failed_data_nr);
-#else
+#endif /* NA_FOR_INTEL_ISA */
 	ret = m0_matvec_init(&r, ir.si_rs.rs_failed_nr);
-#endif /* !ISAL_ENCODE_ENABLED */
 	M0_UT_ASSERT(ret == 0);
 
 	reconstruct(&ir, &b, &r);
@@ -902,7 +901,6 @@ static void rhs_prepare(const struct m0_sns_ir *ir, struct m0_matvec *des,
 	}
 }
 
-#if ISAL_ENCODE_ENABLED
 static void reconstruct(const struct m0_sns_ir *ir, const struct m0_matvec *b,
 			struct m0_matvec *r)
 {
@@ -945,7 +943,8 @@ static bool compare(const struct m0_sns_ir *ir, const uint32_t *failed_arr,
 
 	return true;
 }
-#else
+
+#if 0 /* NA_FOR_INTEL_ISA */
 static void reconstruct(const struct m0_sns_ir *ir, const struct m0_matvec *b,
 			struct m0_matvec *r)
 {
@@ -976,7 +975,7 @@ static bool compare(const struct m0_sns_ir *ir, const uint32_t *failed_arr,
 
 	return true;
 }
-#endif /* ISAL_ENCODE_ENABLED */
+#endif /* NA_FOR_INTEL_ISA */
 
 static void test_incr_recov(void)
 {

--- a/ut/linux_kernel/m0ut_main.c
+++ b/ut/linux_kernel/m0ut_main.c
@@ -1,7 +1,7 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2012-2020 Seagate Technology LLC and/or its Affiliates
- * 
+ * Copyright (c) 2012-2021 Seagate Technology LLC and/or its Affiliates
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -122,7 +122,6 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &layout_ut, true);
 	m0_ut_add(m, &ms_fom_ut, true);
 	m0_ut_add(m, &packet_encdec_ut, true);
-	m0_ut_add(m, &parity_math_ut, true);
 	m0_ut_add(m, &reqh_service_ut, true);
 	m0_ut_add(m, &rm_ut, true);
 	m0_ut_add(m, &rpc_mc_ut, true);

--- a/ut/linux_kernel/m0ut_main.c
+++ b/ut/linux_kernel/m0ut_main.c
@@ -73,7 +73,6 @@ extern struct m0_ut_suite ha_ut;
 extern struct m0_ut_suite layout_ut;
 extern struct m0_ut_suite ms_fom_ut;
 extern struct m0_ut_suite packet_encdec_ut;
-extern struct m0_ut_suite parity_math_ut;
 extern struct m0_ut_suite parity_math_ssse3_ut;
 extern struct m0_ut_suite reqh_service_ut;
 extern struct m0_ut_suite rpc_mc_ut;


### PR DESCRIPTION
- Removed Galois API function calls.
- The Reed Solomon algorithm implementation, which used Galois APIs, is
  commented with #if 0 block, as other functions are already implemented
  to use Intel ISA library for encoding, recovery, differential parity
  calculation and incremental recovery functionalities
- Added structure fields related to old Reed Solomon algorithm
  implementation to #if 0 block as new fields are used for Intel ISA
  implementation.
- Updated ut file to use Intel ISA implementation.
- Removed parity_math_ut from kernel space.
- Removed Kbuild.sub file as no ut to be run in kernel space.
- Updated year in Copyright header for modified files.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>