### PR TITLE
EOS-21940 Fix m0reportbug to work on devvm

### DIFF
--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -753,6 +753,14 @@ m0traces() {
              find $dir -type f -name m0trace.\* |
                  last_modified "${M0TRACES_M0D_MAX:-}"
          done
+         find . -maxdepth 1 -type d -name m0u\* | while read dir; do
+             find $dir -type f -name m0trace.\* |
+                 last_modified "${M0TRACES_MAX:-}"
+         done
+         find . -maxdepth 1 -type d -name systest-\* | while read dir; do
+             find $dir -type f -name m0trace.\* |
+                 last_modified "${M0TRACES_MAX:-}"
+         done
      } | cut -c3- | sort -u | while read path; do
          _tracedump $path $outdir
      done)


### PR DESCRIPTION
In devvm, m0reportbug was only packing m0traces.* files from
/var/motr/ and /var/motr/m0d-* paths, and it was not picking
the files from subdirectories of /var/motr/

Added the code in m0reportbug script to find m0traces.* files
from the relevant paths

Signed-off-by: Bhargav Dekivadiya <bhargav.dekivadiya@seagate.com>