### PR TITLE
Expensive check changes

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3162,7 +3162,8 @@ static int64_t btree_put_root_split_handle(struct m0_btree_op *bop,
 
 	/* Increase height by one */
 	tree->t_height++;
-
+	M0_ASSERT(node_expensive_invariant(lev->l_node));
+	M0_ASSERT(node_expensive_invariant(oi->i_extra_node));
 	node_unlock(lev->l_node);
 	node_unlock(oi->i_extra_node);
 
@@ -3317,6 +3318,8 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 	tgt.s_node == lev->l_node ? node_seq_cnt_update(lev->l_node) :
 				    node_seq_cnt_update(lev->l_alloc);
 	node_fix(tgt.s_node, bop->bo_tx);
+	M0_ASSERT(node_expensive_invariant(lev->l_node));
+	M0_ASSERT(node_expensive_invariant(lev->l_alloc));
 
 	node_unlock(lev->l_alloc);
 	node_unlock(lev->l_node);
@@ -3356,6 +3359,7 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 			node_seq_cnt_update(lev->l_node);
 			node_fix(lev->l_node, bop->bo_tx);
 			btree_callback_add(oi, lev->l_node, lev->l_idx);
+			M0_ASSERT(node_expensive_invariant(lev->l_node));
 
 			node_unlock(lev->l_node);
 			lock_op_unlock(bop->bo_arbor->t_desc);
@@ -3379,6 +3383,8 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 		tgt.s_node == lev->l_node ? node_seq_cnt_update(lev->l_node) :
 					    node_seq_cnt_update(lev->l_alloc);
 		node_fix(tgt.s_node, bop->bo_tx);
+		M0_ASSERT(node_expensive_invariant(lev->l_node));
+		M0_ASSERT(node_expensive_invariant(lev->l_alloc));
 
 		node_unlock(lev->l_alloc);
 		node_unlock(lev->l_node);
@@ -3701,6 +3707,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 		node_seq_cnt_update(lev->l_node);
 		node_fix(lev->l_node, bop->bo_tx);
 		btree_callback_add(oi, lev->l_node, lev->l_idx);
+		M0_ASSERT(node_expensive_invariant(lev->l_node));
 
 		node_unlock(lev->l_node);
 		lock_op_unlock(tree);
@@ -4759,6 +4766,7 @@ static int64_t btree_del_resolve_underflow(struct m0_btree_op *bop)
 		node_fix(node_slot.s_node, bop->bo_tx);
 		btree_callback_add(oi, lev->l_node, lev->l_idx);
 
+		M0_ASSERT(node_expensive_invariant(lev->l_node));
 		node_unlock(lev->l_node);
 
 		/* check if underflow after deletion */
@@ -4798,6 +4806,8 @@ static int64_t btree_del_resolve_underflow(struct m0_btree_op *bop)
 	btree_callback_add(oi, lev->l_node, 0);
 	btree_callback_add(oi, root_child, 0);
 
+	M0_ASSERT(node_expensive_invariant(lev->l_node));
+	M0_ASSERT(node_count_rec(root_child) == 0);
 	node_unlock(lev->l_node);
 	node_unlock(root_child);
 
@@ -5119,6 +5129,7 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 			node_fix(node_slot.s_node, bop->bo_tx);
 			btree_callback_add(oi, lev->l_node, lev->l_idx);
 
+			M0_ASSERT(node_expensive_invariant(lev->l_node));
 			node_unlock(lev->l_node);
 
 			rec.r_flags = M0_BSC_SUCCESS;
@@ -6467,7 +6478,6 @@ static void btree_ut_kv_oper_thread_handler(struct btree_ut_thread_info *ti)
 			keys_put_count++;
 			key_first += ti->ti_key_incr;
 		}
-		M0_ASSERT(node_expensive_invariant(tree->t_desc->t_root));
 		/** GET and ITERATE over the keys which we inserted above. */
 
 		/**  Randomly decide the iteration direction. */

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -1409,7 +1409,6 @@ static bool node_invariant(const struct nd *node)
 /**
  * This function is implemented for debugging purpose and should get called in
  * node lock mode.
- * TBD : This function needs to be removed when debugging is done.
  */
 static bool node_expensive_invariant(const struct nd *node)
 {
@@ -3276,6 +3275,7 @@ static int64_t btree_put_root_split_handle(struct m0_btree_op *bop,
 	/* Increase height by one */
 	tree->t_height++;
 
+	/* TBD : This check needs to be removed when debugging is done. */
 	M0_ASSERT(node_expensive_invariant(lev->l_node));
 	M0_ASSERT(node_expensive_invariant(oi->i_extra_node));
 	node_unlock(lev->l_node);
@@ -3431,6 +3431,7 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 	btree_node_capture_enlist(oi, lev->l_alloc, 0);
 	btree_node_capture_enlist(oi, lev->l_node, 0);
 
+	/* TBD : This check needs to be removed when debugging is done. */
 	M0_ASSERT(node_expensive_invariant(lev->l_alloc));
 	M0_ASSERT(node_expensive_invariant(lev->l_node));
 	node_unlock(lev->l_alloc);
@@ -3472,6 +3473,10 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 			node_fix(lev->l_node, bop->bo_tx);
 			btree_node_capture_enlist(oi, lev->l_node, lev->l_idx);
 
+			/**
+			 * TBD : This check needs to be removed when debugging
+			 * is done.
+			 */
 			M0_ASSERT(node_expensive_invariant(lev->l_node));
 			node_unlock(lev->l_node);
 			return P_CAPTURE;
@@ -3496,6 +3501,10 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 		btree_node_capture_enlist(oi, lev->l_alloc, 0);
 		btree_node_capture_enlist(oi, lev->l_node, 0);
 
+		/**
+		 * TBD : This check needs to be removed when debugging is
+		 * done.
+		 */
 		M0_ASSERT(node_expensive_invariant(lev->l_alloc));
 		M0_ASSERT(node_expensive_invariant(lev->l_node));
 		node_unlock(lev->l_alloc);
@@ -3818,6 +3827,10 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 		node_fix(lev->l_node, bop->bo_tx);
 		btree_node_capture_enlist(oi, lev->l_node, lev->l_idx);
 
+		/**
+		 * TBD : This check needs to be removed when debugging is
+		 * done.
+		 */
 		M0_ASSERT(node_expensive_invariant(lev->l_node));
 		node_unlock(lev->l_node);
 		return P_CAPTURE;
@@ -4903,6 +4916,10 @@ static int64_t btree_del_resolve_underflow(struct m0_btree_op *bop)
 		node_fix(node_slot.s_node, bop->bo_tx);
 		btree_node_capture_enlist(oi, lev->l_node, lev->l_idx);
 
+		/**
+		 * TBD : This check needs to be removed when debugging is
+		 * done.
+		 */
 		M0_ASSERT(node_expensive_invariant(lev->l_node));
 		node_unlock(lev->l_node);
 
@@ -4942,6 +4959,7 @@ static int64_t btree_del_resolve_underflow(struct m0_btree_op *bop)
 	btree_node_capture_enlist(oi, lev->l_node, 0);
 	btree_node_capture_enlist(oi, root_child, 0);
 
+	/* TBD : This check needs to be removed when debugging is done. */
 	M0_ASSERT(node_expensive_invariant(lev->l_node));
 	node_unlock(lev->l_node);
 	node_unlock(root_child);
@@ -5264,6 +5282,10 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 			node_fix(node_slot.s_node, bop->bo_tx);
 			btree_node_capture_enlist(oi, lev->l_node, lev->l_idx);
 
+			/**
+			 * TBD : This check needs to be removed when debugging
+			 * is done.
+			 */
 			M0_ASSERT(node_expensive_invariant(lev->l_node));
 			node_unlock(lev->l_node);
 


### PR DESCRIPTION
- Removed expensive invariant check from ut.
- Added expensive invariant check in insert and delete routine whenever there is modification in node.
- Performing expensive invariant check in node lock mode.