### PR TITLE
Eos 22550 : changes for capturing transactions for KV Delete operation.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7652,6 +7652,7 @@ static void ut_put_del_operation(void)
 					      .ksize = 8,
 					      .vsize = 8, };
 	struct m0_be_tx        *tx          = NULL;
+	struct m0_be_seg       *seg         = NULL;
 	struct m0_btree_op      b_op        = {};
 	struct m0_btree        *tree;
 	void                   *temp_node;
@@ -7681,7 +7682,7 @@ static void ut_put_del_operation(void)
 	temp_node = m0_alloc_aligned((1024 + sizeof(struct nd)), 10);
 	M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 				 m0_btree_create(temp_node, 1024, &btree_type,
-						 nt, &b_op, tx));
+						 nt, &b_op, seg, tx));
 
 	tree = b_op.bo_arbor;
 	inc = false;

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3243,7 +3243,7 @@ static void btree_tx_commit_cb(void *payload)
 	node_unlock(node);
 }
 
-static void btree_tx_node_capture(struct m0_btree_oimpl *oi,
+static void btree_tx_nodes_capture(struct m0_btree_oimpl *oi,
 				  struct m0_be_tx *tx)
 {
 	struct node_capture_info *arr = oi->i_capture;
@@ -3914,7 +3914,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 		return P_CAPTURE;
 	}
 	case P_CAPTURE:
-		btree_tx_node_capture(oi, bop->bo_tx);
+		btree_tx_nodes_capture(oi, bop->bo_tx);
 		lock_op_unlock(tree);
 		return m0_sm_op_sub(&bop->bo_op, P_CLEANUP, P_FINI);
 	case P_CLEANUP:
@@ -5373,7 +5373,7 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 		 * TBD: uncomment function call below once node_free changes
 		 * done.
 		 */
-		/* btree_tx_node_capture(oi, bop->bo_tx); */
+		/* btree_tx_nodes_capture(oi, bop->bo_tx); */
 		return P_FREENODE;
 	case P_FREENODE : {
 		int i;


### PR DESCRIPTION
- calling P_CAPTURE before P_FREENODE
- unlocking tree after node_free operation.

Signed-off-by: Radha Gulhane <radha.gulhane@seagate.com>