### PR TITLE
Eos 22550 modified : changes for capturing transactions for KV Delete operation.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -1458,12 +1458,16 @@ static bool node_verify(const struct nd *node)
 #ifndef __KERNEL__
 /**
  * This function should get called in node_lock or tree_lock mode. As, it deals
- * with header update which will get modified only in tree_lock and node_lock
+ * with header update and n_be_node_valid flag check which will get modified
+ * only node_fini() in node lock mode or node_free() in tree_lock and node_lock
  * mode.
  */
 static bool node_isvalid(const struct nd *node)
 {
-	return node->n_type->nt_isvalid(&node->n_addr);
+	if (node->n_be_node_valid)
+		return node->n_type->nt_isvalid(&node->n_addr);
+
+	return false;
 }
 
 #endif

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7652,6 +7652,7 @@ static void ut_put_del_operation(void)
 					      .ksize = 8,
 					      .vsize = 8, };
 	struct m0_be_tx        *tx          = NULL;
+	struct m0_be_seg       *seg         = NULL;
 	struct m0_btree_op      b_op        = {};
 	struct m0_btree        *tree;
 	void                   *temp_node;
@@ -7681,7 +7682,7 @@ static void ut_put_del_operation(void)
 	temp_node = m0_alloc_aligned((1024 + sizeof(struct nd)), 10);
 	M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 				 m0_btree_create(temp_node, 1024, &btree_type,
-						 nt, &b_op, tx));
+						 nt, &b_op, seg, tx));
 
 	tree = b_op.bo_arbor;
 	inc = false;

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3681,6 +3681,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 
 			node_lock(lev->l_node);
 			lev->l_seq = oi->i_nop.no_node->n_seq;
+			oi->i_nop.no_node = NULL;
 
 			/**
 			 * Node validation is required to determine that the
@@ -3699,8 +3700,6 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
 						    P_SETUP);
 			}
-
-			oi->i_nop.no_node = NULL;
 
 			oi->i_key_found = node_find(&node_slot,
 						    &bop->bo_rec.r_key);
@@ -3800,6 +3799,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 				int vsize;
 				int shift;
 				lev->l_alloc = oi->i_nop.no_node;
+				oi->i_nop.no_node = NULL;
 				node_lock(lev->l_node);
 				if (!node_isvalid(lev->l_node)) {
 					node_unlock(lev->l_node);
@@ -3819,6 +3819,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 
 			} else if (oi->i_extra_node == NULL) {
 				oi->i_extra_node = oi->i_nop.no_node;
+				oi->i_nop.no_node = NULL;
 				return P_LOCK;
 			} else
 				M0_ASSERT(0);
@@ -5232,6 +5233,7 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 
 			node_lock(lev->l_node);
 			lev->l_seq = oi->i_nop.no_node->n_seq;
+			oi->i_nop.no_node = NULL;
 
 			/**
 			 * Node validation is required to determine that the
@@ -5249,8 +5251,6 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
 						    P_SETUP);
 			}
-
-			oi->i_nop.no_node = NULL;
 
 			oi->i_key_found = node_find(&node_slot,
 						    &bop->bo_rec.r_key);
@@ -5314,14 +5314,15 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 			root_child = oi->i_level[1].l_sibling;
 			node_lock(root_child);
 
+			oi->i_level[1].l_sib_seq = oi->i_nop.no_node->n_seq;
+			oi->i_nop.no_node = NULL;
+
 			if (!node_isvalid(root_child) ||
 			    node_count_rec(root_child) == 0) {
 				node_unlock(root_child);
  				return m0_sm_op_sub(&bop->bo_op, P_CLEANUP,
 						    P_SETUP);
 			}
-			/* store child of the root. */
-			oi->i_level[1].l_sib_seq = oi->i_nop.no_node->n_seq;
 
 			node_unlock(root_child);
 			/* Fall through to the next step */

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -1455,7 +1455,7 @@ static bool node_verify(const struct nd *node)
 
 #ifndef __KERNEL__
 /**
- * This function should get called in node_lock mode only.
+ * This function should be called after acquiring node lock.
  */
 static bool node_isvalid(const struct nd *node)
 {

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -2106,7 +2106,6 @@ static void node_put(struct node_op *op, struct nd *node, struct m0_be_tx *tx)
 			m0_rwlock_fini(&node->n_lock);
 			m0_free(node);
 			m0_rwlock_write_unlock(&list_lock);
-			/** Capture in transaction */
 			return;
 		}
 	}
@@ -2131,6 +2130,7 @@ static int64_t node_free(struct node_op *op, struct nd *node,
 	node->n_be_node_valid = false;
 	op->no_addr = node->n_addr;
 	m0_free_aligned(segaddr_addr(&op->no_addr), 1ULL << shift, shift);
+	/** Capture in transaction */
 
 	if (node->n_ref == 0 && node->n_txref == 0) {
 		ndlist_tlink_del_fini(node);
@@ -3789,8 +3789,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 				if (!node_isvalid(lev->l_node)) {
 					node_unlock(lev->l_node);
 					return m0_sm_op_sub(&bop->bo_op,
-								P_CLEANUP,
-								P_SETUP);
+							    P_CLEANUP, P_SETUP);
 				}
 				ksize = node_keysize(lev->l_node);
 				vsize = node_valsize(lev->l_node);
@@ -5391,7 +5390,7 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 		}
 
 		if (oi->i_key_found) {
-			if (oi->i_used == 0 ||  !node_underflow) {
+			if (oi->i_used == 0 || !node_underflow) {
 				/* No Underflow */
 				return P_CAPTURE;
 			}


### PR DESCRIPTION
This is the final PR. 
It includes following changes :
- calling node_fini separately than node_free.
- calling node_fini before P_CAPTURE and then calling P_FREENODE so that issue of freeing node_descriptor bfore node_capture will be resolved.
- Added node_lock at necessary places whenever we call node_isvalid()