### PR TITLE
[DTM0] EOS-22352: PoC of Versioned ordinary catalogues.

### DIFF
--- a/cas/cas.c
+++ b/cas/cas.c
@@ -222,6 +222,68 @@ M0_INTERNAL bool cas_in_ut(void)
 	return M0_FI_ENABLED("ut");
 }
 
+M0_INTERNAL bool m0_crv_tbs(const struct m0_crv *crv)
+{
+	return crv->crv_encoded & M0_CRV_TBS;
+}
+
+M0_INTERNAL void m0_crv_tbs_set(struct m0_crv *crv, bool tbs)
+{
+	if (tbs)
+		crv->crv_encoded |= M0_CRV_TBS;
+	else
+		crv->crv_encoded &= ~M0_CRV_TBS;
+}
+
+M0_INTERNAL struct m0_dtm0_ts m0_crv_ts(const struct m0_crv *crv)
+{
+	return (struct m0_dtm0_ts) {
+		.dts_phys = crv->crv_encoded & ~M0_CRV_TBS
+	};
+}
+
+M0_INTERNAL void m0_crv_ts_set(struct m0_crv           *crv,
+			       const struct m0_dtm0_ts *ts)
+{
+	crv->crv_encoded = (crv->crv_encoded & M0_CRV_TBS) | ts->dts_phys;
+}
+
+M0_INTERNAL void m0_crv_init(struct m0_crv           *crv,
+			     const struct m0_dtm0_ts *ts,
+			     bool                     tbs)
+{
+	uint64_t version = ts->dts_phys;
+
+	M0_PRE(version <= M0_CRV_VER_MAX);
+	M0_PRE(version >= M0_CRV_VER_MIN);
+
+	m0_crv_ts_set(crv, ts);
+	m0_crv_tbs_set(crv, tbs);
+
+	M0_POST(equi(m0_crv_tbs(crv), tbs));
+	M0_POST(m0_crv_ts(crv).dts_phys == version);
+}
+
+/*
+ * Compare two versions.
+ *   Note, tombstones are checked at the end which means that if there are two
+ * different operations with the same version (for example, PUT@10 and DEL@10)
+ * then the operation that puts the tombstone (DEL@10) is always considered
+ * to be "newer" than the other one. It helps to ensure operations have the
+ * same order on any server despite the order of execution.
+ */
+M0_INTERNAL int m0_crv_cmp(const struct m0_crv *left,
+			   const struct m0_crv *right)
+{
+	return M0_3WAY(m0_crv_ts(left).dts_phys, m0_crv_ts(right).dts_phys) ?:
+		M0_3WAY(m0_crv_tbs(left), m0_crv_tbs(right));
+}
+
+M0_INTERNAL bool m0_crv_is_none(const struct m0_crv *crv)
+{
+	return memcmp(crv, &M0_CRV_INIT_NONE, sizeof(*crv)) == 0;
+}
+
 #undef M0_TRACE_SUBSYSTEM
 
 /** @} end of cas group */

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -136,6 +136,21 @@ struct m0_cas_kv_vec {
 } M0_XCA_SEQUENCE M0_XCA_DOMAIN(rpc);
 
 /**
+ * Version of a CAS record.
+ * A version comprises a physical timestamp and a tombstone flag.
+ * The timestamp is set on the client side whenever the corresponding
+ * record was supposed to be modified by PUT or DEL request.
+ * The tombstone flag is set when the corresponding record has been
+ * "logicaly" removed from the storage (although, it still exists
+ * there as a "dead" record).
+ * See ::COF_VERSIONED for details.
+ */
+struct m0_cas_kv_ver {
+	struct m0_dtm0_ts ckv_ts;
+	bool              ckv_tombstone;
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
+
+/**
  * CAS index record.
  */
 struct m0_cas_rec {
@@ -196,6 +211,13 @@ struct m0_cas_rec {
 	 * records.
 	 */
 	uint64_t             cr_rc;
+
+	/**
+	 * Optional version of this record.
+	 * The version is returned as a reply to GET and NEXT requests
+	 * when COF_VERSIONED is specified in the request.
+	 */
+	struct m0_cas_kv_ver cr_ver;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 /**
@@ -290,6 +312,19 @@ enum m0_cas_op_flags {
 	 * use the flag but they do not depend on enabled DTM0).
 	 */
 	COF_VERSIONED = 1 << 8,
+
+	/**
+	 * Makes NEXT return "dead" records (with tombstones) when
+	 * version-aware behavior is specified (see ::COF_VERSIONED).
+	 * By default, COF_VERSIONED does not return dead records for NEXT
+	 * requests but when both flags are specified (VERSIONED | SHOW_DEAD)
+	 * then it yields all records whether they are alive or not.
+	 * It might be used by the client when it wants to analyse the records
+	 * received from several catalogue services, so that it could properly
+	 * merge the results of NEXT operations eliminating inconsistencies.
+	 * In other words, it might be used in degraded mode.
+	 */
+	COF_SHOW_DEAD = 1 << 9,
 };
 
 enum m0_cas_opcode {

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -136,19 +136,26 @@ struct m0_cas_kv_vec {
 } M0_XCA_SEQUENCE M0_XCA_DOMAIN(rpc);
 
 /**
- * Version of a CAS record.
+ * CAS record version and tombstone encoded in on-disk/on-wire format.
+ * Format:
+ *     MSB                             LSB
+ *     +----------------+----------------+
+ *     | 1 bit          | 63 bits        |
+ *     |<- tombstone -> | <- timestamp ->|
+ *     +----------------+----------------+
+ *
  * A version comprises a physical timestamp and a tombstone flag.
  * The timestamp is set on the client side whenever the corresponding
  * record was supposed to be modified by PUT or DEL request.
  * The tombstone flag is set when the corresponding record has been
  * "logicaly" removed from the storage (although, it still exists
  * there as a "dead" record).
- * See ::COF_VERSIONED for details.
+ *
+ * See ::COF_VERSIONED, ::M0_CRV_VER_NONE for details.
  */
-struct m0_cas_kv_ver {
-	struct m0_dtm0_ts ckv_ts;
-	bool              ckv_tombstone;
-} M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
+struct m0_crv {
+	uint64_t crv_encoded;
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc|be);
 
 /**
  * CAS index record.
@@ -217,7 +224,7 @@ struct m0_cas_rec {
 	 * The version is returned as a reply to GET and NEXT requests
 	 * when COF_VERSIONED is specified in the request.
 	 */
-	struct m0_cas_kv_ver cr_ver;
+	struct m0_crv cr_ver;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 /**
@@ -463,6 +470,48 @@ M0_INTERNAL void m0_cas_id_fini(struct m0_cas_id *cid);
 M0_INTERNAL bool m0_cas_id_invariant(const struct m0_cas_id *cid);
 
 M0_INTERNAL bool cas_in_ut(void);
+
+enum {
+	/* Tombstone flag: marks a dead kv pair. We use the MSB here. */
+	M0_CRV_TBS = 1L << (sizeof(uint64_t) * CHAR_BIT - 1),
+	/*
+	 * A special value for the empty version.
+	 * A record with the empty version is always overwritten by any
+	 * PUT or DEL operation that has a valid non-empty version.
+	 * A PUT or DEL operation with the empty version always ignores
+	 * the version-aware behavior: records are actually removed by DEL,
+	 * and overwritten by PUT, no matter what was stored in the catalogue.
+	 */
+	M0_CRV_VER_NONE = 0,
+	/* The maximum possible value of a version. */
+	M0_CRV_VER_MAX = (UINT64_MAX & ~M0_CRV_TBS) - 1,
+	/* The minimum possible value of a version. */
+	M0_CRV_VER_MIN = M0_CRV_VER_NONE + 1,
+};
+
+/*
+ * 100:a == alive record with version 100
+ * 123:d == dead record with version 123
+ */
+#define CRV_F "%" PRIu64 ":%c"
+#define CRV_P(__crv) m0_crv_ts(__crv).dts_phys, m0_crv_tbs(__crv) ? 'd' : 'a'
+
+#define M0_CRV_INIT_NONE ((struct m0_crv) { .crv_encoded = M0_CRV_VER_NONE })
+
+M0_INTERNAL void m0_crv_init(struct m0_crv           *crv,
+			     const struct m0_dtm0_ts *ts,
+			     bool                     tbs);
+
+M0_INTERNAL bool m0_crv_is_none(const struct m0_crv *crv);
+M0_INTERNAL int m0_crv_cmp(const struct m0_crv *left,
+			   const struct m0_crv *right);
+
+M0_INTERNAL bool m0_crv_tbs(const struct m0_crv *crv);
+M0_INTERNAL void m0_crv_tbs_set(struct m0_crv *crv, bool tbs);
+
+M0_INTERNAL struct m0_dtm0_ts m0_crv_ts(const struct m0_crv *crv);
+M0_INTERNAL void m0_crv_ts_set(struct m0_crv           *crv,
+			       const struct m0_dtm0_ts *ts);
 
 /** @} end of cas_dfspec */
 #endif /* __MOTR_CAS_CAS_H__ */

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -251,7 +251,45 @@ enum m0_cas_op_flags {
 	 * For PUT/DEL operation, instructs it to delay reply from CAS service
 	 * until BE transaction is persisted.
 	 */
-	COF_SYNC_WAIT = 1 << 7
+	COF_SYNC_WAIT = 1 << 7,
+
+	/**
+	 * Enables version-aware behavior for PUT, DEL, GET, and NEXT requests.
+	 *
+	 * Overview
+	 * --------
+	 *   Versions are taken from m0_cas_op::cg_txd. When this flag is set,
+	 * the following change happens in the logic of the mentioned request
+	 * types:
+	 *     - PUT does not overwrite "newest" (version-wise) records.
+	 *       Requirements:
+	 *         x COF_OVERWRITE is set.
+	 *         x Transaction descriptor has a valid DTX ID.
+	 *     - DEL puts a tombstone instead of an actual removal. In this
+	 *       mode, DEL does not return -ENOENT in the same way as
+	 *       PUT-with-COF_OVERWRITE does not return -EEXIST.
+	 *       Requirements:
+	 *         x Transaction descriptor has a valid DTX ID.
+	 *     - GET returns only "alive" entries (without tombstones).
+	 *     - NEXT also skips entries with tombstones.
+	 *
+	 * How to enable/disable
+	 * ---------------------
+	 *   This operation mode is enabled only if all the requirements are
+	 * satisfied (the list above). For example, if m0_cas_op::cg_txd does
+	 * not have a valid transaction ID then the request is getting executed
+	 * in the usual manner, without version-aware behavior. Additional
+	 * restictions may be imposed later on, but at this moment it is as
+	 * flexible as possible.
+	 *
+	 * Relation with DTM0
+	 * ------------------
+	 *   The flag should always be enabled if DTM0 is enabled because it
+	 * enables CRDT-ness for catalogues. If DTM0 is not enabled then this
+	 * flag may or may not be enabled (for example, the version-related UTs
+	 * use the flag but they do not depend on enabled DTM0).
+	 */
+	COF_VERSIONED = 1 << 8,
 };
 
 enum m0_cas_opcode {

--- a/cas/client.c
+++ b/cas/client.c
@@ -1843,12 +1843,7 @@ M0_INTERNAL int m0_cas_del(struct m0_cas_req *req,
 	M0_PRE(keys != NULL);
 	M0_PRE(m0_cas_req_is_locked(req));
 	M0_PRE(m0_cas_id_invariant(index));
-	/*
-	 * FIXME: Are we sure it has to be "M0_IN"? In other words,
-	 * is it possibe to specify two flags?
-	 * We should probably use "any-of" rather than "only-one-of".
-	 */
-	M0_PRE(M0_IN(flags, (0, COF_DEL_LOCK, COF_SYNC_WAIT, COF_VERSIONED)));
+	M0_PRE((flags & ~(COF_DEL_LOCK | COF_SYNC_WAIT | COF_VERSIONED)) == 0);
 
 	rc = cas_req_prep(req, index, keys, NULL, keys->ov_vec.v_nr, flags,
 			  &op);

--- a/cas/client.c
+++ b/cas/client.c
@@ -1658,7 +1658,8 @@ M0_INTERNAL int m0_cas_put(struct m0_cas_req      *req,
 	M0_PRE(!(flags & COF_CREATE) || !(flags & COF_OVERWRITE));
 	/* Only create, overwrite, crow and sync_wait flags are allowed. */
 	M0_PRE((flags &
-		~(COF_CREATE | COF_OVERWRITE | COF_CROW | COF_SYNC_WAIT)) == 0);
+		~(COF_CREATE | COF_OVERWRITE | COF_CROW | COF_SYNC_WAIT |
+		  COF_VERSIONED)) == 0);
 	M0_PRE(m0_cas_id_invariant(index));
 
 	rc = cas_req_prep(req, index, keys, values, keys->ov_vec.v_nr, flags,
@@ -1686,9 +1687,10 @@ M0_INTERNAL void m0_cas_put_rep(struct m0_cas_req       *req,
 	M0_LEAVE();
 }
 
-M0_INTERNAL int m0_cas_get(struct m0_cas_req      *req,
-			   struct m0_cas_id       *index,
-			   const struct m0_bufvec *keys)
+M0_INTERNAL int m0_cas__get(struct m0_cas_req      *req,
+			    struct m0_cas_id       *index,
+			    const struct m0_bufvec *keys,
+			    int                     flags)
 {
 	struct m0_cas_op      *op;
 	int                    rc;
@@ -1701,7 +1703,8 @@ M0_INTERNAL int m0_cas_get(struct m0_cas_req      *req,
 	M0_PRE(m0_cas_req_is_locked(req));
 	M0_PRE(m0_cas_id_invariant(index));
 
-	rc = cas_req_prep(req, index, keys, NULL, keys->ov_vec.v_nr, 0, &op);
+	rc = cas_req_prep(req, index, keys, NULL, keys->ov_vec.v_nr, flags,
+			  &op);
 	if (rc != 0)
 		return M0_ERR(rc);
 	for (i = 0; i < keys->ov_vec.v_nr; i++) {
@@ -1728,6 +1731,20 @@ M0_INTERNAL int m0_cas_get(struct m0_cas_req      *req,
 		}
 	}
 	return M0_RC(rc);
+}
+
+M0_INTERNAL int m0_cas_get(struct m0_cas_req      *req,
+			   struct m0_cas_id       *index,
+			   const struct m0_bufvec *keys)
+{
+	return m0_cas__get(req, index, keys, 0);
+}
+
+M0_INTERNAL int m0_cas_versioned_get(struct m0_cas_req      *req,
+				     struct m0_cas_id       *index,
+				     const struct m0_bufvec *keys)
+{
+	return m0_cas__get(req, index, keys, COF_VERSIONED);
 }
 
 M0_INTERNAL void m0_cas_get_rep(const struct m0_cas_req *req,
@@ -1765,8 +1782,9 @@ M0_INTERNAL int m0_cas_next(struct m0_cas_req *req,
 	M0_PRE(start_keys != NULL);
 	M0_PRE(m0_cas_req_is_locked(req));
 	M0_PRE(m0_cas_id_invariant(index));
-	/* Only slant and exclude start key flags are allowed. */
-	M0_PRE((flags & ~(COF_SLANT | COF_EXCLUDE_START_KEY)) == 0);
+	/* Only slant, exclude start key, and versioned flags are allowed. */
+	M0_PRE((flags & ~(COF_SLANT | COF_EXCLUDE_START_KEY |
+			  COF_VERSIONED)) == 0);
 
 	for (i = 0; i < start_keys->ov_vec.v_nr; i++)
 		max_replies_nr += recs_nr[i];
@@ -1825,7 +1843,12 @@ M0_INTERNAL int m0_cas_del(struct m0_cas_req *req,
 	M0_PRE(keys != NULL);
 	M0_PRE(m0_cas_req_is_locked(req));
 	M0_PRE(m0_cas_id_invariant(index));
-	M0_PRE(M0_IN(flags, (0, COF_DEL_LOCK, COF_SYNC_WAIT)));
+	/*
+	 * FIXME: Are we sure it has to be "M0_IN"? In other words,
+	 * is it possibe to specify two flags?
+	 * We should probably use "any-of" rather than "only-one-of".
+	 */
+	M0_PRE(M0_IN(flags, (0, COF_DEL_LOCK, COF_SYNC_WAIT, COF_VERSIONED)));
 
 	rc = cas_req_prep(req, index, keys, NULL, keys->ov_vec.v_nr, flags,
 			  &op);

--- a/cas/client.c
+++ b/cas/client.c
@@ -1761,6 +1761,7 @@ M0_INTERNAL void m0_cas_get_rep(const struct m0_cas_req *req,
 	rcvd = &cas_rep->cgr_rep.cr_rec[idx];
 	sent = &req->ccr_rec_orig.cr_rec[idx];
 	rep->cge_rc = rcvd->cr_rc;
+	rep->cge_ver = rcvd->cr_ver;
 	if (rep->cge_rc == 0)
 	      m0_rpc_at_rep_get(&sent->cr_val, &rcvd->cr_val, &rep->cge_val);
 	M0_LEAVE();
@@ -1784,7 +1785,10 @@ M0_INTERNAL int m0_cas_next(struct m0_cas_req *req,
 	M0_PRE(m0_cas_id_invariant(index));
 	/* Only slant, exclude start key, and versioned flags are allowed. */
 	M0_PRE((flags & ~(COF_SLANT | COF_EXCLUDE_START_KEY |
-			  COF_VERSIONED)) == 0);
+			  COF_VERSIONED | COF_SHOW_DEAD)) == 0);
+	/* COF_SHOW_DEAD cannot be used without COF_VERSIONED */
+	M0_PRE(ergo((flags & COF_SHOW_DEAD) != 0,
+		    (flags & COF_VERSIONED) != 0));
 
 	for (i = 0; i < start_keys->ov_vec.v_nr; i++)
 		max_replies_nr += recs_nr[i];
@@ -1824,6 +1828,7 @@ M0_INTERNAL void m0_cas_next_rep(const struct m0_cas_req  *req,
 	M0_PRE(idx < m0_cas_req_nr(req));
 	M0_PRE(req->ccr_ftype == &cas_cur_fopt);
 	rcvd = &cas_rep->cgr_rep.cr_rec[idx];
+	rep->cnp_ver = rcvd->cr_ver;
 	rep->cnp_rc = cas_next_rc(rcvd->cr_rc) ?:
 		      m0_rpc_at_rep_get(NULL, &rcvd->cr_key, &rep->cnp_key) ?:
 		      m0_rpc_at_rep_get(NULL, &rcvd->cr_val, &rep->cnp_val);

--- a/cas/client.h
+++ b/cas/client.h
@@ -473,8 +473,14 @@ M0_INTERNAL int m0_cas_get(struct m0_cas_req      *req,
 			   struct m0_cas_id       *index,
 			   const struct m0_bufvec *keys);
 
-/** Versioned version of m0_cas_get.
- * Returns a value only if it is "alive" (see ::COF_VERSIONED).
+/**
+ * A version-aware version of m0_cas_get.
+ * It returns the value associated with the given key only this value
+ * does not have a tombstone set (i.e., it was not removed).
+ * Ssee ::COF_VERSIONED.
+ *
+ * TODO: This function will be disolved once ::m0_cas_get gets an extra
+ * argument (flags).
  */
 M0_INTERNAL int m0_cas_versioned_get(struct m0_cas_req      *req,
 				     struct m0_cas_id       *index,

--- a/cas/client.h
+++ b/cas/client.h
@@ -473,6 +473,13 @@ M0_INTERNAL int m0_cas_get(struct m0_cas_req      *req,
 			   struct m0_cas_id       *index,
 			   const struct m0_bufvec *keys);
 
+/** Versioned version of m0_cas_get.
+ * Returns a value only if it is "alive" (see ::COF_VERSIONED).
+ */
+M0_INTERNAL int m0_cas_versioned_get(struct m0_cas_req      *req,
+				     struct m0_cas_id       *index,
+				     const struct m0_bufvec *keys);
+
 /**
  * Gets execution result of m0_cas_get() request.
  *

--- a/cas/client.h
+++ b/cas/client.h
@@ -202,9 +202,11 @@ struct m0_cas_ilist_reply {
  * Single value retrieved by m0_cas_get() request.
  */
 struct m0_cas_get_reply {
-	int           cge_rc;
+	int                  cge_rc;
 	/** Retrieved value. Undefined if cge_rc != 0. */
-	struct m0_buf cge_val;
+	struct m0_buf        cge_val;
+	/** Version of the record. */
+	struct m0_cas_kv_ver cge_ver;
 };
 
 /**
@@ -212,13 +214,15 @@ struct m0_cas_get_reply {
  */
 struct m0_cas_next_reply {
 	/** Return code. -ENOENT means that end of index is reached. */
-	int                cnp_rc;
+	int                  cnp_rc;
 	/** Record key. Set if rc == 0. */
-	struct m0_buf      cnp_key;
+	struct m0_buf        cnp_key;
 	/** Record hint. Not used for now. */
-	struct m0_cas_hint cnp_hint;
+	struct m0_cas_hint   cnp_hint;
 	/** Record value. Set if rc == 0. */
-	struct m0_buf      cnp_val;
+	struct m0_buf        cnp_val;
+	/** Version of the record. */
+	struct m0_cas_kv_ver cnp_ver;
 };
 
 /**
@@ -475,11 +479,11 @@ M0_INTERNAL int m0_cas_get(struct m0_cas_req      *req,
 
 /**
  * A version-aware version of m0_cas_get.
- * It returns the value associated with the given key only this value
- * does not have a tombstone set (i.e., it was not removed).
- * Ssee ::COF_VERSIONED.
+ * It returns the values associated with the given keys only if this values
+ * do not have tombstones set (i.e., they have not been removed).
+ * See ::COF_VERSIONED.
  *
- * TODO: This function will be disolved once ::m0_cas_get gets an extra
+ * TODO: This function may be disolved if ::m0_cas_get gets an extra
  * argument (flags).
  */
 M0_INTERNAL int m0_cas_versioned_get(struct m0_cas_req      *req,

--- a/cas/client.h
+++ b/cas/client.h
@@ -206,7 +206,7 @@ struct m0_cas_get_reply {
 	/** Retrieved value. Undefined if cge_rc != 0. */
 	struct m0_buf        cge_val;
 	/** Version of the record. */
-	struct m0_cas_kv_ver cge_ver;
+	struct m0_crv        cge_ver;
 };
 
 /**
@@ -222,7 +222,7 @@ struct m0_cas_next_reply {
 	/** Record value. Set if rc == 0. */
 	struct m0_buf        cnp_val;
 	/** Version of the record. */
-	struct m0_cas_kv_ver cnp_ver;
+	struct m0_crv        cnp_ver;
 };
 
 /**

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -192,8 +192,8 @@ static int         ctg_cmp   (const void *key0, const void *key1);
 
 static int versioned_put_sync        (struct m0_ctg_op *ctg_op);
 static int versioned_get_sync        (struct m0_ctg_op *op);
-static int versioned_cursor_next_sync(struct m0_ctg_op *op);
-static int versioned_cursor_get_sync (struct m0_ctg_op *op);
+static int versioned_cursor_next_sync(struct m0_ctg_op *op, bool alive_only);
+static int versioned_cursor_get_sync (struct m0_ctg_op *op, bool alive_only);
 
 /**
  * Mutex to provide thread-safety for catalogue store singleton initialisation.
@@ -317,6 +317,19 @@ static uint64_t crv_version_get(const struct cas_rec_ver *crv)
 	return crv->crv_encoded & ~CRV_TBS;
 }
 
+/*
+ * Converts on-disk reprentation into on-wire representation.
+ */
+static struct m0_cas_kv_ver crv_as_cas_kv_ver(const struct cas_rec_ver *crv)
+{
+	return (struct m0_cas_kv_ver) {
+		.ckv_ts = (struct m0_dtm0_ts) {
+			.dts_phys = crv_version_get(crv),
+		},
+		.ckv_tombstone = crv_tbs_is_set(crv),
+	};
+}
+
 static void crv_version_set(struct cas_rec_ver *crv, uint64_t ts)
 {
 	crv->crv_encoded = (crv->crv_encoded & CRV_TBS) | ts;
@@ -364,7 +377,7 @@ static bool crv_is_none(const struct cas_rec_ver *crv)
 #define CRV_P(__crv) crv_version_get(__crv), crv_tbs_is_set(__crv) ? 'd' : 'a'
 
 /**
- * Unpack an an on-disk value data into an in-memory format.
+ * Unpack an an on-disk value data into in-memory format.
  * The function makes "buf" to point to the user-specific data associated
  * with the value (see ::generic_value::gv_data).
  * @param[out] Optional storage for the version of the record.
@@ -406,6 +419,23 @@ static int ctg_vbuf_as_ctg(const struct m0_buf *buf, struct m0_cas_ctg **ctg)
 
 	if (buf->b_nob == sizeof(struct m0_cas_ctg *)) {
 		*ctg = mv->mv_ctg;
+		return M0_RC(0);
+	} else
+		return M0_ERR(-EPROTO);
+}
+
+/**
+ * Get the layout from an unpacked ::layout_value (cctidx value).
+ */
+static int ctg_vbuf_as_layout(const struct m0_buf    *buf,
+			      struct m0_dix_layout **layout)
+{
+	struct layout_value *lv = buf->b_addr - sizeof(struct generic_value);
+
+	M0_ENTRY();
+
+	if (buf->b_nob == sizeof(struct m0_dix_layout)) {
+		*layout = &lv->lv_layout;
 		return M0_RC(0);
 	} else
 		return M0_ERR(-EPROTO);
@@ -622,8 +652,7 @@ M0_INTERNAL int m0_ctg__meta_insert(struct m0_be_btree  *meta,
 	 * It also helps to generalise listing of catalogues
 	 * (see ::m0_ctg_try_init).
 	 */
-	M0_PRE(ergo(ctg == NULL,
-		    m0_fid_eq(fid, &m0_cas_meta_fid)));
+	M0_PRE(ergo(ctg == NULL, m0_fid_eq(fid, &m0_cas_meta_fid)));
 
 	anchor.ba_value.b_nob = value.b_nob;
 	rc = M0_BE_OP_SYNC_RET(op,
@@ -1066,7 +1095,7 @@ static bool ctg_op_cb(struct m0_clink *clink)
 		return true;
 
 	/* Versioned API is synchronous. */
-	if (ctg_op_is_versioned(ctg_op))
+	if (ctg_op->co_is_versioned)
 		return true;
 
 	rc = ctg_berc(ctg_op);
@@ -1284,6 +1313,8 @@ static int ctg_op_exec_versioned(struct m0_ctg_op *ctg_op, int next_phase)
 	int                        opc = ctg_op->co_opcode;
 	int                        ct  = ctg_op->co_ct;
 	struct m0_be_op           *beop = ctg_beop(ctg_op);
+	bool                       alive_only =
+		!(ctg_op->co_flags & COF_SHOW_DEAD);
 
 	M0_PRE(ctg_is_ordinary(ctg_op->co_ctg));
 	M0_PRE(ct == CT_BTREE);
@@ -1300,9 +1331,9 @@ static int ctg_op_exec_versioned(struct m0_ctg_op *ctg_op, int next_phase)
 		break;
 	case CTG_OP_COMBINE(CO_CUR, CT_BTREE):
 		if (ctg_op->co_cur_phase == CPH_GET)
-			rc = versioned_cursor_get_sync(ctg_op);
+			rc = versioned_cursor_get_sync(ctg_op, alive_only);
 		else
-			rc = versioned_cursor_next_sync(ctg_op);
+			rc = versioned_cursor_next_sync(ctg_op, alive_only);
 		break;
 	default:
 		M0_IMPOSSIBLE("The other operations are not allowed here.");
@@ -1343,7 +1374,9 @@ static int ctg_op_exec_versioned(struct m0_ctg_op *ctg_op, int next_phase)
 
 static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 {
-	return ctg_op_is_versioned(ctg_op) ?
+	ctg_op->co_is_versioned = ctg_op_is_versioned(ctg_op);
+
+	return ctg_op->co_is_versioned ?
 		ctg_op_exec_versioned(ctg_op, next_phase) :
 		ctg_op_exec_normal(ctg_op, next_phase);
 }
@@ -1489,7 +1522,6 @@ static int ctg_exec(struct m0_ctg_op    *ctg_op,
 	     ctg_op->co_cur_phase != CPH_NEXT))
 		ctg_op->co_rc = ctg_kbuf_get(&ctg_op->co_key, key);
 
-
 	if (ctg_op->co_rc != 0)
 		m0_fom_phase_set(ctg_op->co_fom, next_phase);
 	else
@@ -1562,6 +1594,17 @@ M0_INTERNAL void m0_ctg_lookup_result(struct m0_ctg_op *ctg_op,
 	M0_PRE(ctg_op->co_rc == 0);
 
 	*buf = ctg_op->co_out_val;
+}
+
+M0_INTERNAL void m0_ctg_op_get_ver(struct m0_ctg_op     *ctg_op,
+				   struct m0_cas_kv_ver *out)
+{
+	M0_PRE(ctg_op != NULL);
+	M0_PRE(out != NULL);
+	M0_PRE(ergo(!m0_dtm0_ts_is_none(&ctg_op->co_out_ver.ckv_ts),
+		    ctg_op->co_is_versioned));
+
+	*out = ctg_op->co_out_ver;
 }
 
 M0_INTERNAL int m0_ctg_minkey(struct m0_ctg_op  *ctg_op,
@@ -1747,6 +1790,7 @@ M0_INTERNAL void m0_ctg_op_init(struct m0_ctg_op *ctg_op,
 	ctg_op->co_fom = fom;
 	ctg_op->co_flags = flags;
 	ctg_op->co_cur_phase = CPH_NONE;
+	ctg_op->co_is_versioned = false;
 }
 
 M0_INTERNAL int m0_ctg_op_rc(struct m0_ctg_op *ctg_op)
@@ -1958,7 +2002,6 @@ M0_INTERNAL int m0_ctg_ctidx_lookup_sync(const struct m0_fid  *fid,
 	struct m0_be_btree_anchor anchor;
 	struct m0_cas_ctg        *ctidx = m0_ctg_ctidx();
 	int                       rc;
-	struct layout_value      *value_data;
 
 	M0_PRE(ctidx != NULL);
 	M0_PRE(fid != NULL);
@@ -1972,14 +2015,9 @@ M0_INTERNAL int m0_ctg_ctidx_lookup_sync(const struct m0_fid  *fid,
 							  &op,
 							  &key,
 							  &anchor),
-			       bo_u.u_btree.t_rc);
-	if (rc == 0) {
-		value_data = anchor.ba_value.b_addr;
-		if (sizeof(value_data) == anchor.ba_value.b_nob) {
-			*layout = &value_data->lv_layout;
-		} else
-			rc = M0_ERR(-EPROTO);
-	}
+			       bo_u.u_btree.t_rc) ?:
+		ctg_vbuf_unpack(&anchor.ba_value, NULL) ?:
+		ctg_vbuf_as_layout(&anchor.ba_value, layout);
 
 	m0_be_btree_release(NULL, &anchor);
 
@@ -2176,6 +2214,9 @@ static bool ctg_op_is_versioned(const struct m0_ctg_op *ctg_op)
 	if (ctg_op->co_fom == NULL)
 		return M0_RC_INFO(false, "No fom, no versions.");
 
+	if (ctg_op->co_fom->fo_fop == NULL)
+		return M0_RC_INFO(false, "No fop, no versions.");
+
 	cas_op = m0_fop_data(ctg_op->co_fom->fo_fop);
 	if (cas_op == NULL)
 		return M0_RC_INFO(false, "No cas op, no versions.");
@@ -2218,7 +2259,7 @@ static void ctg_op_version_get(const struct m0_ctg_op *ctg_op,
 	bool                          tbs;
 
 	M0_ENTRY();
-	M0_PRE(ctg_op_is_versioned(ctg_op));
+	M0_PRE(ctg_op->co_is_versioned);
 
 	if (M0_IN(ctg_op->co_opcode, (CO_PUT, CO_DEL))) {
 		M0_ASSERT_INFO(ctg_op->co_fom != NULL,
@@ -2254,7 +2295,7 @@ static int versioned_put_sync(struct m0_ctg_op *ctg_op)
 	struct cas_rec_ver         old_version = CRV_INIT_NONE;
 	int                        rc;
 
-	M0_PRE(ctg_op_is_versioned(ctg_op));
+	M0_PRE(ctg_op->co_is_versioned);
 	M0_ENTRY();
 
 	ctg_op_version_get(ctg_op, &new_version);
@@ -2309,8 +2350,10 @@ static int versioned_put_sync(struct m0_ctg_op *ctg_op)
 			      &ctg_op->co_val,
 			      &new_version);
 
-		/* TODO: it is too pessimistic. */
-		m0_ctg_state_inc_update(tx, key->b_nob + ctg_op->co_val.b_nob);
+		m0_ctg_state_inc_update(tx,
+					key->b_nob -
+					sizeof(struct generic_key) +
+					ctg_op->co_val.b_nob);
 	}
 
 	return M0_RC(rc);
@@ -2319,6 +2362,7 @@ static int versioned_put_sync(struct m0_ctg_op *ctg_op)
 /*
  * Gets an alive record (without tombstone set) in btree.
  * Returns -ENOENT if tombstone is set.
+ * Always sets co_out_ver if the record physically exists in the tree.
  */
 static int versioned_get_sync(struct m0_ctg_op *ctg_op)
 {
@@ -2327,17 +2371,20 @@ static int versioned_get_sync(struct m0_ctg_op *ctg_op)
 	struct cas_rec_ver         ver;
 	int                        rc;
 
-	M0_PRE(ctg_op_is_versioned(ctg_op));
+	M0_PRE(ctg_op->co_is_versioned);
 
 	rc = M0_BE_OP_SYNC_RET(op,
 			       m0_be_btree_lookup_inplace(btree, &op,
 							  &ctg_op->co_key,
 							  anchor),
-			       bo_u.u_btree.t_rc);
+			       bo_u.u_btree.t_rc) ?:
+		ctg_vbuf_unpack(&anchor->ba_value, &ver);
+
 	if (rc == 0) {
-		rc = ctg_vbuf_unpack(&anchor->ba_value, &ver) ?:
-			(crv_tbs_is_set(&ver) ?  -ENOENT : 0);
-		if (rc == 0)
+		ctg_op->co_out_ver = crv_as_cas_kv_ver(&ver);
+		if (crv_tbs_is_set(&ver))
+			rc = -ENOENT;
+		else
 			ctg_op->co_out_val = anchor->ba_value;
 	}
 
@@ -2346,9 +2393,10 @@ static int versioned_get_sync(struct m0_ctg_op *ctg_op)
 
 /*
  * Synchronously advances the cursor until it reaches an alive
- * key-value pair (without tombstone set) or the end of the tree.
+ * key-value pair (alive_only=true), next key-value pair (alive_only=false),
+ * or the end of the tree.
  */
-static int versioned_cursor_next_sync(struct m0_ctg_op *ctg_op)
+static int versioned_cursor_next_sync(struct m0_ctg_op *ctg_op, bool alive_only)
 {
 	struct m0_be_op           *beop   = ctg_beop(ctg_op);
 	struct cas_rec_ver         ver    = CRV_INIT_NONE;
@@ -2369,8 +2417,15 @@ static int versioned_cursor_next_sync(struct m0_ctg_op *ctg_op)
 		if (rc != 0)
 			break;
 
+		ctg_op->co_out_ver = crv_as_cas_kv_ver(&ver);
+
 		m0_be_op_reset(beop);
-	} while (crv_tbs_is_set(&ver));
+
+	} while (crv_tbs_is_set(&ver) && alive_only);
+
+	/* It should never return dead values. */
+	if (crv_tbs_is_set(&ver))
+		ctg_op->co_out_val = M0_BUF_INIT0;
 
 	return M0_RC(rc);
 }
@@ -2378,23 +2433,26 @@ static int versioned_cursor_next_sync(struct m0_ctg_op *ctg_op)
 /*
  * Positions the cursor at the alive record that corresponds to the
  * specified key or at the alive record next to the specified key
- * depending on the slant flag:
+ * depending on the slant flag. If alive_only=false then it treats
+ * all records as alive.
+ *
+ * The relations between tombstones and slant flag:
  *   Non-slant:
  *     record_at(key) is alive: returns the record.
  *     record_at(key) has tombstone: returns -ENOENT.
  *   Slant:
  *     record_at(key) is alive: returns the record.
  *     record_at(key) has tombstone: finds next alive record.
- * See the ::next_ver UT for examples.
  */
-static int versioned_cursor_get_sync(struct m0_ctg_op *ctg_op)
+static int versioned_cursor_get_sync(struct m0_ctg_op *ctg_op, bool alive_only)
 {
 	struct m0_be_op           *beop   = ctg_beop(ctg_op);
+	struct m0_buf              value  = M0_BUF_INIT0;
 	struct cas_rec_ver         ver    = CRV_INIT_NONE;
 	bool                       slant  = (ctg_op->co_flags & COF_SLANT) != 0;
 	int                        rc;
 
-	M0_PRE(ctg_op_is_versioned(ctg_op));
+	M0_PRE(ctg_op->co_is_versioned);
 
 	m0_be_btree_cursor_get(&ctg_op->co_cur, &ctg_op->co_key, slant);
 	rc = ctg_berc(ctg_op);
@@ -2402,17 +2460,25 @@ static int versioned_cursor_get_sync(struct m0_ctg_op *ctg_op)
 	if (rc == 0) {
 		m0_be_btree_cursor_kv_get(&ctg_op->co_cur,
 					  &ctg_op->co_out_key,
-					  &ctg_op->co_out_val);
+					  &value);
 		rc = ctg_kbuf_unpack(&ctg_op->co_out_key) ?:
-			ctg_vbuf_unpack(&ctg_op->co_out_val, &ver) ?:
-			!crv_tbs_is_set(&ver) ? 0 :
-			(slant ? -EAGAIN : -ENOENT);
-	}
+			ctg_vbuf_unpack(&value, &ver);
+		if (rc == 0) {
+			ctg_op->co_out_ver = crv_as_cas_kv_ver(&ver);
+			if (crv_tbs_is_set(&ver))
+				rc = alive_only ?
+					(slant ? -EAGAIN : -ENOENT) : 0;
+			else
+				ctg_op->co_out_val = value;
+		}
+	} else
+		M0_ASSERT_INFO(rc != EAGAIN,
+			       "btree cursor op returned EAGAIN?");
 
 	m0_be_op_reset(beop);
 
 	if (rc == -EAGAIN)
-		rc = versioned_cursor_next_sync(ctg_op);
+		rc = versioned_cursor_next_sync(ctg_op, alive_only);
 
 	return M0_RC(rc);
 }

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -79,20 +79,33 @@ struct m0_ctg_store {
 
 /* Data schema for CAS catalogues { */
 
-/** Generalised key: versioned counted opaque data. */
+/** Generalised key: counted opaque data. */
 struct generic_key {
+	/* Actual length of gk_data array. */
 	uint64_t gk_length;
 	uint8_t  gk_data[0];
 };
 M0_BASSERT(sizeof(struct generic_key) == M0_CAS_CTG_KEY_HDR_SIZE);
 
+/**
+ * CAS record version and tombstone encoded in on-disk format.
+ * Format:
+ *     MSB                             LSB
+ *     +----------------+----------------+
+ *     | 1 bit          | 63 bits        |
+ *     |<- tombstone -> | <- timestamp ->|
+ *     +----------------+----------------+
+ *
+ * @see ::CRV_TBS.
+ */
 struct cas_rec_ver {
 	uint64_t  crv_encoded;
 };
 M0_BASSERT(sizeof(struct cas_rec_ver) == 8);
 
-/** Generalised value: counted opaque data. */
+/** Generalised value: versioned counted opaque data. */
 struct generic_value {
+	/* Actual length of gv_data array. */
 	uint64_t           gv_length;
 	struct cas_rec_ver gv_version;
 	uint8_t            gv_data[0];
@@ -177,6 +190,10 @@ static m0_bcount_t ctg_ksize (const void *key);
 static m0_bcount_t ctg_vsize (const void *val);
 static int         ctg_cmp   (const void *key0, const void *key1);
 
+static int versioned_put_sync        (struct m0_ctg_op *ctg_op);
+static int versioned_get_sync        (struct m0_ctg_op *op);
+static int versioned_cursor_next_sync(struct m0_ctg_op *op);
+static int versioned_cursor_get_sync (struct m0_ctg_op *op);
 
 /**
  * Mutex to provide thread-safety for catalogue store singleton initialisation.
@@ -211,20 +228,22 @@ static int ctg_berc(struct m0_ctg_op *ctg_op)
 	return ctg_beop(ctg_op)->bo_u.u_btree.t_rc;
 }
 
-void ctg_berc_set_sync(struct m0_ctg_op *ctg_op, int rc)
-{
-	struct m0_be_op *beop   = ctg_beop(ctg_op);
-	m0_be_op_active(beop);
-	m0_be_op_rc_set(beop, rc);
-	/*ctg_beop(ctg_op)->bo_u.u_btree.t_rc = rc;*/
-	m0_be_op_done(beop);
-}
-
+/**
+ * Returns the number of bytes required to store the given "value"
+ * in on-disk format.
+ */
 static m0_bcount_t ctg_vbuf_packed_size(const struct m0_buf *value)
 {
 	return sizeof(struct generic_value) + value->b_nob;
 }
 
+/**
+ * Packs a user-provided value into on-disk representation.
+ * @param src A value to be packed (in-memory representation).
+ * @param dst A buffer to be filled with user data and on-disk format-specific
+ *            information.
+ * @param crv Encoded version of the value.
+ */
 static void ctg_vbuf_pack(struct m0_buf            *dst,
 			  const struct m0_buf      *src,
 			  const struct cas_rec_ver *crv)
@@ -236,28 +255,10 @@ static void ctg_vbuf_pack(struct m0_buf            *dst,
 	memcpy(&value->gv_data, src->b_addr, src->b_nob);
 }
 
-static void ensure_ctg_is_versioned(const struct m0_cas_ctg *ctg)
-{
-	struct m0_format_tag tag = {};
-
-	M0_ENTRY();
-
-	m0_format_header_unpack(&tag, &ctg->cc_head);
-	if (tag.ot_version != M0_CAS_CTG_FORMAT_VERSION) {
-		if (tag.ot_version == M0_CAS_CTG_FORMAT_VERSION_1 &&
-		    M0_CAS_CTG_FORMAT_VERSION == M0_CAS_CTG_FORMAT_VERSION_2) {
-			M0_LOG(M0_FATAL, "Your KVS (CAS) requires key-value "
-			       "versioning feature, but your on-disk metadata "
-			       "has the old (1) format. Please upgrade on-disk "
-			       " metadata.");
-			M0_ASSERT_INFO(false, "Version mismatch (CAS format).");
-		}
-	}
-
-	M0_LEAVE();
-}
-
-/** Create a new m0_buf filled with CAS-specific data (length). */
+/*
+ * Create a new m0_buf filled with CAS-specific data (length).
+ * Note: the function allocates a new buffer.
+ */
 static int ctg_kbuf_get(struct m0_buf *dst, const struct m0_buf *src)
 {
 	struct generic_key *key;
@@ -280,17 +281,18 @@ static int ctg_kbuf_get(struct m0_buf *dst, const struct m0_buf *src)
 enum {
 	/* Tombstone flag: marks a dead kv pair. We use the MSB here. */
 	CRV_TBS = 1L << (sizeof(uint64_t) * CHAR_BIT - 1),
-
 	/*
-	 * A special value that indicates the lack of version-aware behavior.
-	 * When such a version is provided, the functions transparently
-	 * ignore version comparison and tombstones in btree_save/delete.
+	 * A special value for the empty version.
+	 * A record with the empty version is always overwritten by any
+	 * PUT or DEL operation that has a valid non-empty version.
+	 * A PUT or DEL operation with the empty version always ignores
+	 * the version-aware behavior: records are actually removed by DEL,
+	 * and overwritten by PUT, no matter what was stored in the catalogue.
 	 */
 	CRV_VER_NONE = 0,
-
-	/* The biggest possible value of a version. */
+	/* The maximum possible value of a version. */
 	CRV_VER_MAX = (UINT64_MAX & ~CRV_TBS) - 1,
-	/* The lowest possible value of a version. */
+	/* The minimum possible value of a version. */
 	CRV_VER_MIN = CRV_VER_NONE + 1,
 };
 
@@ -304,7 +306,6 @@ static void crv_tbs_set(struct cas_rec_ver *crv)
 {
 	crv->crv_encoded |= CRV_TBS;
 }
-
 
 static void crv_tbs_clear(struct cas_rec_ver *crv)
 {
@@ -335,10 +336,19 @@ static void crv_init(struct cas_rec_ver *crv, uint64_t version, bool tbs)
 
 #define CRV_INIT_NONE ((struct cas_rec_ver) { .crv_encoded = CRV_VER_NONE })
 
-static bool crv_gt(const struct cas_rec_ver *left,
+/*
+ * Compare two versions.
+ *   Note, tombstones are checked at the end which means that if there are two
+ * different operations with the same version (for example, PUT@10 and DEL@10)
+ * then the operation that puts the tombstone (DEL@10) is always considered
+ * to be "newer" than the other one. It helps to ensure operations have the
+ * same order on any server despite the order of execution.
+ */
+static int crv_cmp(const struct cas_rec_ver *left,
 		   const struct cas_rec_ver *right)
 {
-	return crv_version_get(left) > crv_version_get(right);
+	return M0_3WAY(crv_version_get(left), crv_version_get(right)) ?:
+		M0_3WAY(crv_tbs_is_set(left), crv_tbs_is_set(right));
 }
 
 static bool crv_is_none(const struct cas_rec_ver *crv)
@@ -346,12 +356,20 @@ static bool crv_is_none(const struct cas_rec_ver *crv)
 	return memcmp(crv, &CRV_INIT_NONE, sizeof(*crv)) == 0;
 }
 
+/*
+ * 100:a == alive record with version 100
+ * 123:d == dead record with version 123
+ */
+#define CRV_F "%" PRIu64 ":%c"
+#define CRV_P(__crv) crv_version_get(__crv), crv_tbs_is_set(__crv) ? 'd' : 'a'
+
 /**
- * Unpack an an on-disk value datum into an in-memory datum.
+ * Unpack an an on-disk value data into an in-memory format.
  * The function makes "buf" to point to the user-specific data associated
  * with the value (see ::generic_value::gv_data).
  * @param[out] Optional storage for the version of the record.
  * @return 0 or else -EPROTO if on-disk/on-wire buffer has invalid length.
+ * @see ::ctg_vbuf_pack.
  */
 static int ctg_vbuf_unpack(struct m0_buf *buf, struct cas_rec_ver *crv)
 {
@@ -437,39 +455,45 @@ static int ctg_kbuf_unpack(struct m0_buf *buf)
 	.lv_layout = *(__layout),                           \
 }
 
-static m0_bcount_t ctg_ksize(const void *key)
+static m0_bcount_t ctg_ksize(const void *opaque_key)
 {
-	/* TODO: use generic_key */
-	/* Size is stored in the header. */
-	return M0_CAS_CTG_KEY_HDR_SIZE + *(const uint64_t *)key;
+	const struct generic_key *key = opaque_key;
+	M0_PRE(key != NULL);
+	return sizeof(*key) + key->gk_length;
 }
 
-static m0_bcount_t ctg_vsize(const void *val)
+static m0_bcount_t ctg_vsize(const void *opaque_val)
 {
-	/* TODO: use generic_value */
-	return M0_CAS_CTG_VAL_HDR_SIZE + *(const uint64_t *)val;
+	const struct generic_value *val = opaque_val;
+	M0_PRE(val != NULL);
+	return sizeof(*val) + val->gv_length;
 }
 
-static int ctg_cmp(const void *key0, const void *key1)
+static int ctg_cmp(const void *opaque_key_left, const void *opaque_key_right)
 {
-	m0_bcount_t       knob0   = ctg_ksize(key0);
-	m0_bcount_t       knob1   = ctg_ksize(key1);
-	const m0_bcount_t hdr_nob = M0_CAS_CTG_KEY_HDR_SIZE;
-	/**
-	 * @todo Cannot assert on on-disk data, but no interface to report
-	 * errors from here.
+	const struct generic_key *left  = opaque_key_left;
+	const struct generic_key *right = opaque_key_right;
+
+	M0_PRE(left != NULL);
+	M0_PRE(right != NULL);
+
+	/*
+	 * XXX: Origianally, there was an assertion to ensure on-disk data
+	 * is correct, and it looked like that:
+	 *     u64 len  = *(u64 *)key;
+	 *     u64 knob = 8 + len;
+	 *     assert(knob >= 8);
+	 * The problem here is that "len" is always >= 0 (because it is a u64).
+	 * Therefore, the assertion knob >= 8 is always true as well.
 	 */
-	M0_ASSERT(knob0 >= hdr_nob);
-	M0_ASSERT(knob1 >= hdr_nob);
 
-	return memcmp(key0 + hdr_nob, key1 + hdr_nob,
-		      min_check(knob0, knob1) - hdr_nob) ?:
-		M0_3WAY(knob0, knob1);
+	return memcmp(left->gk_data, right->gk_data,
+		      min_check(left->gk_length, right->gk_length)) ?:
+		M0_3WAY(left->gk_length, right->gk_length);
 }
 
 static void ctg_init(struct m0_cas_ctg *ctg, struct m0_be_seg *seg)
 {
-	ensure_ctg_is_versioned(ctg);
 	m0_format_header_pack(&ctg->cc_head, &(struct m0_format_tag){
 		.ot_version = M0_CAS_CTG_FORMAT_VERSION,
 		.ot_type    = M0_FORMAT_TYPE_CAS_CTG,
@@ -581,13 +605,6 @@ M0_INTERNAL int m0_ctg_meta_find_ctg(struct m0_cas_ctg    *meta,
 	return M0_RC(rc);
 }
 
-/*
- * NOTE:
- * If passed catalogue is NULL then it is a stub for meta-catalogue
- * inside itself, inserting records in it is prohibited. This stub
- * is used to generalise listing catalogues operation.
- * Insert real catalogue otherwise (catalogue is not NULL).
- */
 M0_INTERNAL int m0_ctg__meta_insert(struct m0_be_btree  *meta,
 				    const struct m0_fid *fid,
 				    struct m0_cas_ctg   *ctg,
@@ -599,6 +616,18 @@ M0_INTERNAL int m0_ctg__meta_insert(struct m0_be_btree  *meta,
 	struct m0_buf              value = M0_BUF_INIT_PTR(&val_data);
 	struct m0_be_btree_anchor  anchor = {};
 	int                        rc;
+
+	/*
+	 * NOTE: ctg may be equal to NULL.
+	 * Meta-catalogue is a catalogue. Also, it keeps a list of all
+	 * catalogues. In order to avoid paradoxes, we allow this function to
+	 * accept an empty pointer when the meta-catalogue is trying to
+	 * insert itself into the list (see ::ctg_meta_selfadd).
+	 * It also helps to generalise listing of catalogues
+	 * (see ::m0_ctg_try_init).
+	 */
+	M0_PRE(ergo(ctg == NULL,
+		    m0_fid_eq(fid, &m0_cas_meta_fid)));
 
 	anchor.ba_value.b_nob = value.b_nob;
 	rc = M0_BE_OP_SYNC_RET(op,
@@ -1261,11 +1290,6 @@ static int ctg_op_exec_normal(struct m0_ctg_op *ctg_op, int next_phase)
 	return ctg_op_tick_ret(ctg_op, next_phase);
 }
 
-static int versioned_record_put_sync(struct m0_ctg_op *ctg_op);
-static int alive_record_get_sync(struct m0_ctg_op *op);
-static int alive_cursor_next_sync(struct m0_ctg_op *op);
-static int alive_cursor_get_sync(struct m0_ctg_op *op);
-
 static int ctg_op_exec_versioned(struct m0_ctg_op *ctg_op, int next_phase)
 {
 	int                        rc;
@@ -1281,16 +1305,16 @@ static int ctg_op_exec_versioned(struct m0_ctg_op *ctg_op, int next_phase)
 	switch (CTG_OP_COMBINE(opc, ct)) {
 	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
 	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
-		rc = versioned_record_put_sync(ctg_op);
+		rc = versioned_put_sync(ctg_op);
 		break;
 	case CTG_OP_COMBINE(CO_GET, CT_BTREE):
-		rc = alive_record_get_sync(ctg_op);
+		rc = versioned_get_sync(ctg_op);
 		break;
 	case CTG_OP_COMBINE(CO_CUR, CT_BTREE):
 		if (ctg_op->co_cur_phase == CPH_GET)
-			rc = alive_cursor_get_sync(ctg_op);
+			rc = versioned_cursor_get_sync(ctg_op);
 		else
-			rc = alive_cursor_next_sync(ctg_op);
+			rc = versioned_cursor_next_sync(ctg_op);
 		break;
 	default:
 		M0_IMPOSSIBLE("The other operations are not allowed here.");
@@ -2228,7 +2252,12 @@ static void ctg_op_version_get(const struct m0_ctg_op *ctg_op,
 	}
 }
 
-static int versioned_record_put_sync(struct m0_ctg_op *ctg_op)
+/*
+ * Synchronously inserts/updates a key-value record considering the version
+ * and the tombstone that were specified in the operation ("new_version")
+ * and the version+tombstone that were stored in btree ("old_version").
+ */
+static int versioned_put_sync(struct m0_ctg_op *ctg_op)
 {
 	struct m0_buf             *key    = &ctg_op->co_key;
 	struct m0_be_btree        *btree  = &ctg_op->co_ctg->cc_tree;
@@ -2266,24 +2295,20 @@ static int versioned_record_put_sync(struct m0_ctg_op *ctg_op)
 	/* The tree is long-locked anyway. */
 	m0_be_btree_release(NULL, anchor);
 
-	if (!M0_IN(rc, (0, -ENOENT))) {
-		 /* Trace unexpected errors. */
-		rc = M0_ERR(rc);
-		goto out;
-	}
+	if (!M0_IN(rc, (0, -ENOENT)))
+		return M0_ERR(rc);
 
 	/*
-	 * Skip PUT op if the existing record is "newer" (version-wise) than
-	 * the record to be PUT.
+	 * Skip overwrite op if the existing record is "newer" (version-wise)
+	 * than the record to be inserted. Note, <= 0 means that we filter out
+	 * the operations with the exact same version and tombstone.
 	 */
-	if (!crv_is_none(&old_version) && crv_gt(&old_version, &new_version)) {
-		rc = M0_RC(0);
-		goto out;
-	}
+	if (!crv_is_none(&old_version) &&
+	    crv_cmp(&new_version, &old_version) <= 0)
+		return M0_RC(0);
 
-	M0_LOG(M0_DEBUG, "Overwriting %" PRIu64 ":%d with %" PRIu64 ":%d.",
-	       crv_version_get(&old_version), !!crv_tbs_is_set(&old_version),
-	       crv_version_get(&new_version), !!crv_tbs_is_set(&new_version));
+	M0_LOG(M0_DEBUG, "Overwriting " CRV_F " with " CRV_F ".",
+	       CRV_P(&old_version), CRV_P(&new_version));
 
 	anchor->ba_value.b_nob = ctg_vbuf_packed_size(&ctg_op->co_val);
 	rc = M0_BE_OP_SYNC_RET(op,
@@ -2300,11 +2325,15 @@ static int versioned_record_put_sync(struct m0_ctg_op *ctg_op)
 		/* TODO: it is too pessimistic. */
 		m0_ctg_state_inc_update(tx, key->b_nob + ctg_op->co_val.b_nob);
 	}
-out:
+
 	return M0_RC(rc);
 }
 
-static int alive_record_get_sync(struct m0_ctg_op *ctg_op)
+/*
+ * Gets an alive record (without tombstone set) in btree.
+ * Returns -ENOENT if tombstone is set.
+ */
+static int versioned_get_sync(struct m0_ctg_op *ctg_op)
 {
 	struct m0_be_btree        *btree  = &ctg_op->co_ctg->cc_tree;
 	struct m0_be_btree_anchor *anchor = &ctg_op->co_anchor;
@@ -2328,7 +2357,11 @@ static int alive_record_get_sync(struct m0_ctg_op *ctg_op)
 	return M0_RC(rc);
 }
 
-static int alive_cursor_next_sync(struct m0_ctg_op *ctg_op)
+/*
+ * Synchronously advances the cursor until it reaches an alive
+ * key-value pair (without tombstone set) or the end of the tree.
+ */
+static int versioned_cursor_next_sync(struct m0_ctg_op *ctg_op)
 {
 	struct m0_be_op           *beop   = ctg_beop(ctg_op);
 	struct cas_rec_ver         ver    = CRV_INIT_NONE;
@@ -2355,7 +2388,19 @@ static int alive_cursor_next_sync(struct m0_ctg_op *ctg_op)
 	return M0_RC(rc);
 }
 
-static int alive_cursor_get_sync(struct m0_ctg_op *ctg_op)
+/*
+ * Positions the cursor at the alive record that corresponds to the
+ * specified key or at the alive record next to the specified key
+ * depending on the slant flag:
+ *   Non-slant:
+ *     record_at(key) is alive: returns the record.
+ *     record_at(key) has tombstone: returns -ENOENT.
+ *   Slant:
+ *     record_at(key) is alive: returns the record.
+ *     record_at(key) has tombstone: finds next alive record.
+ * See the ::next_ver UT for examples.
+ */
+static int versioned_cursor_get_sync(struct m0_ctg_op *ctg_op)
 {
 	struct m0_be_op           *beop   = ctg_beop(ctg_op);
 	struct cas_rec_ver         ver    = CRV_INIT_NONE;
@@ -2380,7 +2425,7 @@ static int alive_cursor_get_sync(struct m0_ctg_op *ctg_op)
 	m0_be_op_reset(beop);
 
 	if (rc == -EAGAIN)
-		rc = alive_cursor_next_sync(ctg_op);
+		rc = versioned_cursor_next_sync(ctg_op);
 
 	return M0_RC(rc);
 }

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -77,6 +77,54 @@ struct m0_ctg_store {
 	bool                 cs_initialised;
 };
 
+/* Data schema for CAS catalogues { */
+
+/** Generalised key: versioned counted opaque data. */
+struct generic_key {
+	uint64_t gk_length;
+	uint8_t  gk_data[0];
+};
+M0_BASSERT(sizeof(struct generic_key) == M0_CAS_CTG_KEY_HDR_SIZE);
+
+struct cas_rec_ver {
+	uint64_t  crv_encoded;
+};
+M0_BASSERT(sizeof(struct cas_rec_ver) == 8);
+
+/** Generalised value: counted opaque data. */
+struct generic_value {
+	uint64_t           gv_length;
+	struct cas_rec_ver gv_version;
+	uint8_t            gv_data[0];
+};
+M0_BASSERT(sizeof(struct generic_value) == M0_CAS_CTG_VAL_HDR_SIZE);
+
+/** The key type used in meta and ctidx catalogues. */
+struct fid_key {
+	struct generic_key fk_gkey;
+	struct m0_fid      fk_fid;
+};
+M0_BASSERT(sizeof(struct generic_key) + sizeof(struct m0_fid) ==
+	   sizeof(struct fid_key));
+
+/* The value type used in meta catalogue */
+struct meta_value {
+	struct generic_value mv_gval;
+	struct m0_cas_ctg   *mv_ctg;
+};
+M0_BASSERT(sizeof(struct generic_value) + sizeof(struct m0_cas_ctg *) ==
+	   sizeof(struct meta_value));
+
+/* The value type used in ctidx catalogue */
+struct layout_value {
+	struct generic_value lv_gval;
+	struct m0_dix_layout lv_layout;
+};
+M0_BASSERT(sizeof(struct generic_value) + sizeof(struct m0_dix_layout) ==
+	   sizeof(struct layout_value));
+
+/* } end of schema. */
+
 enum cursor_phase {
 	CPH_NONE = 0,
 	CPH_INIT,
@@ -86,10 +134,13 @@ enum cursor_phase {
 
 static struct m0_be_seg *cas_seg(struct m0_be_domain *dom);
 
+static bool ctg_op_is_versioned(const struct m0_ctg_op *op);
 static int  ctg_berc         (struct m0_ctg_op *ctg_op);
-static int  ctg_buf          (const struct m0_buf *val, struct m0_buf *buf);
-static int  ctg_buf_get      (struct m0_buf *dst, const struct m0_buf *src);
-static void ctg_fid_key_fill (void *key, const struct m0_fid *fid);
+static int ctg_vbuf_unpack(struct m0_buf *buf, struct cas_rec_ver *crv);
+static int  ctg_vbuf_as_ctg  (const struct m0_buf *val,
+			      struct m0_cas_ctg **ctg);
+static int  ctg_kbuf_unpack  (struct m0_buf *buf);
+static int  ctg_kbuf_get     (struct m0_buf *dst, const struct m0_buf *src);
 static void ctg_init         (struct m0_cas_ctg *ctg, struct m0_be_seg *seg);
 static void ctg_fini         (struct m0_cas_ctg *ctg);
 static void ctg_destroy      (struct m0_cas_ctg *ctg, struct m0_be_tx *tx);
@@ -160,86 +211,265 @@ static int ctg_berc(struct m0_ctg_op *ctg_op)
 	return ctg_beop(ctg_op)->bo_u.u_btree.t_rc;
 }
 
-static void ctg_memcpy(void *dst, const void *src, uint64_t nob)
+void ctg_berc_set_sync(struct m0_ctg_op *ctg_op, int rc)
 {
-	*(uint64_t *)dst = nob;
-	memcpy(dst + M0_CAS_CTG_KV_HDR_SIZE, src, nob);
+	struct m0_be_op *beop   = ctg_beop(ctg_op);
+	m0_be_op_active(beop);
+	m0_be_op_rc_set(beop, rc);
+	/*ctg_beop(ctg_op)->bo_u.u_btree.t_rc = rc;*/
+	m0_be_op_done(beop);
 }
 
-static int ctg_buf_get(struct m0_buf *dst, const struct m0_buf *src)
+static m0_bcount_t ctg_vbuf_packed_size(const struct m0_buf *value)
 {
-	m0_bcount_t nob = src->b_nob;
+	return sizeof(struct generic_value) + value->b_nob;
+}
+
+static void ctg_vbuf_pack(struct m0_buf            *dst,
+			  const struct m0_buf      *src,
+			  const struct cas_rec_ver *crv)
+{
+	struct generic_value *value = dst->b_addr;
+	M0_PRE(dst->b_nob >= ctg_vbuf_packed_size(src));
+	value->gv_length = src->b_nob;
+	value->gv_version = *crv;
+	memcpy(&value->gv_data, src->b_addr, src->b_nob);
+}
+
+static void ensure_ctg_is_versioned(const struct m0_cas_ctg *ctg)
+{
+	struct m0_format_tag tag = {};
+
+	M0_ENTRY();
+
+	m0_format_header_unpack(&tag, &ctg->cc_head);
+	if (tag.ot_version != M0_CAS_CTG_FORMAT_VERSION) {
+		if (tag.ot_version == M0_CAS_CTG_FORMAT_VERSION_1 &&
+		    M0_CAS_CTG_FORMAT_VERSION == M0_CAS_CTG_FORMAT_VERSION_2) {
+			M0_LOG(M0_FATAL, "Your KVS (CAS) requires key-value "
+			       "versioning feature, but your on-disk metadata "
+			       "has the old (1) format. Please upgrade on-disk "
+			       " metadata.");
+			M0_ASSERT_INFO(false, "Version mismatch (CAS format).");
+		}
+	}
+
+	M0_LEAVE();
+}
+
+/** Create a new m0_buf filled with CAS-specific data (length). */
+static int ctg_kbuf_get(struct m0_buf *dst, const struct m0_buf *src)
+{
+	struct generic_key *key;
+
+	M0_ENTRY();
 
 	if (M0_FI_ENABLED("cas_alloc_fail"))
 		return M0_ERR(-ENOMEM);
-	dst->b_nob  = src->b_nob + M0_CAS_CTG_KV_HDR_SIZE;
-	dst->b_addr = m0_alloc(dst->b_nob);
-	if (dst->b_addr != NULL) {
-		ctg_memcpy(dst->b_addr, src->b_addr, nob);
+
+	key = m0_alloc(src->b_nob + sizeof(*key));
+	if (key != NULL) {
+		key->gk_length = src->b_nob;
+		memcpy(key->gk_data, src->b_addr, src->b_nob);
+		*dst = M0_BUF_INIT(src->b_nob + sizeof(*key), key);
 		return M0_RC(0);
 	} else
 		return M0_ERR(-ENOMEM);
 }
 
-/**
- * Allocate memory and unpack value having format length + data.
- *
- * @param val destination buffer
- * @param buf source buffer
- * @return 0 if ok else error code
- */
-static int ctg_buf(const struct m0_buf *val, struct m0_buf *buf)
-{
-	int result = -EPROTO;
+enum {
+	/* Tombstone flag: marks a dead kv pair. We use the MSB here. */
+	CRV_TBS = 1L << (sizeof(uint64_t) * CHAR_BIT - 1),
 
-	M0_CASSERT(sizeof buf->b_nob == 8);
-	if (val->b_nob >= 8) {
-		buf->b_nob = *(uint64_t *)val->b_addr;
-		if (val->b_nob == buf->b_nob + 8) {
-			buf->b_addr = ((char *)val->b_addr) + 8;
-			result = 0;
-		}
-	}
-	if (result != 0)
-		return M0_ERR_INFO(result, "Unexpected: %"PRIx64"/%"PRIx64,
-				   val->b_nob, buf->b_nob);
-	else
-		return M0_RC(result);
+	/*
+	 * A special value that indicates the lack of version-aware behavior.
+	 * When such a version is provided, the functions transparently
+	 * ignore version comparison and tombstones in btree_save/delete.
+	 */
+	CRV_VER_NONE = 0,
+
+	/* The biggest possible value of a version. */
+	CRV_VER_MAX = (UINT64_MAX & ~CRV_TBS) - 1,
+	/* The lowest possible value of a version. */
+	CRV_VER_MIN = CRV_VER_NONE + 1,
+};
+
+
+static bool crv_tbs_is_set(const struct cas_rec_ver *crv)
+{
+	return crv->crv_encoded & CRV_TBS;
 }
 
-static void ctg_fid_key_fill(void *key, const struct m0_fid *fid)
+static void crv_tbs_set(struct cas_rec_ver *crv)
 {
-	ctg_memcpy(key, fid, sizeof(struct m0_fid));
+	crv->crv_encoded |= CRV_TBS;
+}
+
+
+static void crv_tbs_clear(struct cas_rec_ver *crv)
+{
+	crv->crv_encoded &= ~CRV_TBS;
+}
+
+static uint64_t crv_version_get(const struct cas_rec_ver *crv)
+{
+	return crv->crv_encoded & ~CRV_TBS;
+}
+
+static void crv_version_set(struct cas_rec_ver *crv, uint64_t ts)
+{
+	crv->crv_encoded = (crv->crv_encoded & CRV_TBS) | ts;
+}
+
+static void crv_init(struct cas_rec_ver *crv, uint64_t version, bool tbs)
+{
+	M0_PRE(version <= CRV_VER_MAX);
+	M0_PRE(version >= CRV_VER_MIN);
+
+	crv_version_set(crv, version);
+	(tbs ? crv_tbs_set : crv_tbs_clear)(crv);
+
+	M0_POST(equi(crv_tbs_is_set(crv), tbs));
+	M0_POST(crv_version_get(crv) == version);
+}
+
+#define CRV_INIT_NONE ((struct cas_rec_ver) { .crv_encoded = CRV_VER_NONE })
+
+static bool crv_gt(const struct cas_rec_ver *left,
+		   const struct cas_rec_ver *right)
+{
+	return crv_version_get(left) > crv_version_get(right);
+}
+
+static bool crv_is_none(const struct cas_rec_ver *crv)
+{
+	return memcmp(crv, &CRV_INIT_NONE, sizeof(*crv)) == 0;
+}
+
+/**
+ * Unpack an an on-disk value datum into an in-memory datum.
+ * The function makes "buf" to point to the user-specific data associated
+ * with the value (see ::generic_value::gv_data).
+ * @param[out] Optional storage for the version of the record.
+ * @return 0 or else -EPROTO if on-disk/on-wire buffer has invalid length.
+ */
+static int ctg_vbuf_unpack(struct m0_buf *buf, struct cas_rec_ver *crv)
+{
+	struct generic_value *value;
+
+	M0_ENTRY();
+
+	value = buf->b_addr;
+
+	if (buf->b_nob < sizeof(*value))
+		return M0_ERR_INFO(-EPROTO, "%" PRIu64 " < %" PRIu64,
+				   buf->b_nob, sizeof(*value));
+	if (value->gv_length != buf->b_nob - sizeof(*value))
+		return M0_ERR(-EPROTO);
+
+	if (crv != NULL)
+		*crv = value->gv_version;
+
+	buf->b_nob = value->gv_length;
+	buf->b_addr = &value->gv_data[0];
+
+	return M0_RC(0);
+}
+
+/**
+ * Get a m0_cas_ctg pointer from in-memory representation of a meta-index
+ * value.
+ */
+static int ctg_vbuf_as_ctg(const struct m0_buf *buf, struct m0_cas_ctg **ctg)
+{
+	struct meta_value *mv = buf->b_addr - sizeof(struct generic_value);
+
+	M0_ENTRY();
+
+	if (buf->b_nob == sizeof(struct m0_cas_ctg *)) {
+		*ctg = mv->mv_ctg;
+		return M0_RC(0);
+	} else
+		return M0_ERR(-EPROTO);
+}
+
+/**
+ * Convert a versioned variable length buffer (on-disk data) into user-specific
+ * data (see generic_key::gk_data).
+ */
+static int ctg_kbuf_unpack(struct m0_buf *buf)
+{
+	struct generic_key *key;
+
+	M0_ENTRY();
+
+	key = buf->b_addr;
+
+	if (buf->b_nob < sizeof(*key))
+		return M0_ERR(-EPROTO);
+	if (key->gk_length != buf->b_nob - sizeof(*key))
+		return M0_ERR(-EPROTO);
+
+	buf->b_nob = key->gk_length;
+	buf->b_addr = &key->gk_data[0];
+
+	return M0_RC(0);
+}
+
+#define FID_KEY_INIT(__fid) (struct fid_key) { \
+	.fk_gkey = { \
+		.gk_length = sizeof(*(__fid)), \
+	}, \
+	.fk_fid = *(__fid), \
+}
+
+#define GENERIC_VALUE_INIT(__size) (struct generic_value) { \
+	.gv_length = __size,                                \
+}
+
+#define META_VALUE_INIT(__ctg_ptr) (struct meta_value) {  \
+	.mv_gval = GENERIC_VALUE_INIT(sizeof(__ctg_ptr)), \
+	.mv_ctg    = (__ctg_ptr),                         \
+}
+
+#define LAYOUT_VALUE_INIT(__layout) (struct layout_value) { \
+	.lv_gval = GENERIC_VALUE_INIT(sizeof(*(__layout))), \
+	.lv_layout = *(__layout),                           \
 }
 
 static m0_bcount_t ctg_ksize(const void *key)
 {
+	/* TODO: use generic_key */
 	/* Size is stored in the header. */
-	return M0_CAS_CTG_KV_HDR_SIZE + *(const uint64_t *)key;
+	return M0_CAS_CTG_KEY_HDR_SIZE + *(const uint64_t *)key;
 }
 
 static m0_bcount_t ctg_vsize(const void *val)
 {
-	return ctg_ksize(val);
+	/* TODO: use generic_value */
+	return M0_CAS_CTG_VAL_HDR_SIZE + *(const uint64_t *)val;
 }
 
 static int ctg_cmp(const void *key0, const void *key1)
 {
-	m0_bcount_t knob0 = ctg_ksize(key0);
-	m0_bcount_t knob1 = ctg_ksize(key1);
+	m0_bcount_t       knob0   = ctg_ksize(key0);
+	m0_bcount_t       knob1   = ctg_ksize(key1);
+	const m0_bcount_t hdr_nob = M0_CAS_CTG_KEY_HDR_SIZE;
 	/**
 	 * @todo Cannot assert on on-disk data, but no interface to report
 	 * errors from here.
 	 */
-	M0_ASSERT(knob0 >= 8);
-	M0_ASSERT(knob1 >= 8);
+	M0_ASSERT(knob0 >= hdr_nob);
+	M0_ASSERT(knob1 >= hdr_nob);
 
-	return memcmp(key0 + 8, key1 + 8, min_check(knob0, knob1) - 8) ?:
+	return memcmp(key0 + hdr_nob, key1 + hdr_nob,
+		      min_check(knob0, knob1) - hdr_nob) ?:
 		M0_3WAY(knob0, knob1);
 }
 
 static void ctg_init(struct m0_cas_ctg *ctg, struct m0_be_seg *seg)
 {
+	ensure_ctg_is_versioned(ctg);
 	m0_format_header_pack(&ctg->cc_head, &(struct m0_format_tag){
 		.ot_version = M0_CAS_CTG_FORMAT_VERSION,
 		.ot_type    = M0_FORMAT_TYPE_CAS_CTG,
@@ -330,78 +560,55 @@ M0_INTERNAL int m0_ctg_meta_find_ctg(struct m0_cas_ctg    *meta,
 			             const struct m0_fid  *ctg_fid,
 			             struct m0_cas_ctg   **ctg)
 {
-	uint8_t                   key_data[M0_CAS_CTG_KV_HDR_SIZE +
-		                           sizeof(struct m0_fid)];
-	struct m0_buf             key;
+	struct fid_key            key_data = FID_KEY_INIT(ctg_fid);
+	struct m0_buf             key = M0_BUF_INIT(sizeof(key_data),
+						    &key_data);
 	struct m0_be_btree_anchor anchor;
 	int                       rc;
 
 	*ctg = NULL;
-
-	ctg_fid_key_fill((void *)&key_data, ctg_fid);
-	key = M0_BUF_INIT_PTR(&key_data);
 
 	rc = M0_BE_OP_SYNC_RET(op,
 			       m0_be_btree_lookup_inplace(&meta->cc_tree,
 							  &op,
 							  &key,
 							  &anchor),
-			       bo_u.u_btree.t_rc);
-	if (rc == 0) {
-		struct m0_buf buf = {};
+			       bo_u.u_btree.t_rc) ?:
+		ctg_vbuf_unpack(&anchor.ba_value, NULL) ?:
+		ctg_vbuf_as_ctg(&anchor.ba_value, ctg);
 
-		rc = ctg_buf(&anchor.ba_value, &buf);
-		if (rc == 0) {
-			if (buf.b_nob == sizeof(*ctg))
-				*ctg = *(struct m0_cas_ctg **)buf.b_addr;
-			else
-				rc = M0_ERR_INFO(-EPROTO, "Unexpected: %"PRIx64,
-						 buf.b_nob);
-		}
-	}
-
-	/*
-	 * Free read lock acquired in m0_be_btree_lookup_inplace().
-	 */
-		m0_be_btree_release(NULL, &anchor);
+	m0_be_btree_release(NULL, &anchor);
 	return M0_RC(rc);
 }
 
+/*
+ * NOTE:
+ * If passed catalogue is NULL then it is a stub for meta-catalogue
+ * inside itself, inserting records in it is prohibited. This stub
+ * is used to generalise listing catalogues operation.
+ * Insert real catalogue otherwise (catalogue is not NULL).
+ */
 M0_INTERNAL int m0_ctg__meta_insert(struct m0_be_btree  *meta,
 				    const struct m0_fid *fid,
 				    struct m0_cas_ctg   *ctg,
 				    struct m0_be_tx     *tx)
 {
-	uint8_t                    key_data[M0_CAS_CTG_KV_HDR_SIZE +
-					    sizeof(struct m0_fid)];
-	struct m0_buf              key;
+	struct fid_key             key_data = FID_KEY_INIT(fid);
+	struct meta_value          val_data = META_VALUE_INIT(ctg);
+	struct m0_buf              key = M0_BUF_INIT_PTR(&key_data);
+	struct m0_buf              value = M0_BUF_INIT_PTR(&val_data);
 	struct m0_be_btree_anchor  anchor = {};
-	void                      *val_data;
 	int                        rc;
 
-	ctg_fid_key_fill((void *)&key_data, fid);
-	key = M0_BUF_INIT_PTR(&key_data);
-	anchor.ba_value.b_nob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg);
+	anchor.ba_value.b_nob = value.b_nob;
 	rc = M0_BE_OP_SYNC_RET(op,
 		       m0_be_btree_insert_inplace(meta, tx, &op,
 						  &key, &anchor,
 						  M0_BITS(M0_BAP_NORMAL)),
 		       bo_u.u_btree.t_rc);
-	/*
-	 * If passed catalogue is NULL then it is a stub for meta-catalogue
-	 * inside itself, inserting records in it is prohibited. This stub
-	 * is used to generalise listing catalogues operation.
-	 * Insert real catalogue otherwise (catalogue is not NULL).
-	 */
-	if (rc == 0) {
-		val_data = anchor.ba_value.b_addr;
-		/*
-		 * Meta entry format: length + ptr to cas_ctg.
-		 * Memory for ctg allocated elsewhere and must be persistent.
-		 */
-		*(uint64_t *)val_data = sizeof(ctg);
-		*(struct m0_cas_ctg**)(val_data + M0_CAS_CTG_KV_HDR_SIZE) = ctg;
-	}
+	if (rc == 0)
+		m0_buf_memcpy(&anchor.ba_value, &value);
+
 	m0_be_btree_release(tx, &anchor);
 	return M0_RC(rc);
 }
@@ -416,12 +623,10 @@ static void ctg_meta_delete(struct m0_be_btree  *meta,
 			    const struct m0_fid *fid,
 			    struct m0_be_tx     *tx)
 {
-	uint8_t       key_data[M0_CAS_CTG_KV_HDR_SIZE + sizeof(struct m0_fid)];
-	struct m0_buf key;
+	struct fid_key             key_data = FID_KEY_INIT(fid);
+	struct m0_buf              key = M0_BUF_INIT_PTR(&key_data);
 
 	M0_ENTRY();
-	ctg_fid_key_fill((void *)&key_data, fid);
-	key = M0_BUF_INIT_PTR(&key_data);
 	M0_BE_OP_SYNC(op, m0_be_btree_delete(meta, tx, &op, &key));
 }
 
@@ -438,9 +643,8 @@ static void ctg_meta_insert_credit(struct m0_be_btree     *bt,
 	struct m0_cas_ctg *ctg;
 
 	m0_be_btree_insert_credit2(bt, nr,
-				   M0_CAS_CTG_KV_HDR_SIZE +
-				   sizeof(struct m0_fid),
-				   M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg),
+				   sizeof(struct fid_key),
+				   sizeof(struct meta_value),
 				   accum);
 	/*
 	 * Will allocate space for cas_ctg body then put ptr to it into btree.
@@ -456,9 +660,8 @@ static void ctg_meta_delete_credit(struct m0_be_btree     *bt,
 	struct m0_cas_ctg *ctg;
 
 	m0_be_btree_delete_credit(bt, nr,
-				  M0_CAS_CTG_KV_HDR_SIZE +
-				  sizeof(struct m0_fid),
-				  M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg),
+				   sizeof(struct fid_key),
+				   sizeof(struct meta_value),
 				  accum);
 	M0_BE_FREE_CREDIT_PTR(ctg, seg, accum);
 }
@@ -823,41 +1026,35 @@ static bool ctg_is_ordinary(const struct m0_cas_ctg *ctg)
 
 static bool ctg_op_cb(struct m0_clink *clink)
 {
-	struct m0_ctg_op *ctg_op   = M0_AMB(ctg_op, clink, co_clink);
-	struct m0_be_op  *op      = ctg_beop(ctg_op);
-	int               opc     = ctg_op->co_opcode;
-	int               ct      = ctg_op->co_ct;
-	struct m0_be_tx  *tx      = &ctg_op->co_fom->fo_tx.tx_betx;
-	void             *arena   = ctg_op->co_anchor.ba_value.b_addr;
-	struct m0_buf     cur_key = {};
-	struct m0_buf     cur_val = {};
-	struct m0_chan   *ctg_chan = &ctg_op->co_ctg->cc_chan.bch_chan;
-	struct m0_buf    *dst;
-	struct m0_buf    *src;
-	int               rc;
+	struct m0_ctg_op  *ctg_op   = M0_AMB(ctg_op, clink, co_clink);
+	struct m0_be_op   *op      = ctg_beop(ctg_op);
+	int                opc     = ctg_op->co_opcode;
+	int                ct      = ctg_op->co_ct;
+	struct m0_be_tx   *tx      = &ctg_op->co_fom->fo_tx.tx_betx;
+	struct m0_chan    *ctg_chan = &ctg_op->co_ctg->cc_chan.bch_chan;
+	int                rc;
+	struct m0_cas_ctg *ctg;
+	struct fid_key    *fk;
+	struct meta_value *mv;
 
 	if (op->bo_sm.sm_state != M0_BOS_DONE)
+		return true;
+
+	/* Versioned API is synchronous. */
+	if (ctg_op_is_versioned(ctg_op))
 		return true;
 
 	rc = ctg_berc(ctg_op);
 	if (rc == 0) {
 		switch (CTG_OP_COMBINE(opc, ct)) {
-		case CTG_OP_COMBINE(CO_GET, CT_BTREE):
 		case CTG_OP_COMBINE(CO_GET, CT_META):
-			rc = ctg_buf(&ctg_op->co_anchor.ba_value,
-				     &ctg_op->co_out_val);
-			/*
-			 * After get from meta we have struct m0_cas_ctg* in
-			 * ctg_op->co_out_val buffer.
-			 */
-			if (rc == 0 && ct == CT_META &&
-			    ctg_op->co_out_val.b_nob !=
-			    sizeof(struct m0_cas_ctg *))
-				rc = M0_ERR(-EFAULT);
-			if (rc == 0 && ct == CT_META) {
-				m0_ctg_try_init(*(struct m0_cas_ctg **)
-					     ctg_op->co_out_val.b_addr);
-			}
+		case CTG_OP_COMBINE(CO_GET, CT_BTREE):
+			ctg_op->co_out_val = ctg_op->co_anchor.ba_value;
+			rc = ctg_vbuf_unpack(&ctg_op->co_out_val, NULL);
+			if (rc == 0 && ct == CT_META)
+				rc = ctg_vbuf_as_ctg(&ctg_op->co_out_val, &ctg);
+			if (rc == 0 && ct == CT_META)
+				m0_ctg_try_init(ctg);
 			break;
 		case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
 			if (ctg_is_ordinary(ctg_op->co_ctg))
@@ -871,64 +1068,58 @@ static bool ctg_op_cb(struct m0_clink *clink)
 			m0_chan_broadcast_lock(ctg_chan);
 			break;
 		case CTG_OP_COMBINE(CO_MIN, CT_BTREE):
-			ctg_buf(&ctg_op->co_out_key, &cur_key);
-			ctg_op->co_out_key = cur_key;
+			rc = ctg_kbuf_unpack(&ctg_op->co_out_key);
 			break;
 		case CTG_OP_COMBINE(CO_CUR, CT_META):
 		case CTG_OP_COMBINE(CO_CUR, CT_BTREE):
 			m0_be_btree_cursor_kv_get(&ctg_op->co_cur,
-						  &cur_key,
-						  &cur_val);
-			rc = ctg_buf(&cur_key, &ctg_op->co_out_key);
-			if (rc == 0)
-				rc = ctg_buf(&cur_val, &ctg_op->co_out_val);
+						  &ctg_op->co_out_key,
+						  &ctg_op->co_out_val);
+			rc = ctg_kbuf_unpack(&ctg_op->co_out_key) ?:
+				ctg_vbuf_unpack(&ctg_op->co_out_val, NULL);
 			if (rc == 0 && ct == CT_META)
-				m0_ctg_try_init(*(struct m0_cas_ctg **)
-					     ctg_op->co_out_val.b_addr);
+				rc = ctg_vbuf_as_ctg(&ctg_op->co_out_val, &ctg);
+			if (rc == 0 && ct == CT_META)
+				m0_ctg_try_init(ctg);
 			break;
 		case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
-			ctg_memcpy(arena, ctg_op->co_val.b_addr,
-				   ctg_op->co_val.b_nob);
+			ctg_vbuf_pack(&ctg_op->co_anchor.ba_value,
+				      &ctg_op->co_val, &CRV_INIT_NONE);
 			if (ctg_is_ordinary(ctg_op->co_ctg))
 				m0_ctg_state_inc_update(tx,
 					ctg_op->co_key.b_nob -
-				       	M0_CAS_CTG_KV_HDR_SIZE +
+					sizeof(struct generic_key) +
 					ctg_op->co_val.b_nob);
-			m0_chan_broadcast_lock(ctg_chan);
+			else
+				m0_chan_broadcast_lock(ctg_chan);
 			break;
 		case CTG_OP_COMBINE(CO_PUT, CT_META):
-			*(uint64_t *)arena = sizeof(struct m0_cas_ctg *);
+			fk = ctg_op->co_key.b_addr;
+			mv = ctg_op->co_anchor.ba_value.b_addr;
 			/*
-			 * After successful insert inplace fill value of meta by
-			 * length & pointer to cas_ctg. m0_ctg_create() creates
-			 * cas_ctg, including memory alloc.
+			 * XXX: Why do we have a special CO_MEM_PLACE
+			 * that just allocates a datum for imask but
+			 * here we have an allocation (m0_cas_ctg object)
+			 * and tree creation (m0_cas_ctg::cc_tree) in
+			 * a single call that is called when PUT is almost
+			 * done? Shouldn't it be done beforehand?
 			 */
 			rc = m0_ctg_create(cas_seg(tx->t_engine->eng_domain),
-					tx,
-					arena + M0_CAS_CTG_KV_HDR_SIZE,
-					/*
-					 * Meta key have a fid of index/ctg
-					 * store.  It is located after KV
-					 * header.
-					 */
-					 ctg_op->co_key.b_addr +
-					 M0_CAS_CTG_KV_HDR_SIZE);
-			if (rc == 0)
+					   tx, &ctg, &fk->fk_fid);
+			if (rc == 0) {
+				*mv = META_VALUE_INIT(ctg);
 				m0_chan_broadcast_lock(ctg_chan);
+			}
 			break;
 		case CTG_OP_COMBINE(CO_MEM_PLACE, CT_MEM):
 			/*
 			 * Copy user provided buffer to the buffer allocated in
 			 * BE and capture it.
 			 */
-			src = &ctg_op->co_val;
-			dst = &ctg_op->co_mem_buf;
-			M0_ASSERT(src->b_nob == dst->b_nob);
-			memcpy(dst->b_addr, src->b_addr, src->b_nob);
-			m0_be_tx_capture(
-				&ctg_op->co_fom->fo_tx.tx_betx,
-				&M0_BE_REG(cas_seg(tx->t_engine->eng_domain),
-					   dst->b_nob, dst->b_addr));
+			m0_buf_memcpy(&ctg_op->co_mem_buf, &ctg_op->co_val);
+			M0_BE_TX_CAPTURE_BUF(cas_seg(tx->t_engine->eng_domain),
+					     &ctg_op->co_fom->fo_tx.tx_betx,
+					     &ctg_op->co_mem_buf);
 			break;
 		case CTG_OP_COMBINE(CO_MEM_FREE, CT_MEM):
 			/* Nothing to do. */
@@ -947,7 +1138,7 @@ static bool ctg_op_cb(struct m0_clink *clink)
 	    rc == -EEXIST)
 		rc = 0;
 
-	ctg_op->co_rc = rc;
+	ctg_op->co_rc = M0_RC(rc);
 	m0_chan_broadcast_lock(&ctg_op->co_channel);
 	/*
 	 * This callback may be called directly from ctg_op_tick_ret()
@@ -989,7 +1180,17 @@ static int ctg_op_tick_ret(struct m0_ctg_op *ctg_op,
 	return ret;
 }
 
-static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
+/*
+ * Returns a bitmap of zones that could be used within the given operation.
+ * See ::m0_be_alloc_zone_type.
+ */
+static uint32_t ctg_op_zones(const struct m0_ctg_op *ctg_op)
+{
+	return M0_BITS(M0_BAP_NORMAL) |
+		((ctg_op->co_flags & COF_RESERVE) ? M0_BITS(M0_BAP_REPAIR) : 0);
+}
+
+static int ctg_op_exec_normal(struct m0_ctg_op *ctg_op, int next_phase)
 {
 	struct m0_buf             *key    = &ctg_op->co_key;
 	struct m0_be_btree        *btree  = &ctg_op->co_ctg->cc_tree;
@@ -999,23 +1200,20 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 	struct m0_be_op           *beop   = ctg_beop(ctg_op);
 	int                        opc    = ctg_op->co_opcode;
 	int                        ct     = ctg_op->co_ct;
-	uint64_t                   zones;
-
-	zones = M0_BITS(M0_BAP_NORMAL) |
-		((ctg_op->co_flags & COF_RESERVE) ? M0_BITS(M0_BAP_REPAIR) : 0);
+	uint64_t                   zones = ctg_op_zones(ctg_op);
 
 	switch (CTG_OP_COMBINE(opc, ct)) {
 	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
-		anchor->ba_value.b_nob = M0_CAS_CTG_KV_HDR_SIZE +
+		anchor->ba_value.b_nob = sizeof(struct generic_value) +
 					 ctg_op->co_val.b_nob;
-		m0_be_btree_save_inplace(btree, tx, beop, key, anchor,
+		m0_be_btree_save_inplace(btree, tx, beop,
+					 key, anchor,
 					 !!(ctg_op->co_flags & COF_OVERWRITE),
 					 zones);
 		break;
 	case CTG_OP_COMBINE(CO_PUT, CT_META):
 		M0_ASSERT(!(ctg_op->co_flags & COF_OVERWRITE));
-		anchor->ba_value.b_nob = M0_CAS_CTG_KV_HDR_SIZE +
-					 sizeof(struct m0_cas_ctg *);
+		anchor->ba_value.b_nob = sizeof(struct meta_value);
 		m0_be_btree_insert_inplace(btree, tx, beop, key, anchor, zones);
 		break;
 	case CTG_OP_COMBINE(CO_PUT, CT_DEAD_INDEX):
@@ -1024,7 +1222,7 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 		 * there. Do not fill anything in the callback after
 		 * m0_be_btree_insert_inplace() have 0 there.
 		 */
-		anchor->ba_value.b_nob = 8;
+		anchor->ba_value.b_nob = sizeof(struct generic_value);
 		m0_be_btree_insert_inplace(btree, tx, beop, key, anchor, zones);
 		break;
 	case CTG_OP_COMBINE(CO_GET, CT_BTREE):
@@ -1041,6 +1239,8 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 		m0_be_btree_destroy(btree, tx, beop);
 		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
+		m0_be_btree_delete(btree, tx, beop, key);
+		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_META):
 		m0_be_btree_delete(btree, tx, beop, key);
 		break;
@@ -1049,8 +1249,7 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 		break;
 	case CTG_OP_COMBINE(CO_CUR, CT_BTREE):
 	case CTG_OP_COMBINE(CO_CUR, CT_META):
-		M0_ASSERT(ctg_op->co_cur_phase == CPH_GET ||
-			  ctg_op->co_cur_phase == CPH_NEXT);
+		M0_ASSERT(M0_IN(ctg_op->co_cur_phase, (CPH_GET, CPH_NEXT)));
 		if (ctg_op->co_cur_phase == CPH_GET)
 			m0_be_btree_cursor_get(cur, key,
 				       !!(ctg_op->co_flags & COF_SLANT));
@@ -1060,6 +1259,81 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 	}
 
 	return ctg_op_tick_ret(ctg_op, next_phase);
+}
+
+static int versioned_record_put_sync(struct m0_ctg_op *ctg_op);
+static int alive_record_get_sync(struct m0_ctg_op *op);
+static int alive_cursor_next_sync(struct m0_ctg_op *op);
+static int alive_cursor_get_sync(struct m0_ctg_op *op);
+
+static int ctg_op_exec_versioned(struct m0_ctg_op *ctg_op, int next_phase)
+{
+	int                        rc;
+	int                        opc = ctg_op->co_opcode;
+	int                        ct  = ctg_op->co_ct;
+	struct m0_be_op           *beop = ctg_beop(ctg_op);
+
+	M0_PRE(ctg_is_ordinary(ctg_op->co_ctg));
+	M0_PRE(ct == CT_BTREE);
+	M0_PRE(ergo(opc == CO_CUR,
+		    M0_IN(ctg_op->co_cur_phase, (CPH_GET, CPH_NEXT))));
+
+	switch (CTG_OP_COMBINE(opc, ct)) {
+	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
+	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
+		rc = versioned_record_put_sync(ctg_op);
+		break;
+	case CTG_OP_COMBINE(CO_GET, CT_BTREE):
+		rc = alive_record_get_sync(ctg_op);
+		break;
+	case CTG_OP_COMBINE(CO_CUR, CT_BTREE):
+		if (ctg_op->co_cur_phase == CPH_GET)
+			rc = alive_cursor_get_sync(ctg_op);
+		else
+			rc = alive_cursor_next_sync(ctg_op);
+		break;
+	default:
+		M0_IMPOSSIBLE("The other operations are not allowed here.");
+	}
+
+	ctg_op->co_rc = rc;
+
+	/* It is either untouched or DONE right away. */
+	M0_ASSERT(M0_IN(beop->bo_sm.sm_state, (M0_BOS_INIT, M0_BOS_DONE)));
+	/* Only cursor operation may reach DONE state. */
+	M0_ASSERT(ergo(beop->bo_sm.sm_state == M0_BOS_DONE, opc == CO_CUR));
+
+	if (opc == CO_CUR) {
+		/*
+		 * BE cursor has its own BE operation. It gets initialised
+		 * everytime in m0_ctg_cursor_* and m0_ctg_meta_cursor_*.
+		 * Since a ctg op may be re-used (for example, as a part
+		 * of GET+NEXT sequence of calls), we need to make it
+		 * ready to be initialised again.
+		 */
+		m0_be_op_fini(beop);
+		M0_SET0(beop);
+	} else {
+		/*
+		 * Non-CO_CUR operations are completely ignoring the BE op
+		 * embedded into ctg_op. They are operating in synchrnonous
+		 * manner on local ops. Thus, we need to advance the state
+		 * of the embedded op to let the other parts function
+		 * properly (for example, ::m0_ctg_lookup_result).
+		 */
+		m0_be_op_active(beop);
+		m0_be_op_done(beop);
+	}
+
+	m0_fom_phase_set(ctg_op->co_fom, next_phase);
+	return M0_FSO_AGAIN;
+}
+
+static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
+{
+	return ctg_op_is_versioned(ctg_op) ?
+		ctg_op_exec_versioned(ctg_op, next_phase) :
+		ctg_op_exec_normal(ctg_op, next_phase);
 }
 
 static int ctg_mem_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
@@ -1087,7 +1361,7 @@ static int ctg_meta_exec(struct m0_ctg_op    *ctg_op,
 			 const struct m0_fid *fid,
 			 int                  next_phase)
 {
-	int ret;
+	int            ret;
 
 	ctg_op->co_ctg = ctg_store.cs_state->cs_meta;
 	ctg_op->co_ct = CT_META;
@@ -1095,10 +1369,8 @@ static int ctg_meta_exec(struct m0_ctg_op    *ctg_op,
 	if (ctg_op->co_opcode != CO_GC &&
 	    (ctg_op->co_opcode != CO_CUR ||
 	     ctg_op->co_cur_phase != CPH_NEXT))
-		ctg_op->co_rc = ctg_buf_get(&ctg_op->co_key,
-					    &M0_BUF_INIT_CONST(
-						    sizeof(struct m0_fid),
-						    fid));
+		ctg_op->co_rc = ctg_kbuf_get(&ctg_op->co_key,
+					     &M0_BUF_INIT_PTR_CONST(fid));
 	if (ctg_op->co_rc != 0) {
 		ret = M0_FSO_AGAIN;
 		m0_fom_phase_set(ctg_op->co_fom, next_phase);
@@ -1158,8 +1430,8 @@ struct m0_cas_ctg *m0_ctg_meta_lookup_result(struct m0_ctg_op *ctg_op)
 	M0_PRE(ctg_op->co_opcode == CO_GET);
 	M0_PRE(ctg_op->co_ct == CT_META);
 
-	if (ctg_op->co_rc == 0)
-		ctg = *(struct m0_cas_ctg **)ctg_op->co_out_val.b_addr;
+	ctg_op->co_rc = ctg_op->co_rc ?:
+		ctg_vbuf_as_ctg(&ctg_op->co_out_val, &ctg);
 
 	return ctg;
 }
@@ -1181,23 +1453,13 @@ M0_INTERNAL int m0_ctg_dead_index_insert(struct m0_ctg_op  *ctg_op,
 					 struct m0_cas_ctg *ctg,
 					 int                next_phase)
 {
-	int ret;
-
 	ctg_op->co_ctg = m0_ctg_dead_index();
 	ctg_op->co_ct = CT_DEAD_INDEX;
 	ctg_op->co_opcode = CO_PUT;
-	/*
-	 * Actually we need just a catalogue.
-	 * Put struct m0_cas_ctg* into dead_index as a key, keep value empty.
-	 */
-	ctg_op->co_rc = ctg_buf_get(&ctg_op->co_key,
-				    &M0_BUF_INIT_CONST(sizeof(ctg), &ctg));
-	if (ctg_op->co_rc != 0) {
-		ret = M0_FSO_AGAIN;
-		m0_fom_phase_set(ctg_op->co_fom, next_phase);
-	} else
-		ret = ctg_op_exec(ctg_op, next_phase);
-	return ret;
+	/* Dead index value is empty */
+	ctg_op->co_val = M0_BUF_INIT0;
+	/* Dead index key is a pointer to a catalogue */
+	return ctg_exec(ctg_op, ctg, &M0_BUF_INIT_PTR(&ctg), next_phase);
 }
 
 static int ctg_exec(struct m0_ctg_op    *ctg_op,
@@ -1205,7 +1467,7 @@ static int ctg_exec(struct m0_ctg_op    *ctg_op,
 		    const struct m0_buf *key,
 		    int                  next_phase)
 {
-	int ret = M0_FSO_AGAIN;
+	int               ret     = M0_FSO_AGAIN;
 
 	ctg_op->co_ctg = ctg;
 	ctg_op->co_ct = CT_BTREE;
@@ -1213,7 +1475,8 @@ static int ctg_exec(struct m0_ctg_op    *ctg_op,
 	if (!M0_IN(ctg_op->co_opcode, (CO_MIN, CO_TRUNC, CO_DROP)) &&
 	    (ctg_op->co_opcode != CO_CUR ||
 	     ctg_op->co_cur_phase != CPH_NEXT))
-		ctg_op->co_rc = ctg_buf_get(&ctg_op->co_key, key);
+		ctg_op->co_rc = ctg_kbuf_get(&ctg_op->co_key, key);
+
 
 	if (ctg_op->co_rc != 0)
 		m0_fom_phase_set(ctg_op->co_fom, next_phase);
@@ -1350,7 +1613,9 @@ M0_INTERNAL void m0_ctg_cursor_init(struct m0_ctg_op  *ctg_op,
 	ctg_op->co_cur_phase = CPH_INIT;
 	M0_SET0(&ctg_op->co_cur.bc_op);
 
-	m0_be_btree_cursor_init(&ctg_op->co_cur, &ctg_op->co_ctg->cc_tree);
+	m0_be_btree_cursor_init(&ctg_op->co_cur,
+				&ctg_op->co_ctg->cc_tree);
+
 	ctg_op->co_cur_initialised = true;
 }
 
@@ -1506,12 +1771,12 @@ M0_INTERNAL void m0_ctg_mark_deleted_credit(struct m0_be_tx_credit *accum)
 	struct m0_be_btree *mbtree = &m0_ctg_dead_index()->cc_tree;
 	struct m0_cas_ctg  *ctg;
 
-	knob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(struct m0_fid);
-	vnob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg);
+	knob = sizeof(struct fid_key);
+	vnob = sizeof(struct meta_value);
 	/* Delete from meta. */
 	m0_be_btree_delete_credit(btree, 1, knob, vnob, accum);
-	knob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg);
-	vnob = 8;
+	knob = sizeof(struct generic_key) + sizeof(ctg);
+	vnob = sizeof(struct generic_value);
 	/* Insert into dead index. */
 	m0_be_btree_insert_credit2(mbtree, 1, knob, vnob, accum);
 }
@@ -1525,8 +1790,8 @@ M0_INTERNAL void m0_ctg_create_credit(struct m0_be_tx_credit *accum)
 
 	m0_be_btree_create_credit(btree, 1, accum);
 
-	knob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(struct m0_fid);
-	vnob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg);
+	knob = sizeof(struct fid_key);
+	vnob = sizeof(struct meta_value);
 	m0_be_btree_insert_credit2(btree, 1, knob, vnob, accum);
 	/*
 	 * That are credits for cas_ctg body.
@@ -1589,8 +1854,8 @@ M0_INTERNAL void m0_ctg_dead_clean_credit(struct m0_be_tx_credit *accum)
 	/*
 	 * Define credits for delete from dead index.
 	 */
-	knob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg);
-	vnob = M0_CAS_CTG_KV_HDR_SIZE;
+	knob = sizeof(struct generic_key) + sizeof(ctg);
+	vnob = sizeof(struct generic_value);
 	m0_be_btree_delete_credit(btree, 1, knob, vnob, accum);
 	/*
 	 * Credits for ctg free.
@@ -1612,6 +1877,15 @@ M0_INTERNAL void m0_ctg_delete_credit(struct m0_cas_ctg      *ctg,
 				      struct m0_be_tx_credit *accum)
 {
 	m0_be_btree_delete_credit(&ctg->cc_tree, 1, knob, vnob, accum);
+
+	/* XXX: performance.
+	 * At this moment we do not know for sure if the CAS operation should
+	 * have version-aware behavior. So that we are doing a pessimistic
+	 * estimate here: reserving credits for both delete and insert.
+	 */
+	if (ctg_is_ordinary(ctg)) {
+		m0_be_btree_insert_credit2(&ctg->cc_tree, 1, knob, vnob, accum);
+	}
 }
 
 static void ctg_ctidx_op_credits(struct m0_cas_id       *cid,
@@ -1624,8 +1898,8 @@ static void ctg_ctidx_op_credits(struct m0_cas_id       *cid,
 	m0_bcount_t                knob;
 	m0_bcount_t                vnob;
 
-	knob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(struct m0_fid);
-	vnob = M0_CAS_CTG_KV_HDR_SIZE + sizeof(struct m0_dix_layout);
+	knob = sizeof(struct fid_key);
+	vnob = sizeof(struct layout_value);
 	if (insert)
 		m0_be_btree_insert_credit2(btree, 1, knob, vnob, accum);
 	else
@@ -1667,21 +1941,18 @@ M0_INTERNAL void m0_ctg_ctidx_delete_credits(struct m0_cas_id       *cid,
 M0_INTERNAL int m0_ctg_ctidx_lookup_sync(const struct m0_fid  *fid,
 					 struct m0_dix_layout **layout)
 {
-	uint8_t                   key_data[M0_CAS_CTG_KV_HDR_SIZE +
-		                           sizeof(struct m0_fid)];
-	struct m0_buf             key;
+	struct fid_key            key_data = FID_KEY_INIT(fid);
+	struct m0_buf             key = M0_BUF_INIT_PTR(&key_data);
 	struct m0_be_btree_anchor anchor;
 	struct m0_cas_ctg        *ctidx = m0_ctg_ctidx();
 	int                       rc;
+	struct layout_value      *value_data;
 
 	M0_PRE(ctidx != NULL);
 	M0_PRE(fid != NULL);
 	M0_PRE(layout != NULL);
 
 	*layout = NULL;
-
-	ctg_fid_key_fill(&key_data, fid);
-	key = M0_BUF_INIT_PTR(&key_data);
 
 	/** @todo Make it asynchronous. */
 	rc = M0_BE_OP_SYNC_RET(op,
@@ -1691,17 +1962,13 @@ M0_INTERNAL int m0_ctg_ctidx_lookup_sync(const struct m0_fid  *fid,
 							  &anchor),
 			       bo_u.u_btree.t_rc);
 	if (rc == 0) {
-		struct m0_buf buf = {};
-
-		rc = ctg_buf(&anchor.ba_value, &buf);
-		if (rc == 0) {
-			if (buf.b_nob == sizeof(struct m0_dix_layout))
-				*layout = (struct m0_dix_layout *)buf.b_addr;
-			else
-				rc = M0_ERR_INFO(-EPROTO, "Unexpected: %"PRIx64,
-						 buf.b_nob);
-		}
+		value_data = anchor.ba_value.b_addr;
+		if (sizeof(value_data) == anchor.ba_value.b_nob) {
+			*layout = &value_data->lv_layout;
+		} else
+			rc = M0_ERR(-EPROTO);
 	}
+
 	m0_be_btree_release(NULL, &anchor);
 
 	return M0_RC(rc);
@@ -1710,30 +1977,28 @@ M0_INTERNAL int m0_ctg_ctidx_lookup_sync(const struct m0_fid  *fid,
 M0_INTERNAL int m0_ctg_ctidx_insert_sync(const struct m0_cas_id *cid,
 					 struct m0_be_tx        *tx)
 {
-	uint8_t                    key_data[M0_CAS_CTG_KV_HDR_SIZE +
-					    sizeof(struct m0_fid)];
+	/* The key is a component catalogue FID. */
+	struct fid_key             key_data = FID_KEY_INIT(&cid->ci_fid);
+	struct m0_buf              key = M0_BUF_INIT_PTR(&key_data);
+	struct layout_value        value_data;
+	struct m0_buf              value = M0_BUF_INIT_PTR(&value_data);
 	struct m0_cas_ctg         *ctidx  = m0_ctg_ctidx();
 	struct m0_be_btree_anchor  anchor = {};
 	struct m0_dix_layout      *layout;
 	struct m0_ext             *im_range;
 	const struct m0_dix_imask *imask;
-	struct m0_buf              key;
 	m0_bcount_t                size;
 	int                        rc;
 
-	/* The key is a component catalogue FID. */
-	ctg_fid_key_fill((void *)&key_data, &cid->ci_fid);
-	key = M0_BUF_INIT_PTR(&key_data);
-	anchor.ba_value.b_nob = M0_CAS_CTG_KV_HDR_SIZE +
-		                sizeof(struct m0_dix_layout);
+	value_data = LAYOUT_VALUE_INIT(&cid->ci_layout);
+	anchor.ba_value.b_nob = value.b_nob;
 	/** @todo Make it asynchronous. */
 	rc = M0_BE_OP_SYNC_RET(op,
 		m0_be_btree_insert_inplace(&ctidx->cc_tree, tx, &op, &key,
 					   &anchor, M0_BITS(M0_BAP_NORMAL)),
 		bo_u.u_btree.t_rc);
 	if (rc == 0) {
-		ctg_memcpy(anchor.ba_value.b_addr, &cid->ci_layout,
-			   sizeof(cid->ci_layout));
+		m0_buf_memcpy(&anchor.ba_value, &value);
 		imask = &cid->ci_layout.u.dl_desc.ld_imask;
 		if (!m0_dix_imask_is_empty(imask)) {
 			/*
@@ -1750,9 +2015,8 @@ M0_INTERNAL int m0_ctg_ctidx_insert_sync(const struct m0_cas_id *cid,
 					 cas_seg(tx->t_engine->eng_domain),
 					 size, im_range));
 			/* Assign newly allocated imask ranges. */
-			layout = (struct m0_dix_layout *)
-				 (anchor.ba_value.b_addr +
-				  M0_CAS_CTG_KV_HDR_SIZE);
+			layout = &((struct layout_value *)
+				   anchor.ba_value.b_addr)->lv_layout;
 			layout->u.dl_desc.ld_imask.im_range = im_range;
 		}
 		m0_chan_broadcast_lock(&ctidx->cc_chan.bch_chan);
@@ -1766,10 +2030,10 @@ M0_INTERNAL int m0_ctg_ctidx_delete_sync(const struct m0_cas_id *cid,
 {
 	struct m0_dix_layout *layout;
 	struct m0_dix_imask  *imask;
-	uint8_t               key_data[M0_CAS_CTG_KV_HDR_SIZE +
-		                       sizeof(struct m0_fid)];
+	/* The key is a component catalogue FID. */
+	struct fid_key        key_data = FID_KEY_INIT(&cid->ci_fid);
 	struct m0_cas_ctg    *ctidx  = m0_ctg_ctidx();
-	struct m0_buf         key;
+	struct m0_buf         key = M0_BUF_INIT_PTR(&key_data);
 	int                   rc;
 
 	/* Firstly we should free buffer allocated for imask ranges array. */
@@ -1785,9 +2049,6 @@ M0_INTERNAL int m0_ctg_ctidx_delete_sync(const struct m0_cas_id *cid,
 		imask->im_range = NULL;
 		imask->im_nr = 0;
 	}
-	/* The key is a component catalogue FID. */
-	ctg_fid_key_fill((void *)&key_data, &cid->ci_fid);
-	key = M0_BUF_INIT_PTR(&key_data);
 	/** @todo Make it asynchronous. */
 	M0_BE_OP_SYNC(op, m0_be_btree_delete(&ctidx->cc_tree, tx, &op, &key));
 	m0_chan_broadcast_lock(&ctidx->cc_chan.bch_chan);
@@ -1882,6 +2143,247 @@ static const struct m0_be_btree_kv_ops cas_btree_ops = {
 	.ko_vsize   = &ctg_vsize,
 	.ko_compare = &ctg_cmp
 };
+
+
+static bool ctg_op_is_versioned(const struct m0_ctg_op *ctg_op)
+{
+	const struct m0_cas_op       *cas_op;
+	bool                          has_txd;
+
+	/*
+	 * Since the versioned behavior is optional, it may get turned off
+	 * for a variety of resons. These reasons are listed here
+	 * as M0_RC_INFO messages to aid debugging of the cases
+	 * where the behavior should have not been turned off.
+	 */
+
+	M0_ENTRY("ctg_op=%p", ctg_op);
+
+	if (!ctg_is_ordinary(ctg_op->co_ctg))
+		return M0_RC_INFO(false, "Non-ordinary catalogue.");
+
+	if (ctg_op->co_fom == NULL)
+		return M0_RC_INFO(false, "No fom, no versions.");
+
+	cas_op = m0_fop_data(ctg_op->co_fom->fo_fop);
+	if (cas_op == NULL)
+		return M0_RC_INFO(false, "No cas op, no versions.");
+
+	if ((ctg_op->co_flags & COF_VERSIONED) == 0)
+		return M0_RC_INFO(false, "CAS request is not versioned.");
+
+	has_txd = !m0_dtm0_tx_desc_is_none(&cas_op->cg_txd);
+
+	switch (CTG_OP_COMBINE(ctg_op->co_opcode, ctg_op->co_ct)) {
+	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
+		if ((ctg_op->co_flags & COF_OVERWRITE) == 0)
+			return M0_RC_INFO(false,
+					  "PUT request without OVERWRITE is "
+					  "not versioned.");
+	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
+		if (has_txd)
+			return M0_RC(true);
+		else
+			return M0_RC_INFO(false,
+					  "%s request is has an empty txd.",
+					  ctg_op->co_opcode == CO_PUT ?
+					  "PUT" : "DEL");
+	case CTG_OP_COMBINE(CO_GET, CT_BTREE):
+	case CTG_OP_COMBINE(CO_CUR, CT_BTREE):
+		return M0_RC(true);
+	default:
+		break;
+	}
+
+	return M0_RC_INFO(false, "Non-versioned operation.");
+}
+
+static void ctg_op_version_get(const struct m0_ctg_op *ctg_op,
+			       struct cas_rec_ver     *out)
+{
+	const struct m0_dtm0_tid     *tid;
+	const struct m0_cas_op       *cas_op;
+	uint64_t                      version;
+	bool                          tbs;
+
+	M0_ENTRY();
+	M0_PRE(ctg_op_is_versioned(ctg_op));
+
+	if (M0_IN(ctg_op->co_opcode, (CO_PUT, CO_DEL))) {
+		M0_ASSERT_INFO(ctg_op->co_fom != NULL,
+			       "Versioned op without FOM?");
+		cas_op = m0_fop_data(ctg_op->co_fom->fo_fop);
+		M0_ASSERT_INFO(cas_op != NULL, "Versioned op without cas_op?");
+		tbs = ctg_op->co_opcode == CO_DEL;
+		tid = &cas_op->cg_txd.dtd_id;
+		version = tid->dti_ts.dts_phys;
+		crv_init(out, version, tbs);
+
+		M0_LEAVE("ctg_op=%p, cas_op=%p, txid=" DTID0_F ", ver=%" PRIu64
+			 ", ver_enc=%" PRIu64, ctg_op,
+			 cas_op, DTID0_P(tid), version, out->crv_encoded);
+	} else {
+		*out = CRV_INIT_NONE;
+		M0_LEAVE("ctg_op=%p, no version", ctg_op);
+	}
+}
+
+static int versioned_record_put_sync(struct m0_ctg_op *ctg_op)
+{
+	struct m0_buf             *key    = &ctg_op->co_key;
+	struct m0_be_btree        *btree  = &ctg_op->co_ctg->cc_tree;
+	struct m0_be_btree_anchor *anchor = &ctg_op->co_anchor;
+	struct m0_be_tx           *tx     = &ctg_op->co_fom->fo_tx.tx_betx;
+	struct cas_rec_ver         new_version = CRV_INIT_NONE;
+	struct cas_rec_ver         old_version = CRV_INIT_NONE;
+	int                        rc;
+
+	M0_PRE(ctg_op_is_versioned(ctg_op));
+	M0_ENTRY();
+
+	ctg_op_version_get(ctg_op, &new_version);
+	M0_ASSERT_INFO(!crv_is_none(&new_version),
+		       "Versioned PUT or DEL without a valid version?");
+
+	/*
+	 * TODO: Performance.
+	 * This lookup call can be avoided if the version comparison
+	 * was shifted into btree. However, at this moment the cost of
+	 * such a lookup is much lower than the cost of re-working btree API.
+	 * See the be_btree_search() call inside ::btree_save. It is the
+	 * point where btree_save does its own "lookup". Versions could
+	 * be compared right in there. Alternatively, btree_save could
+	 * use btree_cursor as a "hint".
+	 */
+	rc = M0_BE_OP_SYNC_RET(op,
+			       m0_be_btree_lookup_inplace(btree,
+							  &op,
+							  key,
+							  anchor),
+			       bo_u.u_btree.t_rc) ?:
+		ctg_vbuf_unpack(&anchor->ba_value, &old_version);
+
+	/* The tree is long-locked anyway. */
+	m0_be_btree_release(NULL, anchor);
+
+	if (!M0_IN(rc, (0, -ENOENT))) {
+		 /* Trace unexpected errors. */
+		rc = M0_ERR(rc);
+		goto out;
+	}
+
+	/*
+	 * Skip PUT op if the existing record is "newer" (version-wise) than
+	 * the record to be PUT.
+	 */
+	if (!crv_is_none(&old_version) && crv_gt(&old_version, &new_version)) {
+		rc = M0_RC(0);
+		goto out;
+	}
+
+	M0_LOG(M0_DEBUG, "Overwriting %" PRIu64 ":%d with %" PRIu64 ":%d.",
+	       crv_version_get(&old_version), !!crv_tbs_is_set(&old_version),
+	       crv_version_get(&new_version), !!crv_tbs_is_set(&new_version));
+
+	anchor->ba_value.b_nob = ctg_vbuf_packed_size(&ctg_op->co_val);
+	rc = M0_BE_OP_SYNC_RET(op,
+			       m0_be_btree_save_inplace(btree, tx, &op,
+							key, anchor, true,
+							ctg_op_zones(ctg_op)),
+			       bo_u.u_btree.t_rc);
+
+	if (rc == 0) {
+		ctg_vbuf_pack(&ctg_op->co_anchor.ba_value,
+			      &ctg_op->co_val,
+			      &new_version);
+
+		/* TODO: it is too pessimistic. */
+		m0_ctg_state_inc_update(tx, key->b_nob + ctg_op->co_val.b_nob);
+	}
+out:
+	return M0_RC(rc);
+}
+
+static int alive_record_get_sync(struct m0_ctg_op *ctg_op)
+{
+	struct m0_be_btree        *btree  = &ctg_op->co_ctg->cc_tree;
+	struct m0_be_btree_anchor *anchor = &ctg_op->co_anchor;
+	struct cas_rec_ver         ver;
+	int                        rc;
+
+	M0_PRE(ctg_op_is_versioned(ctg_op));
+
+	rc = M0_BE_OP_SYNC_RET(op,
+			       m0_be_btree_lookup_inplace(btree, &op,
+							  &ctg_op->co_key,
+							  anchor),
+			       bo_u.u_btree.t_rc);
+	if (rc == 0) {
+		rc = ctg_vbuf_unpack(&anchor->ba_value, &ver) ?:
+			(crv_tbs_is_set(&ver) ?  -ENOENT : 0);
+		if (rc == 0)
+			ctg_op->co_out_val = anchor->ba_value;
+	}
+
+	return M0_RC(rc);
+}
+
+static int alive_cursor_next_sync(struct m0_ctg_op *ctg_op)
+{
+	struct m0_be_op           *beop   = ctg_beop(ctg_op);
+	struct cas_rec_ver         ver    = CRV_INIT_NONE;
+	int                        rc;
+
+	do {
+		m0_be_btree_cursor_next(&ctg_op->co_cur);
+
+		rc = ctg_berc(ctg_op);
+		if (rc != 0)
+			break;
+
+		m0_be_btree_cursor_kv_get(&ctg_op->co_cur,
+					  &ctg_op->co_out_key,
+					  &ctg_op->co_out_val);
+		rc = ctg_kbuf_unpack(&ctg_op->co_out_key) ?:
+			ctg_vbuf_unpack(&ctg_op->co_out_val, &ver);
+		if (rc != 0)
+			break;
+
+		m0_be_op_reset(beop);
+	} while (crv_tbs_is_set(&ver));
+
+	return M0_RC(rc);
+}
+
+static int alive_cursor_get_sync(struct m0_ctg_op *ctg_op)
+{
+	struct m0_be_op           *beop   = ctg_beop(ctg_op);
+	struct cas_rec_ver         ver    = CRV_INIT_NONE;
+	bool                       slant  = (ctg_op->co_flags & COF_SLANT) != 0;
+	int                        rc;
+
+	M0_PRE(ctg_op_is_versioned(ctg_op));
+
+	m0_be_btree_cursor_get(&ctg_op->co_cur, &ctg_op->co_key, slant);
+	rc = ctg_berc(ctg_op);
+
+	if (rc == 0) {
+		m0_be_btree_cursor_kv_get(&ctg_op->co_cur,
+					  &ctg_op->co_out_key,
+					  &ctg_op->co_out_val);
+		rc = ctg_kbuf_unpack(&ctg_op->co_out_key) ?:
+			ctg_vbuf_unpack(&ctg_op->co_out_val, &ver) ?:
+			!crv_tbs_is_set(&ver) ? 0 :
+			(slant ? -EAGAIN : -ENOENT);
+	}
+
+	m0_be_op_reset(beop);
+
+	if (rc == -EAGAIN)
+		rc = alive_cursor_next_sync(ctg_op);
+
+	return M0_RC(rc);
+}
 
 #undef M0_TRACE_SUBSYSTEM
 

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -435,14 +435,15 @@ static int ctg_kbuf_unpack(struct m0_buf *buf)
 }
 
 #define FID_KEY_INIT(__fid) (struct fid_key) { \
-	.fk_gkey = { \
+	.fk_gkey = {                           \
 		.gk_length = sizeof(*(__fid)), \
-	}, \
-	.fk_fid = *(__fid), \
+	},                                     \
+	.fk_fid = *(__fid),                    \
 }
 
 #define GENERIC_VALUE_INIT(__size) (struct generic_value) { \
-	.gv_length = __size,                                \
+	.gv_length  = __size,                               \
+	.gv_version = CRV_INIT_NONE,                        \
 }
 
 #define META_VALUE_INIT(__ctg_ptr) (struct meta_value) {  \
@@ -458,14 +459,12 @@ static int ctg_kbuf_unpack(struct m0_buf *buf)
 static m0_bcount_t ctg_ksize(const void *opaque_key)
 {
 	const struct generic_key *key = opaque_key;
-	M0_PRE(key != NULL);
 	return sizeof(*key) + key->gk_length;
 }
 
 static m0_bcount_t ctg_vsize(const void *opaque_val)
 {
 	const struct generic_value *val = opaque_val;
-	M0_PRE(val != NULL);
 	return sizeof(*val) + val->gv_length;
 }
 
@@ -473,9 +472,6 @@ static int ctg_cmp(const void *opaque_key_left, const void *opaque_key_right)
 {
 	const struct generic_key *left  = opaque_key_left;
 	const struct generic_key *right = opaque_key_right;
-
-	M0_PRE(left != NULL);
-	M0_PRE(right != NULL);
 
 	/*
 	 * XXX: Origianally, there was an assertion to ensure on-disk data
@@ -1125,14 +1121,6 @@ static bool ctg_op_cb(struct m0_clink *clink)
 		case CTG_OP_COMBINE(CO_PUT, CT_META):
 			fk = ctg_op->co_key.b_addr;
 			mv = ctg_op->co_anchor.ba_value.b_addr;
-			/*
-			 * XXX: Why do we have a special CO_MEM_PLACE
-			 * that just allocates a datum for imask but
-			 * here we have an allocation (m0_cas_ctg object)
-			 * and tree creation (m0_cas_ctg::cc_tree) in
-			 * a single call that is called when PUT is almost
-			 * done? Shouldn't it be done beforehand?
-			 */
 			rc = m0_ctg_create(cas_seg(tx->t_engine->eng_domain),
 					   tx, &ctg, &fk->fk_fid);
 			if (rc == 0) {
@@ -2004,17 +1992,17 @@ M0_INTERNAL int m0_ctg_ctidx_insert_sync(const struct m0_cas_id *cid,
 	/* The key is a component catalogue FID. */
 	struct fid_key             key_data = FID_KEY_INIT(&cid->ci_fid);
 	struct m0_buf              key = M0_BUF_INIT_PTR(&key_data);
-	struct layout_value        value_data;
+	struct layout_value        value_data =
+		LAYOUT_VALUE_INIT(&cid->ci_layout);
 	struct m0_buf              value = M0_BUF_INIT_PTR(&value_data);
 	struct m0_cas_ctg         *ctidx  = m0_ctg_ctidx();
 	struct m0_be_btree_anchor  anchor = {};
 	struct m0_dix_layout      *layout;
 	struct m0_ext             *im_range;
-	const struct m0_dix_imask *imask;
+	const struct m0_dix_imask *imask = &cid->ci_layout.u.dl_desc.ld_imask;
 	m0_bcount_t                size;
 	int                        rc;
 
-	value_data = LAYOUT_VALUE_INIT(&cid->ci_layout);
 	anchor.ba_value.b_nob = value.b_nob;
 	/** @todo Make it asynchronous. */
 	rc = M0_BE_OP_SYNC_RET(op,
@@ -2023,7 +2011,8 @@ M0_INTERNAL int m0_ctg_ctidx_insert_sync(const struct m0_cas_id *cid,
 		bo_u.u_btree.t_rc);
 	if (rc == 0) {
 		m0_buf_memcpy(&anchor.ba_value, &value);
-		imask = &cid->ci_layout.u.dl_desc.ld_imask;
+		layout = &((struct layout_value *)
+			   anchor.ba_value.b_addr)->lv_layout;
 		if (!m0_dix_imask_is_empty(imask)) {
 			/*
 			 * Alloc memory in BE segment for imask ranges
@@ -2039,8 +2028,6 @@ M0_INTERNAL int m0_ctg_ctidx_insert_sync(const struct m0_cas_id *cid,
 					 cas_seg(tx->t_engine->eng_domain),
 					 size, im_range));
 			/* Assign newly allocated imask ranges. */
-			layout = &((struct layout_value *)
-				   anchor.ba_value.b_addr)->lv_layout;
 			layout->u.dl_desc.ld_imask.im_range = im_range;
 		}
 		m0_chan_broadcast_lock(&ctidx->cc_chan.bch_chan);

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -87,30 +87,15 @@ struct generic_key {
 };
 M0_BASSERT(sizeof(struct generic_key) == M0_CAS_CTG_KEY_HDR_SIZE);
 
-/**
- * CAS record version and tombstone encoded in on-disk format.
- * Format:
- *     MSB                             LSB
- *     +----------------+----------------+
- *     | 1 bit          | 63 bits        |
- *     |<- tombstone -> | <- timestamp ->|
- *     +----------------+----------------+
- *
- * @see ::CRV_TBS.
- */
-struct cas_rec_ver {
-	uint64_t  crv_encoded;
-};
-M0_BASSERT(sizeof(struct cas_rec_ver) == 8);
-
 /** Generalised value: versioned counted opaque data. */
 struct generic_value {
 	/* Actual length of gv_data array. */
 	uint64_t           gv_length;
-	struct cas_rec_ver gv_version;
+	struct m0_crv      gv_version;
 	uint8_t            gv_data[0];
 };
 M0_BASSERT(sizeof(struct generic_value) == M0_CAS_CTG_VAL_HDR_SIZE);
+M0_BASSERT(sizeof(struct m0_crv) == 8);
 
 /** The key type used in meta and ctidx catalogues. */
 struct fid_key {
@@ -149,7 +134,7 @@ static struct m0_be_seg *cas_seg(struct m0_be_domain *dom);
 
 static bool ctg_op_is_versioned(const struct m0_ctg_op *op);
 static int  ctg_berc         (struct m0_ctg_op *ctg_op);
-static int ctg_vbuf_unpack(struct m0_buf *buf, struct cas_rec_ver *crv);
+static int ctg_vbuf_unpack(struct m0_buf *buf, struct m0_crv *crv);
 static int  ctg_vbuf_as_ctg  (const struct m0_buf *val,
 			      struct m0_cas_ctg **ctg);
 static int  ctg_kbuf_unpack  (struct m0_buf *buf);
@@ -246,7 +231,7 @@ static m0_bcount_t ctg_vbuf_packed_size(const struct m0_buf *value)
  */
 static void ctg_vbuf_pack(struct m0_buf            *dst,
 			  const struct m0_buf      *src,
-			  const struct cas_rec_ver *crv)
+			  const struct m0_crv *crv)
 {
 	struct generic_value *value = dst->b_addr;
 	M0_PRE(dst->b_nob >= ctg_vbuf_packed_size(src));
@@ -278,104 +263,6 @@ static int ctg_kbuf_get(struct m0_buf *dst, const struct m0_buf *src)
 		return M0_ERR(-ENOMEM);
 }
 
-enum {
-	/* Tombstone flag: marks a dead kv pair. We use the MSB here. */
-	CRV_TBS = 1L << (sizeof(uint64_t) * CHAR_BIT - 1),
-	/*
-	 * A special value for the empty version.
-	 * A record with the empty version is always overwritten by any
-	 * PUT or DEL operation that has a valid non-empty version.
-	 * A PUT or DEL operation with the empty version always ignores
-	 * the version-aware behavior: records are actually removed by DEL,
-	 * and overwritten by PUT, no matter what was stored in the catalogue.
-	 */
-	CRV_VER_NONE = 0,
-	/* The maximum possible value of a version. */
-	CRV_VER_MAX = (UINT64_MAX & ~CRV_TBS) - 1,
-	/* The minimum possible value of a version. */
-	CRV_VER_MIN = CRV_VER_NONE + 1,
-};
-
-
-static bool crv_tbs_is_set(const struct cas_rec_ver *crv)
-{
-	return crv->crv_encoded & CRV_TBS;
-}
-
-static void crv_tbs_set(struct cas_rec_ver *crv)
-{
-	crv->crv_encoded |= CRV_TBS;
-}
-
-static void crv_tbs_clear(struct cas_rec_ver *crv)
-{
-	crv->crv_encoded &= ~CRV_TBS;
-}
-
-static uint64_t crv_version_get(const struct cas_rec_ver *crv)
-{
-	return crv->crv_encoded & ~CRV_TBS;
-}
-
-/*
- * Converts on-disk reprentation into on-wire representation.
- */
-static struct m0_cas_kv_ver crv_as_cas_kv_ver(const struct cas_rec_ver *crv)
-{
-	return (struct m0_cas_kv_ver) {
-		.ckv_ts = (struct m0_dtm0_ts) {
-			.dts_phys = crv_version_get(crv),
-		},
-		.ckv_tombstone = crv_tbs_is_set(crv),
-	};
-}
-
-static void crv_version_set(struct cas_rec_ver *crv, uint64_t ts)
-{
-	crv->crv_encoded = (crv->crv_encoded & CRV_TBS) | ts;
-}
-
-static void crv_init(struct cas_rec_ver *crv, uint64_t version, bool tbs)
-{
-	M0_PRE(version <= CRV_VER_MAX);
-	M0_PRE(version >= CRV_VER_MIN);
-
-	crv_version_set(crv, version);
-	(tbs ? crv_tbs_set : crv_tbs_clear)(crv);
-
-	M0_POST(equi(crv_tbs_is_set(crv), tbs));
-	M0_POST(crv_version_get(crv) == version);
-}
-
-#define CRV_INIT_NONE ((struct cas_rec_ver) { .crv_encoded = CRV_VER_NONE })
-
-/*
- * Compare two versions.
- *   Note, tombstones are checked at the end which means that if there are two
- * different operations with the same version (for example, PUT@10 and DEL@10)
- * then the operation that puts the tombstone (DEL@10) is always considered
- * to be "newer" than the other one. It helps to ensure operations have the
- * same order on any server despite the order of execution.
- */
-static int crv_cmp(const struct cas_rec_ver *left,
-		   const struct cas_rec_ver *right)
-{
-	return M0_3WAY(crv_version_get(left), crv_version_get(right)) ?:
-		M0_3WAY(crv_tbs_is_set(left), crv_tbs_is_set(right));
-}
-
-static bool crv_is_none(const struct cas_rec_ver *crv)
-{
-	return memcmp(crv, &CRV_INIT_NONE, sizeof(*crv)) == 0;
-}
-
-/*
- * 100:a == alive record with version 100
- * 123:d == dead record with version 123
- */
-#define CRV_F "%" PRIu64 ":%c"
-#define CRV_P(__crv) crv_version_get(__crv), crv_tbs_is_set(__crv) ? 'd' : 'a'
-
 /**
  * Unpack an an on-disk value data into in-memory format.
  * The function makes "buf" to point to the user-specific data associated
@@ -384,7 +271,7 @@ static bool crv_is_none(const struct cas_rec_ver *crv)
  * @return 0 or else -EPROTO if on-disk/on-wire buffer has invalid length.
  * @see ::ctg_vbuf_pack.
  */
-static int ctg_vbuf_unpack(struct m0_buf *buf, struct cas_rec_ver *crv)
+static int ctg_vbuf_unpack(struct m0_buf *buf, struct m0_crv *crv)
 {
 	struct generic_value *value;
 
@@ -473,7 +360,7 @@ static int ctg_kbuf_unpack(struct m0_buf *buf)
 
 #define GENERIC_VALUE_INIT(__size) (struct generic_value) { \
 	.gv_length  = __size,                               \
-	.gv_version = CRV_INIT_NONE,                        \
+	.gv_version = M0_CRV_INIT_NONE,                     \
 }
 
 #define META_VALUE_INIT(__ctg_ptr) (struct meta_value) {  \
@@ -1138,7 +1025,7 @@ static bool ctg_op_cb(struct m0_clink *clink)
 			break;
 		case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
 			ctg_vbuf_pack(&ctg_op->co_anchor.ba_value,
-				      &ctg_op->co_val, &CRV_INIT_NONE);
+				      &ctg_op->co_val, &M0_CRV_INIT_NONE);
 			if (ctg_is_ordinary(ctg_op->co_ctg))
 				m0_ctg_state_inc_update(tx,
 					ctg_op->co_key.b_nob -
@@ -1597,11 +1484,11 @@ M0_INTERNAL void m0_ctg_lookup_result(struct m0_ctg_op *ctg_op,
 }
 
 M0_INTERNAL void m0_ctg_op_get_ver(struct m0_ctg_op     *ctg_op,
-				   struct m0_cas_kv_ver *out)
+				   struct m0_crv *out)
 {
 	M0_PRE(ctg_op != NULL);
 	M0_PRE(out != NULL);
-	M0_PRE(ergo(!m0_dtm0_ts_is_none(&ctg_op->co_out_ver.ckv_ts),
+	M0_PRE(ergo(!m0_crv_is_none(&ctg_op->co_out_ver),
 		    ctg_op->co_is_versioned));
 
 	*out = ctg_op->co_out_ver;
@@ -2251,11 +2138,10 @@ static bool ctg_op_is_versioned(const struct m0_ctg_op *ctg_op)
 }
 
 static void ctg_op_version_get(const struct m0_ctg_op *ctg_op,
-			       struct cas_rec_ver     *out)
+			       struct m0_crv          *out)
 {
 	const struct m0_dtm0_tid     *tid;
 	const struct m0_cas_op       *cas_op;
-	uint64_t                      version;
 	bool                          tbs;
 
 	M0_ENTRY();
@@ -2268,14 +2154,14 @@ static void ctg_op_version_get(const struct m0_ctg_op *ctg_op,
 		M0_ASSERT_INFO(cas_op != NULL, "Versioned op without cas_op?");
 		tbs = ctg_op->co_opcode == CO_DEL;
 		tid = &cas_op->cg_txd.dtd_id;
-		version = tid->dti_ts.dts_phys;
-		crv_init(out, version, tbs);
+		m0_crv_init(out, &tid->dti_ts, tbs);
 
 		M0_LEAVE("ctg_op=%p, cas_op=%p, txid=" DTID0_F ", ver=%" PRIu64
 			 ", ver_enc=%" PRIu64, ctg_op,
-			 cas_op, DTID0_P(tid), version, out->crv_encoded);
+			 cas_op, DTID0_P(tid), tid->dti_ts.dts_phys,
+			 out->crv_encoded);
 	} else {
-		*out = CRV_INIT_NONE;
+		*out = M0_CRV_INIT_NONE;
 		M0_LEAVE("ctg_op=%p, no version", ctg_op);
 	}
 }
@@ -2291,15 +2177,15 @@ static int versioned_put_sync(struct m0_ctg_op *ctg_op)
 	struct m0_be_btree        *btree  = &ctg_op->co_ctg->cc_tree;
 	struct m0_be_btree_anchor *anchor = &ctg_op->co_anchor;
 	struct m0_be_tx           *tx     = &ctg_op->co_fom->fo_tx.tx_betx;
-	struct cas_rec_ver         new_version = CRV_INIT_NONE;
-	struct cas_rec_ver         old_version = CRV_INIT_NONE;
+	struct m0_crv              new_version = M0_CRV_INIT_NONE;
+	struct m0_crv              old_version = M0_CRV_INIT_NONE;
 	int                        rc;
 
 	M0_PRE(ctg_op->co_is_versioned);
 	M0_ENTRY();
 
 	ctg_op_version_get(ctg_op, &new_version);
-	M0_ASSERT_INFO(!crv_is_none(&new_version),
+	M0_ASSERT_INFO(!m0_crv_is_none(&new_version),
 		       "Versioned PUT or DEL without a valid version?");
 
 	/*
@@ -2331,8 +2217,8 @@ static int versioned_put_sync(struct m0_ctg_op *ctg_op)
 	 * than the record to be inserted. Note, <= 0 means that we filter out
 	 * the operations with the exact same version and tombstone.
 	 */
-	if (!crv_is_none(&old_version) &&
-	    crv_cmp(&new_version, &old_version) <= 0)
+	if (!m0_crv_is_none(&old_version) &&
+	    m0_crv_cmp(&new_version, &old_version) <= 0)
 		return M0_RC(0);
 
 	M0_LOG(M0_DEBUG, "Overwriting " CRV_F " with " CRV_F ".",
@@ -2368,7 +2254,6 @@ static int versioned_get_sync(struct m0_ctg_op *ctg_op)
 {
 	struct m0_be_btree        *btree  = &ctg_op->co_ctg->cc_tree;
 	struct m0_be_btree_anchor *anchor = &ctg_op->co_anchor;
-	struct cas_rec_ver         ver;
 	int                        rc;
 
 	M0_PRE(ctg_op->co_is_versioned);
@@ -2378,11 +2263,10 @@ static int versioned_get_sync(struct m0_ctg_op *ctg_op)
 							  &ctg_op->co_key,
 							  anchor),
 			       bo_u.u_btree.t_rc) ?:
-		ctg_vbuf_unpack(&anchor->ba_value, &ver);
+		ctg_vbuf_unpack(&anchor->ba_value, &ctg_op->co_out_ver);
 
 	if (rc == 0) {
-		ctg_op->co_out_ver = crv_as_cas_kv_ver(&ver);
-		if (crv_tbs_is_set(&ver))
+		if (m0_crv_tbs(&ctg_op->co_out_ver))
 			rc = -ENOENT;
 		else
 			ctg_op->co_out_val = anchor->ba_value;
@@ -2399,7 +2283,6 @@ static int versioned_get_sync(struct m0_ctg_op *ctg_op)
 static int versioned_cursor_next_sync(struct m0_ctg_op *ctg_op, bool alive_only)
 {
 	struct m0_be_op           *beop   = ctg_beop(ctg_op);
-	struct cas_rec_ver         ver    = CRV_INIT_NONE;
 	int                        rc;
 
 	do {
@@ -2413,18 +2296,17 @@ static int versioned_cursor_next_sync(struct m0_ctg_op *ctg_op, bool alive_only)
 					  &ctg_op->co_out_key,
 					  &ctg_op->co_out_val);
 		rc = ctg_kbuf_unpack(&ctg_op->co_out_key) ?:
-			ctg_vbuf_unpack(&ctg_op->co_out_val, &ver);
+			ctg_vbuf_unpack(&ctg_op->co_out_val,
+					&ctg_op->co_out_ver);
 		if (rc != 0)
 			break;
 
-		ctg_op->co_out_ver = crv_as_cas_kv_ver(&ver);
-
 		m0_be_op_reset(beop);
 
-	} while (crv_tbs_is_set(&ver) && alive_only);
+	} while (m0_crv_tbs(&ctg_op->co_out_ver) && alive_only);
 
 	/* It should never return dead values. */
-	if (crv_tbs_is_set(&ver))
+	if (m0_crv_tbs(&ctg_op->co_out_ver))
 		ctg_op->co_out_val = M0_BUF_INIT0;
 
 	return M0_RC(rc);
@@ -2448,7 +2330,6 @@ static int versioned_cursor_get_sync(struct m0_ctg_op *ctg_op, bool alive_only)
 {
 	struct m0_be_op           *beop   = ctg_beop(ctg_op);
 	struct m0_buf              value  = M0_BUF_INIT0;
-	struct cas_rec_ver         ver    = CRV_INIT_NONE;
 	bool                       slant  = (ctg_op->co_flags & COF_SLANT) != 0;
 	int                        rc;
 
@@ -2462,10 +2343,9 @@ static int versioned_cursor_get_sync(struct m0_ctg_op *ctg_op, bool alive_only)
 					  &ctg_op->co_out_key,
 					  &value);
 		rc = ctg_kbuf_unpack(&ctg_op->co_out_key) ?:
-			ctg_vbuf_unpack(&value, &ver);
+			ctg_vbuf_unpack(&value, &ctg_op->co_out_ver);
 		if (rc == 0) {
-			ctg_op->co_out_ver = crv_as_cas_kv_ver(&ver);
-			if (crv_tbs_is_set(&ver))
+			if (m0_crv_tbs(&ctg_op->co_out_ver))
 				rc = alive_only ?
 					(slant ? -EAGAIN : -ENOENT) : 0;
 			else

--- a/cas/ctg_store.h
+++ b/cas/ctg_store.h
@@ -114,12 +114,16 @@ struct m0_cas_ctg {
 enum m0_cas_ctg_format_version {
 	M0_CAS_CTG_FORMAT_VERSION_1 = 1,
 
-	/* future versions, uncomment and update M0_CAS_CTG_FORMAT_VERSION */
-	/*M0_CAS_CTG_FORMAT_VERSION_2,*/
+	/*
+	 * CAS with versioned key-value pair feature.
+	 * There is no backward compatibility with ver1 at the moment.
+	 */
+	M0_CAS_CTG_FORMAT_VERSION_2,
 	/*M0_CAS_CTG_FORMAT_VERSION_3,*/
+	/*M0_CAS_CTG_FORMAT_VERSION_4,*/
 
 	/** Current version, should point to the latest version present */
-	M0_CAS_CTG_FORMAT_VERSION = M0_CAS_CTG_FORMAT_VERSION_1,
+	M0_CAS_CTG_FORMAT_VERSION = M0_CAS_CTG_FORMAT_VERSION_2,
 };
 
 enum m0_cas_state_format_version {
@@ -135,10 +139,14 @@ enum m0_cas_state_format_version {
 
 enum {
 	/**
-	 * Every key and value is stored with an individual 64-bit header.
-	 * Currently header contains key/value length in bytes.
+	 * Every value has a header that holds its size.
 	 */
-	M0_CAS_CTG_KV_HDR_SIZE = sizeof(uint64_t),
+	M0_CAS_CTG_VAL_HDR_SIZE = sizeof(uint64_t) + sizeof(uint64_t),
+	/**
+	 * Every key has a header that holds the size of the key and
+	 * the version of the key-value pair.
+	 */
+	M0_CAS_CTG_KEY_HDR_SIZE = sizeof(uint64_t),
 };
 
 /** Catalogue store state persisted on a disk. */

--- a/cas/ctg_store.h
+++ b/cas/ctg_store.h
@@ -139,12 +139,12 @@ enum m0_cas_state_format_version {
 
 enum {
 	/**
-	 * Every value has a header that holds its size.
+	 * Every value has a header that holds its size and the version
+	 * of the key-value record.
 	 */
 	M0_CAS_CTG_VAL_HDR_SIZE = sizeof(uint64_t) + sizeof(uint64_t),
 	/**
-	 * Every key has a header that holds the size of the key and
-	 * the version of the key-value pair.
+	 * Every key has a header that holds the size of the key.
 	 */
 	M0_CAS_CTG_KEY_HDR_SIZE = sizeof(uint64_t),
 };
@@ -213,6 +213,8 @@ struct m0_ctg_op {
 	struct m0_buf             co_out_key;
 	/** Value out buffer. */
 	struct m0_buf             co_out_val;
+	/* Version of the co_out_val+co_out_key record. */
+	struct m0_cas_kv_ver      co_out_ver;
 	struct m0_buf             co_mem_buf;
 	/** Operation code to be executed. */
 	int                       co_opcode;
@@ -227,6 +229,12 @@ struct m0_ctg_op {
 	 * operation, see m0_ctg_truncate().
 	 */
 	m0_bcount_t               co_cnt;
+	/**
+	 * A flag to be set when versioned behavior is enabled for
+	 * execution of this operation.
+	 * See ::COF_VERSIONED for details.
+	 */
+	bool                      co_is_versioned;
 };
 
 #define CTG_OP_COMBINE(opc, ct) (((uint64_t)(opc)) | ((ct) << 16))
@@ -437,6 +445,12 @@ M0_INTERNAL int m0_ctg_lookup(struct m0_ctg_op    *ctg_op,
  */
 M0_INTERNAL void m0_ctg_lookup_result(struct m0_ctg_op *ctg_op,
 				      struct m0_buf    *buf);
+
+/**
+ * Returns the version of the record the operation ctg_op worked on.
+ */
+M0_INTERNAL void m0_ctg_op_get_ver(struct m0_ctg_op     *ctg_op,
+				   struct m0_cas_kv_ver *out);
 
 /**
  * Gets the minimal key in the tree (wrapper over m0_be_btree_minkey()).

--- a/cas/ctg_store.h
+++ b/cas/ctg_store.h
@@ -214,7 +214,7 @@ struct m0_ctg_op {
 	/** Value out buffer. */
 	struct m0_buf             co_out_val;
 	/* Version of the co_out_val+co_out_key record. */
-	struct m0_cas_kv_ver      co_out_ver;
+	struct m0_crv             co_out_ver;
 	struct m0_buf             co_mem_buf;
 	/** Operation code to be executed. */
 	int                       co_opcode;
@@ -450,7 +450,7 @@ M0_INTERNAL void m0_ctg_lookup_result(struct m0_ctg_op *ctg_op,
  * Returns the version of the record the operation ctg_op worked on.
  */
 M0_INTERNAL void m0_ctg_op_get_ver(struct m0_ctg_op     *ctg_op,
-				   struct m0_cas_kv_ver *out);
+				   struct m0_crv *out);
 
 /**
  * Gets the minimal key in the tree (wrapper over m0_be_btree_minkey()).

--- a/cas/service.c
+++ b/cas/service.c
@@ -1184,15 +1184,20 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	int                 next_phase;
 
 	M0_ENTRY("fom %p phase %d", fom, phase);
-	is_index_drop = op_is_index_drop(opc, ct);
 	M0_PRE(ctidx != NULL);
 	M0_PRE(cas_fom_invariant(fom));
 	M0_PRE(ergo(ENABLE_DTM0 && !M0_IS0(&op->cg_txd),
 		    m0_dtm0_tx_desc__invariant(&op->cg_txd)));
-	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT) {
+
+	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT)
 		M0_LOG(M0_DEBUG, "Got CAS with txid: " DTID0_F,
 		       DTID0_P(&op->cg_txd.dtd_id));
-	}
+
+	if (M0_FI_ENABLED("skip-dtm0-phases"))
+		is_dtm0_used = false;
+
+	is_index_drop = op_is_index_drop(opc, ct);
+
 	switch (phase) {
 	case M0_FOPH_INIT ... M0_FOPH_NR - 1:
 

--- a/cas/service.c
+++ b/cas/service.c
@@ -1177,7 +1177,7 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	struct m0_cas_ctg  *meta    = m0_ctg_meta();
 	struct m0_cas_ctg  *ctidx   = m0_ctg_ctidx();
 	struct m0_cas_rec  *rec     = NULL;
-	bool                is_dtm0_used =
+	bool                is_dtm0_used = ENABLE_DTM0 &&
 		!m0_dtm0_tx_desc_is_none(&op->cg_txd);
 	bool                is_index_drop;
 	bool                do_ctidx;
@@ -1186,15 +1186,11 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	M0_ENTRY("fom %p phase %d", fom, phase);
 	M0_PRE(ctidx != NULL);
 	M0_PRE(cas_fom_invariant(fom));
-	M0_PRE(ergo(ENABLE_DTM0 && !M0_IS0(&op->cg_txd),
-		    m0_dtm0_tx_desc__invariant(&op->cg_txd)));
+	M0_PRE(ergo(is_dtm0_used, m0_dtm0_tx_desc__invariant(&op->cg_txd)));
 
 	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT)
 		M0_LOG(M0_DEBUG, "Got CAS with txid: " DTID0_F,
 		       DTID0_P(&op->cg_txd.dtd_id));
-
-	if (M0_FI_ENABLED("skip-dtm0-phases"))
-		is_dtm0_used = false;
 
 	is_index_drop = op_is_index_drop(opc, ct);
 
@@ -1643,6 +1639,8 @@ static int cas_fom_tick(struct m0_fom *fom0)
 		M0_ASSERT(fom->cf_opos < rep->cgr_rep.cr_nr);
 		rec = cas_out_at(rep, fom->cf_opos);
 		M0_ASSERT(rec != NULL);
+		m0_ctg_op_get_ver(ctg_op,
+				  &cas_out_at(rep, fom->cf_opos)->cr_ver);
 		if (rec->cr_rc == 0) {
 			rec->cr_rc = m0_ctg_op_rc(ctg_op);
 			if (rec->cr_rc == 0) {

--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -37,6 +37,7 @@
 #include "cas/client.h"
 #include "cas/ctg_store.h"             /* m0_ctg_recs_nr */
 #include "lib/finject.h"
+#include "dtm0/dtx.h"                  /* m0_dtm0_dtx */
 
 #define SERVER_LOG_FILE_NAME       "cas_server.log"
 #define IFID(x, y) M0_FID_TINIT('i', (x), (y))
@@ -418,17 +419,54 @@ static int ut_idx_list(struct cl_ctx             *cctx,
 	return rc;
 }
 
-static int ut_rec_put(struct cl_ctx           *cctx,
-		      struct m0_cas_id        *index,
-		      const struct m0_bufvec  *keys,
-		      const struct m0_bufvec  *values,
-		      struct m0_cas_rec_reply *rep,
-		      uint32_t                 flags)
+static void ut_dtx_init(struct m0_dtx **out, uint64_t version)
+{
+	struct m0_dtm0_dtx *dtx0;
+	int                 rc;
+
+	/* No version => no DTX */
+	if (version == 0) {
+		*out = NULL;
+		return;
+	}
+
+	M0_ALLOC_PTR(dtx0);
+	M0_UT_ASSERT(dtx0 != NULL);
+
+	rc = m0_dtm0_tx_desc_init(&dtx0->dd_txd, 1);
+	M0_UT_ASSERT(rc == 0);
+	dtx0->dd_txd.dtd_id = (struct m0_dtm0_tid) {
+		.dti_ts.dts_phys = version,
+		.dti_fid = g_process_fid,
+	};
+
+	dtx0->dd_ancient_dtx.tx_dtx = dtx0;
+
+	*out = &dtx0->dd_ancient_dtx;
+}
+
+static void ut_dtx_fini(struct m0_dtx *dtx)
+{
+	if (dtx != NULL)
+		m0_free(dtx->tx_dtx);
+}
+
+static int ut_rec_common_put(struct cl_ctx           *cctx,
+			     struct m0_cas_id        *index,
+			     const struct m0_bufvec  *keys,
+			     const struct m0_bufvec  *values,
+			     struct m0_dtx           *dtx,
+			     struct m0_cas_rec_reply *rep,
+			     uint32_t                 flags)
 {
 	struct m0_cas_req  req;
 	struct m0_chan    *chan;
 	int                rc;
 	uint64_t           i;
+
+	M0_PRE(ergo(dtx != NULL,
+		    (((flags & COF_VERSIONED) != 0) &&
+		     keys->ov_vec.v_nr == 1)));
 
 	/* start operation */
 	M0_SET0(&req);
@@ -440,7 +478,7 @@ static int ut_rec_put(struct cl_ctx           *cctx,
 	m0_clink_add_lock(chan, &cctx->cl_wait.aw_clink);
 
 	m0_cas_req_lock(&req);
-	rc = m0_cas_put(&req, index, keys, values, NULL, flags);
+	rc = m0_cas_put(&req, index, keys, values, dtx, flags);
 	if (rc == 0) {
 		/* wait results */
 		m0_cas_req_wait(&req, M0_BITS(CASREQ_FINAL), M0_TIME_NEVER);
@@ -456,6 +494,46 @@ static int ut_rec_put(struct cl_ctx           *cctx,
 	return rc;
 }
 
+/* Submits CAS requests separately one-by-one for each kv pair */
+int ut_rec_common_put_seq(struct cl_ctx                 *cctx,
+			  struct m0_cas_id              *index,
+			  const struct m0_bufvec        *keys,
+			  const struct m0_bufvec        *values,
+			  struct m0_dtx                 *dtx,
+			  struct m0_cas_rec_reply       *rep,
+			  uint32_t                       flags)
+{
+	struct m0_bufvec k;
+	struct m0_bufvec v;
+	m0_bcount_t      i;
+	int              rc = 0;
+
+	for (i = 0; i < keys->ov_vec.v_nr; i++) {
+		k = M0_BUFVEC_INIT_BUF(&keys->ov_buf[i],
+				       &keys->ov_vec.v_count[i]);
+		v = M0_BUFVEC_INIT_BUF(&values->ov_buf[i],
+				       &values->ov_vec.v_count[i]);
+		rc |= ut_rec_common_put(cctx, index, &k, &v, dtx, rep + i,
+					flags);
+		if (rc != 0)
+			break;
+	}
+
+	return rc;
+}
+
+static int ut_rec_put(struct cl_ctx           *cctx,
+		      struct m0_cas_id        *index,
+		      const struct m0_bufvec  *keys,
+		      const struct m0_bufvec  *values,
+		      struct m0_cas_rec_reply *rep,
+		      uint32_t                 flags)
+{
+	return ((flags & COF_VERSIONED) != 0 ?
+		ut_rec_common_put_seq : ut_rec_common_put)
+		(cctx, index, keys, values, NULL, rep, flags);
+}
+
 static void ut_get_rep_clear(struct m0_cas_get_reply *rep, uint32_t nr)
 {
 	uint32_t i;
@@ -464,10 +542,11 @@ static void ut_get_rep_clear(struct m0_cas_get_reply *rep, uint32_t nr)
 		m0_free(rep[i].cge_val.b_addr);
 }
 
-static int ut_rec_get(struct cl_ctx           *cctx,
-		      struct m0_cas_id        *index,
-		      const struct m0_bufvec  *keys,
-		      struct m0_cas_get_reply *rep)
+static int ut_rec__get(struct cl_ctx           *cctx,
+		       struct m0_cas_id        *index,
+		       const struct m0_bufvec  *keys,
+		       struct m0_cas_get_reply *rep,
+		       uint64_t                 flags)
 {
 	struct m0_cas_req  req;
 	struct m0_chan    *chan;
@@ -484,7 +563,8 @@ static int ut_rec_get(struct cl_ctx           *cctx,
 	m0_clink_add_lock(chan, &cctx->cl_wait.aw_clink);
 
 	m0_cas_req_lock(&req);
-	rc = m0_cas_get(&req, index, keys);
+	rc = ((flags & COF_VERSIONED) != 0 ?
+	      m0_cas_versioned_get : m0_cas_get)(&req, index, keys);
 	if (rc == 0) {
 		/* wait results */
 		m0_cas_req_wait(&req, M0_BITS(CASREQ_FINAL), M0_TIME_NEVER);
@@ -507,6 +587,14 @@ static int ut_rec_get(struct cl_ctx           *cctx,
 	m0_cas_req_fini_lock(&req);
 	m0_clink_fini(&cctx->cl_wait.aw_clink);
 	return rc;
+}
+
+static int ut_rec_get(struct cl_ctx           *cctx,
+		      struct m0_cas_id        *index,
+		      const struct m0_bufvec  *keys,
+		      struct m0_cas_get_reply *rep)
+{
+	return ut_rec__get(cctx, index, keys, rep, 0);
 }
 
 static void ut_next_rep_clear(struct m0_cas_next_reply *rep, uint64_t nr)
@@ -568,15 +656,21 @@ static int ut_next_rec(struct cl_ctx            *cctx,
 	return rc;
 }
 
-static int ut_rec_del(struct cl_ctx           *cctx,
-		      struct m0_cas_id        *index,
-		      struct m0_bufvec        *keys,
-		      struct m0_cas_rec_reply *rep)
+static int ut_rec_common_del(struct cl_ctx           *cctx,
+			     struct m0_cas_id        *index,
+			     const struct m0_bufvec  *keys,
+			     struct m0_dtx           *dtx,
+			     struct m0_cas_rec_reply *rep,
+			     uint64_t                 flags)
 {
 	struct m0_cas_req  req;
 	struct m0_chan    *chan;
 	int                rc;
 	uint64_t           i;
+
+	M0_PRE(ergo(dtx != NULL,
+		    (((flags & COF_VERSIONED) != 0) &&
+		     keys->ov_vec.v_nr == 1)));
 
 	/* start operation */
 	M0_SET0(&req);
@@ -588,7 +682,7 @@ static int ut_rec_del(struct cl_ctx           *cctx,
 	m0_clink_add_lock(chan, &cctx->cl_wait.aw_clink);
 
 	m0_cas_req_lock(&req);
-	rc = m0_cas_del(&req, index, keys, NULL, 0);
+	rc = m0_cas_del(&req, index, (struct m0_bufvec *) keys, dtx, flags);
 	if (rc == 0) {
 		/* wait results */
 		m0_cas_req_wait(&req, M0_BITS(CASREQ_FINAL), M0_TIME_NEVER);
@@ -604,6 +698,41 @@ static int ut_rec_del(struct cl_ctx           *cctx,
 	m0_cas_req_fini_lock(&req);
 	m0_clink_fini(&cctx->cl_wait.aw_clink);
 	return rc;
+}
+
+/* Submits CAS requests separately one-by-one for each key. */
+static int ut_rec_common_del_seq(struct cl_ctx           *cctx,
+				 struct m0_cas_id        *index,
+				 const struct m0_bufvec  *keys,
+				 struct m0_dtx           *dtx,
+				 struct m0_cas_rec_reply *rep,
+				 uint64_t                 flags)
+{
+	struct m0_bufvec k;
+	m0_bcount_t      i;
+	int              rc = 0;
+
+	for (i = 0; i < keys->ov_vec.v_nr; i++) {
+		k = M0_BUFVEC_INIT_BUF(&keys->ov_buf[i],
+				       &keys->ov_vec.v_count[i]);
+		rc |= ut_rec_common_del(cctx, index, &k, dtx, rep + i, flags);
+		if (rc != 0)
+			break;
+	}
+
+	return rc;
+}
+
+static int ut_rec_del(struct cl_ctx           *cctx,
+		      struct m0_cas_id        *index,
+		      const struct m0_bufvec  *keys,
+		      struct m0_cas_rec_reply *rep,
+		      uint64_t                 flags)
+{
+
+	return ((flags & COF_VERSIONED) != 0 ?
+		ut_rec_common_del_seq : ut_rec_common_del)
+		(cctx, index, keys, NULL, rep, flags);
 }
 
 static void idx_create(void)
@@ -641,7 +770,7 @@ static void idx_create_fail(void)
 	rc = ut_lookup_idx(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep.crr_rc == -ENOENT);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
 	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep.crr_rc == -ENOMEM);
@@ -651,7 +780,7 @@ static void idx_create_fail(void)
 	m0_fi_enable_once("creq_op_alloc", "cas_alloc_fail");
 	rc = ut_lookup_idx(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
 	rc = ut_lookup_idx(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep.crr_rc == -ENOMEM);
@@ -729,7 +858,7 @@ static void idx_delete_fail(void)
 	rc = ut_lookup_idx(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep.crr_rc == 0);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
 	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep.crr_rc == -ENOMEM);
@@ -1060,7 +1189,7 @@ static void idx_list_fail(void)
 	m0_fi_enable_once("creq_op_alloc", "cas_alloc_fail");
 	rc = ut_idx_list(&casc_ut_cctx, &ifid[0], COUNT, &rep_count, rep_list);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
 	rc = ut_idx_list(&casc_ut_cctx, &ifid[0], COUNT, &rep_count, rep_list);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep_count == COUNT);
@@ -1192,6 +1321,329 @@ static void next_common(struct m0_bufvec *keys,
 
 	m0_bufvec_free(&start_key);
 }
+
+static int get_reply2bufvec(struct m0_cas_get_reply *get_rep, m0_bcount_t nr,
+			    struct m0_bufvec        *out)
+{
+	int         rc;
+	m0_bcount_t i;
+
+	rc = m0_bufvec_empty_alloc(out, nr);
+	if (rc != 0)
+		return rc;
+	for (i = 0; i < nr; ++i) {
+		out->ov_buf[i] = get_rep[i].cge_val.b_addr;
+		out->ov_vec.v_count[i] = get_rep[i].cge_val.b_nob;
+	}
+
+	return rc;
+}
+
+static int bufvec_cmp(const struct m0_bufvec *left,
+		      const struct m0_bufvec *right)
+{
+	struct m0_bufvec_cursor rcur;
+	struct m0_bufvec_cursor lcur;
+	m0_bufvec_cursor_init(&lcur, left);
+	m0_bufvec_cursor_init(&rcur, right);
+	return m0_bufvec_cursor_cmp(&lcur, &rcur);
+}
+
+/*
+ * Returns "true" if GET operation successfully returns all expected_values
+ * (if they have been specified) or all the records exist (if expected_values
+ * is NULL).
+ */
+static bool has_values(struct m0_cas_id       *index,
+		       const struct m0_bufvec *keys,
+		       const struct m0_bufvec *expected_values,
+		       uint64_t                flags)
+{
+	int                      rc;
+	struct m0_cas_get_reply *get_rep;
+	bool                     result;
+	struct m0_bufvec         actual_values;
+
+	M0_ALLOC_ARR(get_rep, keys->ov_vec.v_nr);
+	M0_UT_ASSERT(get_rep != NULL);
+
+	rc = ut_rec__get(&casc_ut_cctx, index, keys, get_rep, flags);
+	M0_UT_ASSERT(rc == 0);
+
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+			       M0_IN(get_rep[i].cge_rc, (0, -ENOENT))));
+
+	if (m0_exists(i, keys->ov_vec.v_nr, get_rep[i].cge_rc == -ENOENT)) {
+		M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+				       get_rep[i].cge_rc == -ENOENT));
+		return false;
+	}
+
+	if (expected_values != NULL) {
+		rc = get_reply2bufvec(get_rep, keys->ov_vec.v_nr,
+				      &actual_values);
+		M0_UT_ASSERT(rc == 0);
+		result = bufvec_cmp(&actual_values, expected_values) == 0;
+		m0_bufvec_free2(&actual_values);
+	} else
+		result = true;
+
+	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
+	m0_free(get_rep);
+	return result;
+}
+
+/*
+ * Tombstones are not exposed but it is easy to detect them: if the value
+ * is visible via a non-versioned GET but not visible via a versioned GET
+ * then the record definitely has the tombstone flag set.
+ */
+static bool has_tombstones(struct m0_cas_id       *index,
+			   const struct m0_bufvec *keys)
+{
+	return has_values(index, keys, NULL, 0) &&
+		!has_values(index, keys, NULL, COF_VERSIONED);
+}
+
+static void next_verified(struct m0_cas_id *index,
+			  struct m0_bufvec *start_key,
+			  uint32_t          requested_keys_nr,
+			  struct m0_bufvec *expected_keys,
+			  int               flags)
+{
+	struct m0_cas_next_reply *next_rep;
+	uint64_t                  rep_count;
+	int                       rc;
+
+	M0_ALLOC_ARR(next_rep, requested_keys_nr);
+	M0_UT_ASSERT(next_rep != NULL);
+
+	rc = ut_next_rec(&casc_ut_cctx, index, start_key, &requested_keys_nr,
+			 next_rep, &rep_count, flags);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(rep_count == requested_keys_nr);
+
+	if (expected_keys == NULL)
+		M0_UT_ASSERT(m0_forall(i, rep_count,
+				       next_rep[i].cnp_rc == -ENOENT));
+	else {
+		M0_UT_ASSERT(m0_forall(i, rep_count, next_rep[i].cnp_rc == 0));
+		M0_UT_ASSERT(rep_count == expected_keys->ov_vec.v_nr);
+		M0_UT_ASSERT(m0_forall(i, expected_keys->ov_vec.v_nr,
+				       memcmp(next_rep[i].cnp_key.b_addr,
+					      expected_keys->ov_buf[i],
+					      next_rep[i].cnp_key.b_nob) == 0));
+	}
+
+	ut_next_rep_clear(next_rep, rep_count);
+	m0_free(next_rep);
+}
+
+static void ut_rec_common_put_verified(struct m0_cas_id       *index,
+				       const struct m0_bufvec *keys,
+				       const struct m0_bufvec *values,
+				       uint64_t                version,
+				       uint64_t                flags)
+{
+	struct m0_cas_rec_reply *rep;
+	struct m0_dtx           *dtx;
+	int                      rc;
+
+	M0_UT_ASSERT(keys != NULL && values != NULL);
+	M0_ALLOC_ARR(rep, keys->ov_vec.v_nr);
+	M0_UT_ASSERT(rep != NULL);
+
+	ut_dtx_init(&dtx, version);
+	rc = ut_rec_common_put_seq(&casc_ut_cctx, index, keys, values, dtx,
+				   rep, flags);
+	ut_dtx_fini(dtx);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr, rep[i].crr_rc == 0));
+	m0_free(rep);
+}
+
+static void ut_rec_common_del_verified(struct m0_cas_id       *index,
+				       const struct m0_bufvec *keys,
+				       uint64_t                version,
+				       uint64_t                flags)
+{
+	struct m0_cas_rec_reply *rep;
+	struct m0_dtx           *dtx;
+	int                      rc;
+
+	M0_UT_ASSERT(keys != NULL);
+	M0_ALLOC_ARR(rep, keys->ov_vec.v_nr);
+	M0_UT_ASSERT(rep != NULL);
+
+	ut_dtx_init(&dtx, version);
+	rc = ut_rec_common_del_seq(&casc_ut_cctx, index, keys, dtx, rep, flags);
+	ut_dtx_fini(dtx);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr, rep[i].crr_rc == 0));
+	m0_free(rep);
+}
+
+/*
+ * PUTs (keys, values) and then ensures that expected_values are visible
+ * via GET operation.
+ */
+static void put_get_verified(struct m0_cas_id *index,
+			     struct m0_bufvec *keys,
+			     struct m0_bufvec *values,
+			     struct m0_bufvec *expected_values,
+			     uint64_t          version,
+			     int               put_flags,
+			     int               get_flags)
+{
+	ut_rec_common_put_verified(index, keys, values, version, put_flags);
+	M0_UT_ASSERT(has_values(index, keys, expected_values, get_flags));
+}
+
+/*
+ * DELetes (keys, values) and then ensures that the values are not visible
+ * via GET operation.
+ */
+static void del_get_verified(struct m0_cas_id *index,
+			     struct m0_bufvec *keys,
+			     uint64_t          version,
+			     uint64_t          del_flags,
+			     uint64_t          get_flags)
+{
+	ut_rec_common_del_verified(index, keys, version, del_flags);
+	M0_UT_ASSERT(!has_values(index, keys, NULL, get_flags));
+}
+
+
+/*
+ * Initialise a single-element bufvec using an element taken from
+ * the target bufvec at position specified by __idx:
+ * @verbatim
+ *   bufvec target = [buf A, buf B, buf C]
+ *   bufvec slice  = target.slice(1)
+ *   assert slice == [buf B]
+ * @endverbatim
+ */
+#define M0_BUFVEC_SLICE(__bufvec, __idx)		 \
+	M0_BUFVEC_INIT_BUF((__bufvec)->ov_buf + (__idx), \
+			   (__bufvec)->ov_vec.v_count + (__idx))
+
+/*
+ * A test case where we are verifying that NEXT works well with
+ * combinations of PUT and DEL.
+ */
+void next_ver(void)
+{
+	enum { V_PAST, V_FUTURE, V_NR };
+	struct m0_bufvec        keys;
+	struct m0_bufvec        values;
+	struct m0_bufvec        kodd;
+	struct m0_bufvec        keven;
+	int                     rc;
+	uint64_t                version[V_NR] = { 2, 3 };
+	int                     i;
+	struct m0_cas_id        index = {};
+	struct m0_cas_rec_reply rep;
+	const struct m0_fid     ifid = IFID(2, 3);
+
+	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
+
+	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
+	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	index.ci_fid = ifid;
+
+	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr == COUNT);
+	rc = m0_bufvec_alloc(&values, keys.ov_vec.v_nr, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr == values.ov_vec.v_nr);
+	rc = m0_bufvec_alloc(&kodd, keys.ov_vec.v_nr / 2, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_bufvec_alloc(&keven, keys.ov_vec.v_nr / 2, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+
+	for (i = 0; i < keys.ov_vec.v_nr; i++) {
+		*(uint64_t*)keys.ov_buf[i] = i;
+		*(uint64_t*)values.ov_buf[i] = i;
+		memcpy(((i & 0x01) == 0 ? &keven : &kodd)->ov_buf[i / 2],
+		       keys.ov_buf[i], keys.ov_vec.v_count[i]);
+	}
+
+	/* Insert all the keys. */
+	put_get_verified(&index, &keys, &values, &values, version[V_PAST],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+
+	/* Only even records will be alive in the future. */
+	del_get_verified(&index, &kodd, version[V_FUTURE],
+			 COF_VERSIONED, COF_VERSIONED);
+
+	/*
+	 * Case:
+	 * NEXT with the first alive key and the number records equal to
+	 * (number_of_alive_keys - 1) should return all the alive keys.
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0),
+		      keys.ov_vec.v_nr / 2, &keven, COF_VERSIONED);
+
+	/*
+	 * Case:
+	 * Requesting one record with NEXT with the first dead key
+	 * should return nothing (ENOENT).
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&kodd, 0), 1, NULL,
+		      COF_VERSIONED);
+
+	/*
+	 * Case:
+	 * Requesting one record with NEXT(SLANT) with the first dead key
+	 * should return the second alive key.
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&kodd, 0), 1,
+		      &M0_BUFVEC_SLICE(&keven, 1), COF_SLANT | COF_VERSIONED);
+
+	/*
+	 * Case:
+	 * Requesting one record with NEXT(SLANT|EXECLUDE_START_KEY) with
+	 * start key equal to the first alive record should return one single
+	 * pair with the next alive record.
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&keven, 0), 1,
+		      &M0_BUFVEC_SLICE(&keven, 1),
+		      COF_SLANT | COF_EXCLUDE_START_KEY | COF_VERSIONED);
+
+	/* Now the index should have no keys. */
+	del_get_verified(&index, &keven, version[V_FUTURE],
+			 COF_VERSIONED, COF_VERSIONED);
+
+	/*
+	 * Case:
+	 * Requesting one record with NEXT(SLANT) should yield no keys at all
+	 * on an empty index (ENOENT).
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0), 1, NULL,
+		      COF_VERSIONED);
+
+	/*
+	 * Case:
+	 * When version-awre behavior is disabled (no COF_VERSIONED),
+	 * NEXT should yield all the keys that were inserted initially.
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0),
+		      keys.ov_vec.v_nr, &keys, 0);
+
+	m0_bufvec_free(&keys);
+	m0_bufvec_free(&values);
+	m0_bufvec_free(&keven);
+	m0_bufvec_free(&kodd);
+
+	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
+	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
+}
+#undef M0_BUFVEC_SLICE
 
 static void next(void)
 {
@@ -1363,7 +1815,7 @@ static void next_fail(void)
 	rc = ut_next_rec(&casc_ut_cctx, &index, &start_key, &recs_nr, next_rep,
 			 &rep_count, 0);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
 	rc = ut_next_rec(&casc_ut_cctx, &index, &start_key, &recs_nr,
 			 next_rep, &rep_count, 0);
 	M0_UT_ASSERT(rc == -ENOMEM);
@@ -1500,27 +1952,135 @@ static void next_multi_bulk(void)
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
 }
 
-static void put_common(struct m0_bufvec *keys, struct m0_bufvec *values)
+static void put_common_with_ver(struct m0_bufvec *keys,
+				struct m0_bufvec *values,
+				uint64_t          version)
 {
-	struct m0_cas_rec_reply rep[COUNT];
-	const struct m0_fid     ifid = IFID(2, 3);
-	struct m0_cas_id        index = {};
-	int                     rc;
+	const struct m0_fid      ifid = IFID(2, 3);
+	struct m0_cas_id         index = {};
+	int                      rc;
+	struct m0_cas_rec_reply  rep;
 
 	M0_UT_ASSERT(keys != NULL && values != NULL);
 
-	M0_SET_ARR0(rep);
+	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	index.ci_fid = ifid;
+
+	ut_rec_common_put_verified(&index, keys, values, version,
+				   version == 0 ? 0 : (COF_VERSIONED |
+						       COF_OVERWRITE));
+
+	/* Remove index. */
+	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+}
+
+static void put_common(struct m0_bufvec *keys, struct m0_bufvec *values)
+{
+	put_common_with_ver(keys, values, 0);
+}
+
+/*
+ * PUTs keys and ensures that "older" keys are overwritten by "newer" keys,
+ * while "older" keys cannot overwrite "newer" keys.
+ * The test case is supposed to work in both kinds of environment (DTM
+ * and non-DTM).
+ */
+static void put_overwrite_ver(void)
+{
+	enum v { V_NONE, V_PAST, V_NOW, V_FUTURE, V_NR};
+	struct m0_bufvec         keys;
+	struct m0_bufvec         vals[V_NR];
+	uint64_t                 version[V_NR] = {};
+	int                      rc;
+	int                      i;
+	int                      j;
+	struct m0_cas_id         index = {};
+	struct m0_cas_rec_reply  rep[1];
+	const struct m0_fid      ifid = IFID(2, 3);
+
+	M0_UT_ASSERT((UINT64_MAX / COUNT) > (1L << V_NR));
+
+	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
+	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
+
+	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr != 0);
+	for (j = 0; j < V_NR; j++) {
+		rc = m0_bufvec_alloc(&vals[j], keys.ov_vec.v_nr,
+				     sizeof(uint64_t));
+		M0_UT_ASSERT(rc == 0);
+		version[j] = j;
+	}
+
+	for (i = 0; i < keys.ov_vec.v_nr; i++) {
+		*(uint64_t*)keys.ov_buf[i] = i;
+		for (j = 0; j < V_NR; j++) {
+			*(uint64_t*)vals[j].ov_buf[i] = i << j;
+			M0_UT_ASSERT(keys.ov_vec.v_nr == vals[j].ov_vec.v_nr);
+		}
+	}
 
 	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, rep);
 	M0_UT_ASSERT(rc == 0);
 	index.ci_fid = ifid;
-	rc = ut_rec_put(&casc_ut_cctx, &index, keys, values, rep, 0);
-	M0_UT_ASSERT(rc == 0);
-	M0_UT_ASSERT(m0_forall(i, COUNT, rep[i].crr_rc == 0));
 
-	/* Remove index. */
+	/* PUT@now */
+	put_get_verified(&index, &keys, vals + V_NOW, vals + V_NOW,
+			 version[V_NOW],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+
+	/* PUT@future */
+	put_get_verified(&index, &keys, vals + V_FUTURE, vals + V_FUTURE,
+			 version[V_FUTURE],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+
+	/* PUT@past (values should not be changed) */
+	put_get_verified(&index, &keys, vals + V_PAST, vals + V_FUTURE,
+			 version[V_PAST],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+
 	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, rep);
 	M0_UT_ASSERT(rc == 0);
+	for (j = 0; j < V_NR; j++)
+		m0_bufvec_free(&vals[j]);
+	m0_bufvec_free(&keys);
+	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
+	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
+}
+
+/*
+ * Put a versioned key-value pair.
+ */
+static void put_ver(void)
+{
+	struct m0_bufvec keys;
+	struct m0_bufvec values;
+	int              rc;
+
+	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
+	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
+
+	rc = m0_bufvec_alloc(&keys, 1, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_bufvec_alloc(&values, 1, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr != 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr == values.ov_vec.v_nr);
+	m0_forall(i, keys.ov_vec.v_nr, (*(uint64_t*)keys.ov_buf[i]   = i,
+					*(uint64_t*)values.ov_buf[i] = i * i,
+					true));
+	put_common_with_ver(&keys, &values, 1);
+	m0_bufvec_free(&keys);
+	m0_bufvec_free(&values);
+
+	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
+	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
 }
 
 /*
@@ -1658,7 +2218,7 @@ static void recs_fragm(void)
 	m0_fi_enable_off_n_on_m("m0_rpc_item_max_payload_exceeded",
 				"payload_too_large2",
 				10, 1);
-	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep);
+	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep, 0);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_forall(i, COUNT, rep[i].crr_rc == 0));
 	m0_fi_disable("m0_rpc_item_max_payload_exceeded", "payload_too_large2");
@@ -1975,11 +2535,11 @@ static void put_crow_fail(void)
 
 	M0_SET_ARR0(rep);
 
-	m0_fi_enable_off_n_on_m("ctg_buf_get", "cas_alloc_fail", 1, 1);
+	m0_fi_enable_off_n_on_m("ctg_kbuf_get", "cas_alloc_fail", 1, 1);
 	index.ci_fid = ifid;
 	rc = ut_rec_put(&casc_ut_cctx, &index, &keys, &values, rep, COF_CROW);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_disable("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_disable("ctg_kbuf_get", "cas_alloc_fail");
 
 	rc = ut_rec_get(&casc_ut_cctx, &index, &keys, grep);
 	M0_UT_ASSERT(rc == -ENOENT);
@@ -2011,7 +2571,7 @@ static void put_fail_common(struct m0_bufvec *keys, struct m0_bufvec *values)
 	m0_fi_enable_once("creq_op_alloc", "cas_alloc_fail");
 	rc = ut_rec_put(&casc_ut_cctx, &index, keys, values, rep, 0);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
 	rc = ut_rec_put(&casc_ut_cctx, &index, keys, values, rep, 0);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
@@ -2103,35 +2663,58 @@ static void upd(void)
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
 }
 
-static void del_common(struct m0_bufvec *keys, struct m0_bufvec *values)
+static void del_common(struct m0_bufvec *keys,
+		       struct m0_bufvec *values,
+		       uint64_t          version,
+		       uint64_t          put_flags,
+		       uint64_t          del_flags,
+		       uint64_t          get_flags)
 {
-	struct m0_cas_rec_reply rep[COUNT];
-	struct m0_cas_get_reply get_rep[COUNT];
-	const struct m0_fid     ifid = IFID(2, 3);
-	struct m0_cas_id        index = {};
-	int                     rc;
+	struct m0_cas_rec_reply  rep;
+	const struct m0_fid      ifid = IFID(2, 3);
+	struct m0_cas_id         index = {};
+	int                      rc;
+	uint64_t                 del_version = version == 0 ? 0 : version + 1;
 
-	M0_SET_ARR0(rep);
-	M0_SET_ARR0(get_rep);
-	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, rep);
+	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	index.ci_fid = ifid;
-	/* Insert new records */
-	rc = ut_rec_put(&casc_ut_cctx, &index, keys, values, rep, 0);
-	M0_UT_ASSERT(rc == 0);
-	/* Delete all records */
-	rc = ut_rec_del(&casc_ut_cctx, &index, keys, rep);
-	M0_UT_ASSERT(rc == 0);
-	M0_UT_ASSERT(m0_forall(i, COUNT, rep[i].crr_rc == 0));
-	/* check selected values - must be empty*/
-	rc = ut_rec_get(&casc_ut_cctx, &index, keys, get_rep);
-	M0_UT_ASSERT(rc == 0);
-	M0_UT_ASSERT(m0_forall(i, COUNT, get_rep[i].cge_rc == -ENOENT));
-	ut_get_rep_clear(get_rep, COUNT);
 
-	/* Remove index. */
-	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, rep);
+	ut_rec_common_put_verified(&index, keys, values, version, put_flags);
+	ut_rec_common_del_verified(&index, keys, del_version, del_flags);
+	M0_UT_ASSERT(!has_values(&index, keys, NULL, get_flags));
+
+	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
+}
+
+static void del_ver(void)
+{
+	struct m0_bufvec keys;
+	struct m0_bufvec values;
+	int              rc;
+
+	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
+	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
+
+	rc = m0_bufvec_alloc(&keys, 1, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_bufvec_alloc(&values, 1, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr != 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr == values.ov_vec.v_nr);
+	m0_forall(i, keys.ov_vec.v_nr, (*(uint64_t*)keys.ov_buf[i]   = i,
+					*(uint64_t*)values.ov_buf[i] = i * i,
+					true));
+	del_common(&keys, &values, 1,
+		   COF_OVERWRITE | COF_VERSIONED,
+		   COF_VERSIONED,
+		   COF_VERSIONED);
+	m0_bufvec_free(&keys);
+	m0_bufvec_free(&values);
+
+	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
+	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
 }
 
 static void del(void)
@@ -2150,7 +2733,7 @@ static void del(void)
 	m0_forall(i, keys.ov_vec.v_nr, (*(uint64_t*)keys.ov_buf[i]   = i,
 					*(uint64_t*)values.ov_buf[i] = i * i,
 					true));
-	del_common(&keys, &values);
+	del_common(&keys, &values, 0, 0, 0, 0);
 	m0_bufvec_free(&keys);
 	m0_bufvec_free(&values);
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
@@ -2165,7 +2748,7 @@ static void del_bulk(void)
 	/* Bulk keys and  values. */
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
-	del_common(&keys, &values);
+	del_common(&keys, &values, 0, 0, 0, 0);
 	m0_bufvec_free(&keys);
 	m0_bufvec_free(&values);
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
@@ -2202,10 +2785,10 @@ static void del_fail(void)
 	M0_UT_ASSERT(rc == 0);
 	/* Delete all records */
 	m0_fi_enable_once("creq_op_alloc", "cas_alloc_fail");
-	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep);
+	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep, 0);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
-	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep);
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
+	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep, 0);
 	M0_UT_ASSERT(rc == -ENOMEM);
 	/* check selected values - must be empty*/
 	m0_forall(i, values.ov_vec.v_nr,
@@ -2251,7 +2834,7 @@ static void del_n(void)
 	M0_UT_ASSERT(rc == 0);
 	/* Delete several records */
 	keys.ov_vec.v_nr /= 3;
-	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep);
+	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep, 0);
 	M0_UT_ASSERT(rc == 0);
 	/* restore old count value */
 	keys.ov_vec.v_nr = COUNT;
@@ -2326,7 +2909,7 @@ static void null_value(void)
 	m0_bufvec_free(&start_key);
 
 	/* Delete records. */
-	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep);
+	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep, 0);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_forall(i, COUNT, rep[i].crr_rc == 0));
 
@@ -2481,7 +3064,7 @@ static void get_fail(void)
 	m0_fi_enable_once("creq_op_alloc", "cas_alloc_fail");
 	rc = ut_rec_get(&casc_ut_cctx, &index, &keys, get_rep);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_enable_once("ctg_buf_get", "cas_alloc_fail");
+	m0_fi_enable_once("ctg_kbuf_get", "cas_alloc_fail");
 	rc = ut_rec_get(&casc_ut_cctx, &index, &keys, get_rep);
 	M0_UT_ASSERT(rc == -ENOMEM);
 	m0_bufvec_free(&keys);
@@ -2518,7 +3101,7 @@ static void recs_count(void)
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_ctg_rec_nr() == COUNT);
 	M0_UT_ASSERT(m0_ctg_rec_size() == COUNT * 2 * sizeof(uint64_t));
-	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep);
+	rc = ut_rec_del(&casc_ut_cctx, &index, &keys, rep, 0);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(m0_ctg_rec_nr() == 0);
 	/* Currently total size of records is not decremented on deletion. */
@@ -2603,6 +3186,253 @@ static void reply_too_large(void)
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
 }
 
+enum named_version {
+	PAST   = 2,
+	FUTURE = 3,
+};
+
+enum named_outcome {
+	/* No value at all. */
+	TOMBSTONE,
+	/* New value was not inserted. */
+	PRESERVED,
+	/* Old value was replaced by the new value. */
+	OVERWRITTEN,
+};
+
+enum named_op {
+	NOP,
+	PUT,
+	DEL,
+};
+
+/* PUT or DEL operation with a human-readable version description. */
+struct cas_ver_op {
+	enum named_version ver;
+	enum named_op      op;
+	uint64_t           key;
+	uint64_t           value;
+};
+
+struct put_del_ver_case {
+	struct cas_ver_op  before;
+	struct cas_ver_op  after;
+	enum named_outcome outcome;
+};
+
+static void cas_ver_op_execute(const struct cas_ver_op *cvop,
+			       struct m0_cas_id        *index)
+{
+	m0_bcount_t      nr_bytes = sizeof(cvop->key);
+	uint64_t         version = cvop->ver;
+	const void *key_data = &cvop->key;
+	const void *val_data = &cvop->value;
+	const struct m0_bufvec keys =
+		M0_BUFVEC_INIT_BUF((void **) &key_data, &nr_bytes);
+	const struct m0_bufvec values =
+		M0_BUFVEC_INIT_BUF((void **) &val_data, &nr_bytes);
+	M0_CASSERT(sizeof(cvop->key) == sizeof(cvop->value));
+
+	switch (cvop->op) {
+	case PUT:
+		ut_rec_common_put_verified(index, &keys, &values, version,
+					   COF_VERSIONED | COF_OVERWRITE);
+		break;
+	case DEL:
+		ut_rec_common_del_verified(index, &keys, version,
+					   COF_VERSIONED);
+		break;
+	case NOP:
+		/* Nothing to do. */
+		break;
+	}
+}
+
+static void put_del_ver_case_execute(const struct put_del_ver_case *c,
+				     struct m0_cas_id              *index)
+{
+	cas_ver_op_execute(&c->before, index);
+	cas_ver_op_execute(&c->after, index);
+}
+
+/*
+ * Versions are not exposed via CAS client API but
+ * we can make an educated guess by executing a set of destructive operations
+ * to verify the following properties:
+ *  Put a tombstone:
+ *   DEL@version
+ *   has_tombstone => true
+ *  Put some old version:
+ *   PUT@(version - 1)
+ *   has_tombstone => true
+ *  Put some new version:
+ *   PUT@(version + 1)
+ *   has_tombstone => false.
+ */
+static void ensure_has_version(struct m0_cas_id *index,
+			       const struct m0_bufvec *keys,
+			       uint64_t version)
+{
+	int                      rc;
+	struct m0_cas_get_reply *get_rep;
+	struct m0_bufvec         values;
+
+	M0_ALLOC_ARR(get_rep, keys->ov_vec.v_nr);
+	M0_UT_ASSERT(get_rep != NULL);
+
+	/* Save the existing values. */
+	rc = ut_rec__get(&casc_ut_cctx, index, keys, get_rep, 0);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+			       get_rep[i].cge_rc == 0));
+	rc = get_reply2bufvec(get_rep, keys->ov_vec.v_nr, &values);
+	M0_UT_ASSERT(rc == 0);
+	m0_free(get_rep);
+
+	ut_rec_common_del_verified(index, keys, version, COF_VERSIONED);
+	M0_UT_ASSERT(has_tombstones(index, keys));
+
+	ut_rec_common_put_verified(index, keys, &values, version - 1,
+				   COF_VERSIONED | COF_OVERWRITE);
+	M0_UT_ASSERT(has_tombstones(index, keys));
+
+	ut_rec_common_put_verified(index, keys, &values, version + 1,
+				   COF_VERSIONED | COF_OVERWRITE);
+	M0_UT_ASSERT(!has_tombstones(index, keys));
+
+	/* Restore the existing values. */
+	ut_rec_common_del_verified(index, keys, 0, 0);
+	ut_rec_common_put_verified(index, keys, &values, version,
+				   COF_VERSIONED | COF_OVERWRITE);
+	M0_UT_ASSERT(!has_tombstones(index, keys));
+}
+
+static void put_del_ver_case_verify(const struct put_del_ver_case *c,
+				    struct m0_cas_id              *index)
+{
+	m0_bcount_t            nr_bytes = sizeof(c->before.key);
+	const void *key_data = &c->before.key;
+	const struct m0_bufvec keys =
+		M0_BUFVEC_INIT_BUF((void **) &key_data, &nr_bytes);
+	const void *before_val_data = &c->before.value;
+	const struct m0_bufvec before_values =
+		M0_BUFVEC_INIT_BUF((void **) &before_val_data, &nr_bytes);
+	const void *after_val_data = &c->after.value;
+	const struct m0_bufvec after_values =
+		M0_BUFVEC_INIT_BUF((void **) &after_val_data, &nr_bytes);
+
+	switch (c->outcome) {
+	case TOMBSTONE:
+		M0_UT_ASSERT(has_tombstones(index, &keys));
+		M0_UT_ASSERT(!has_values(index, &keys, &before_values,
+				       COF_VERSIONED));
+		M0_UT_ASSERT(!has_values(index, &keys, &after_values,
+				       COF_VERSIONED));
+		break;
+	case OVERWRITTEN:
+		M0_UT_ASSERT(!has_tombstones(index, &keys));
+		/*
+		 * The values should be overwritten no matter what behavior we
+		 * have specified.
+		 */
+		M0_UT_ASSERT(has_values(index, &keys, &after_values, 0));
+		M0_UT_ASSERT(has_values(index, &keys, &after_values,
+				       COF_VERSIONED));
+		M0_UT_ASSERT(!has_values(index, &keys, &before_values, 0));
+		M0_UT_ASSERT(!has_values(index, &keys, &before_values,
+				       COF_VERSIONED));
+		break;
+	case PRESERVED:
+		M0_UT_ASSERT(!has_tombstones(index, &keys));
+		/*
+		 * The values should be preserved, and it should be visible
+		 * even if the versioned behavior was not requested by GET
+		 * operation.
+		 */
+		M0_UT_ASSERT(has_values(index, &keys, &before_values, 0));
+		M0_UT_ASSERT(has_values(index, &keys, &before_values,
+				       COF_VERSIONED));
+		M0_UT_ASSERT(!has_values(index, &keys, &after_values, 0));
+		M0_UT_ASSERT(!has_values(index, &keys, &after_values,
+				       COF_VERSIONED));
+		break;
+	}
+
+	ensure_has_version(index, &keys, FUTURE);
+
+	/* Wipe out the records at the end of the iteration. */
+	ut_rec_common_del_verified(index, &keys, 0, 0);
+}
+
+static void put_del_ver(void)
+{
+#define BEFORE(_what, _when)         \
+	.before = {                  \
+		.ver   = _when,      \
+		.op    = _what,      \
+		.key   = 1,          \
+		.value = 1,          \
+	},
+
+#define AFTER(_what, _when)         \
+	.after = {                  \
+		.ver   = _when,     \
+		.op    = _what,     \
+		.key   = 1,         \
+		.value = 2,         \
+	},
+
+#define OUTCOME(_result) .outcome = _result,
+
+	/*
+	 * TODO: the outcome could be inferred from the newest operation:
+	 * PUT@FUTURE is always preserved or overwritten (depending on the pos).
+	 * DEL@FUTURE always keeps the tombstone intact.
+	 */
+	static const struct put_del_ver_case cases[] = {
+		{ BEFORE(PUT, PAST)   AFTER(DEL, FUTURE) OUTCOME(TOMBSTONE)   },
+		{ BEFORE(PUT, PAST)   AFTER(PUT, FUTURE) OUTCOME(OVERWRITTEN) },
+
+		{ BEFORE(PUT, FUTURE) AFTER(PUT, PAST)   OUTCOME(PRESERVED)   },
+		{ BEFORE(PUT, FUTURE) AFTER(DEL, PAST)   OUTCOME(PRESERVED)   },
+
+		{ BEFORE(DEL, FUTURE) AFTER(DEL, PAST)   OUTCOME(TOMBSTONE)   },
+		{ BEFORE(DEL, FUTURE) AFTER(PUT, PAST)   OUTCOME(TOMBSTONE)   },
+
+		{ BEFORE(DEL, PAST)   AFTER(DEL, FUTURE) OUTCOME(TOMBSTONE)   },
+		{ BEFORE(DEL, PAST)   AFTER(PUT, FUTURE) OUTCOME(OVERWRITTEN) },
+
+		{ BEFORE(NOP, PAST)   AFTER(DEL, FUTURE) OUTCOME(TOMBSTONE)   },
+		{ BEFORE(NOP, PAST)   AFTER(PUT, FUTURE) OUTCOME(OVERWRITTEN) },
+	};
+#undef BEFORE
+#undef AFTER
+#undef OUTCOME
+
+	int                     rc;
+	int                     i;
+	struct m0_cas_id        index = {};
+	struct m0_cas_rec_reply rep;
+	const struct m0_fid     ifid = IFID(2, 3);
+
+	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
+
+	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
+	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	index.ci_fid = ifid;
+
+	for (i = 0; i < ARRAY_SIZE(cases); ++i) {
+		put_del_ver_case_execute(&cases[i], &index);
+		put_del_ver_case_verify(&cases[i],  &index);
+	}
+
+	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
+	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
+
+}
 
 struct m0_ut_suite cas_client_ut = {
 	.ts_name   = "cas-client",
@@ -2649,6 +3479,11 @@ struct m0_ut_suite cas_client_ut = {
 		{ "reply-too-large",        reply_too_large,        "Sergey" },
 		{ "recs-fragm",             recs_fragm,             "Sergey" },
 		{ "recs_fragm_fail",        recs_fragm_fail,        "Sergey" },
+		{ "put-ver",                put_ver,                "Ivan"   },
+		{ "put-overwrite-ver",      put_overwrite_ver,      "Ivan"   },
+		{ "del-ver",                del_ver,                "Ivan"   },
+		{ "next-ver",               next_ver,               "Ivan"   },
+		{ "put-del-ver",            put_del_ver,            "Ivan"   },
 		{ NULL, NULL }
 	}
 };

--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -38,6 +38,7 @@
 #include "cas/ctg_store.h"             /* m0_ctg_recs_nr */
 #include "lib/finject.h"
 #include "dtm0/dtx.h"                  /* m0_dtm0_dtx */
+#include "cas/cas.h"                   /* m0_cas_kv_ver */
 
 #define SERVER_LOG_FILE_NAME       "cas_server.log"
 #define IFID(x, y) M0_FID_TINIT('i', (x), (y))
@@ -111,6 +112,17 @@ static int bufvec_empty_alloc(struct m0_bufvec *bufvec,
 	M0_UT_ASSERT(bufvec->ov_buf != NULL);
 	return 0;
 }
+
+static int bufvec_cmp(const struct m0_bufvec *left,
+		      const struct m0_bufvec *right)
+{
+	struct m0_bufvec_cursor rcur;
+	struct m0_bufvec_cursor lcur;
+	m0_bufvec_cursor_init(&lcur, left);
+	m0_bufvec_cursor_init(&rcur, right);
+	return m0_bufvec_cursor_cmp(&lcur, &rcur);
+}
+
 
 static void value_create(int size, int num, char *buf)
 {
@@ -1339,16 +1351,6 @@ static int get_reply2bufvec(struct m0_cas_get_reply *get_rep, m0_bcount_t nr,
 	return rc;
 }
 
-static int bufvec_cmp(const struct m0_bufvec *left,
-		      const struct m0_bufvec *right)
-{
-	struct m0_bufvec_cursor rcur;
-	struct m0_bufvec_cursor lcur;
-	m0_bufvec_cursor_init(&lcur, left);
-	m0_bufvec_cursor_init(&rcur, right);
-	return m0_bufvec_cursor_cmp(&lcur, &rcur);
-}
-
 /*
  * Returns "true" if GET operation successfully returns all expected_values
  * (if they have been specified) or all the records exist (if expected_values
@@ -1363,6 +1365,61 @@ static bool has_values(struct m0_cas_id       *index,
 	struct m0_cas_get_reply *get_rep;
 	bool                     result;
 	struct m0_bufvec         actual_values;
+	struct m0_bufvec         empty_values;
+
+	M0_ALLOC_ARR(get_rep, keys->ov_vec.v_nr);
+	M0_UT_ASSERT(get_rep != NULL);
+
+	rc = ut_rec__get(&casc_ut_cctx, index, keys, get_rep, flags);
+	M0_UT_ASSERT(rc == 0);
+
+	rc = m0_bufvec_empty_alloc(&empty_values, keys->ov_vec.v_nr);
+	M0_UT_ASSERT(rc == 0);
+
+	if (expected_values == NULL)
+		expected_values = &empty_values;
+
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+			       M0_IN(get_rep[i].cge_rc, (0, -ENOENT))));
+
+	if (m0_exists(i, keys->ov_vec.v_nr, get_rep[i].cge_rc == -ENOENT)) {
+		M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+				       get_rep[i].cge_rc == -ENOENT));
+
+		rc = get_reply2bufvec(get_rep, keys->ov_vec.v_nr,
+				      &actual_values);
+		M0_UT_ASSERT(rc == 0);
+		M0_UT_ASSERT(bufvec_cmp(&actual_values, expected_values) == 0);
+		m0_bufvec_free2(&actual_values);
+		result = false;
+		goto out;
+	} else {
+		rc = get_reply2bufvec(get_rep, keys->ov_vec.v_nr,
+				      &actual_values);
+		M0_UT_ASSERT(rc == 0);
+		result = bufvec_cmp(&actual_values, expected_values) == 0;
+		m0_bufvec_free2(&actual_values);
+	}
+
+out:
+	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
+	m0_free(get_rep);
+	m0_bufvec_free(&empty_values);
+	return result;
+}
+
+/*
+ * Returns "true" all values returned by GET operation are the same as
+ * the specified version.
+ */
+static bool has_versions(struct m0_cas_id *index,
+			 const struct m0_bufvec *keys,
+			 uint64_t version,
+			 uint64_t flags)
+{
+	int                      rc;
+	struct m0_cas_get_reply *get_rep;
+	bool                     result;
 
 	M0_ALLOC_ARR(get_rep, keys->ov_vec.v_nr);
 	M0_UT_ASSERT(get_rep != NULL);
@@ -1373,47 +1430,120 @@ static bool has_values(struct m0_cas_id       *index,
 	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
 			       M0_IN(get_rep[i].cge_rc, (0, -ENOENT))));
 
-	if (m0_exists(i, keys->ov_vec.v_nr, get_rep[i].cge_rc == -ENOENT)) {
-		M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
-				       get_rep[i].cge_rc == -ENOENT));
-		return false;
-	}
-
-	if (expected_values != NULL) {
-		rc = get_reply2bufvec(get_rep, keys->ov_vec.v_nr,
-				      &actual_values);
-		M0_UT_ASSERT(rc == 0);
-		result = bufvec_cmp(&actual_values, expected_values) == 0;
-		m0_bufvec_free2(&actual_values);
-	} else
-		result = true;
+	result = m0_forall(i, keys->ov_vec.v_nr,
+			   get_rep[i].cge_ver.ckv_ts.dts_phys == version);
 
 	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
 	m0_free(get_rep);
 	return result;
 }
 
-/*
- * Tombstones are not exposed but it is easy to detect them: if the value
- * is visible via a non-versioned GET but not visible via a versioned GET
- * then the record definitely has the tombstone flag set.
- */
 static bool has_tombstones(struct m0_cas_id       *index,
 			   const struct m0_bufvec *keys)
 {
-	return has_values(index, keys, NULL, 0) &&
-		!has_values(index, keys, NULL, COF_VERSIONED);
+	int                      rc;
+	struct m0_cas_get_reply *get_rep;
+	bool                     result;
+
+	M0_ALLOC_ARR(get_rep, keys->ov_vec.v_nr);
+	M0_UT_ASSERT(get_rep != NULL);
+
+	rc = ut_rec__get(&casc_ut_cctx, index, keys, get_rep, COF_VERSIONED);
+	M0_UT_ASSERT(rc == 0);
+
+	/* Ensure the rcs are within the range of allowed rcs. */
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+			       M0_IN(get_rep[i].cge_rc, (0, -ENOENT))));
+
+	/* Ensure all-or-nothing (either all have tbs or there are no tbs). */
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+			     get_rep[0].cge_ver.ckv_tombstone ==
+			     get_rep[i].cge_ver.ckv_tombstone));
+
+	/* Ensure -ENOENT matches with tombstone flag. */
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+		       ergo(!m0_dtm0_ts_is_none(&get_rep[i].cge_ver.ckv_ts),
+				    (get_rep[i].cge_ver.ckv_tombstone ==
+				     (get_rep[i].cge_rc == -ENOENT)))));
+
+	/* Ensure versions are always present on dead records. */
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
+			       ergo(get_rep[i].cge_ver.ckv_tombstone,
+				    !m0_dtm0_ts_is_none(
+						&get_rep[i].cge_ver.ckv_ts))));
+
+	result = get_rep[0].cge_ver.ckv_tombstone;
+
+	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
+	memset(get_rep, 0, sizeof(get_rep) * keys->ov_vec.v_nr);
+
+	/*
+	 * Additionally, ensure that all the records are visible
+	 * when versioned behavior is disabled.
+	 */
+	rc = ut_rec__get(&casc_ut_cctx, index, keys, get_rep, 0);
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr, get_rep[i].cge_rc == 0));
+	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
+
+
+	m0_free(get_rep);
+	return result;
 }
 
-static void next_verified(struct m0_cas_id *index,
-			  struct m0_bufvec *start_key,
-			  uint32_t          requested_keys_nr,
-			  struct m0_bufvec *expected_keys,
-			  int               flags)
+/*
+ * Breaks an array of GET replies down into pieces (keys, values, versions).
+ * In other words, it transmutes a vector of tuples into a tuple of vectors.
+ */
+static void next_reply_breakdown(struct m0_cas_next_reply  *next_rep,
+				 m0_bcount_t                nr,
+				 struct m0_bufvec          *out_key,
+				 struct m0_bufvec          *out_val,
+				 struct m0_cas_kv_ver     **out_ver)
+{
+	int                   rc;
+	m0_bcount_t           i;
+	struct m0_cas_kv_ver *ver;
+
+	rc = m0_bufvec_empty_alloc(out_key, nr);
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_bufvec_empty_alloc(out_val, nr);
+	M0_UT_ASSERT(rc == 0);
+	M0_ALLOC_ARR(ver, nr);
+	M0_UT_ASSERT(ver != NULL);
+
+	for (i = 0; i < nr; ++i) {
+		out_key->ov_buf[i] = next_rep[i].cnp_key.b_addr;
+		out_key->ov_vec.v_count[i] = next_rep[i].cnp_key.b_nob;
+
+		out_val->ov_buf[i] = next_rep[i].cnp_val.b_addr;
+		out_val->ov_vec.v_count[i] = next_rep[i].cnp_val.b_nob;
+
+		ver[i] = next_rep[i].cnp_ver;
+	}
+
+	*out_ver = ver;
+}
+
+
+/*
+ * Ensures that NEXT yields the expected keys, values and versions.
+ * Values and version are optional (ignored when set to NULL).
+ */
+static void next_records_verified(struct m0_cas_id     *index,
+				  struct m0_bufvec     *start_key,
+				  uint32_t              requested_keys_nr,
+				  struct m0_bufvec     *expected_keys,
+				  struct m0_bufvec     *expected_values,
+				  struct m0_cas_kv_ver *expected_versions,
+				  int                   flags)
 {
 	struct m0_cas_next_reply *next_rep;
 	uint64_t                  rep_count;
 	int                       rc;
+	struct m0_bufvec          actual_keys;
+	struct m0_bufvec          actual_values;
+	struct m0_cas_kv_ver     *actual_versions;
 
 	M0_ALLOC_ARR(next_rep, requested_keys_nr);
 	M0_UT_ASSERT(next_rep != NULL);
@@ -1423,21 +1553,52 @@ static void next_verified(struct m0_cas_id *index,
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep_count == requested_keys_nr);
 
-	if (expected_keys == NULL)
+	if (expected_keys == NULL) {
+		M0_UT_ASSERT(expected_values == NULL);
+		M0_UT_ASSERT(expected_versions == NULL);
 		M0_UT_ASSERT(m0_forall(i, rep_count,
 				       next_rep[i].cnp_rc == -ENOENT));
-	else {
+	} else {
 		M0_UT_ASSERT(m0_forall(i, rep_count, next_rep[i].cnp_rc == 0));
 		M0_UT_ASSERT(rep_count == expected_keys->ov_vec.v_nr);
-		M0_UT_ASSERT(m0_forall(i, expected_keys->ov_vec.v_nr,
-				       memcmp(next_rep[i].cnp_key.b_addr,
-					      expected_keys->ov_buf[i],
-					      next_rep[i].cnp_key.b_nob) == 0));
+		next_reply_breakdown(next_rep, rep_count,
+				     &actual_keys,
+				     &actual_values,
+				     &actual_versions);
+		M0_UT_ASSERT(bufvec_cmp(expected_keys,
+					&actual_keys) == 0);
+
+		if (expected_values != NULL)
+			M0_UT_ASSERT(bufvec_cmp(expected_values,
+						&actual_values) == 0);
+		if (expected_versions != NULL)
+			M0_UT_ASSERT(memcmp(expected_versions,
+					    actual_versions,
+					    rep_count *
+					    sizeof(expected_versions[0])) == 0);
+
+		m0_bufvec_free2(&actual_keys);
+		m0_bufvec_free2(&actual_values);
+		m0_free(actual_versions);
 	}
 
 	ut_next_rep_clear(next_rep, rep_count);
 	m0_free(next_rep);
 }
+
+/*
+ * Ensures that NEXT yields the expected keys.
+ */
+static void next_keys_verified(struct m0_cas_id *index,
+			       struct m0_bufvec *start_key,
+			       uint32_t          requested_keys_nr,
+			       struct m0_bufvec *expected_keys,
+			       int               flags)
+{
+	return next_records_verified(index, start_key, requested_keys_nr,
+				     expected_keys, NULL, NULL, flags);
+}
+
 
 static void ut_rec_common_put_verified(struct m0_cas_id       *index,
 				       const struct m0_bufvec *keys,
@@ -1496,7 +1657,9 @@ static void put_get_verified(struct m0_cas_id *index,
 			     int               get_flags)
 {
 	ut_rec_common_put_verified(index, keys, values, version, put_flags);
-	M0_UT_ASSERT(has_values(index, keys, expected_values, get_flags));
+	if (expected_values != NULL)
+		M0_UT_ASSERT(has_values(index, keys, expected_values,
+					get_flags));
 }
 
 /*
@@ -1511,6 +1674,16 @@ static void del_get_verified(struct m0_cas_id *index,
 {
 	ut_rec_common_del_verified(index, keys, version, del_flags);
 	M0_UT_ASSERT(!has_values(index, keys, NULL, get_flags));
+
+	/*
+	 * When version is set to zero, the value actually gets removed, so
+	 * that tombstones are not available. Still, we can ensure that
+	 * versions were wiped out.
+	 */
+	if (version == 0)
+		M0_UT_ASSERT(has_versions(index, keys, 0, COF_VERSIONED));
+	else
+		M0_UT_ASSERT(has_tombstones(index, keys));
 }
 
 
@@ -1521,19 +1694,13 @@ static void del_get_verified(struct m0_cas_id *index,
  *   bufvec target = [buf A, buf B, buf C]
  *   bufvec slice  = target.slice(1)
  *   assert slice == [buf B]
+ *          slice  = target.slice(2)
+ *   assert slice == [buf C]
  * @endverbatim
  */
 #define M0_BUFVEC_SLICE(__bufvec, __idx)		 \
 	M0_BUFVEC_INIT_BUF((__bufvec)->ov_buf + (__idx), \
 			   (__bufvec)->ov_vec.v_count + (__idx))
-
-#define M0_BUFVEC_SUB(__bufvec, __idx, __count)	(struct m0_bufvec) {	\
-	.ov_vec = {							\
-		.v_nr = (__count),					\
-		.v_count = (__bufvec)->ov_vec.v_count + (__idx),	\
-	},								\
-	.ov_buf = (__bufvec)->ov_buf + (__idx)				\
-}
 
 /*
  * A test case where we are verifying that NEXT works well with
@@ -1552,8 +1719,6 @@ static void next_ver(void)
 	struct m0_cas_id        index = {};
 	struct m0_cas_rec_reply rep;
 	const struct m0_fid     ifid = IFID(2, 3);
-
-	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
 
 	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
 	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
@@ -1582,42 +1747,50 @@ static void next_ver(void)
 	put_get_verified(&index, &keys, &values, &values, version[V_PAST],
 			 COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_PAST], COF_VERSIONED));
 
 	/* Only even records will be alive in the future. */
 	del_get_verified(&index, &kodd, version[V_FUTURE],
 			 COF_VERSIONED, COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &kodd,
+				  version[V_FUTURE], COF_VERSIONED));
+	M0_UT_ASSERT(has_versions(&index, &keven,
+				  version[V_PAST], COF_VERSIONED));
 
 	/*
 	 * Case:
 	 * NEXT with the first alive key and the number records equal to
 	 * (number_of_alive_keys - 1) should return all the alive keys.
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0),
-		      keys.ov_vec.v_nr / 2, &keven, COF_VERSIONED);
+	next_keys_verified(&index, &M0_BUFVEC_SLICE(&keys, 0),
+			   keys.ov_vec.v_nr / 2, &keven, COF_VERSIONED);
 
 	/*
 	 * Case:
 	 * Requesting one record with NEXT with the first dead key
 	 * should return nothing (ENOENT).
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&kodd, 0), 1, NULL,
-		      COF_VERSIONED);
+	next_keys_verified(&index, &M0_BUFVEC_SLICE(&kodd, 0), 1, NULL,
+			   COF_VERSIONED);
 
 	/*
 	 * Case:
 	 * Requesting one record with NEXT(SLANT) with the first dead key
 	 * should return the second alive key.
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&kodd, 0), 1,
-		      &M0_BUFVEC_SLICE(&keven, 1), COF_SLANT | COF_VERSIONED);
+	next_keys_verified(&index, &M0_BUFVEC_SLICE(&kodd, 0), 1,
+			   &M0_BUFVEC_SLICE(&keven, 1),
+			   COF_SLANT | COF_VERSIONED);
 
 	/*
 	 * Case:
 	 * Requesting NEXT(SLANT) record with with last dead key should
 	 * return -ENOENT.
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&kodd, kodd.ov_vec.v_nr - 1), 1,
-		      NULL, COF_SLANT | COF_VERSIONED);
+	next_keys_verified(&index,
+			   &M0_BUFVEC_SLICE(&kodd, kodd.ov_vec.v_nr - 1), 1,
+			   NULL, COF_SLANT | COF_VERSIONED);
 
 	/*
 	 * Case:
@@ -1625,9 +1798,9 @@ static void next_ver(void)
 	 * start key equal to the first alive record should return one single
 	 * pair with the next alive record.
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&keven, 0), 1,
-		      &M0_BUFVEC_SLICE(&keven, 1),
-		      COF_SLANT | COF_EXCLUDE_START_KEY | COF_VERSIONED);
+	next_keys_verified(&index, &M0_BUFVEC_SLICE(&keven, 0), 1,
+			   &M0_BUFVEC_SLICE(&keven, 1),
+			   COF_SLANT | COF_EXCLUDE_START_KEY | COF_VERSIONED);
 
 	/* Now the index should have no keys. */
 	del_get_verified(&index, &keven, version[V_FUTURE],
@@ -1638,8 +1811,8 @@ static void next_ver(void)
 	 * Requesting one record with NEXT(SLANT) should yield no keys at all
 	 * (ENOENT) on an index that does not have alive records.
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0), 1, NULL,
-		      COF_VERSIONED);
+	next_keys_verified(&index, &M0_BUFVEC_SLICE(&keys, 0), 1, NULL,
+			   COF_VERSIONED);
 
 	/*
 	 * Case:
@@ -1647,8 +1820,8 @@ static void next_ver(void)
 	 * NEXT should yield all the keys that were inserted initially even
 	 * if all of them have tombstones.
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0),
-		      keys.ov_vec.v_nr, &keys, 0);
+	next_keys_verified(&index, &M0_BUFVEC_SLICE(&keys, 0),
+			   keys.ov_vec.v_nr, &keys, 0);
 
 	/* Now insert a non-versioned record at the "end". */
 	del_get_verified(&index, &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 1),
@@ -1660,15 +1833,17 @@ static void next_ver(void)
 	/*
 	 * Case:
 	 * A record without version should be treaten as an alive record.
-	 * Requesting one record with NEXT(SLANT) with stat key equal to the
-	 * last dead record should the non-versioned record.
+	 * Requesting one record with NEXT(SLANT) with start key equal to the
+	 * last dead record should yield the non-versioned record.
 	 * However, if SLANT was not set it should still return ENOENT.
 	 */
-	next_verified(&index, &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 2), 1,
-		      &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 1),
-		      COF_SLANT | COF_VERSIONED);
-	next_verified(&index, &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 2), 1,
-		      NULL , COF_VERSIONED);
+	next_keys_verified(&index,
+			   &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 2), 1,
+			   &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 1),
+			   COF_SLANT | COF_VERSIONED);
+	next_keys_verified(&index,
+			   &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 2), 1,
+			   NULL , COF_VERSIONED);
 
 	m0_bufvec_free(&keys);
 	m0_bufvec_free(&values);
@@ -1678,7 +1853,120 @@ static void next_ver(void)
 	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
-	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
+}
+
+/*
+ * A test case where we are verifying that version and tombstones exposed
+ * by CAS API (see COF_VERSIONED and COF_SHOW_DEAD) show expected
+ * behavior with combinations of PUT, DEL and NEXT.
+ */
+static void next_ver_exposed(void)
+{
+	enum { V_PAST, V_FUTURE, V_NR };
+	struct m0_bufvec        keys;
+	struct m0_bufvec        values;
+	struct m0_bufvec        expected_values;
+	struct m0_bufvec        kodd;
+	struct m0_bufvec        keven;
+	int                     rc;
+	uint64_t                version[V_NR] = { 2, 3 };
+	int                     i;
+	struct m0_cas_id        index = {};
+	struct m0_cas_rec_reply rep;
+	struct m0_cas_kv_ver   *versions;
+	bool                    is_even;
+	const struct m0_fid     ifid = IFID(2, 3);
+
+	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
+	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	index.ci_fid = ifid;
+
+
+	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr == COUNT);
+	M0_ALLOC_ARR(versions, keys.ov_vec.v_nr);
+	M0_UT_ASSERT(versions != NULL);
+	rc = m0_bufvec_alloc(&values, keys.ov_vec.v_nr, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_bufvec_alloc(&expected_values,
+			     keys.ov_vec.v_nr, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr == values.ov_vec.v_nr);
+	rc = m0_bufvec_alloc(&kodd, keys.ov_vec.v_nr / 2, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_bufvec_alloc(&keven, keys.ov_vec.v_nr / 2, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+
+	for (i = 0; i < keys.ov_vec.v_nr; i++) {
+		is_even = (i & 0x01) == 0 ;
+
+		*(uint64_t*)keys.ov_buf[i] = i;
+		*(uint64_t*)values.ov_buf[i] = i;
+		if (is_even)
+			*(uint64_t*)expected_values.ov_buf[i] = i;
+		else
+			expected_values.ov_vec.v_count[i] = 0;
+
+		memcpy((is_even ? &keven : &kodd)->ov_buf[i / 2],
+		       keys.ov_buf[i], keys.ov_vec.v_count[i]);
+
+		versions[i].ckv_ts.dts_phys =
+			version[!is_even ? V_FUTURE : V_PAST];
+		versions[i].ckv_tombstone = !is_even;
+	}
+
+	/* Insert all the keys. */
+	put_get_verified(&index, &keys, &values, &values, version[V_PAST],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+
+	/* Only even records will be alive in the future. */
+	del_get_verified(&index, &kodd, version[V_FUTURE],
+			 COF_VERSIONED, COF_VERSIONED);
+
+	/*
+	 * Case:
+	 * If even records are alive and odd records are dead then
+	 * NEXT must return all the requested keys if COF_SHOW_DEAD is set.
+	 * The dead records must me "younger" then the alive records,
+	 * and the dead record must have tombstones set.
+	 */
+	next_records_verified(&index,
+			      &M0_BUFVEC_SLICE(&keys, 0), keys.ov_vec.v_nr,
+			      &keys, &expected_values, versions,
+			      COF_VERSIONED | COF_SHOW_DEAD);
+
+	/*
+	 * Case:
+	 * When COF_SHOW_DEAD is specified, dead record is not skipped.
+	 */
+	next_records_verified(&index,
+			      &M0_BUFVEC_SLICE(&keys, 1), 1,
+			      &M0_BUFVEC_SLICE(&keys, 1),
+			      &expected_values, versions + 1,
+			      COF_VERSIONED | COF_SHOW_DEAD);
+
+	/*
+	 * Case:
+	 * Dead record is not skipped when (SHOW_DEAD | SLANT) is specified.
+	 */
+	next_records_verified(&index,
+			      &M0_BUFVEC_SLICE(&keys, 1), 1,
+			      &M0_BUFVEC_SLICE(&keys, 1),
+			      &expected_values, versions + 1,
+			      COF_VERSIONED | COF_SHOW_DEAD | COF_SLANT);
+
+	m0_bufvec_free(&keys);
+	m0_bufvec_free(&values);
+	m0_bufvec_free(&keven);
+	m0_bufvec_free(&kodd);
+	m0_free(versions);
+
+	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
 }
 #undef M0_BUFVEC_SLICE
 
@@ -2043,7 +2331,6 @@ static void put_overwrite_ver(void)
 	 */
 	M0_CASSERT((UINT64_MAX / COUNT) > (1L << V_NR));
 
-	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
 	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
 
 	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
@@ -2070,21 +2357,29 @@ static void put_overwrite_ver(void)
 	put_get_verified(&index, &keys, &vals[V_NOW], &vals[V_NOW],
 			 version[V_NOW], COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_NOW], COF_VERSIONED));
 
 	/* PUT at "future" (overwrites "now"). */
 	put_get_verified(&index, &keys, &vals[V_FUTURE], &vals[V_FUTURE],
 			 version[V_FUTURE], COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_FUTURE], COF_VERSIONED));
 
 	/* PUT at "past" (values should not be changed) */
 	put_get_verified(&index, &keys, &vals[V_PAST], &vals[V_FUTURE],
 			 version[V_PAST], COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_FUTURE], COF_VERSIONED));
 
 	/* However, empty version disables the versioned behavior. */
 	put_get_verified(&index, &keys, &vals[V_PAST], &vals[V_PAST],
 			 version[V_NONE], COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_NONE], COF_VERSIONED));
 
 	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, rep);
 	M0_UT_ASSERT(rc == 0);
@@ -2116,7 +2411,6 @@ static void put_overwrite_ver(void)
 		m0_bufvec_free(&vals[j]);
 	m0_bufvec_free(&keys);
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
-	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
 }
 
 /*
@@ -2128,7 +2422,6 @@ static void put_ver(void)
 	struct m0_bufvec values;
 	int              rc;
 
-	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
 	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
 
 	rc = m0_bufvec_alloc(&keys, 1, sizeof(uint64_t));
@@ -2145,7 +2438,6 @@ static void put_ver(void)
 	m0_bufvec_free(&values);
 
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
-	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
 }
 
 /*
@@ -2759,7 +3051,6 @@ static void del_ver(void)
 	struct m0_bufvec values;
 	int              rc;
 
-	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
 	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
 
 	rc = m0_bufvec_alloc(&keys, 1, sizeof(uint64_t));
@@ -2779,7 +3070,84 @@ static void del_ver(void)
 	m0_bufvec_free(&values);
 
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
-	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
+}
+
+/*
+ * Ensures that versions exposed by GET are visible.
+ */
+static void get_ver_exposed(void)
+{
+	struct m0_bufvec        keys;
+	struct m0_bufvec        values;
+	struct m0_cas_rec_reply rep;
+	int                     rc;
+	const struct m0_fid     ifid = IFID(2, 3);
+	struct m0_cas_id        index = {};
+	enum v { V_NONE, V_PAST, V_NOW, V_FUTURE, V_NR};
+	uint64_t                version[V_NR] = { 0, 1, 2, 3,};
+
+	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
+
+	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	index.ci_fid = ifid;
+
+	rc = m0_bufvec_alloc(&keys, 1, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_bufvec_alloc(&values, 1, sizeof(uint64_t));
+	M0_UT_ASSERT(rc == 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr != 0);
+	M0_UT_ASSERT(keys.ov_vec.v_nr == values.ov_vec.v_nr);
+	m0_forall(i, keys.ov_vec.v_nr, (*(uint64_t*)keys.ov_buf[i]   = i,
+					*(uint64_t*)values.ov_buf[i] = i * i,
+					true));
+
+	/* Insert @past */
+	put_get_verified(&index, &keys, &values, &values, version[V_PAST],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_PAST], COF_VERSIONED));
+
+	/* Delete @future */
+	del_get_verified(&index, &keys, version[V_FUTURE],
+			 COF_VERSIONED, COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_FUTURE], COF_VERSIONED));
+
+	/* Cleanup */
+	del_get_verified(&index, &keys, version[V_NONE], 0, 0);
+
+	/* Delete @now */
+	del_get_verified(&index, &keys, version[V_NOW],
+			 COF_VERSIONED, COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_NOW], COF_VERSIONED));
+	M0_UT_ASSERT(has_tombstones(&index, &keys));
+
+	/* Insert @past */
+	put_get_verified(&index, &keys, &values, NULL, version[V_PAST],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_NOW], COF_VERSIONED));
+	M0_UT_ASSERT(has_tombstones(&index, &keys));
+
+	/* Insert @future */
+	put_get_verified(&index, &keys, &values, NULL, version[V_FUTURE],
+			 COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+	M0_UT_ASSERT(has_versions(&index, &keys,
+				  version[V_FUTURE], COF_VERSIONED));
+	M0_UT_ASSERT(!has_tombstones(&index, &keys));
+
+
+	m0_bufvec_free(&keys);
+	m0_bufvec_free(&values);
+
+	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
+	M0_UT_ASSERT(rc == 0);
+	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
 }
 
 static void del(void)
@@ -3313,9 +3681,7 @@ static void put_del_ver_case_execute(const struct put_del_ver_case *c,
 }
 
 /*
- * Versions are not exposed via CAS client API but we can make an educated
- * guess by executing a set of destructive operations to verify
- * the following properties:
+ * The function verifies the following properties:
  *  Put a tombstone:
  *   DEL@version
  *   has_tombstone => true
@@ -3326,9 +3692,9 @@ static void put_del_ver_case_execute(const struct put_del_ver_case *c,
  *   PUT@(version + 1)
  *   has_tombstone => false.
  */
-static void ensure_has_version(struct m0_cas_id *index,
-			       const struct m0_bufvec *keys,
-			       uint64_t version)
+static void verify_version_properties(struct m0_cas_id       *index,
+				      const struct m0_bufvec *keys,
+				      uint64_t                version)
 {
 	int                      rc;
 	struct m0_cas_get_reply *get_rep;
@@ -3439,7 +3805,8 @@ static void put_del_ver_case_verify(const struct put_del_ver_case *c,
 		break;
 	}
 
-	ensure_has_version(index, keys, FUTURE);
+	M0_UT_ASSERT(has_versions(index, keys, FUTURE, COF_VERSIONED));
+	verify_version_properties(index, keys, FUTURE);
 }
 
 static void put_del_ver(void)
@@ -3503,8 +3870,6 @@ static void put_del_ver(void)
 	struct m0_cas_rec_reply rep;
 	const struct m0_fid     ifid = IFID(2, 3);
 
-	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
-
 	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
 	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
@@ -3519,7 +3884,6 @@ static void put_del_ver(void)
 	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
-	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
 }
 
 struct m0_ut_suite cas_client_ut = {
@@ -3572,6 +3936,8 @@ struct m0_ut_suite cas_client_ut = {
 		{ "del-ver",                del_ver,                "Ivan"   },
 		{ "next-ver",               next_ver,               "Ivan"   },
 		{ "put-del-ver",            put_del_ver,            "Ivan"   },
+		{ "next-ver-exposed",       next_ver_exposed,       "Ivan"   },
+		{ "get-ver-exposed",        get_ver_exposed,        "Ivan"   },
 		{ NULL, NULL }
 	}
 };

--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -38,7 +38,7 @@
 #include "cas/ctg_store.h"             /* m0_ctg_recs_nr */
 #include "lib/finject.h"
 #include "dtm0/dtx.h"                  /* m0_dtm0_dtx */
-#include "cas/cas.h"                   /* m0_cas_kv_ver */
+#include "cas/cas.h"                   /* m0_crv      */
 
 #define SERVER_LOG_FILE_NAME       "cas_server.log"
 #define IFID(x, y) M0_FID_TINIT('i', (x), (y))
@@ -1431,7 +1431,7 @@ static bool has_versions(struct m0_cas_id *index,
 			       M0_IN(get_rep[i].cge_rc, (0, -ENOENT))));
 
 	result = m0_forall(i, keys->ov_vec.v_nr,
-			   get_rep[i].cge_ver.ckv_ts.dts_phys == version);
+			   m0_crv_ts(&get_rep[i].cge_ver).dts_phys == version);
 
 	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
 	m0_free(get_rep);
@@ -1457,22 +1457,21 @@ static bool has_tombstones(struct m0_cas_id       *index,
 
 	/* Ensure all-or-nothing (either all have tbs or there are no tbs). */
 	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
-			     get_rep[0].cge_ver.ckv_tombstone ==
-			     get_rep[i].cge_ver.ckv_tombstone));
+			     m0_crv_tbs(&get_rep[0].cge_ver)==
+			     m0_crv_tbs(&get_rep[i].cge_ver)));
 
 	/* Ensure -ENOENT matches with tombstone flag. */
 	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
-		       ergo(!m0_dtm0_ts_is_none(&get_rep[i].cge_ver.ckv_ts),
-				    (get_rep[i].cge_ver.ckv_tombstone ==
-				     (get_rep[i].cge_rc == -ENOENT)))));
+		       ergo(!m0_crv_is_none(&get_rep[i].cge_ver),
+				    m0_crv_tbs(&get_rep[i].cge_ver) ==
+				     (get_rep[i].cge_rc == -ENOENT))));
 
 	/* Ensure versions are always present on dead records. */
 	M0_UT_ASSERT(m0_forall(i, keys->ov_vec.v_nr,
-			       ergo(get_rep[i].cge_ver.ckv_tombstone,
-				    !m0_dtm0_ts_is_none(
-						&get_rep[i].cge_ver.ckv_ts))));
+			       ergo(m0_crv_tbs(&get_rep[i].cge_ver),
+				    !m0_crv_is_none(&get_rep[i].cge_ver))));
 
-	result = get_rep[0].cge_ver.ckv_tombstone;
+	result = m0_crv_tbs(&get_rep[0].cge_ver);
 
 	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
 	memset(get_rep, 0, sizeof(get_rep) * keys->ov_vec.v_nr);
@@ -1499,11 +1498,11 @@ static void next_reply_breakdown(struct m0_cas_next_reply  *next_rep,
 				 m0_bcount_t                nr,
 				 struct m0_bufvec          *out_key,
 				 struct m0_bufvec          *out_val,
-				 struct m0_cas_kv_ver     **out_ver)
+				 struct m0_crv            **out_ver)
 {
-	int                   rc;
-	m0_bcount_t           i;
-	struct m0_cas_kv_ver *ver;
+	int            rc;
+	m0_bcount_t    i;
+	struct m0_crv *ver;
 
 	rc = m0_bufvec_empty_alloc(out_key, nr);
 	M0_UT_ASSERT(rc == 0);
@@ -1535,7 +1534,7 @@ static void next_records_verified(struct m0_cas_id     *index,
 				  uint32_t              requested_keys_nr,
 				  struct m0_bufvec     *expected_keys,
 				  struct m0_bufvec     *expected_values,
-				  struct m0_cas_kv_ver *expected_versions,
+				  struct m0_crv        *expected_versions,
 				  int                   flags)
 {
 	struct m0_cas_next_reply *next_rep;
@@ -1543,7 +1542,7 @@ static void next_records_verified(struct m0_cas_id     *index,
 	int                       rc;
 	struct m0_bufvec          actual_keys;
 	struct m0_bufvec          actual_values;
-	struct m0_cas_kv_ver     *actual_versions;
+	struct m0_crv            *actual_versions;
 
 	M0_ALLOC_ARR(next_rep, requested_keys_nr);
 	M0_UT_ASSERT(next_rep != NULL);
@@ -1873,7 +1872,7 @@ static void next_ver_exposed(void)
 	int                     i;
 	struct m0_cas_id        index = {};
 	struct m0_cas_rec_reply rep;
-	struct m0_cas_kv_ver   *versions;
+	struct m0_crv          *versions;
 	bool                    is_even;
 	const struct m0_fid     ifid = IFID(2, 3);
 
@@ -1912,9 +1911,12 @@ static void next_ver_exposed(void)
 		memcpy((is_even ? &keven : &kodd)->ov_buf[i / 2],
 		       keys.ov_buf[i], keys.ov_vec.v_count[i]);
 
-		versions[i].ckv_ts.dts_phys =
-			version[!is_even ? V_FUTURE : V_PAST];
-		versions[i].ckv_tombstone = !is_even;
+		m0_crv_init(&versions[i],
+			    &(struct m0_dtm0_ts) {
+				.dts_phys =
+				version[!is_even ? V_FUTURE : V_PAST],
+			    },
+			    !is_even);
 	}
 
 	/* Insert all the keys. */

--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -1474,7 +1474,7 @@ static bool has_tombstones(struct m0_cas_id       *index,
 	result = m0_crv_tbs(&get_rep[0].cge_ver);
 
 	ut_get_rep_clear(get_rep, keys->ov_vec.v_nr);
-	memset(get_rep, 0, sizeof(get_rep) * keys->ov_vec.v_nr);
+	memset(get_rep, 0, sizeof(*get_rep) * keys->ov_vec.v_nr);
 
 	/*
 	 * Additionally, ensure that all the records are visible

--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -1527,11 +1527,19 @@ static void del_get_verified(struct m0_cas_id *index,
 	M0_BUFVEC_INIT_BUF((__bufvec)->ov_buf + (__idx), \
 			   (__bufvec)->ov_vec.v_count + (__idx))
 
+#define M0_BUFVEC_SUB(__bufvec, __idx, __count)	(struct m0_bufvec) {	\
+	.ov_vec = {							\
+		.v_nr = (__count),					\
+		.v_count = (__bufvec)->ov_vec.v_count + (__idx),	\
+	},								\
+	.ov_buf = (__bufvec)->ov_buf + (__idx)				\
+}
+
 /*
  * A test case where we are verifying that NEXT works well with
  * combinations of PUT and DEL.
  */
-void next_ver(void)
+static void next_ver(void)
 {
 	enum { V_PAST, V_FUTURE, V_NR };
 	struct m0_bufvec        keys;
@@ -1605,6 +1613,14 @@ void next_ver(void)
 
 	/*
 	 * Case:
+	 * Requesting NEXT(SLANT) record with with last dead key should
+	 * return -ENOENT.
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&kodd, kodd.ov_vec.v_nr - 1), 1,
+		      NULL, COF_SLANT | COF_VERSIONED);
+
+	/*
+	 * Case:
 	 * Requesting one record with NEXT(SLANT|EXECLUDE_START_KEY) with
 	 * start key equal to the first alive record should return one single
 	 * pair with the next alive record.
@@ -1620,7 +1636,7 @@ void next_ver(void)
 	/*
 	 * Case:
 	 * Requesting one record with NEXT(SLANT) should yield no keys at all
-	 * on an empty index (ENOENT).
+	 * (ENOENT) on an index that does not have alive records.
 	 */
 	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0), 1, NULL,
 		      COF_VERSIONED);
@@ -1628,10 +1644,31 @@ void next_ver(void)
 	/*
 	 * Case:
 	 * When version-awre behavior is disabled (no COF_VERSIONED),
-	 * NEXT should yield all the keys that were inserted initially.
+	 * NEXT should yield all the keys that were inserted initially even
+	 * if all of them have tombstones.
 	 */
 	next_verified(&index, &M0_BUFVEC_SLICE(&keys, 0),
 		      keys.ov_vec.v_nr, &keys, 0);
+
+	/* Now insert a non-versioned record at the "end". */
+	del_get_verified(&index, &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 1),
+			 0, 0, 0);
+	put_get_verified(&index, &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 1),
+			 &M0_BUFVEC_SLICE(&values, values.ov_vec.v_nr - 1),
+			 &M0_BUFVEC_SLICE(&values, values.ov_vec.v_nr - 1),
+			 0, 0, 0);
+	/*
+	 * Case:
+	 * A record without version should be treaten as an alive record.
+	 * Requesting one record with NEXT(SLANT) with stat key equal to the
+	 * last dead record should the non-versioned record.
+	 * However, if SLANT was not set it should still return ENOENT.
+	 */
+	next_verified(&index, &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 2), 1,
+		      &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 1),
+		      COF_SLANT | COF_VERSIONED);
+	next_verified(&index, &M0_BUFVEC_SLICE(&keys, keys.ov_vec.v_nr - 2), 1,
+		      NULL , COF_VERSIONED);
 
 	m0_bufvec_free(&keys);
 	m0_bufvec_free(&values);
@@ -2000,7 +2037,11 @@ static void put_overwrite_ver(void)
 	struct m0_cas_rec_reply  rep[1];
 	const struct m0_fid      ifid = IFID(2, 3);
 
-	M0_UT_ASSERT((UINT64_MAX / COUNT) > (1L << V_NR));
+	/*
+	 * For every i-th key we have V_NR values from i to i << (V_NR - 1).
+	 * Ensure it will not overflow.
+	 */
+	M0_CASSERT((UINT64_MAX / COUNT) > (1L << V_NR));
 
 	m0_fi_enable("cas_fom_tick", "skip-dtm0-phases");
 	casc_ut_init(&casc_ut_sctx, &casc_ut_cctx);
@@ -2017,36 +2058,60 @@ static void put_overwrite_ver(void)
 
 	for (i = 0; i < keys.ov_vec.v_nr; i++) {
 		*(uint64_t*)keys.ov_buf[i] = i;
-		for (j = 0; j < V_NR; j++) {
+		for (j = 0; j < V_NR; j++)
 			*(uint64_t*)vals[j].ov_buf[i] = i << j;
-			M0_UT_ASSERT(keys.ov_vec.v_nr == vals[j].ov_vec.v_nr);
-		}
 	}
 
 	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, rep);
 	M0_UT_ASSERT(rc == 0);
 	index.ci_fid = ifid;
 
-	/* PUT@now */
-	put_get_verified(&index, &keys, vals + V_NOW, vals + V_NOW,
-			 version[V_NOW],
-			 COF_VERSIONED | COF_OVERWRITE,
+	/* PUT at "now". */
+	put_get_verified(&index, &keys, &vals[V_NOW], &vals[V_NOW],
+			 version[V_NOW], COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
 
-	/* PUT@future */
-	put_get_verified(&index, &keys, vals + V_FUTURE, vals + V_FUTURE,
-			 version[V_FUTURE],
-			 COF_VERSIONED | COF_OVERWRITE,
+	/* PUT at "future" (overwrites "now"). */
+	put_get_verified(&index, &keys, &vals[V_FUTURE], &vals[V_FUTURE],
+			 version[V_FUTURE], COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
 
-	/* PUT@past (values should not be changed) */
-	put_get_verified(&index, &keys, vals + V_PAST, vals + V_FUTURE,
-			 version[V_PAST],
-			 COF_VERSIONED | COF_OVERWRITE,
+	/* PUT at "past" (values should not be changed) */
+	put_get_verified(&index, &keys, &vals[V_PAST], &vals[V_FUTURE],
+			 version[V_PAST], COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+
+	/* However, empty version disables the versioned behavior. */
+	put_get_verified(&index, &keys, &vals[V_PAST], &vals[V_PAST],
+			 version[V_NONE], COF_VERSIONED | COF_OVERWRITE,
 			 COF_VERSIONED);
 
 	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, rep);
 	M0_UT_ASSERT(rc == 0);
+
+	rc = ut_idx_create(&casc_ut_cctx, &ifid, 1, rep);
+	M0_UT_ASSERT(rc == 0);
+	index.ci_fid = ifid;
+
+	/*
+	 * Insertion of a pair without COF_OVERWRITE flag set disables
+	 * the versioned behavior even if the version was specified.
+	 * Let's insert some values first.
+	 */
+	put_get_verified(&index, &keys, &vals[V_FUTURE], &vals[V_FUTURE],
+			 version[V_FUTURE], COF_VERSIONED, COF_VERSIONED);
+	/*
+	 * And now let's check if they are overwritten. We expect that
+	 * the values will be overwritten because the previous operation
+	 * inserted the records but did not set their versions.
+	 */
+	put_get_verified(&index, &keys, &vals[V_PAST], &vals[V_PAST],
+			 version[V_PAST], COF_VERSIONED | COF_OVERWRITE,
+			 COF_VERSIONED);
+
+	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, rep);
+	M0_UT_ASSERT(rc == 0);
+
 	for (j = 0; j < V_NR; j++)
 		m0_bufvec_free(&vals[j]);
 	m0_bufvec_free(&keys);
@@ -3208,38 +3273,30 @@ enum named_op {
 
 /* PUT or DEL operation with a human-readable version description. */
 struct cas_ver_op {
-	enum named_version ver;
-	enum named_op      op;
-	uint64_t           key;
-	uint64_t           value;
+	enum named_version       ver;
+	enum named_op            op;
+	const struct m0_bufvec  *keys;
+	const struct m0_bufvec  *values;
 };
 
 struct put_del_ver_case {
+	/* An operation to be executed first. */
 	struct cas_ver_op  before;
+	/* Second operation that happen right after the first one. */
 	struct cas_ver_op  after;
-	enum named_outcome outcome;
 };
 
 static void cas_ver_op_execute(const struct cas_ver_op *cvop,
 			       struct m0_cas_id        *index)
 {
-	m0_bcount_t      nr_bytes = sizeof(cvop->key);
-	uint64_t         version = cvop->ver;
-	const void *key_data = &cvop->key;
-	const void *val_data = &cvop->value;
-	const struct m0_bufvec keys =
-		M0_BUFVEC_INIT_BUF((void **) &key_data, &nr_bytes);
-	const struct m0_bufvec values =
-		M0_BUFVEC_INIT_BUF((void **) &val_data, &nr_bytes);
-	M0_CASSERT(sizeof(cvop->key) == sizeof(cvop->value));
-
 	switch (cvop->op) {
 	case PUT:
-		ut_rec_common_put_verified(index, &keys, &values, version,
+		ut_rec_common_put_verified(index, cvop->keys, cvop->values,
+					   cvop->ver,
 					   COF_VERSIONED | COF_OVERWRITE);
 		break;
 	case DEL:
-		ut_rec_common_del_verified(index, &keys, version,
+		ut_rec_common_del_verified(index, cvop->keys, cvop->ver,
 					   COF_VERSIONED);
 		break;
 	case NOP:
@@ -3256,9 +3313,9 @@ static void put_del_ver_case_execute(const struct put_del_ver_case *c,
 }
 
 /*
- * Versions are not exposed via CAS client API but
- * we can make an educated guess by executing a set of destructive operations
- * to verify the following properties:
+ * Versions are not exposed via CAS client API but we can make an educated
+ * guess by executing a set of destructive operations to verify
+ * the following properties:
  *  Put a tombstone:
  *   DEL@version
  *   has_tombstone => true
@@ -3276,6 +3333,7 @@ static void ensure_has_version(struct m0_cas_id *index,
 	int                      rc;
 	struct m0_cas_get_reply *get_rep;
 	struct m0_bufvec         values;
+	bool                     tombstones;
 
 	M0_ALLOC_ARR(get_rep, keys->ov_vec.v_nr);
 	M0_UT_ASSERT(get_rep != NULL);
@@ -3288,6 +3346,8 @@ static void ensure_has_version(struct m0_cas_id *index,
 	rc = get_reply2bufvec(get_rep, keys->ov_vec.v_nr, &values);
 	M0_UT_ASSERT(rc == 0);
 	m0_free(get_rep);
+	/* Save the existing tombstones (assuming all-or-nothing). */
+	tombstones = has_tombstones(index, keys);
 
 	ut_rec_common_del_verified(index, keys, version, COF_VERSIONED);
 	M0_UT_ASSERT(has_tombstones(index, keys));
@@ -3305,105 +3365,133 @@ static void ensure_has_version(struct m0_cas_id *index,
 	ut_rec_common_put_verified(index, keys, &values, version,
 				   COF_VERSIONED | COF_OVERWRITE);
 	M0_UT_ASSERT(!has_tombstones(index, keys));
+	/* Restore the existing tombstones. */
+	if (tombstones) {
+		ut_rec_common_del_verified(index, keys, version,
+					   COF_VERSIONED);
+		M0_UT_ASSERT(has_tombstones(index, keys));
+	}
+}
+
+static enum named_outcome outcome(const struct put_del_ver_case *c)
+{
+	const struct cas_ver_op *before = &c->before;
+	const struct cas_ver_op *after  = &c->after;
+	const struct cas_ver_op *winner;
+
+	/* Get the operation with the "latest" version. */
+	if (before->ver == FUTURE)
+		winner = before;
+	else if (after->ver == FUTURE)
+		winner = after;
+	else
+		M0_IMPOSSIBLE("Did you forget to add an op with FUTURE?");
+
+	if (winner->op == DEL)
+		return TOMBSTONE;
+	else if (winner == before)
+		return PRESERVED;
+	else
+		return OVERWRITTEN;
 }
 
 static void put_del_ver_case_verify(const struct put_del_ver_case *c,
 				    struct m0_cas_id              *index)
 {
-	m0_bcount_t            nr_bytes = sizeof(c->before.key);
-	const void *key_data = &c->before.key;
-	const struct m0_bufvec keys =
-		M0_BUFVEC_INIT_BUF((void **) &key_data, &nr_bytes);
-	const void *before_val_data = &c->before.value;
-	const struct m0_bufvec before_values =
-		M0_BUFVEC_INIT_BUF((void **) &before_val_data, &nr_bytes);
-	const void *after_val_data = &c->after.value;
-	const struct m0_bufvec after_values =
-		M0_BUFVEC_INIT_BUF((void **) &after_val_data, &nr_bytes);
+	const struct m0_bufvec *keys = c->before.keys;
+	const struct m0_bufvec *before_values = c->before.values;
+	const struct m0_bufvec *after_values = c->after.values;
 
-	switch (c->outcome) {
+	switch (outcome(c)) {
 	case TOMBSTONE:
-		M0_UT_ASSERT(has_tombstones(index, &keys));
-		M0_UT_ASSERT(!has_values(index, &keys, &before_values,
+		M0_UT_ASSERT(has_tombstones(index, keys));
+		M0_UT_ASSERT(!has_values(index, keys, before_values,
 				       COF_VERSIONED));
-		M0_UT_ASSERT(!has_values(index, &keys, &after_values,
+		M0_UT_ASSERT(!has_values(index, keys, after_values,
 				       COF_VERSIONED));
 		break;
 	case OVERWRITTEN:
-		M0_UT_ASSERT(!has_tombstones(index, &keys));
+		M0_UT_ASSERT(!has_tombstones(index, keys));
 		/*
 		 * The values should be overwritten no matter what behavior we
 		 * have specified.
 		 */
-		M0_UT_ASSERT(has_values(index, &keys, &after_values, 0));
-		M0_UT_ASSERT(has_values(index, &keys, &after_values,
+		M0_UT_ASSERT(has_values(index, keys, after_values, 0));
+		M0_UT_ASSERT(has_values(index, keys, after_values,
 				       COF_VERSIONED));
-		M0_UT_ASSERT(!has_values(index, &keys, &before_values, 0));
-		M0_UT_ASSERT(!has_values(index, &keys, &before_values,
+		M0_UT_ASSERT(!has_values(index, keys, before_values, 0));
+		M0_UT_ASSERT(!has_values(index, keys, before_values,
 				       COF_VERSIONED));
 		break;
 	case PRESERVED:
-		M0_UT_ASSERT(!has_tombstones(index, &keys));
+		M0_UT_ASSERT(!has_tombstones(index, keys));
 		/*
 		 * The values should be preserved, and it should be visible
 		 * even if the versioned behavior was not requested by GET
 		 * operation.
 		 */
-		M0_UT_ASSERT(has_values(index, &keys, &before_values, 0));
-		M0_UT_ASSERT(has_values(index, &keys, &before_values,
+		M0_UT_ASSERT(has_values(index, keys, before_values, 0));
+		M0_UT_ASSERT(has_values(index, keys, before_values,
 				       COF_VERSIONED));
-		M0_UT_ASSERT(!has_values(index, &keys, &after_values, 0));
-		M0_UT_ASSERT(!has_values(index, &keys, &after_values,
+		M0_UT_ASSERT(!has_values(index, keys, after_values, 0));
+		M0_UT_ASSERT(!has_values(index, keys, after_values,
 				       COF_VERSIONED));
 		break;
 	}
 
-	ensure_has_version(index, &keys, FUTURE);
-
-	/* Wipe out the records at the end of the iteration. */
-	ut_rec_common_del_verified(index, &keys, 0, 0);
+	ensure_has_version(index, keys, FUTURE);
 }
 
 static void put_del_ver(void)
 {
-#define BEFORE(_what, _when)         \
-	.before = {                  \
-		.ver   = _when,      \
-		.op    = _what,      \
-		.key   = 1,          \
-		.value = 1,          \
+	const uint64_t           key = 1;
+	const uint64_t           before_value = 1;
+	const uint64_t           after_value  = 2;
+	const m0_bcount_t        nr_bytes = sizeof(key);
+	const void              *key_data = &key;
+	const void              *before_val_data = &before_value;
+	const void              *after_val_data = &after_value;
+	const struct m0_bufvec   keys =
+		M0_BUFVEC_INIT_BUF((void **) &key_data,
+				   (m0_bcount_t *) &nr_bytes);
+	const struct m0_bufvec   before_values =
+		M0_BUFVEC_INIT_BUF((void **) &before_val_data,
+				   (m0_bcount_t *) &nr_bytes);
+	const struct m0_bufvec   after_values =
+		M0_BUFVEC_INIT_BUF((void **) &after_val_data,
+				   (m0_bcount_t *) &nr_bytes);
+
+#define BEFORE(_what, _when)              \
+	.before = {                       \
+		.ver   = _when,           \
+		.op    = _what,           \
+		.keys   = &keys,          \
+		.values = &before_values, \
 	},
 
-#define AFTER(_what, _when)         \
-	.after = {                  \
-		.ver   = _when,     \
-		.op    = _what,     \
-		.key   = 1,         \
-		.value = 2,         \
+#define AFTER(_what, _when)              \
+	.after = {                       \
+		.ver    = _when,         \
+		.op     = _what,         \
+		.keys   = &keys,         \
+		.values = &after_values, \
 	},
 
-#define OUTCOME(_result) .outcome = _result,
+	const struct put_del_ver_case cases[] = {
+		{ BEFORE(PUT, PAST)   AFTER(DEL, FUTURE) },
+		{ BEFORE(PUT, PAST)   AFTER(PUT, FUTURE) },
 
-	/*
-	 * TODO: the outcome could be inferred from the newest operation:
-	 * PUT@FUTURE is always preserved or overwritten (depending on the pos).
-	 * DEL@FUTURE always keeps the tombstone intact.
-	 */
-	static const struct put_del_ver_case cases[] = {
-		{ BEFORE(PUT, PAST)   AFTER(DEL, FUTURE) OUTCOME(TOMBSTONE)   },
-		{ BEFORE(PUT, PAST)   AFTER(PUT, FUTURE) OUTCOME(OVERWRITTEN) },
+		{ BEFORE(PUT, FUTURE) AFTER(PUT, PAST)   },
+		{ BEFORE(PUT, FUTURE) AFTER(DEL, PAST)   },
 
-		{ BEFORE(PUT, FUTURE) AFTER(PUT, PAST)   OUTCOME(PRESERVED)   },
-		{ BEFORE(PUT, FUTURE) AFTER(DEL, PAST)   OUTCOME(PRESERVED)   },
+		{ BEFORE(DEL, FUTURE) AFTER(DEL, PAST)   },
+		{ BEFORE(DEL, FUTURE) AFTER(PUT, PAST)   },
 
-		{ BEFORE(DEL, FUTURE) AFTER(DEL, PAST)   OUTCOME(TOMBSTONE)   },
-		{ BEFORE(DEL, FUTURE) AFTER(PUT, PAST)   OUTCOME(TOMBSTONE)   },
+		{ BEFORE(DEL, PAST)   AFTER(DEL, FUTURE) },
+		{ BEFORE(DEL, PAST)   AFTER(PUT, FUTURE) },
 
-		{ BEFORE(DEL, PAST)   AFTER(DEL, FUTURE) OUTCOME(TOMBSTONE)   },
-		{ BEFORE(DEL, PAST)   AFTER(PUT, FUTURE) OUTCOME(OVERWRITTEN) },
-
-		{ BEFORE(NOP, PAST)   AFTER(DEL, FUTURE) OUTCOME(TOMBSTONE)   },
-		{ BEFORE(NOP, PAST)   AFTER(PUT, FUTURE) OUTCOME(OVERWRITTEN) },
+		{ BEFORE(NOP, PAST)   AFTER(DEL, FUTURE) },
+		{ BEFORE(NOP, PAST)   AFTER(PUT, FUTURE) },
 	};
 #undef BEFORE
 #undef AFTER
@@ -3425,13 +3513,13 @@ static void put_del_ver(void)
 	for (i = 0; i < ARRAY_SIZE(cases); ++i) {
 		put_del_ver_case_execute(&cases[i], &index);
 		put_del_ver_case_verify(&cases[i],  &index);
+		ut_rec_common_del_verified(&index, cases[i].before.keys, 0, 0);
 	}
 
 	rc = ut_idx_delete(&casc_ut_cctx, &ifid, 1, &rep);
 	M0_UT_ASSERT(rc == 0);
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
 	m0_fi_disable("cas_fom_tick", "skip-dtm0-phases");
-
 }
 
 struct m0_ut_suite cas_client_ut = {

--- a/dtm0/clk_src.c
+++ b/dtm0/clk_src.c
@@ -115,6 +115,11 @@ static const struct m0_dtm0_clk_src_ops cs_phys_ops = {
 	.cso_now      = cs_phys_now,
 };
 
+M0_INTERNAL bool m0_dtm0_ts_is_none(const struct m0_dtm0_ts *ts)
+{
+	return ts->dts_phys == 0;
+}
+
 #undef M0_TRACE_SUBSYSTEM
 
 /*

--- a/dtm0/clk_src.h
+++ b/dtm0/clk_src.h
@@ -100,6 +100,8 @@ struct m0_dtm0_ts {
 /** Defines an invalid (but defined) value for a CS.TS. */
 #define M0_DTM0_TS_INIT (struct m0_dtm0_ts) { .dts_phys = UINT64_MAX }
 
+#define M0_DTM0_TS_NONE (struct m0_dtm0_ts) { .dts_phys = 0 }
+
 #define DTS0_P(_ts) ((_ts)->dts_phys)
 #define DTS0_F "@%" PRIu64
 
@@ -142,6 +144,8 @@ M0_INTERNAL void m0_dtm0_clk_src_now(struct m0_dtm0_clk_src *cs,
 				     struct m0_dtm0_ts      *now);
 
 M0_INTERNAL bool m0_dtm0_ts__invariant(const struct m0_dtm0_ts *ts);
+
+M0_INTERNAL bool m0_dtm0_ts_is_none(const struct m0_dtm0_ts *ts);
 
 /** @} end of dtm group */
 #endif /* __MOTR_DTM0_CLK_SRC_H__ */


### PR DESCRIPTION
The patch introduces tombstones and versions into CAS.
Tombstones and versions may be used to enable the
"conflict-free" behavior: a set of key-value pairs
can always be merged with another set (for example,
a set of REDO records sent from another process).

Notes:
This PR is a continuation of https://github.com/Seagate/cortx-motr/pull/662. Initially, versions had been added into btree but Nikita recommended to put them into CAS.
The PR is not ready for a formal review -- DTM team needs to do internal review first.