### PR TITLE
EOS-21940 Fix m0reportbug to work on devvm

### DIFF
--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -105,15 +105,7 @@ main() {
                 warn "$IN_DIR: no such directory"
                 continue
             }
-            # This check is commented because R2 does not have symlinks for /var/motr unlike R1.
-            #[[ -L $IN_DIR ]] && {
-                # As per our design, after failover softlink /var/motr is
-                # created to points /var/motr{1-2}, and since our INPUT_DIR
-                # is globe pattern (/var/motr*) we end up collecting m0traces
-                # and cores twice unnecessary, hence skipped data collection
-                # if IN_DIR is a soft link.
-                #continue
-            #}
+
             export IN_DIR=$(readlink -f $IN_DIR)
 
             local label=$stage

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -105,14 +105,15 @@ main() {
                 warn "$IN_DIR: no such directory"
                 continue
             }
-            [[ -L $IN_DIR ]] && {
+            # This check is commented because R2 does not have symlinks for /var/motr unlike R1.
+            #[[ -L $IN_DIR ]] && {
                 # As per our design, after failover softlink /var/motr is
                 # created to points /var/motr{1-2}, and since our INPUT_DIR
                 # is globe pattern (/var/motr*) we end up collecting m0traces
                 # and cores twice unnecessary, hence skipped data collection
                 # if IN_DIR is a soft link.
-                continue
-            }
+                #continue
+            #}
             export IN_DIR=$(readlink -f $IN_DIR)
 
             local label=$stage


### PR DESCRIPTION
Commented the check for symlinks because R2 does not have
symlinks for /var/motr unlike R1.

Signed-off-by: Bhargav Dekivadiya <bhargav.dekivadiya@seagate.com>