### PR TITLE
EOS-22449: Make Intel ISA mandatory (No fallback)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,16 +185,7 @@ motr_libmotr_la_CPPFLAGS  = -DM0_TARGET='libmotr' $(AM_CPPFLAGS)
 motr_libmotr_la_LDFLAGS   = -version-info @LT_VERSION@ -pthread $(AM_LDFLAGS)
 motr_libmotr_la_LIBADD    = @MATH_LIBS@ @PTHREAD_LIBS@ @AIO_LIBS@ @RT_LIBS@ \
                             @YAML_LIBS@ @PROFILER_LIBS@ @UUID_LIBS@ \
-                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@
-
-if HAVE_ISAL
-motr_libmotr_la_LIBADD += @ISAL_LIBS@
-else
-motr_libmotr_la_LIBADD += @GALOIS_LIBS@
-# override is needed to allow user to provide some additional options in
-# RPMBUILD_FLAGS variable in command line
-override RPMBUILD_FLAGS += --without isal
-endif
+                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@ @ISAL_LIBS@
 
 # install directory for public libmotr headers
 motr_includedir             = $(includedir)/motr

--- a/configure.ac
+++ b/configure.ac
@@ -169,7 +169,6 @@ AH_TEMPLATE([HAVE_MALLINFO],          [Have mallinfo() function])
 AH_TEMPLATE([HAVE_MALLOC_SIZE],       [Have malloc_size() function])
 AH_TEMPLATE([HAVE_BACKTRACE],         [Have backtrace(3) function])
 AH_TEMPLATE([HAVE_SYSTEMD],           [Have systemd available])
-AH_TEMPLATE([HAVE_ISAL],              [Have Intel ISA-L available])
 
 # enable/disable options ------------------------------ {{{2
 
@@ -794,40 +793,14 @@ AS_IF([test x$with_lustre != xno],[
 #
 # Checking Intel ISA library --------------------------------------------------------- {{{1
 #
-AC_ARG_ENABLE([isal],
-        [AS_HELP_STRING([--disable-isal],
-                        [Disable use Intel ISA. Instead use Galois library.])],
-        [],[enable_isal=yes]
+MOTR_SEARCH_LIBS([ec_encode_data], [c isal], [ISAL_LIBS],
+        [ec_encode_data cannot be found! Try to install Intel ISA library package.]
 )
-
-AM_CONDITIONAL([HAVE_ISAL],
-               [test "x$enable_isal" = xyes])
-
-
-AS_IF([test x$enable_isal = xyes],
-      [
-              AC_CHECK_HEADERS([isa-l.h],
-              [
-                      # check for isa library
-                      MOTR_SEARCH_LIBS(
-                              [ec_encode_data], [c isal], [ISAL_LIBS],
-                              [ec_encode_data cannot be found! \
-                               Try to install Intel ISA library package.]
-                      )
-                      AC_SUBST([ISAL_LIBS])
-
-                      # define MACROs
-                      AC_DEFINE([HAVE_ISAL])
-                      # AM_CONDITIONAL([HAVE_ISAL], [true])
-                      AC_MSG_NOTICE([INTEL ISA-L Headers Available])
-              ],
-              [
-                      AM_CONDITIONAL([HAVE_ISAL], [false])
-                      AC_MSG_NOTICE([No INTEL ISA-L Headers])
-              ])
-      ]
+AC_SUBST([ISAL_LIBS])
+AC_CHECK_HEADERS([isa-l.h],
+                 [AC_MSG_NOTICE([INTEL ISA-L Headers Available])],
+                 [AC_MSG_ERROR([No INTEL ISA-L Headers])]
 )
-
 
 #
 # Checking Lustre --------------------------------------------------------- {{{1
@@ -1087,9 +1060,7 @@ echo "PROFILER_LIBS  :  \"$PROFILER_LIBS\""
 echo "GALOIS_LIBS    :  \"$GALOIS_LIBS\""
 echo "YAML_LIBS      :  \"$YAML_LIBS\""
 echo "UUID_LIBS      :  \"$UUID_LIBS\""
-AS_IF([test x$enable_isal = xyes],[
 echo "ISAL_LIBS      :  \"$ISAL_LIBS\""
-])
 echo ""
 echo "Gcc            :  \"$BUILD_GCC\""
 AS_IF([test x$with_lustre != xno],[

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -4,12 +4,6 @@
 %bcond_with cassandra
 %bcond_with ivt
 
-# Below line will enable the isal by default. This will add Intel ISA as
-# dependency by default. User can override this by using '--without isal'
-# in makefile to disable it. To change the default value i.e. to disable
-# Intel ISA dependency by default, use '%bcond_with isal'.
-%bcond_without isal
-
 # configure options
 %define with_linux  %( test -n "$kernel_src" && echo "--with-linux=$kernel_src" )
 %define with_lustre %( test -n "$lustre_src" && echo "--with-lustre=$lustre_src" )
@@ -45,14 +39,11 @@
 %if %{with cassandra}
 %define  configure_cassandra_opts   --with-cassandra
 %endif
-%if !%{with isal}
-%define  configure_isal_opts   --disable-isal
-%endif
 
 %if %{with ivt} || %{with ut}
-%define  configure_opts  %{configure_ut_opts} %{?configure_cassandra_opts} %{?configure_isal_opts}
+%define  configure_opts  %{configure_ut_opts} %{?configure_cassandra_opts}
 %else
-%define  configure_opts  %{configure_release_opts} %{?configure_cassandra_opts} %{?configure_isal_opts}
+%define  configure_opts  %{configure_release_opts} %{?configure_cassandra_opts}
 %endif
 
 Name:           @PACKAGE@
@@ -113,9 +104,7 @@ BuildRequires:  python-devel
 BuildRequires:  python2-devel
 %endif
 BuildRequires:  libedit-devel
-%if %{with isal}
 BuildRequires:  isa-l
-%endif
 %if %{with cassandra}
 BuildRequires:  libcassandra
 BuildRequires:  libuv
@@ -143,9 +132,7 @@ Requires:       facter
 Requires:       rubygem-net-ssh
 Requires:       python36-ply
 Requires:       libedit
-%if %{with isal}
 Requires:       isa-l
-%endif
 Requires(pre):  shadow-utils
 Requires(post): findutils
 

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -25,7 +25,6 @@ readonly SELF="$(readlink -f $0)"
 readonly TOP_SRCDIR="${SELF%/*/*}"
 dry_run=
 install_epel=true
-install_isal=true
 
 #
 # Usage
@@ -48,8 +47,6 @@ Usage: $PROG_NAME [-h|--help] [-n|--dry-run]
 
        --no-epel        Skip EPEL repository installation.
 
-       --no-isal        Skip Intel ISA library installtion
-
     -h|--help           Print this help screen.
 USAGE_END
 }
@@ -64,7 +61,7 @@ parse_cli_options()
     # Note that we use `"$@"' to let each command-line parameter expand to a
     # separate word. The quotes around `$@' are essential!
     # We need TEMP as the `eval set --' would nuke the return value of getopt.
-    TEMP=$( getopt -o hn --long help,dry-run,no-epel,no-isal -n "$PROG_NAME" -- "$@" )
+    TEMP=$( getopt -o hn --long help,dry-run,no-epel -n "$PROG_NAME" -- "$@" )
 
     [[ $? != 0 ]] && help
 
@@ -76,7 +73,6 @@ parse_cli_options()
             -h|--help)          help stdout ;;
             -n|--dry-run)       dry_run=--dry-run ; shift ;;
                --no-epel)       install_epel=false ; shift ;;
-               --no-isal)       install_isal=false ; shift ;;
             --)                 shift; break ;;
             *)                  echo 'getopt: internal error...'; exit 1 ;;
         esac
@@ -138,10 +134,6 @@ fi
 
 if ! $install_epel ; then
     skip_tags+=,epel
-fi
-
-if ! $install_isal ; then
-    skip_tags+=,isa-l
 fi
 
 $TOP_SRCDIR/scripts/setup-node localhost \


### PR DESCRIPTION
- Removed option which disables the use of Intel ISA .
- If Intel ISA is not present, the compilation will stop with message to
  install Intel ISA.
- Removed option from install-build-deps to skip installation of Intel
  ISA.
- Added Intel ISA rpm as mandatory build time and run time dependency.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>