### PR TITLE
EOS-23124: Improve Troubleshooting section in Quick-Start-Guide

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -114,10 +114,11 @@ Unit Benchmark
 
 Troubleshooting
 ================
-- If the pip installation fails while installing build dependencies,
+- If an installation failure due to ``DistributionNotFound: ipaddress``
+  while installing build dependencies,
   run the following commands::
 
-    sudo python -m pip uninstall pip setuptools
+    sudo pip install ipaddress
     sudo scripts/install-build-deps
 
 - If an installation failure occurs due to the dependency of ``pip3`` ,

--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -114,11 +114,11 @@ Unit Benchmark
 
 Troubleshooting
 ================
-- If an installation failure due to ``DistributionNotFound: ipaddress``
-  while installing build dependencies,
-  run the following commands::
+- If pip fails to install a package while installing build dependencies,
+  try to manually install the package.
+  run the following commands if package is ipaddress::
 
-    sudo pip install ipaddress
+    sudo pip install python-ipaddress
     sudo scripts/install-build-deps
 
 - If an installation failure occurs due to the dependency of ``pip3`` ,

--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -115,7 +115,7 @@ Unit Benchmark
 Troubleshooting
 ================
 - If pip fails to install a package while installing build dependencies,
-  try to manually install the package.
+  try installing packages using pip installer.
   run the following commands if package is ipaddress::
 
     sudo pip install python-ipaddress

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -107,9 +107,6 @@ parse_cli_options $@
 (( UID == 0 )) ||
     die 'Error: Please, run this script with "root" privileges'
 
-#
-# Added fix to handle issue EOS-23124
-#
 case $(distro_type) in
     redhat) yum -y install python-ipaddress ;;
     debian) apt install python-ipaddress ;;

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -107,6 +107,14 @@ parse_cli_options $@
 (( UID == 0 )) ||
     die 'Error: Please, run this script with "root" privileges'
 
+#
+# Added fix to handle issue EOS-23124
+#
+case $(distro_type) in
+    redhat) yum -y install python-ipaddress ;;
+    debian) apt install python-ipaddress ;;
+esac
+
 if ! which ansible &>/dev/null ; then
     case $(distro_type) in
         redhat) yum -y install ansible ;;


### PR DESCRIPTION
Modified Quick-Start-Guide to handle "DistributionNotFound: ipaddress"
issue.

Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>