### PR TITLE
utils: fix help example in m0spiel

### DIFF
--- a/utils/spiel/m0spiel
+++ b/utils/spiel/m0spiel
@@ -700,7 +700,8 @@ The following example illustrates usage of the tool:
 
 Execute commands from command line:
 
-\techo 'print(service_init(Fid(1,1)))' | sudo ./m0spiel''')
+\techo 'print(service_init(Fid(1,1)))' | sudo ./m0spiel\n''')
+
     parser.add_option('--ha', '-s', default=default_ha_ep,
                       help='HA endpoint. Default value: ' +
                       default_ha_ep)

--- a/utils/spiel/m0spiel
+++ b/utils/spiel/m0spiel
@@ -700,7 +700,7 @@ The following example illustrates usage of the tool:
 
 Execute commands from command line:
 
-\techo 'print(spiel_service_init(Fid(1,1)))' | sudo ./m0spiel''')
+\techo 'print(service_init(Fid(1,1)))' | sudo ./m0spiel''')
     parser.add_option('--ha', '-s', default=default_ha_ep,
                       help='HA endpoint. Default value: ' +
                       default_ha_ep)


### PR DESCRIPTION
The function should be service_init(), not spiel_service_init() in the example.