### PR TITLE
Revert "EOS-23180: motr panic while bootstrapping cluster"

### DIFF
--- a/motr/setup.c
+++ b/motr/setup.c
@@ -81,21 +81,12 @@ extern struct m0_reqh_service_type m0_ss_svc_type;
  * due to fragmentation or some other reasons it may be not sufficient, so
  * special "safety" coefficient is introduced to increase space in repair zone.
  * Safety coefficient is defined as "safety mul"/"safety div".
- *
- * EOS-23180: Previous safety coefficent[3/2] was causing issues and
- * repair zone was occupying more space than normal zone. Details are in the bug.
- * Getting rid of the safety coefficient. Also adding an ASSERT that
- * repair zone percentage should not cross M0_BC_REPAIR_ZONE_MAX_ALLOWED percent.
- * User has to make sure repair zone percentage should not cross this by
- * choosing appropriate spare value.
  */
 enum {
 	/** Multiplier of a repair zone safety coefficient. */
-	M0_BC_REPAIR_ZONE_SAFETY_MUL = 1,
+	M0_BC_REPAIR_ZONE_SAFETY_MUL = 3,
 	/** Divider of a repair zone safety coefficient. */
-	M0_BC_REPAIR_ZONE_SAFETY_DIV = 1,
-	/** Maximum allowed repair zone percentage */
-	M0_BC_REPAIR_ZONE_MAX_ALLOWED = 33
+	M0_BC_REPAIR_ZONE_SAFETY_DIV = 2
 };
 
 M0_TL_DESCR_DEFINE(cs_buffer_pools, "buffer pools in the motr context",
@@ -1424,8 +1415,7 @@ static int be_repair_zone_pcnt_get(struct m0_reqh *reqh,
 			       &croot->rt_imeta_pver)) {
 			continue;
 		}
-
-		*repair_zone_pcnt = pver_obj->pv_u.subtree.pvs_attr.pa_S *
+		*repair_zone_pcnt = pver_obj->pv_u.subtree.pvs_attr.pa_K *
 			100 /
 			pver_obj->pv_u.subtree.pvs_attr.pa_P *
 			M0_BC_REPAIR_ZONE_SAFETY_MUL /
@@ -1436,8 +1426,6 @@ static int be_repair_zone_pcnt_get(struct m0_reqh *reqh,
 		       pver_obj->pv_u.subtree.pvs_attr.pa_K,
 		       pver_obj->pv_u.subtree.pvs_attr.pa_P,
 		       *repair_zone_pcnt);
-
-		M0_ASSERT(*repair_zone_pcnt <= M0_BC_REPAIR_ZONE_MAX_ALLOWED);
 	}
 	if (rc == 0)
 		m0_conf_diter_fini(&it);


### PR DESCRIPTION
Reverts Seagate/cortx-motr#912

The patch introduced the regression into dix-client-ut:

```
motr[154233]:  1770  FATAL  [lib/assert.c:50:m0_panic]  panic: (*repair_zone_pcnt <= M0_BC_REPAIR_ZONE_MAX_ALLOWED) at be_repair_zone_pcnt_get() (/root/motr/motr_test_github_workdir/workdir/src/motr/setup.c:1440)  [git: Cred-Test-43-g8707ca6-dirty] /var/motr/m0ut/m0trace.154233
Motr panic: (*repair_zone_pcnt <= M0_BC_REPAIR_ZONE_MAX_ALLOWED) at be_repair_zone_pcnt_get() /root/motr/motr_test_github_workdir/workdir/src/motr/setup.c:1440 (errno: 12) (last failed: none) [git: Cred-Test-43-g8707ca6-dirty] pid: 154233  /var/motr/m0ut/m0trace.154233
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_arch_backtrace+0x20)[0x7fb91ae8ca90]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_arch_panic+0xe6)[0x7fb91ae8cc46]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(+0x3767c4)[0x7fb91ae7b7c4]
/root/motr/motr_test_github_workdir/workdir/src/ut/.libs/libmotr-ut.so.0(+0x1d259e)[0x7fb91c4ec59e]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(+0x3c755e)[0x7fb91aecc55e]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_module_init+0x1a)[0x7fb91aecc5fa]
/root/motr/motr_test_github_workdir/workdir/src/ut/.libs/libmotr-ut.so.0(m0_cs_setup_env+0x51)[0x7fb91c4ed741]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_rpc_server_start+0xcf)[0x7fb91af1180f]
/root/motr/motr_test_github_workdir/workdir/src/ut/.libs/libmotr-ut.so.0(+0x17483f)[0x7fb91c48e83f]
/root/motr/motr_test_github_workdir/workdir/src/ut/.libs/libmotr-ut.so.0(+0x175309)[0x7fb91c48f309]
/root/motr/motr_test_github_workdir/workdir/src/ut/.libs/libmotr-ut.so.0(m0_ut_run+0x263)[0x7fb91c598b53]
/root/motr/motr_test_github_workdir/workdir/src/ut/.libs/lt-m0ut(main+0x11b7)[0x404737]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7fb9193b3505]
/root/motr/motr_test_github_workdir/workdir/src/ut/.libs/lt-m0ut[0x4048af]
/root/motr/motr_test_github_workdir/workdir/src/utils//m0run: line 416: 154233 Aborted                 (core dumped) $(srcdir_path_of $binary) "$@"
```