### PR TITLE
No need to add extra ref after fdmi record is already processed.

### DIFF
--- a/fdmi/plugin_dock.c
+++ b/fdmi/plugin_dock.c
@@ -469,8 +469,8 @@ static void pdock_record_release(struct m0_ref *ref)
 	}
 
 	/* FIXME: TEMP */
-	M0_LOG(M0_WARN, "Processed FDMI rec "
-	       U128X_F, U128_P(&rreg->frr_rec->fr_rec_id));
+	M0_LOG(M0_DEBUG, "Processed FDMI rec "U128X_F". Releasing it now.",
+			 U128_P(&rreg->frr_rec->fr_rec_id));
 
 	rc = pdock_client_post(req, rreg->frr_sess, &release_ri_ops);
 	if (rc != 0) {

--- a/fdmi/plugin_dock_fom.c
+++ b/fdmi/plugin_dock_fom.c
@@ -301,25 +301,19 @@ static int pdock_fom_tick__feed_plugin_with_rec(struct m0_fom *fom)
 				 fids[pd_fom->pf_pos]);
 	if (rc == 0) {
 		/*
-		 * Plugin accepted the record,
-		 * so increment fdmi record refc
+		 * Plugin accepted the record. We already have a ref on
+		 * this record. No need to take extra ref.
 		 */
-		struct m0_fdmi_record_reg *rreg;
-
-		rreg = m0_fdmi__pdock_record_reg_find(&frec->fr_rec_id);
-
-		if (rreg == NULL) {
-			/* critical error,
-			   have to finish with no registration */
-			m0_fom_phase_set(fom,
-					 FDMI_PLG_DOCK_FOM_FINISH_WITH_REC);
-			M0_LOG(M0_ERROR,
-			       "record not registered in plugin dock");
-			M0_LEAVE();
-			return M0_FSO_AGAIN;
-		}
-
-		m0_ref_get(&rreg->frr_ref);
+		/*
+		 * If the plugin wants to do more work after returning
+		 * from the pcb->po_fdmi_rec(), it should increase fdmi
+		 * record refc, and then release it when done.
+		 * pseudo code:
+		 * struct m0_fdmi_record_reg *rreg;
+		 * rreg = m0_fdmi__pdock_record_reg_find(&frec->fr_rec_id);
+		 * if (rreg != NULL)
+		 *	m0_ref_get(&rreg->frr_ref);
+		 */
 	} else {
 		M0_LOG(M0_NOTICE,
 		       "plugin has rejected the record processing: "


### PR DESCRIPTION
* No need to add extra ref after fdmi record is already processed.
* proper shutdown of fdmi service on plugin app side.

Signed-off-by: Hua Huang <hua.huang@seagate.com>