### PR TITLE
Unload free extents[LRU] framework.

### DIFF
--- a/balloc/Makefile.sub
+++ b/balloc/Makefile.sub
@@ -1,4 +1,4 @@
 nobase_motr_include_HEADERS += balloc/balloc.h
 motr_libmotr_la_SOURCES  += balloc/balloc.c
 nodist_motr_libmotr_la_SOURCES  += balloc/balloc_xc.c
-XC_FILES += balloc/balloc_xc.h
+XC_FILES += balloc/balloc_xc.h lib/bitmap_xc.h

--- a/balloc/balloc.h
+++ b/balloc/balloc.h
@@ -383,7 +383,6 @@ M0_INTERNAL void m0_balloc_debug_dump_group(const char *tag,
 M0_INTERNAL void m0_balloc_lock_group(struct m0_balloc_group_info *grp);
 M0_INTERNAL int m0_balloc_trylock_group(struct m0_balloc_group_info *grp);
 M0_INTERNAL void m0_balloc_unlock_group(struct m0_balloc_group_info *grp);
-M0_INTERNAL void m0_balloc_release_memory(struct m0_balloc *cb);
 
 /** @} end of balloc */
 

--- a/balloc/balloc.h
+++ b/balloc/balloc.h
@@ -29,11 +29,13 @@
 #include "lib/types.h"
 #include "lib/list.h"
 #include "lib/mutex.h"
+#include "lib/bitmap.h" /** bitmap */
 #include "be/btree.h"
 #include "be/btree_xc.h"
 #include "format/format.h"
 #include "stob/ad.h"
 #include "stob/ad_xc.h"
+#include "lib/bitmap_xc.h"
 
 /**
    @defgroup balloc data-block-allocator
@@ -157,6 +159,10 @@ struct m0_balloc_group_info {
 	struct m0_balloc_zone_param  bgi_spare;
 	/** Array of group extents */
 	struct m0_lext              *bgi_extents;
+	/** Last loaded time */
+	uint64_t                     bgi_loaded_time;
+	/** Last used time */
+	uint64_t                     bgi_used_time;
 	/** per-group lock */
 	struct m0_be_mutex           bgi_mutex;
 };
@@ -183,6 +189,7 @@ struct m0_balloc_super_block {
 	m0_bcount_t     bsb_freespare;        /**< nr free spare blocks */
 	m0_bcount_t     bsb_sparesize;        /**< spare blocks per group */
 #endif
+	struct m0_fid   bsb_ad_stob_id;       /** ad stob id */
 	m0_bcount_t	bsb_blocksize;        /**< block size in bytes */
 	m0_bcount_t	bsb_groupsize;        /**< group size in blocks */
 	uint32_t	bsb_bsbits;           /**< block size bits: power of 2*/
@@ -267,6 +274,8 @@ struct m0_balloc {
 
 	/** array of group info */
 	struct m0_balloc_group_info *cb_group_info;
+	/** Loaded inmemory groupno bits identifier */
+	struct m0_bitmap             ld_group_info;
 	/** super block lock */
 	struct m0_be_mutex           cb_sb_mutex;
 	struct m0_be_seg            *cb_be_seg;
@@ -374,6 +383,7 @@ M0_INTERNAL void m0_balloc_debug_dump_group(const char *tag,
 M0_INTERNAL void m0_balloc_lock_group(struct m0_balloc_group_info *grp);
 M0_INTERNAL int m0_balloc_trylock_group(struct m0_balloc_group_info *grp);
 M0_INTERNAL void m0_balloc_unlock_group(struct m0_balloc_group_info *grp);
+M0_INTERNAL void m0_balloc_release_memory(struct m0_balloc *cb);
 
 /** @} end of balloc */
 

--- a/balloc/balloc.h
+++ b/balloc/balloc.h
@@ -239,6 +239,7 @@ enum {
 	BALLOC_DEF_INDEXES_NR           = 1,
 	/** Used as minimal group size */
 	BALLOC_DEF_BLOCKS_PER_GROUP     = 32768,
+	BALLOC_DEF_PERCENTILE_UNLOAD    = 75,
 };
 
 /**

--- a/lib/bitmap.h
+++ b/lib/bitmap.h
@@ -44,7 +44,7 @@ struct m0_bitmap {
 	size_t    b_nr;
 	/** Words with bits. */
 	uint64_t *b_words;
-};
+} M0_XCA_SEQUENCE M0_XCA_DOMAIN(be);;
 
 struct m0_bitmap_onwire {
 	/** size of bo_words. */

--- a/stob/ad.h
+++ b/stob/ad.h
@@ -128,7 +128,8 @@ struct m0_ad_balloc_ops {
  	 * release in-memory extents list.
  	 *
  	 */ 
-	int (*bo_release_mem)(struct m0_ad_balloc *ballroom);
+	int (*bo_release_mem)(struct m0_ad_balloc *ballroom,
+			      uint64_t percentile);
 };
 
 enum { AD_PATHLEN = 4096 };

--- a/stob/ad.h
+++ b/stob/ad.h
@@ -124,6 +124,11 @@ struct m0_ad_balloc_ops {
 	int  (*bo_reserve_extent)(struct m0_ad_balloc *ballroom,
 				 struct m0_be_tx *tx, struct m0_ext *ext,
 				 uint64_t alloc_zone);
+	/**
+ 	 * release in-memory extents list.
+ 	 *
+ 	 */ 
+	int (*bo_release_mem)(struct m0_ad_balloc *ballroom);
 };
 
 enum { AD_PATHLEN = 4096 };


### PR DESCRIPTION
LRU based unload in memory extents has been implemented.
It has been exposed as a callback per ad balloc free_entents.
This framework per AD can be called by thread or a RPC.
