### PR TITLE
EOS-23582: update the format of support.yaml file

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/conf/support.yaml
+++ b/scripts/install/opt/seagate/cortx/motr/conf/support.yaml
@@ -1,4 +1,2 @@
-
-bundle:
-    create:
-      url: "sh /opt/seagate/cortx/motr/libexec/m0reportbug-bundler"
+support_bundle:
+    - "sh /opt/seagate/cortx/motr/libexec/m0reportbug-bundler"


### PR DESCRIPTION
The new format of support.yaml is:
support_bundle:
    - "sh /opt/seagate/cortx/motr/libexec/m0reportbug-bundler"

Signed-off-by: Mehul Joshi <mehul.joshi@seagate.com>