### PR TITLE
Generate FDMI event on kv delete operation 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -691,6 +691,16 @@ motr_examples_example2_LDADD    = $(top_builddir)/motr/libmotr.la
 include $(top_srcdir)/motr/examples/Makefile.sub
 
 #
+# fdmi/plugins/fdmi_sample_plugin --------------------- {{{2
+#
+
+noinst_PROGRAMS    += fdmi/plugins/fdmi_sample_plugin
+fdmi_plugins_fdmi_sample_plugin_CPPFLAGS  = -DM0_TARGET='fdmi_sample_plugin' $(AM_CPPFLAGS)
+fdmi_plugins_fdmi_sample_plugin_LDADD     = $(top_builddir)/motr/libmotr.la
+
+include $(top_srcdir)/fdmi/plugins/Makefile.sub
+
+#
 # motr/crate ----------------------------------------- {{{2
 #
 sbin_PROGRAMS                    += motr/m0crate/m0crate

--- a/be/log.h
+++ b/be/log.h
@@ -335,6 +335,20 @@ struct m0_be_log_record {
 	/** Pointer to the previous record inside log */
 	m0_bindex_t          lgr_prev_pos;
 	m0_bcount_t          lgr_prev_size;
+	/**
+	 * It MUST be set to a log pointer for which all log records with
+	 * lgr_position less than the pointer have already became persistent.
+	 *
+	 * It's set to BE log header flh_discarded pointer at the time when
+	 * m0_be_log_record_io_prepare() is executed for this record.
+	 *
+	 * Use case: discard FOL records (sent as FDMI records) at FDMI plugin.
+	 * This value allows to filter out FDMI records that are never going to
+	 * be resent because BE log records before this pointer are never going
+	 * to be recovered (they are already fully written to BE segments and BE
+	 * log header is updated to reflect that).
+	 */
+	m0_bindex_t          lgr_log_header_discarded;
 
 	uint64_t             lgr_magic;
 	struct m0_tlink      lgr_linkage;
@@ -448,6 +462,18 @@ m0_be_log_record_io_bufvec(struct m0_be_log_record *record,
 M0_INTERNAL void m0_be_log_record_io_launch(struct m0_be_log_record *record,
 					    struct m0_be_op         *op);
 
+
+/** Returns absolute position of this log record in BE log */
+M0_INTERNAL m0_bindex_t
+m0_be_log_record_position(const struct m0_be_log_record *record);
+
+/**
+ * Returns BE log discarded pointer before or at the time the record was
+ * written to the log.
+ */
+M0_INTERNAL m0_bindex_t
+m0_be_log_record_discarded(const struct m0_be_log_record *record);
+
 /**
  * Reserves space for a log record. Reserved size can be bigger than actual
  * size of the log record.
@@ -480,6 +506,8 @@ M0_INTERNAL int m0_be_log_header_read(struct m0_be_log            *log,
 
 struct m0_be_log_record_iter {
 	struct m0_be_fmt_log_record_header lri_header;
+	/** @see lgr_log_header_discarded */
+	m0_bindex_t                        lri_log_header_discarded;
 	struct m0_tlink                    lri_linkage;
 	uint64_t                           lri_magic;
 };

--- a/be/tx.c
+++ b/be/tx.c
@@ -740,6 +740,37 @@ M0_INTERNAL void m0_be_tx_gc_enable(struct m0_be_tx *tx,
 	tx->t_gc_param   = param;
 }
 
+M0_INTERNAL void m0_be_tx_lsn_set(struct m0_be_tx *tx,
+                                  m0_bindex_t      lsn,
+                                  m0_bindex_t      lsn_discarded)
+{
+	/*
+	 * This function is called from m0_be_tx_group_close().
+	 * When the BE tx group this transaction belongs to is being closed
+	 * the tx sm group is not locked - this is why BE_TX_LOCKED_AT_STATE
+	 * could not be used here.
+	 */
+	M0_PRE(m0_be_tx_state(tx) == M0_BTS_CLOSED);
+
+	tx->t_lsn = lsn;
+	tx->t_lsn_discarded = lsn_discarded;
+	M0_LEAVE("tx=%p t_lsn=%"PRIu64" t_lsn_discarded=%"PRIu64,
+	         tx, tx->t_lsn, tx->t_lsn_discarded);
+}
+
+M0_INTERNAL void m0_be_tx_lsn_get(struct m0_be_tx *tx,
+                                  m0_bindex_t     *lsn,
+                                  m0_bindex_t     *lsn_discarded)
+{
+	M0_ENTRY("tx=%p t_lsn=%"PRIu64" t_lsn_discarded=%"PRIu64,
+	         tx, tx->t_lsn, tx->t_lsn_discarded);
+	M0_PRE(BE_TX_LOCKED_AT_STATE(tx, (M0_BTS_LOGGED, M0_BTS_PLACED,
+	                                  M0_BTS_DONE)));
+
+	*lsn = tx->t_lsn;
+	*lsn_discarded = tx->t_lsn_discarded;
+}
+
 M0_EXTERN struct m0_sm_conf op_states_conf;
 M0_INTERNAL int m0_be_tx_mod_init(void)
 {

--- a/be/tx.h
+++ b/be/tx.h
@@ -343,6 +343,12 @@ struct m0_be_tx {
 	 */
 	uint64_t               t_lsn;
 	/**
+	 * No BE transaction with lsn less than this is going to be recovered by
+	 * BE recovery.
+	 * @see m0_be_log_record::lgr_log_header_discarded.
+	 */
+	m0_bindex_t            t_lsn_discarded;
+	/**
 	 * Payload area.
 	 *
 	 * - memory for the payload area is managed by the transaction. It is
@@ -659,6 +665,14 @@ M0_INTERNAL bool m0_be_should_break(struct m0_be_engine          *eng,
 M0_INTERNAL bool m0_be_should_break_half(struct m0_be_engine          *eng,
 					 const struct m0_be_tx_credit *accum,
 					 const struct m0_be_tx_credit *delta);
+
+
+M0_INTERNAL void m0_be_tx_lsn_set(struct m0_be_tx *tx,
+                                  m0_bindex_t      lsn,
+                                  m0_bindex_t      lsn_discarded);
+M0_INTERNAL void m0_be_tx_lsn_get(struct m0_be_tx *tx,
+                                  m0_bindex_t     *lsn,
+                                  m0_bindex_t     *lsn_discarded);
 
 /** @} end of be group */
 #endif /* __MOTR_BE_TX_H__ */

--- a/be/tx_group_format.c
+++ b/be/tx_group_format.c
@@ -451,6 +451,18 @@ m0_be_group_format_log_reserved_size(struct m0_be_log       *log,
 	return m0_be_log_reserved_size(log, lio_size, 2);
 }
 
+M0_INTERNAL m0_bindex_t
+m0_be_group_format_log_position(const struct m0_be_group_format *gft)
+{
+	return m0_be_log_record_position(&gft->gft_log_record);
+}
+
+M0_INTERNAL m0_bindex_t
+m0_be_group_format_log_discarded(const struct m0_be_group_format *gft)
+{
+	return m0_be_log_record_discarded(&gft->gft_log_record);
+}
+
 M0_INTERNAL void
 m0_be_group_format_log_use(struct m0_be_group_format *gft,
 			   m0_bcount_t                size_reserved)

--- a/be/tx_group_format.h
+++ b/be/tx_group_format.h
@@ -184,6 +184,15 @@ m0_be_group_format_log_reserved_size(struct m0_be_log       *log,
 M0_INTERNAL void
 m0_be_group_format_log_use(struct m0_be_group_format *gft,
 			   m0_bcount_t                size_reserved);
+
+/** Returns absolutute position of this group in BE log */
+M0_INTERNAL m0_bindex_t
+m0_be_group_format_log_position(const struct m0_be_group_format *gft);
+
+/** Returns BE log discarded pointer at m0_be_group_format_log_use() time. */
+M0_INTERNAL m0_bindex_t
+m0_be_group_format_log_discarded(const struct m0_be_group_format *gft);
+
 M0_INTERNAL void
 m0_be_group_format_recovery_prepare(struct m0_be_group_format *gft,
 				    struct m0_be_log          *log);

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -985,7 +985,8 @@ static int ctg_op_tick_ret(struct m0_ctg_op *ctg_op,
 
 	if (!op_is_active)
 		clink->cl_cb(clink);
-	m0_fom_phase_set(fom, next_state);
+	if (next_state >= 0)
+		m0_fom_phase_set(fom, next_state);
 	return ret;
 }
 

--- a/cas/ctg_store.h
+++ b/cas/ctg_store.h
@@ -205,6 +205,8 @@ struct m0_ctg_op {
 	struct m0_buf             co_out_key;
 	/** Value out buffer. */
 	struct m0_buf             co_out_val;
+	/** Value out buffer for lookup done on del op. */
+	struct m0_buf             co_tmp_buf;
 	struct m0_buf             co_mem_buf;
 	/** Operation code to be executed. */
 	int                       co_opcode;

--- a/cas/ctg_store.h
+++ b/cas/ctg_store.h
@@ -205,8 +205,6 @@ struct m0_ctg_op {
 	struct m0_buf             co_out_key;
 	/** Value out buffer. */
 	struct m0_buf             co_out_val;
-	/** Value out buffer for lookup done on del op. */
-	struct m0_buf             co_tmp_buf;
 	struct m0_buf             co_mem_buf;
 	/** Operation code to be executed. */
 	int                       co_opcode;

--- a/cas/service.c
+++ b/cas/service.c
@@ -2185,7 +2185,6 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 		ret = m0_ctg_insert(ctg_op, ctg, &kbuf, &vbuf, next);
 		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
-<<<<<<< HEAD
 		op = cas_op(fom0);
 		rec = cas_at(op, rec_pos);
 
@@ -2226,8 +2225,6 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 		/* Now deleting the key. */
 		m0_ctg_op_fini(ctg_op);
 		m0_ctg_op_init(ctg_op, fom0, flags);
-=======
->>>>>>> - changed the originl approch and do the lookup in a more comphortable place, whcih is only used for btree record del, not meta index del
 		ret = m0_ctg_delete(ctg_op, ctg, &kbuf, next);
 		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_META):
@@ -2349,7 +2346,6 @@ static int cas_ctidx_delete(struct cas_fom *fom, const struct m0_cas_id *in_cid,
 	struct m0_ctg_op          *ctg_op = &fom->cf_ctg_op;
 	enum m0_fom_phase_outcome  ret    = M0_FSO_AGAIN;
 	struct m0_buf              kbuf;
-	struct m0_buf              lbuf;
 
 	if (m0_ctg_op_rc(ctg_op) == 0) {
 		m0_ctg_op_fini(ctg_op);
@@ -2437,13 +2433,7 @@ static int cas_prep_send(struct cas_fom *fom, enum m0_cas_opcode opc,
 		break;
 	case CTG_OP_COMBINE(CO_GET, CT_META):
 	case CTG_OP_COMBINE(CO_DEL, CT_META):
-		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
-		if (ctg_op->co_tmp_buf.b_nob > 0) {
-			rc = cas_place(&fom->cf_out_val, &ctg_op->co_tmp_buf, rpc_cutoff);
-			m0_buf_free(&ctg_op->co_tmp_buf);
-		}
-		break;
 	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
 	case CTG_OP_COMBINE(CO_PUT, CT_META):
 		/* Nothing to do: return code is all the user gets. */

--- a/cas/service.c
+++ b/cas/service.c
@@ -2156,6 +2156,7 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 	struct m0_fom             *fom0   = &fom->cf_fom;
 	uint32_t                   flags  = cas_op(fom0)->cg_flags;
 	struct m0_buf              kbuf;
+	struct m0_buf              lbuf;
 	struct m0_buf              vbuf;
 	struct m0_buf              lbuf;
 	struct m0_cas_id          *cid;
@@ -2434,6 +2435,11 @@ static int cas_prep_send(struct cas_fom *fom, enum m0_cas_opcode opc,
 	case CTG_OP_COMBINE(CO_GET, CT_META):
 	case CTG_OP_COMBINE(CO_DEL, CT_META):
 	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
+		m0_ctg_lookup_result(ctg_op, &val);
+		rc = cas_place(&fom->cf_out_val, &val, rpc_cutoff);
+		/* Here we also need to free the memory after m0_buf_free() */
+		m0_buf_free(&ctg_op->co_out_val);
+		break;
 	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
 	case CTG_OP_COMBINE(CO_PUT, CT_META):
 		/* Nothing to do: return code is all the user gets. */

--- a/cas/service.c
+++ b/cas/service.c
@@ -2156,7 +2156,6 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 	struct m0_fom             *fom0   = &fom->cf_fom;
 	uint32_t                   flags  = cas_op(fom0)->cg_flags;
 	struct m0_buf              kbuf;
-	struct m0_buf              lbuf;
 	struct m0_buf              vbuf;
 	struct m0_buf              lbuf;
 	struct m0_cas_id          *cid;
@@ -2186,6 +2185,7 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 		ret = m0_ctg_insert(ctg_op, ctg, &kbuf, &vbuf, next);
 		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
+<<<<<<< HEAD
 		op = cas_op(fom0);
 		rec = cas_at(op, rec_pos);
 
@@ -2226,6 +2226,8 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 		/* Now deleting the key. */
 		m0_ctg_op_fini(ctg_op);
 		m0_ctg_op_init(ctg_op, fom0, flags);
+=======
+>>>>>>> - changed the originl approch and do the lookup in a more comphortable place, whcih is only used for btree record del, not meta index del
 		ret = m0_ctg_delete(ctg_op, ctg, &kbuf, next);
 		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_META):
@@ -2347,6 +2349,7 @@ static int cas_ctidx_delete(struct cas_fom *fom, const struct m0_cas_id *in_cid,
 	struct m0_ctg_op          *ctg_op = &fom->cf_ctg_op;
 	enum m0_fom_phase_outcome  ret    = M0_FSO_AGAIN;
 	struct m0_buf              kbuf;
+	struct m0_buf              lbuf;
 
 	if (m0_ctg_op_rc(ctg_op) == 0) {
 		m0_ctg_op_fini(ctg_op);
@@ -2434,11 +2437,12 @@ static int cas_prep_send(struct cas_fom *fom, enum m0_cas_opcode opc,
 		break;
 	case CTG_OP_COMBINE(CO_GET, CT_META):
 	case CTG_OP_COMBINE(CO_DEL, CT_META):
+		break;
 	case CTG_OP_COMBINE(CO_DEL, CT_BTREE):
-		m0_ctg_lookup_result(ctg_op, &val);
-		rc = cas_place(&fom->cf_out_val, &val, rpc_cutoff);
-		/* Here we also need to free the memory after m0_buf_free() */
-		m0_buf_free(&ctg_op->co_out_val);
+		if (ctg_op->co_tmp_buf.b_nob > 0) {
+			rc = cas_place(&fom->cf_out_val, &ctg_op->co_tmp_buf, rpc_cutoff);
+			m0_buf_free(&ctg_op->co_tmp_buf);
+		}
 		break;
 	case CTG_OP_COMBINE(CO_PUT, CT_BTREE):
 	case CTG_OP_COMBINE(CO_PUT, CT_META):

--- a/cas/service.c
+++ b/cas/service.c
@@ -2208,7 +2208,7 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 		 *
 		 * Since m0_cas_op is completely added to the fol rec, we
 		 * have these buffers available for the FDMI and don't have
-		 * to send them to to the client.
+		 * to send them to the client.
 		 */
 
 		/* Both buffers released in cas_fom_fini(). */

--- a/cas/service.c
+++ b/cas/service.c
@@ -2211,7 +2211,7 @@ static int cas_exec(struct cas_fom *fom, enum m0_cas_opcode opc,
 		 * to send them to to the client.
 		 */
 
-                /* Both buffers released in cas_fom_fini(). */
+		/* Both buffers released in cas_fom_fini(). */
 		m0_rpc_at_init(&rec->cr_key);
 		rec->cr_key.ab_type = M0_RPC_AT_INLINE;
 		rec->cr_key.u.ab_buf = M0_BUF_INIT0;
@@ -2350,9 +2350,9 @@ static int cas_ctidx_delete(struct cas_fom *fom, const struct m0_cas_id *in_cid,
 	if (m0_ctg_op_rc(ctg_op) == 0) {
 		m0_ctg_op_fini(ctg_op);
 		m0_ctg_op_init(ctg_op, fom0, 0);
-                /* The key is a component catalogue FID. */
-                kbuf = M0_BUF_INIT_PTR_CONST(&in_cid->ci_fid);
-	        ret = m0_ctg_delete(ctg_op, m0_ctg_ctidx(), &kbuf, next);
+		/* The key is a component catalogue FID. */
+		kbuf = M0_BUF_INIT_PTR_CONST(&in_cid->ci_fid);
+		ret = m0_ctg_delete(ctg_op, m0_ctg_ctidx(), &kbuf, next);
 	} else
 		m0_fom_phase_set(fom0, next);
 	return ret;

--- a/fdmi/flt_eval.c
+++ b/fdmi/flt_eval.c
@@ -29,6 +29,8 @@
 #include "fdmi/filter.h"
 #include "fdmi/flt_eval.h"
 
+#include "conf/obj.h"           /* m0_conf_fdmi_filter */
+
 static int eval_or(struct m0_fdmi_flt_operands *opnds,
                    struct m0_fdmi_flt_operand  *res)
 {
@@ -179,8 +181,8 @@ static int eval_flt_node(struct m0_fdmi_eval_ctx    *ctx,
 	return M0_RC(rc);
 }
 
-M0_INTERNAL int m0_fdmi_eval_flt(struct m0_fdmi_eval_ctx *ctx,
-                                 struct m0_fdmi_filter   *flt,
+M0_INTERNAL int m0_fdmi_eval_flt(struct m0_fdmi_eval_ctx      *ctx,
+                                 struct m0_conf_fdmi_filter   *filter,
                                  struct m0_fdmi_eval_var_info *var_info)
 {
 	int                        rc;
@@ -188,7 +190,7 @@ M0_INTERNAL int m0_fdmi_eval_flt(struct m0_fdmi_eval_ctx *ctx,
 
 	M0_ENTRY();
 
-	rc = eval_flt_node(ctx, flt->ff_root, &res, var_info);
+	rc = eval_flt_node(ctx, filter->ff_filter.ff_root, &res, var_info);
 
 	if (rc == 0) {
 		M0_ASSERT(res.ffo_type == M0_FF_OPND_BOOL);

--- a/fdmi/flt_eval.h
+++ b/fdmi/flt_eval.h
@@ -34,6 +34,9 @@
  * @{
  */
 
+
+struct m0_conf_fdmi_filter;
+
 /**
  * Array of operands
  */
@@ -108,15 +111,15 @@ M0_INTERNAL void m0_fdmi_eval_del_op_cb(struct m0_fdmi_eval_ctx *ctx,
  *
  * Result of filter expression is always boolean.
  *
+ * @param filter   FDMI filter
  * @param ctx      FDMI filter evaluator context
- * @param flt      FDMI filter
  * @param var_info Information about how to get value of variable nodes
  * @return  <0, if some error occured, @n
  *           0, if result of evaluation is False @n
  *           1, if result of evaluation is True
  */
-M0_INTERNAL int m0_fdmi_eval_flt(struct m0_fdmi_eval_ctx *ctx,
-                                 struct m0_fdmi_filter   *flt,
+M0_INTERNAL int m0_fdmi_eval_flt(struct m0_fdmi_eval_ctx      *ctx,
+                                 struct m0_conf_fdmi_filter   *filter,
                                  struct m0_fdmi_eval_var_info *var_info);
 
 /**

--- a/fdmi/fol_fdmi_src.c
+++ b/fdmi/fol_fdmi_src.c
@@ -778,7 +778,8 @@ m0_fol_fdmi_filter_kv_substring(struct m0_fdmi_eval_ctx      *ctx,
 		if (fol_frag->rp_ops->rpo_type != &m0_fop_fol_frag_type)
 			continue;
 		fop_fol_frag = fol_frag->rp_data;
-		if (fop_fol_frag->ffrp_fop_code != M0_CAS_PUT_FOP_OPCODE)
+		if (fop_fol_frag->ffrp_fop_code != M0_CAS_PUT_FOP_OPCODE &&
+		    fop_fol_frag->ffrp_fop_code != M0_CAS_DEL_FOP_OPCODE)
 			continue;
 		cas_op = fop_fol_frag->ffrp_fop;
 		M0_ASSERT(cas_op != NULL);

--- a/fdmi/fol_fdmi_src.c
+++ b/fdmi/fol_fdmi_src.c
@@ -109,6 +109,97 @@
  * rh_lsn_discarded for its BE domain could be discarded from deduplication
  * persistence because there is nothing in the cluster that is going to send
  * FDMI FOL record about this operation.
+ *
+ * @section FDMI FOL records resend
+ *
+ * There are 2 major cases here:
+ *
+ * 1. FDMI plugin restarts, FDMI source is not. In this case FDMI source needs
+ *    to resend everything FDMI plugin hasn't confirmed consumption for. This
+ *    could be done by FDMI source dock fom by indefinitely resending FDMI
+ *    records until either FDMI plugin confirms consumption or FDMI plugin
+ *    process fails permanently.
+ * 2. FDMI source restarts. The following description is about this case.
+ *
+ * FDMI source may restart unexpectedly (crash/restart) or it might restart
+ * gracefully (graceful shutdown/startup). In either case there may be FDMI FOL
+ * records that don't have consumption confirmation from FDMI plugin. Current
+ * implementation takes BE tx reference until there is such confirmation from
+ * FDMI plugin. BE tx reference taken means in this case that BE tx wouldn't be
+ * discarded from BE log until the reference is put. BE recovery recovers all
+ * transactions that were not discarded, which is very useful for FDMI FOL
+ * record resend case: if all FOL records for such recovered transactions are
+ * resent as FDMI FOL records then there will be no FDMI FOL record missing on
+ * FDMI plugin side regardless whether FDMI source restarts or not, how and how
+ * many times it restarts.
+ *
+ * It leads to an obvious solution: just send all FOL records as FDMI FOL
+ * records during BE recovery.
+ *
+ * There are several ways this task could be done.
+ *
+ * @subsection Original FOM for each FOL record
+ *
+ * For each FOL record a fom with the orignal fom type is created. A special
+ * flag is added to indicate that the fom was created during BE recovery . It
+ * allows the fom to not to execute it's usual actions, but to close BE tx
+ * immediatelly. Then, after BE tx goes to M0_BTS_LOGGED phase a generic fom
+ * phase calls m0_fom_fdmi_record_post(), which sends FDMI record to FDMI plugin
+ * as usual.
+ *
+ * @subsection Special FOM for each FOL record
+ *
+ * A special FOM would be created for each recovered BE tx. The purpose of the
+ * fom would be post FDMI record with the FOL record for this BE tx and then
+ * wait until consumption of the FDMI record is acklowledged.
+ *
+ * @subsection Post FDMI records for every BE tx
+ *
+ * FDMI FOL record for every recovered BE tx is posted as usual. FDMI source
+ * dock fom would make a queue of all the records and it would send them and
+ * wait for consumption acknowledgement as usual.
+ *
+ * @subsection A special BE recovery FOM phase
+ *
+ * A special FOM phase is added to every fom that stores something in BE. If the
+ * fom is created during BE recovery, then initial phase of the fom is this
+ * special phase. This allows each fom to handle BE recovery as it sees fit.
+ * Default generic phase sequence should also include this special fom phase and
+ * by default it would post FDMI FOL record in the same way it's done currently
+ * for normal FOM phase sequence.
+ *
+ * @subsection Implementation details
+ *
+ * - Motr process should be able to send FDMI fops during BE recovery. BE
+ *   recovery happens before DTM recovery, so at this stage only HA and Motr
+ *   configuration should be brought up (along with their dependencies). It
+ *   means that ioservice and DIX would be down at that time;
+ * - FOL record shouldn't be discarded until it's consumed by FDMI plugin.
+ *   Currently FOL record is in BE tx payload, so this requriement means that BE
+ *   tx shouldn't be discarded from BE log before FDMI FOL record is consumed by
+ *   FDMI plugin. It has several side effects:
+ *   - current implementation recovers BE tx groups one by one, and the next
+ *     group is recovered only after references to all transactions from the
+ *     previous BE tx group are put. It means that FDMI plugin must consume all
+ *     the records before the next BE tx group is recovered. Which doesn't sound
+ *     complex on it's own, but there is a use case when it becomes critical:
+ *   - if FDMI plugin needs to save FDMI record in a distributed index which is
+ *     located on the same set of Motr processes as FDMI source, then we may
+ *     have a deadlock even during usual cluster startup after non-clean
+ *     shutdown: BE recovery would have some transactions on every participating
+ *     server, so DIX wouldn't be operational. And FDMI plugin would require DIX
+ *     to be at least somehow operational to consume FDMI records. This could be
+ *     solved by allowing to have all BE tx groups to be recovered at the same
+ *     time (which would require some rework in BE grouping and BE tx group
+ *     fom), but even in this case we may get a deadlock if BE log is full. This
+ *     could be solved by always having some part of BE log to be allocted to BE
+ *     recovery activities, but with multiple subsequent failures during BE
+ *     recovery even this part of the log may get full. It could be solved by
+ *     preallocating space in BE segment to copy BE tx payloads from BE log to
+ *     handle this particular case, but hey, we only want to resend FDMI records
+ *     during BE recovery and record them to DIX in FDMI plugin and now we have
+ *     to do several major changes to Motr components archivecture already.
+ *
  * @{
  */
 

--- a/fdmi/fol_fdmi_src.c
+++ b/fdmi/fol_fdmi_src.c
@@ -24,6 +24,7 @@
 #include "lib/trace.h"
 #include "lib/memory.h"
 #include "lib/finject.h" /* M0_FI_ENABLED */
+#include "lib/string.h"         /* strlen */
 
 #include "fdmi/fdmi.h"
 #include "fdmi/source_dock.h"
@@ -31,7 +32,10 @@
 #include "fdmi/filter.h"
 #include "fdmi/source_dock_internal.h"
 #include "fdmi/module.h"
-#include "fop/fop.h"     /* m0_fop_fol_frag */
+#include "fop/fop.h"            /* m0_fop_fol_frag */
+#include "rpc/rpc_opcodes.h"    /* M0_CAS_PUT_FOP_OPCODE */
+#include "cas/cas.h"            /* m0_cas_op */
+
 
 /**
  * @addtogroup fdmi_fol_src
@@ -598,6 +602,67 @@ M0_INTERNAL void m0_fol_fdmi_post_record(struct m0_fom *fom)
 	 */
 
 	M0_LEAVE();
+}
+
+M0_INTERNAL bool
+m0_fol_fdmi__filter_kv_substring_match(struct m0_buf  *value,
+                                       const char    **substrings)
+{
+	struct m0_buf s;
+	m0_bcount_t   j;
+	bool          match;
+	int           i;
+
+	for (i = 0; substrings[i] != NULL; ++i) {
+		s = M0_BUF_INIT_CONST(strlen(substrings[i]), substrings[i]);
+		if (value->b_nob < s.b_nob)
+			return false;
+		match = false;
+		/* brute-force */
+		for (j = 0; j <= value->b_nob - s.b_nob; ++j) {
+			if (m0_buf_eq(&s, &M0_BUF_INIT(s.b_nob,
+			                               value->b_addr + j))) {
+				match = true;
+				break;
+			}
+		}
+		if (!match)
+			return false;
+	}
+	return true;
+}
+
+M0_INTERNAL int
+m0_fol_fdmi_filter_kv_substring(struct m0_fdmi_eval_ctx      *ctx,
+                                struct m0_conf_fdmi_filter   *filter,
+                                struct m0_fdmi_eval_var_info *var_info)
+{
+	struct m0_fdmi_src_rec *src_rec = var_info->user_data;
+	struct m0_fop_fol_frag *fop_fol_frag;
+	struct m0_fol_frag     *fol_frag;
+	struct m0_fol_rec      *fol_rec;
+	struct m0_cas_rec      *cas_rec;
+	struct m0_cas_op       *cas_op;
+	int                     i;
+
+	fol_rec = container_of(src_rec, struct m0_fol_rec, fr_fdmi_rec);
+	m0_tl_for(m0_rec_frag, &fol_rec->fr_frags, fol_frag) {
+		if (fol_frag->rp_ops->rpo_type != &m0_fop_fol_frag_type)
+			continue;
+		fop_fol_frag = fol_frag->rp_data;
+		if (fop_fol_frag->ffrp_fop_code != M0_CAS_PUT_FOP_OPCODE)
+			continue;
+		cas_op = fop_fol_frag->ffrp_fop;
+		M0_ASSERT(cas_op != NULL);
+		for (i = 0; i < cas_op->cg_rec.cr_nr; ++i) {
+			cas_rec = &cas_op->cg_rec.cr_rec[i];
+			if (m0_fol_fdmi__filter_kv_substring_match(
+				   &cas_rec->cr_val.u.ab_buf,
+				   filter->ff_substrings))
+				return 1;
+		}
+	} m0_tl_endfor;
+	return 0;
 }
 
 /**

--- a/fdmi/fol_fdmi_src.h
+++ b/fdmi/fol_fdmi_src.h
@@ -29,6 +29,9 @@
 
 /* Forward declarations */
 struct m0_fom;
+struct m0_conf_fdmi_filter;
+struct m0_fdmi_eval_ctx;
+struct m0_fdmi_eval_var_info;
 
 /**
  * @defgroup fdmi_fol_src FDMI FOL source
@@ -85,6 +88,17 @@ M0_INTERNAL int m0_fol_fdmi_src_deinit(void);
 /** Submit new FOL entry to FDMI. */
 M0_INTERNAL void m0_fol_fdmi_post_record(struct m0_fom *fom);
 
+/** Implements M0_FDMI_FILTER_TYPE_KV_SUBSTRING filter. */
+M0_INTERNAL int
+m0_fol_fdmi_filter_kv_substring(struct m0_fdmi_eval_ctx      *ctx,
+                                struct m0_conf_fdmi_filter   *filter,
+                                struct m0_fdmi_eval_var_info *var_info);
+
+
+/** Internal function used to match the strings. Exported for UTs. */
+M0_INTERNAL bool
+m0_fol_fdmi__filter_kv_substring_match(struct m0_buf  *value,
+                                       const char    **substrings);
 /** @} group fdmi_fol_src */
 
 #endif /* __MOTR_FOL_FDMI_SRC_H__ */

--- a/fdmi/plugin_dock.c
+++ b/fdmi/plugin_dock.c
@@ -469,8 +469,8 @@ static void pdock_record_release(struct m0_ref *ref)
 	}
 
 	/* FIXME: TEMP */
-	M0_LOG(M0_WARN, "Processed FDMI rec "
-	       U128X_F, U128_P(&rreg->frr_rec->fr_rec_id));
+	M0_LOG(M0_DEBUG, "Processed FDMI rec "U128X_F". Releasing it now.",
+			 U128_P(&rreg->frr_rec->fr_rec_id));
 
 	rc = pdock_client_post(req, rreg->frr_sess, &release_ri_ops);
 	if (rc != 0) {

--- a/fdmi/plugin_dock_fom.c
+++ b/fdmi/plugin_dock_fom.c
@@ -301,25 +301,19 @@ static int pdock_fom_tick__feed_plugin_with_rec(struct m0_fom *fom)
 				 fids[pd_fom->pf_pos]);
 	if (rc == 0) {
 		/*
-		 * Plugin accepted the record,
-		 * so increment fdmi record refc
+		 * Plugin accepted the record. We already have a ref on
+		 * this record. No need to take extra ref.
 		 */
-		struct m0_fdmi_record_reg *rreg;
-
-		rreg = m0_fdmi__pdock_record_reg_find(&frec->fr_rec_id);
-
-		if (rreg == NULL) {
-			/* critical error,
-			   have to finish with no registration */
-			m0_fom_phase_set(fom,
-					 FDMI_PLG_DOCK_FOM_FINISH_WITH_REC);
-			M0_LOG(M0_ERROR,
-			       "record not registered in plugin dock");
-			M0_LEAVE();
-			return M0_FSO_AGAIN;
-		}
-
-		m0_ref_get(&rreg->frr_ref);
+		/*
+		 * If the plugin wants to do more work after returning
+		 * from the pcb->po_fdmi_rec(), it should increase fdmi
+		 * record refc, and then release it when done.
+		 * pseudo code:
+		 * struct m0_fdmi_record_reg *rreg;
+		 * rreg = m0_fdmi__pdock_record_reg_find(&frec->fr_rec_id);
+		 * if (rreg != NULL)
+		 *	m0_ref_get(&rreg->frr_ref);
+		 */
 	} else {
 		M0_LOG(M0_NOTICE,
 		       "plugin has rejected the record processing: "

--- a/fdmi/plugins/.gitignore
+++ b/fdmi/plugins/.gitignore
@@ -1,0 +1,1 @@
+fdmi_sample_plugin

--- a/fdmi/plugins/Makefile.sub
+++ b/fdmi/plugins/Makefile.sub
@@ -1,0 +1,2 @@
+fdmi_plugins_fdmi_sample_plugin_SOURCES = fdmi/plugins/fdmi_sample_plugin.c
+EXTRA_DIST	+= fdmi/plugins/fdmi_app

--- a/fdmi/plugins/debug.c
+++ b/fdmi/plugins/debug.c
@@ -1,0 +1,239 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+/*
+M0_INTERNAL void m0_save_m0_xcode_type(int fd, char tab[], const struct m0_xcode_type *xf_type)
+{
+	if (xf_type == NULL)
+		return;
+	int buffer_len = 4096;
+	char buffer[buffer_len] = {0};
+	int i = 0;
+	sprintf(buffer, "%sstruct m0_xcode_type: %p { \n", tab,xf_type);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_aggr: %d\n", tab, xf_type->xct_aggr);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_name: %s\n", tab, xf_type->xct_name);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_ops: %p\n", tab, xf_type->xct_ops);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_atype: %d\n", tab, xf_type->xct_atype);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_flags: %d\n", tab, xf_type->xct_flags);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_decor: %p\n", tab, xf_type->xct_decor);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_sizeof: %d\n", tab, (int)xf_type->xct_sizeof);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t%sxct_nr: %d\n", tab, (int)xf_type->xct_nr);
+	write(fd, buffer, strlen(buffer));
+
+	for  ( i = 0;i < (int)xf_type->xct_nr; i++) {
+		sprintf(buffer, "\t%sstruct m0_xcode_field: { \n", tab);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t%sxf_name: %s\n", tab, xf_type->xct_child[i].xf_name);
+		write(fd, buffer, strlen(buffer));
+
+		strcat(tab,"\t");
+		m0_save_m0_xcode_type(fd, tab, xf_type->xct_child[i].xf_type);
+
+		sprintf(buffer, "\t\t%sxf_tag: %lu\n", tab, xf_type->xct_child[i].xf_tag);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t%sxf_offset: %d\n", tab, xf_type->xct_child[i].xf_offset);
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t%s}\n", tab); //struct m0_xcode_field
+		write(fd, buffer, strlen(buffer));
+	}
+
+	sprintf(buffer, "%s}\n", tab); //struct m0_xcode_type
+	write(fd, buffer, strlen(buffer));
+}
+
+M0_INTERNAL void m0_save_m0_fol_rec(struct m0_fol_rec *rec, const char *prefix)
+{
+	char filename[32] = {0};
+	int buffer_len = 4096;
+	char buffer[buffer_len] = {0};
+	int fd = 0;
+	static int fc = 0;
+	sprintf(filename, "/tmp/fol_rec_%s_%p_%d", prefix, rec, fc);
+	M0_ENTRY("m0_save_m0_fol_rec fol rec=%p\n ", rec);
+	++fc;
+
+	//open the file
+	fd = open(filename, O_WRONLY | O_CREAT);
+	if (fd == -1)
+		return;
+
+	//using m0_fol_rec_to_str
+	//int len = m0_fol_rec_to_str(rec, buffer, buffer_len);
+	//write(fd, buffer, len);
+
+	//fill the buffer and write buffer
+	sprintf(buffer, "\nstruct m0_fol_rec {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\tm0_fol: %p\n", rec->fr_fol);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\tfr_tid: %lu\n", rec->fr_tid);
+	write(fd, buffer, strlen(buffer));
+
+	//struct m0_fol_rec_header
+	sprintf(buffer, "\tstruct m0_fol_rec_header {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\trh_frags_nr: %u\n", rec->fr_header.rh_frags_nr);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\trh_data_len: %u\n", rec->fr_header.rh_data_len);
+	write(fd, buffer, strlen(buffer));
+
+	//struct m0_update_id
+	sprintf(buffer, "\t\tstruct m0_update_id {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\t\tui_node: %u\n", rec->fr_header.rh_self.ui_node);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\t\tui_update: %lu\n", rec->fr_header.rh_self.ui_update);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\t\trh_magic: %lu\n", rec->fr_header.rh_magic);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\tfr_epoch: %p\n", rec->fr_epoch);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\tfr_sibling: %p\n", rec->fr_sibling);
+	write(fd, buffer, strlen(buffer));
+
+	//m0_fol_frag:rp_link to this list
+	struct m0_fol_frag     *frag;
+	sprintf(buffer, "\tstruct m0_tl {\n");
+	m0_tl_for(m0_rec_frag, &rec->fr_frags, frag) {
+		sprintf(buffer, "\t\tstruct m0_fol_frag {\n");
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t struct m0_fol_frag_ops = %p {\n", frag->rp_ops);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t struct m0_fol_frag_type : %p{\n", frag->rp_ops->rpo_type);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\trpt_index: %d\n", frag->rp_ops->rpo_type->rpt_index);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\trpt_name: %s\n", frag->rp_ops->rpo_type->rpt_name);
+		write(fd, buffer, strlen(buffer));
+
+		//const struct m0_xcode_type        *rpt_xt;
+		char tab[100] = "\t\t\t\t\t";
+		m0_save_m0_xcode_type(fd, tab, frag->rp_ops->rpo_type->rpt_xt);
+
+		sprintf(buffer, "\t\t\t\t}\n");//struct m0_fol_frag_ops
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t}\n");
+		write(fd, buffer, strlen(buffer));
+
+		struct m0_fop_fol_frag *fp_frag = frag->rp_data;
+		sprintf(buffer, "\t\t\tstruct m0_fop_fol_frag: %p{\n", fp_frag);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\tffrp_fop_code: %d\n", fp_frag->ffrp_fop_code);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\tffrp_rep_code: %d\n", fp_frag->ffrp_rep_code);
+		write(fd, buffer, strlen(buffer));
+		struct m0_xcode_obj obj = {
+			//.xo_type = m0_fop_fol_frag_xc,
+			.xo_type = m0_cas_op_xc,
+			.xo_ptr = fp_frag->ffrp_fop
+			//.xo_ptr = frag->rp_data
+		};
+		//m0_xcode_print(&obj, buffer, buffer_len);
+
+		struct m0_cas_op *cas_op = fp_frag->ffrp_fop;
+		M0_LOG(M0_DEBUG, "m0_save rec: %p cas_op=%p ", rec, cas_op);
+		sprintf(buffer, "\t\t\t\tstruct m0_cas_op: %p {\n", cas_op);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\t\tfid:"FID_F"\n", FID_P(&cas_op->cg_id.ci_fid));
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\t\t\tstruct m0_cas_recv: {\n");
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t\t\tcr_nr: %lu\n", cas_op->cg_rec.cr_nr);
+		write(fd, buffer, strlen(buffer));
+		int i=0;
+		for (i = 0; i < cas_op->cg_rec.cr_nr; i++) {
+			sprintf(buffer, "\n\t\t\t\t\t\tcr_key: %lu bytes ", cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_nob);
+			write(fd, buffer, strlen(buffer));
+			write(fd, cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_addr,
+			      cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_nob);
+			sprintf(buffer, "\n\t\t\t\t\t\tcr_val: %lu bytes ", cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_nob);
+			write(fd, buffer, strlen(buffer));
+			write(fd, cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_addr,
+			      cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_nob);
+			M0_LOG(M0_DEBUG, "op = %p key: %lu value=%lu ", cas_op, cas_op->cg_rec.cr_rec[i].cr_key.u.ab_buf.b_nob,
+			       cas_op->cg_rec.cr_rec[i].cr_val.u.ab_buf.b_nob);
+		}
+		sprintf(buffer, "\n\t\t\t\t\t}\n"); //struct m0_cas_recv
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\t\t\t\tcg_flags: %d\n", cas_op->cg_flags);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\t\t}\n"); //struct m0_cas_op
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\t}\n"); //struct m0_fop_fol_frag
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t\trp_magic: %lu\n", frag->rp_magic);
+		write(fd, buffer, strlen(buffer));
+		sprintf(buffer, "\t\t\trp_flag: %d\n", frag->rp_flag);
+		write(fd, buffer, strlen(buffer));
+
+		sprintf(buffer, "\t\t}\n");
+		write(fd, buffer, strlen(buffer));
+
+	} m0_tl_endfor;
+	sprintf(buffer, "\t}\n");
+
+        //struct m0_fdmi_src_rec
+	sprintf(buffer, "\tstruct m0_fdmi_src_rec {\n");
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tfsr_magic: %lu\n",rec->fr_fdmi_rec.fsr_magic);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tstruct *m0_fdmi_src fsr_src =%p{\n",rec->fr_fdmi_rec.fsr_src);
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\t\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "\t\tfsr_rec_id:"U128X_F"\n",U128_P(&rec->fr_fdmi_rec.fsr_rec_id));
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tfsr_matched: %d\n",rec->fr_fdmi_rec.fsr_matched);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t\tfsr_dryrun: %d\n",rec->fr_fdmi_rec.fsr_dryrun);
+	write(fd, buffer, strlen(buffer));
+	sprintf(buffer, "\t}\n");
+	write(fd, buffer, strlen(buffer));
+
+	sprintf(buffer, "}\n");
+	write(fd, buffer, strlen(buffer));
+
+	close(fd);
+	M0_LEAVE("fol rec ptr=%p\n", rec);
+}
+*/
+

--- a/fdmi/plugins/fdmi_app
+++ b/fdmi/plugins/fdmi_app
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# This is the FDMI sample application. It serves as a hub for the FDMI
+# records delivered fdmi_sample_plugin C-program via stdout. To do so
+# it gathers the cluster configuration with 'hctl status' command,
+# forks fdmi_sample_plugin and waits for the FDMI events in JSON form.
+# The reason to use it is simply because it is much easier to parse data
+# and develop new features in python in compare to C.
+
+# For now it is just a demo that prints FDMI records to console, but
+# except this it can perform records de-dup and for example, replication
+# coordination by means of set of the replication python programs that
+# perform actual data move.
+
+import subprocess
+import signal
+import shlex
+import sys
+import json
+import codecs
+
+# Global cluster info including information required for running
+# fdmi_sample_plugin C-program.
+cluster_info = dict()
+
+# Global key-value cache used for records de-duplication. KV pairs
+# are available by the kv['cr_key']
+kv_records = dict()
+
+# Global list of fdmi_sample_plugin processes that this program
+# is communicating.
+processes = []
+
+
+def str_decode(encoded):
+    if encoded is None:
+        return None
+    if encoded == '0':
+        return encoded
+    return codecs.decode(encoded, 'hex')
+
+
+# Process the FDMI records in form of JSON and perform some useful actions
+# such as de-dup, logging and/or sending to the replicator program for data
+# move.
+def process_fdmi_record(kv_record):
+    kvs = json.loads(kv_record)
+    fid = str_decode(kvs.get('fid'))
+    if fid is None:
+        print('Invalid fid in kv_record {}'.format(kv_record), file=sys.stderr)
+        return
+    cr_key = str_decode(kvs.get('cr_key'))
+    if cr_key is None:
+        print('Invalid cr_key in kv_record {}'.format(kv_record), file=sys.stderr)
+        return
+    cr_val = str_decode(kvs.get('cr_val'))
+    if cr_val is None:
+        print('Invalid cr_val in kv_record {}'.format(kv_record), file=sys.stderr)
+        return
+    kv = {
+        'fid': fid,
+        'cr_key': cr_key,
+        'cr_val': cr_val
+    }
+
+    # Check de-dup records
+    kv_i = kv_records.get(cr_key)
+    if kv_i is not None and kv['cr_val'] != "0":
+        print('de-dup: {} {}'.format(kv_i, kv), file=sys.stderr)
+    elif kv['cr_val'] != "0":
+        print('new key-value: {}'.format(kv), file=sys.stderr)
+        kv_records['cr_key'] = kv
+
+
+# Handle SIGNT and SIGTERM. Stop the underlying processes and exit.
+def signal_handler(sig, frame):
+    print('CTRL + C pressed', file=sys.stderr)
+    print('Stopping all fdmi_sample_plugin processes...')
+    for p in processes:
+        p.send_signal(sig)
+        p.wait()
+    sys.exit(0)
+
+
+# Fork the process and capture its output
+def execute_command_and_get_output(cmd):
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            shell=True)
+    stdout, stderr = proc.communicate()
+    output_var = str(stdout, 'utf-8')
+    return output_var
+
+
+# fdmi_sample_plugin -l 192.168.52.53@tcp:12345:4:1 -h 192.168.52.53@tcp:12345:1:1
+# -p 0x7000000000000001:0x37 -f 0x7200000000000001:0x19 -g 0x6c00000000000001:0x81
+def get_plugin_cmd(args):
+    # fdmi_sample_plugin = "/path/to/cortx-motr/fdmi/plugins/fdmi_sample_plugin"
+    opts = " -l " + cluster_info['local_endpoint']
+    opts += " -h " + cluster_info['ha_endpoint']
+    opts += " -p " + cluster_info['profile_fid']
+    opts += " -f " + cluster_info['process_fid']
+    opts += " -g " + cluster_info['fdmi_filter_fid']
+    return args.plugin_path + opts
+
+
+# Gather the cluster info with 'hctl status --json' command, which is
+# need for running fdmi_sample_plugin. In case that --filter-id is omitted
+# then parse /etc/motr/confd.xc to find the filter-id for fdmi_sample_plugin
+def get_cluster_info(args):
+    info = dict()
+    cmd = '{} status --json'.format(args.hctl_path)
+    output = execute_command_and_get_output(cmd)
+    if output is None:
+        print('Failed to execute {}. Please make sure the path to '
+              '{} is correct'.format(cmd, args.hctl_path), file=sys.stderr)
+        return None
+    cluster_js = json.loads(output)
+    if cluster_js is None:
+        print('Failed to fetch cluster info.', file=sys.stderr)
+        return None
+
+    profiles = cluster_js.get('profiles')
+    if profiles is None or len(profiles) == 0:
+        print('Failed to fetch profiles from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+
+    profile_fid = str(profiles[0].get('fid'))
+    if profile_fid is None or len(profile_fid) == 0:
+        print('Failed to fetch profiles[0]/fid from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+    info['profile_fid'] = profile_fid
+
+    nodes_data = cluster_js.get('nodes')
+    if nodes_data is None or len(nodes_data) == 0:
+        print('Failed to fetch nodes from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+    services = nodes_data[0].get('svcs')
+    if services is None or len(services) == 0:
+        print('Failed to fetch nodes/svcs from cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+        return None
+
+    for svc in services:
+        if svc['name'] == 'hax':
+            ha_endpoint = str(svc.get('ep'))
+            if ha_endpoint is None or len(ha_endpoint) == 0:
+                print('Invalid nodes/svcs/hax/ep in cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+                return None
+            info['ha_endpoint'] = ha_endpoint
+
+        svc_name = str(svc.get('name'))
+        if svc_name is None or len(svc_name) == 0:
+            print('Invalid nodes/svcs/name in cluster info:\n{}'.format(cluster_js), file=sys.stderr)
+            return None
+
+        # Always using the first m0client
+        if svc_name == 'm0_client':
+            local_endpoint = str(svc.get('ep'))
+            if local_endpoint is None or len(local_endpoint) == 0:
+                print('Invalid nodes/svcs/m0_client/ep in cluster info:\n{}'.format(cluster_js),
+                      file=sys.stderr)
+                return None
+            info['local_endpoint'] = local_endpoint
+
+            process_fid = str(svc.get('fid'))
+            if process_fid is None or len(process_fid) == 0:
+                print('Invalid nodes/svcs/m0_client/fid in cluster info:\n{}'.format(cluster_js),
+                      file=sys.stderr)
+                return None
+            info['process_fid'] = process_fid
+            break
+
+    if args.filter_id is None:
+        with open(args.config_path) as f:
+            for s in f.readlines():
+                # Example: ' {0x6c| ((^l|1:81), 2, ^l|1:81, "", ^n|1:3, ^v|1:66, [1: "Bucket-Name"],
+                # [1: "192.168.12.2@tcp:12345:4:1"])},'
+                if s.startswith(' {0x6c| ((^l|'):
+                    s = s[15:]
+                    s = s[:s.index(')')]
+                    fdmi_filter_fid = f"0x6c00000000000001:{int(s):#x}"
+                    info['fdmi_filter_fid'] = fdmi_filter_fid
+                    break
+    else:
+        info['fdmi_filter_fid'] = args.filter_id
+
+    if info.get('ha_endpoint') is None:
+        print('Failed to get Hare endpoint from the cluster info.', file=sys.stderr)
+        return None
+    if info.get('process_fid') is None:
+        print('Failed to get client process fid from the cluster info.', file=sys.stderr)
+        return None
+    if info.get('local_endpoint') is None:
+        print('Failed to get local client endpoint from the cluster info.', file=sys.stderr)
+        return None
+    if info.get('fdmi_filter_fid') is None:
+        print('Failed to get fdmi filter id from the cluster config.', file=sys.stderr)
+        return None
+
+    print('  {}'.format(info), file=sys.stderr)
+    return info
+
+
+# For the plugin C-program and wait for data on stdout.
+def listen_on_command(command):
+    global processes
+    p = subprocess.Popen(shlex.split(command), stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if p is None:
+        print('Failed to run {}'.format(command), file=sys.stderr)
+        return -1
+    processes.append(p)
+
+    print('Listening for FDMI events on:\n  {}'.format(command), file=sys.stderr)
+    while True:
+        output = p.stdout.readline()
+        if output is not None:
+            fid = "fid"
+            record = output.decode("utf-8")
+            if fid in record:
+                process_fdmi_record(record)
+
+        rc = p.poll()
+        if rc is not None:
+            print('Exiting because fdmi_sample_plugin exited with:', file=sys.stderr)
+            print('  error code = {}'.format(rc), file=sys.stderr)
+            _, error = p.communicate()
+            if error is not None:
+                error = error.decode('utf-8')
+            if error is not None and len(error) > 0:
+                print('  error text = {}'.format(error), file=sys.stderr)
+            break
+
+    return p.poll()
+
+
+def main(args):
+    global cluster_info
+    einval = 22
+
+    # Filter id is used by Motr FDMI subsystem for identifying the
+    # FDMI plugins, because there are possible more than one.
+    # If the --filter-id is omitted then this program is looking
+    # for the corrct filter id in /etc/motr/confd.xc config file.
+
+    # Example: ' {0x6c| ((^l|1:81), 2, ^l|1:81, "", ^n|1:3, ^v|1:66, [1: "Bucket-Name"],
+    # [1: "192.168.12.2@tcp:12345:4:1"])},'
+
+    # The fid we need is 0x6c00000000000001:0x81 in this particular example.
+    if args.config_path is None and args.filter_id is None:
+        print('Either --config-path or --filter-id is required.', file=sys.stderr)
+        sys.exit(einval)
+
+    print('Using the following settings:', file=sys.stderr)
+    print('  plugin-path = {}'.format(args.plugin_path), file=sys.stderr)
+    print('  hctl-path = {}'.format(args.hctl_path), file=sys.stderr)
+
+    config_path = args.config_path
+    if config_path is None:
+        config_path = 'using filter-id'
+    print('  config-path = {}'.format(config_path), file=sys.stderr)
+
+    filter_id = args.filter_id
+    if filter_id is None:
+        filter_id = 'using config-path'
+    print('  filter-id = {}'.format(filter_id), file=sys.stderr)
+
+    print('Register SIGINT signal handler', file=sys.stderr)
+    signal.signal(signal.SIGINT, signal_handler)
+
+    print('Cluster info:', file=sys.stderr)
+    cluster_info = get_cluster_info(args)
+    if cluster_info is None:
+        sys.exit(einval)
+
+    # Execute fdmi_sample_plugin with cluster info in loop and wait for
+    # the FDMI events in form of JSON metadata.
+    listen_on_command(get_plugin_cmd(args))
+
+
+if __name__ == '__main__':
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('-pp', '--plugin-path', required=False,
+                    help='path to fdmi_sample_plugin executable',
+                    type=str, default='./fdmi_sample_plugin')
+    ap.add_argument('-hp', '--hctl-path', required=False, help='path to hctl executable',
+                    type=str, default='hctl')
+    ap.add_argument('-cp', '--config-path', required=False, help='path to confd.xc file',
+                    type=str, default='/etc/motr/confd.xc')
+    ap.add_argument('-fi', '--filter-id', required=False, help='plugin filter id',
+                    type=str)
+    main(ap.parse_args())

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -63,7 +63,6 @@ do_some_kv_operations()
 					      get    "$DIX_FID" "key1"                     \
 					      put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
 					      get    "$DIX_FID" "key2"                     \
-					      del    "$DIX_FID" "key2"                     \
 				 || {
 			rc=$?
 			echo "m0kv failed"

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -59,6 +59,7 @@ do_some_kv_operations()
 					      get    "$DIX_FID" "key1"                     \
 					      put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
 					      get    "$DIX_FID" "key2"                     \
+					      del    "$DIX_FID" "key2"                     \
 				 || {
 			rc=$?
 			echo "m0kv failed"

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -68,21 +68,21 @@ do_some_kv_operations()
 			echo "m0kv failed"
 		}
 
-                echo "Now, let's delete 'key2' from this index. The plugin must show the del op coming"
-                $M0_SRC_DIR/utils/m0kv ${MOTR_PARAM}                                       \
-                                        index del    "$DIX_FID" "key2"                     \
-                                 || {
-                        rc=$?
-                        echo "m0kv index del failed"
-                }
+		echo "Now, let's delete 'key2' from this index. The plugin must show the del op coming"
+		$M0_SRC_DIR/utils/m0kv ${MOTR_PARAM}                                       \
+					index del    "$DIX_FID" "key2"                     \
+				 || {
+			rc=$?
+			echo "m0kv index del failed"
+		}
 
-                echo "Now, let's get 'key2' from this index again. It should fail."
-                $M0_SRC_DIR/utils/m0kv ${MOTR_PARAM}                                       \
-                                        index get    "$DIX_FID" "key2"                     \
-                                 && {
-                        rc=22 # EINVAL to indicate the test is failed
-                        echo "m0kv index get expected to fail, but did not."
-                }
+		echo "Now, let's get 'key2' from this index again. It should fail."
+		$M0_SRC_DIR/utils/m0kv ${MOTR_PARAM}                                       \
+				index get    "$DIX_FID" "key2"                     \
+				 && {
+			rc=22 # EINVAL to indicate the test is failed
+			echo "m0kv index get expected to fail, but did not."
+		}
 
 	done
 	return $rc
@@ -97,14 +97,14 @@ start_fdmi_plugin()
 		    -h ${lnet_nid}:$HA_EP -p $PROF_OPT    \
 		    -f $M0T1FS_PROC_ID                    "
 
-	$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g $FDMI_FILTER_FID &
+	$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g "$FDMI_FILTER_FID" &
 	sleep 5
 
 	# Checking for the pid of the started plugin process
-        local pid=$(pgrep -f "lt-fdmi_sample_plugin")
+	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
 	if test "x$pid" = x; then
-	    echo "Failed to start FDMI plugin"
-	    rc=22 # EINVAL to indidate plugin start is failed
+		echo "Failed to start FDMI plugin"
+		rc=22 # EINVAL to indidate plugin start is failed
 	fi
 	return $rc
 }
@@ -112,11 +112,11 @@ start_fdmi_plugin()
 
 stop_fdmi_plugin()
 {
-        local pid=$(pgrep -f "lt-fdmi_sample_plugin")
+	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
 	if test "x$pid" != x; then
-	    echo "Terminating ${pid}"
-	    kill -TERM "${pid}"
-	    wait "${pid}"
+		echo "Terminating ${pid}"
+		kill -TERM "${pid}"
+	wait "${pid}"
 	fi
 	return 0
 }
@@ -147,7 +147,7 @@ motr_fdmi_plugin_test()
 		# if kv operations fail.
 		rc=$?
 		echo "Test failed with error $rc"
-        }
+	}
 
 	# wait_and_exit
 

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+
+TOPDIR=$(dirname "$0")/../../
+
+. "${TOPDIR}/m0t1fs/linux_kernel/st/common.sh"
+. "${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh"
+. "${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_client_inc.sh"
+. "${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_server_inc.sh"
+. "${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh"
+
+
+export MOTR_CLIENT_ONLY=1
+
+wait_and_exit()
+{
+	while [ true ] ; do
+		echo "Please type EXIT or QUIT to quit"
+		read keystroke
+		if [ "$keystroke" == "EXIT" -o "$keystroke" == "QUIT" ] ; then
+			return 0
+		fi
+	done
+}
+
+do_some_kv_operations()
+{
+	local rc=0
+
+	for ((i=0; i < 1; i++)) ; do
+		DIX_FID="12345:12345$i"
+		MOTR_PARAM="-l ${lnet_nid}:$SNS_MOTR_CLI_EP  \
+			    -h ${lnet_nid}:$HA_EP -p $PROF_OPT \
+			    -f $M0T1FS_PROC_ID -s "
+
+		$M0_SRC_DIR/utils/m0kv ${MOTR_PARAM}                                       \
+					index create "$DIX_FID"                            \
+					      put    "$DIX_FID" "somekey" "somevalue"      \
+					      get    "$DIX_FID" "somekey"                  \
+					      put    "$DIX_FID" "key1" "something1 anotherstring2 YETanotherstring3"      \
+					      get    "$DIX_FID" "key1"                     \
+					      put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
+					      get    "$DIX_FID" "key2"                     \
+				 || {
+			rc=$?
+			echo "m0kv failed"
+		}
+	done
+	return $rc
+}
+
+start_fdmi_plugin()
+{
+	local rc=0
+
+	# We are using FDMI_PLUGIN_EP
+	MOTR_PARAM="-l ${lnet_nid}:$FDMI_PLUGIN_EP        \
+		    -h ${lnet_nid}:$HA_EP -p $PROF_OPT    \
+		    -f $M0T1FS_PROC_ID                    "
+
+	$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g "$FDMI_FILTER_FID" &
+	sleep 5
+
+	return $rc
+}
+
+
+
+motr_fdmi_plugin_test()
+{
+	local rc=0
+
+	echo "Starting Motr FDMI Plugin testing ..."
+
+	echo
+	echo
+	echo "MOTR is UP."
+	echo "Motr client config:"
+	echo
+	echo "HA_addr        : ${lnet_nid}:$HA_EP           "
+	echo "Client_addr    : ${lnet_nid}:$SNS_MOTR_CLI_EP "
+	echo "Profile_fid    : $PROF_OPT                    "
+	echo "Process_fid    : $M0T1FS_PROC_ID              "
+	echo "FDMI_plugin_ep : ${lnet_nid}:$FDMI_PLUGIN_EP  "
+	echo "FDMI_FILTER_FID: $FDMI_FILTER_FID             "
+	echo
+	echo
+
+	start_fdmi_plugin
+
+	do_some_kv_operations
+
+#	wait_and_exit
+
+	sleep 3
+
+	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
+	echo "Terminating ${pid}"
+	kill -TERM "${pid}"
+	wait "${pid}"
+
+	return 0
+}
+
+main()
+{
+	local rc=0
+
+	sandbox_init
+
+	local multiple_pools=0
+	motr_service start "$multiple_pools" "$stride" "$N" "$K" "$S" "$P" || {
+		echo "Failed to start Motr Service."
+		return 1
+	}
+
+
+	if [[ $rc -eq 0 ]] && ! motr_fdmi_plugin_test ; then
+		echo "Failed: SNS repair failed.."
+		rc=1
+	fi
+
+	motr_service stop || {
+		echo "Failed to stop Motr Service."
+		rc=1
+	}
+
+	if [ $rc -eq 0 ]; then
+		sandbox_fini
+	fi
+	return $rc
+}
+
+trap unprepare EXIT
+main
+report_and_exit "motr_fdmi_plugin_test" $?

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -63,6 +63,7 @@ do_some_kv_operations()
 					      get    "$DIX_FID" "key1"                     \
 					      put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
 					      get    "$DIX_FID" "key2"                     \
+					      del    "$DIX_FID" "key2"                     \
 				 || {
 			rc=$?
 			echo "m0kv failed"

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -17,6 +17,10 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
+# Authors:
+#   hua.huang@seagate.com
+#   yuriy.umanets@seagate.com
+#
 
 
 TOPDIR=$(dirname "$0")/../../
@@ -45,7 +49,7 @@ do_some_kv_operations()
 {
 	local rc=0
 
-	for ((i=0; i < 1; i++)) ; do
+	for ((i=0; i<1; i++)) ; do
 		DIX_FID="12345:12345$i"
 		MOTR_PARAM="-l ${lnet_nid}:$SNS_MOTR_CLI_EP  \
 			    -h ${lnet_nid}:$HA_EP -p $PROF_OPT \
@@ -59,11 +63,27 @@ do_some_kv_operations()
 					      get    "$DIX_FID" "key1"                     \
 					      put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
 					      get    "$DIX_FID" "key2"                     \
-					      del    "$DIX_FID" "key2"                     \
 				 || {
 			rc=$?
 			echo "m0kv failed"
 		}
+
+                echo "Now, let's delete 'key2' from this index. The plugin must show the del op coming"
+                $M0_SRC_DIR/utils/m0kv ${MOTR_PARAM}                                       \
+                                        index del    "$DIX_FID" "key2"                     \
+                                 || {
+                        rc=$?
+                        echo "m0kv index del failed"
+                }
+
+                echo "Now, let's get 'key2' from this index again. It should fail."
+                $M0_SRC_DIR/utils/m0kv ${MOTR_PARAM}                                       \
+                                        index get    "$DIX_FID" "key2"                     \
+                                 && {
+                        rc=22 # EINVAL to indicate the test is failed
+                        echo "m0kv index get expected to fail, but did not."
+                }
+
 	done
 	return $rc
 }
@@ -77,12 +97,29 @@ start_fdmi_plugin()
 		    -h ${lnet_nid}:$HA_EP -p $PROF_OPT    \
 		    -f $M0T1FS_PROC_ID                    "
 
-	$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g "$FDMI_FILTER_FID" &
+	$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g $FDMI_FILTER_FID &
 	sleep 5
 
+	# Checking for the pid of the started plugin process
+        local pid=$(pgrep -f "lt-fdmi_sample_plugin")
+	if test "x$pid" = x; then
+	    echo "Failed to start FDMI plugin"
+	    rc=22 # EINVAL to indidate plugin start is failed
+	fi
 	return $rc
 }
 
+
+stop_fdmi_plugin()
+{
+        local pid=$(pgrep -f "lt-fdmi_sample_plugin")
+	if test "x$pid" != x; then
+	    echo "Terminating ${pid}"
+	    kill -TERM "${pid}"
+	    wait "${pid}"
+	fi
+	return 0
+}
 
 
 motr_fdmi_plugin_test()
@@ -96,29 +133,27 @@ motr_fdmi_plugin_test()
 	echo "MOTR is UP."
 	echo "Motr client config:"
 	echo
-	echo "HA_addr        : ${lnet_nid}:$HA_EP           "
-	echo "Client_addr    : ${lnet_nid}:$SNS_MOTR_CLI_EP "
-	echo "Profile_fid    : $PROF_OPT                    "
-	echo "Process_fid    : $M0T1FS_PROC_ID              "
-	echo "FDMI_plugin_ep : ${lnet_nid}:$FDMI_PLUGIN_EP  "
-	echo "FDMI_FILTER_FID: $FDMI_FILTER_FID             "
+	echo "HA addr        : ${lnet_nid}:$HA_EP           "
+	echo "Client addr    : ${lnet_nid}:$SNS_MOTR_CLI_EP "
+	echo "Profile fid    : $PROF_OPT                    "
+	echo "Process fid    : $M0T1FS_PROC_ID              "
+	echo "FDMI plugin ep : ${lnet_nid}:$FDMI_PLUGIN_EP  "
+	echo "FDMI filter fid: $FDMI_FILTER_FID             "
 	echo
 	echo
 
-	start_fdmi_plugin
+	start_fdmi_plugin && do_some_kv_operations || {
+		# Make the rc available for the caller and fail the test
+		# if kv operations fail.
+		rc=$?
+		echo "Test failed with error $rc"
+        }
 
-	do_some_kv_operations
-
-#	wait_and_exit
+	# wait_and_exit
 
 	sleep 3
-
-	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
-	echo "Terminating ${pid}"
-	kill -TERM "${pid}"
-	wait "${pid}"
-
-	return 0
+	stop_fdmi_plugin
+	return $rc
 }
 
 main()
@@ -135,7 +170,7 @@ main()
 
 
 	if [[ $rc -eq 0 ]] && ! motr_fdmi_plugin_test ; then
-		echo "Failed: SNS repair failed.."
+		echo "FDMI plugin test failed."
 		rc=1
 	fi
 

--- a/fdmi/plugins/fdmi_sample_plugin.c
+++ b/fdmi/plugins/fdmi_sample_plugin.c
@@ -103,8 +103,16 @@ static struct m0_reqh_service *fsp_fdmi_service = NULL;
 #define MAX_LEN 8192
 static char buffer[MAX_LEN];
 
+static char *to_str(void *addr, int len)
+{
+	if (len > MAX_LEN - 1)
+		len = MAX_LEN - 1;
+	memcpy(buffer, addr, len);
+	buffer[len] = '\0';
+	return buffer;
+}
 
-static char *to_hex(void *addr, int len)
+M0_UNUSED static char *to_hex(void *addr, int len)
 {
 	int i, j;
 	if ((2 * len) > MAX_LEN) {
@@ -113,7 +121,7 @@ static char *to_hex(void *addr, int len)
 	}
 	for(i = 0, j = 0; i < (2 * len) && j < len; ++j)
 		i += sprintf(buffer + i, "%02x", ((char *)addr)[j]);
-	buffer[2 * len - 2] = '\0';
+	buffer[2 * len] = '\0';
 	return buffer;
 }
 
@@ -131,20 +139,20 @@ static void dump_fol_rec_to_json(struct m0_fol_rec *rec)
 		for (i = 0; i < cg_rec.cr_nr; i++) {
 			int len = 0;
 
-			m0_console_printf("{ ");
+			m0_console_printf("{ \"opcode\"=\"%d\", ", fp_frag->ffrp_fop_code);
 
 			len = sizeof(struct m0_fid);
-			m0_console_printf("\"fid\": \"%s\", ",
-					  to_hex((void *)&cas_op->cg_id.ci_fid, len));
+			m0_console_printf("\"fid\": \""FID_F"\", ",
+					  FID_P(&cas_op->cg_id.ci_fid));
 
 			len = cr_rec[i].cr_key.u.ab_buf.b_nob;
 			m0_console_printf("\"cr_key\": \"%s\", ",
-					  to_hex(cr_rec[i].cr_key.u.ab_buf.b_addr, len));
+					  to_str(cr_rec[i].cr_key.u.ab_buf.b_addr, len));
 
 			len = cr_rec[i].cr_val.u.ab_buf.b_nob;
 			if (len > 0) {
 				m0_console_printf("\"cr_val\": \"%s\"",
-						  to_hex(cr_rec[i].cr_val.u.ab_buf.b_addr, len));
+						  to_str(cr_rec[i].cr_val.u.ab_buf.b_addr, len));
 			} else {
 				m0_console_printf("\"cr_val\": \"0\"");
 			}
@@ -164,7 +172,7 @@ static void fsp_usage(void)
 		"Usage example for common arguments: \n"
 		"fdmi_sample_plugin -l 192.168.52.53@tcp:12345:4:1 "
 		"-h 192.168.52.53@tcp:12345:1:1 "
-		"-p 0x7000000000000001:0x37 -f 0x7200000000000001:0x19"
+		"-p 0x7000000000000001:0x37 -f 0x7200000000000001:0x19 "
 		"-g 0x6c00000000000001:0x51"
 		"\n");
 }
@@ -298,7 +306,7 @@ static int init_fdmi_plugin(struct m0_fsp_params *params)
 	fsp_pdo = m0_fdmi_plugin_dock_api_get();
 
 	rc = fsp_pdo->fpo_register_filter(&params->spp_fdmi_plugin_fid, &fd, &pcb);
-	fprintf(stderr, "Plugin registration failed: rc=%d\n", rc);
+	fprintf(stderr, "Plugin registration: rc=%d\n", rc);
 	if (rc != 0)
 		return rc;
 

--- a/fdmi/plugins/fdmi_sample_plugin.c
+++ b/fdmi/plugins/fdmi_sample_plugin.c
@@ -1,0 +1,446 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_FDMI
+#include "lib/trace.h"
+
+#include "motr/client.h"
+#include "fid/fid.h"
+#include "motr/client_internal.h"
+#include "lib/getopts.h"	/* M0_GETOPTS */
+#include "fdmi/fdmi.h"
+#include "fdmi/plugin_dock.h"
+#include "fdmi/service.h"
+#include "reqh/reqh.h"
+
+/**
+ * Plugin sample conf params. Here _fsp means "fdmi sample plugin"
+ * and _spp - "sample plugin params".
+ */
+struct m0_fsp_params {
+	char          *spp_local_addr;
+	char          *spp_hare_addr;
+	char          *spp_profile_fid;
+	char          *spp_process_fid;
+	char          *spp_fdmi_plugin_fid_s;
+	struct m0_fid  spp_fdmi_plugin_fid;
+};
+
+/**
+ * This is the FDMI plugin program. Its purpose is to start the listener
+ * for the special type of the FDMI events and forward them to the fdmi_app
+ * wrapper written in python. The communication is done via stdout.
+ */
+
+/**
+ * Storage for the program run parameters passed from console or the wrapper
+ * application.
+ */
+struct m0_fsp_params fsp_params;
+
+/**
+ * The main loop semaphore. The main loop here is just sleeping most of
+ * the time and waiting for some stop signal (e.g ctrl+c) from the python
+ * fdmi_app that controls this plugin program.
+ *
+ * The main job is done in one of the Motr locality threads, that handles
+ * the fops with FDMI data and call the callback function installed by this
+ * program if the type of the plugin match is found.
+ */
+static struct m0_semaphore fsp_sem;
+
+/**
+ * This program is basically adding the new client to the cluster. To do so
+ * we need to specify the client endpoint and the address of the cluster
+ * configuration service. This structure is used for delivering this info
+ * to the Motr core.
+ */
+static struct m0_config	fsp_conf = {};
+
+/**
+ * Pointer to the initialized m0_client structure denoting our program
+ * functionality.
+ */
+static struct m0_client	*fsp_client = NULL;
+
+/* DIX service (client interface for kv storage) config. */
+static struct m0_idx_dix_config	fsp_dix_conf = {};
+
+/**
+ * The vector of the FDMI plugin callback operations. They are called by
+ * the Motr when the new FDMI event occurs.
+ */
+const struct m0_fdmi_pd_ops *fsp_pdo;
+
+/**
+ * The handle of the local FDMI service that we start. Its purpose is to
+ * receive the FDMI rpcs, find the local consumer (this program) and send
+ * forward them to the consumer plugin in the form of FDMI records.
+ */
+static struct m0_reqh_service *fsp_fdmi_service = NULL;
+
+/**
+ * Aux buffer, used for data parsing.
+ */
+#define MAX_LEN 8192
+static char buffer[MAX_LEN];
+
+
+static char *to_hex(void *addr, int len)
+{
+	int i, j;
+	if ((2 * len) > MAX_LEN) {
+		fprintf(stderr, "to_hex() failed with (2 * len) > MAX_LEN\n");
+		return NULL;
+	}
+	for(i = 0, j = 0; i < (2 * len) && j < len; ++j)
+		i += sprintf(buffer + i, "%02x", ((char *)addr)[j]);
+	buffer[2 * len - 2] = '\0';
+	return buffer;
+}
+
+static void dump_fol_rec_to_json(struct m0_fol_rec *rec)
+{
+	struct m0_fol_frag *frag;
+	int i;
+
+	m0_tl_for(m0_rec_frag, &rec->fr_frags, frag) {
+		struct m0_fop_fol_frag *fp_frag = frag->rp_data;
+		struct m0_cas_op *cas_op = fp_frag->ffrp_fop;
+		struct m0_cas_recv cg_rec = cas_op->cg_rec;
+		struct m0_cas_rec *cr_rec = cg_rec.cr_rec;
+
+		for (i = 0; i < cg_rec.cr_nr; i++) {
+			int len = 0;
+
+			m0_console_printf("{ ");
+
+			len = sizeof(struct m0_fid);
+			m0_console_printf("\"fid\": \"%s\", ",
+					  to_hex((void *)&cas_op->cg_id.ci_fid, len));
+
+			len = cr_rec[i].cr_key.u.ab_buf.b_nob;
+			m0_console_printf("\"cr_key\": \"%s\", ",
+					  to_hex(cr_rec[i].cr_key.u.ab_buf.b_addr, len));
+
+			len = cr_rec[i].cr_val.u.ab_buf.b_nob;
+			if (len > 0) {
+				m0_console_printf("\"cr_val\": \"%s\"",
+						  to_hex(cr_rec[i].cr_val.u.ab_buf.b_addr, len));
+			} else {
+				m0_console_printf("\"cr_val\": \"0\"");
+			}
+			m0_console_printf(" }\n");
+
+		}
+	} m0_tl_endfor;
+}
+
+static void fsp_usage(void)
+{
+	fprintf(stderr,
+		"Usage: fdmi_sample_plugin "
+		"-l local_addr -h ha_addr -p profile_fid -f process_fid "
+		"-g fdmi_plugin_fid\n"
+		"Use -? or -i for more verbose help on common arguments.\n"
+		"Usage example for common arguments: \n"
+		"fdmi_sample_plugin -l 192.168.52.53@tcp:12345:4:1 "
+		"-h 192.168.52.53@tcp:12345:1:1 "
+		"-p 0x7000000000000001:0x37 -f 0x7200000000000001:0x19"
+		"-g 0x6c00000000000001:0x51"
+		"\n");
+}
+
+/**
+ * @retval 0      Success.
+ * @retval -Exxx  Error.
+ */
+static int fsp_args_parse(struct m0_fsp_params *params, int argc, char ** argv)
+{
+	int rc = 0;
+
+	params->spp_local_addr 	= NULL;
+	params->spp_hare_addr   = NULL;
+	params->spp_profile_fid = NULL;
+	params->spp_process_fid = NULL;
+	params->spp_fdmi_plugin_fid_s = NULL;
+
+	rc = M0_GETOPTS("fdmi_sample_plugin", argc, argv,
+			M0_HELPARG('?'),
+			M0_VOIDARG('i', "more verbose help",
+				   LAMBDA(void, (void) {
+						   fsp_usage();
+						   exit(0);
+					   })),
+			M0_STRINGARG('l', "Local endpoint address",
+				     LAMBDA(void, (const char *string) {
+						     params->spp_local_addr = (char*)string;
+					     })),
+			M0_STRINGARG('h', "HA address",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_hare_addr = (char*)str;
+					     })),
+			M0_STRINGARG('f', "Process FID",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_process_fid = (char*)str;
+					     })),
+			M0_STRINGARG('p', "Profile options for client",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_profile_fid = (char*)str;
+					     })),
+			M0_STRINGARG('g', "FDMI plugin fid",
+				     LAMBDA(void, (const char *str) {
+						     params->spp_fdmi_plugin_fid_s =
+							     (char*)str;
+					     })));
+	if (rc != 0)
+		return M0_ERR(rc);
+
+        /* All mandatory params must be defined. */
+        if (params->spp_local_addr == NULL  || params->spp_hare_addr == NULL   ||
+	    params->spp_profile_fid == NULL || params->spp_process_fid == NULL ||
+	    params->spp_fdmi_plugin_fid_s == NULL) {
+		fsp_usage();
+		return M0_ERR(-EINVAL);
+	}
+
+	rc = m0_fid_sscanf(params->spp_fdmi_plugin_fid_s, &params->spp_fdmi_plugin_fid);
+	if (rc != 0) {
+		rc = M0_ERR_INFO(rc, "Invalid FDMI plugin fid format: fid=%s",
+				 params->spp_fdmi_plugin_fid_s);
+	}
+
+	return rc;
+}
+
+/**
+ * Callback function called by the FDMI service to deliver the FDMI event
+ * to the plugin program.
+ */
+static int process_fdmi_record(struct m0_uint128 *rec_id,
+			       struct m0_buf fdmi_rec,
+		   	       struct m0_fid filter_id)
+{
+	struct m0_fol_rec fol_rec;
+	int               rc;
+
+	m0_fol_rec_init(&fol_rec, NULL);
+	rc = m0_fol_rec_decode(&fol_rec, &fdmi_rec);
+	if (rc != 0)
+		goto out;
+	dump_fol_rec_to_json(&fol_rec);
+out:
+	m0_fol_rec_fini(&fol_rec);
+	return rc;
+}
+
+static int fdmi_service_start(struct m0_client *m0c)
+{
+	struct m0_reqh *reqh = &m0c->m0c_reqh;
+	struct m0_reqh_service_type *stype;
+	bool start_service = false;
+	int rc = 0;
+
+	stype = m0_reqh_service_type_find("M0_CST_FDMI");
+	if (stype == NULL) {
+		M0_LOG(M0_ERROR, "FDMI service type is not found.");
+		return M0_ERR_INFO(-EINVAL, "Unknown reqh service type: M0_CST_FDMI");
+	}
+
+	fsp_fdmi_service = m0_reqh_service_find(stype, reqh);
+	if (fsp_fdmi_service == NULL) {
+		rc = m0_reqh_service_allocate(&fsp_fdmi_service, &m0_fdmi_service_type, NULL);
+		if (rc != 0)
+			return M0_RC_INFO(rc, "Failed to allocate FDMI service.");
+		m0_reqh_service_init(fsp_fdmi_service, reqh, NULL);
+		start_service = true;
+	}
+
+	if (start_service)
+        	rc = m0_reqh_service_start(fsp_fdmi_service);
+	return M0_RC(rc);
+}
+
+static void fdmi_service_stop(void)
+{
+	if (fsp_fdmi_service != NULL) {
+		m0_reqh_service_stop(fsp_fdmi_service);
+		fsp_fdmi_service = NULL;
+	}
+}
+
+static int init_fdmi_plugin(struct m0_fsp_params *params)
+{
+	const static struct m0_fdmi_plugin_ops pcb = {
+		.po_fdmi_rec = process_fdmi_record
+	};
+	const struct m0_fdmi_filter_desc fd;
+	int rc;
+
+	fsp_pdo = m0_fdmi_plugin_dock_api_get();
+
+	rc = fsp_pdo->fpo_register_filter(&params->spp_fdmi_plugin_fid, &fd, &pcb);
+	fprintf(stderr, "Plugin registration failed: rc=%d\n", rc);
+	if (rc != 0)
+		return rc;
+
+	fsp_pdo->fpo_enable_filters(true, &params->spp_fdmi_plugin_fid, 1);
+	return rc;
+}
+
+static void fini_fdmi_plugin(struct m0_fsp_params *params)
+{
+	fsp_pdo->fpo_enable_filters(false, &params->spp_fdmi_plugin_fid, 1);
+	fsp_pdo->fpo_deregister_plugin(&params->spp_fdmi_plugin_fid, 1);
+}
+
+static int fsp_init(struct m0_fsp_params *params)
+{
+	int rc;
+
+	fsp_conf.mc_local_addr            = params->spp_local_addr;
+	fsp_conf.mc_ha_addr               = params->spp_hare_addr;
+	fsp_conf.mc_profile               = params->spp_profile_fid;
+	fsp_conf.mc_process_fid           = params->spp_process_fid;
+	fsp_conf.mc_tm_recv_queue_min_len = M0_NET_TM_RECV_QUEUE_DEF_LEN;
+	fsp_conf.mc_max_rpc_msg_size      = M0_RPC_DEF_MAX_RPC_MSG_SIZE;
+	fsp_conf.mc_layout_id             = 1;
+	fsp_conf.mc_is_oostore            = 1;
+	fsp_conf.mc_is_read_verify        = 0;
+	fsp_conf.mc_idx_service_id        = M0_IDX_DIX;
+
+	fsp_dix_conf.kc_create_meta 	 = false;
+	fsp_conf.mc_idx_service_conf 	 = &fsp_dix_conf;
+
+	/* Client instance init */
+	rc = m0_client_init(&fsp_client, &fsp_conf, true);
+	if (rc != 0)
+		return rc;
+
+	M0_POST(fsp_client != NULL);
+
+	rc = fdmi_service_start(fsp_client);
+	if (rc != 0) {
+		m0_client_fini(fsp_client, true);
+		return rc;
+	}
+
+	rc = init_fdmi_plugin(params);
+	if (rc != 0) {
+		fdmi_service_stop();
+		m0_client_fini(fsp_client, true);
+	}
+	return rc;
+}
+
+static void fsp_fini(struct m0_fsp_params *params)
+{
+	fini_fdmi_plugin(params);
+
+	/* Client stops its services including FDMI */
+	m0_client_fini(fsp_client, true);
+}
+
+/*
+ * Signals handling
+ */
+static void fsp_sighandler(int signum)
+{
+	fprintf(stderr, "fdmi_sample_plugin interrupted by signal %d\n", signum);
+	m0_semaphore_up(&fsp_sem);
+
+        /* Restore default handlers. */
+	signal(SIGINT, SIG_DFL);
+	signal(SIGTERM, SIG_DFL);
+}
+
+static int fsp_sighandler_init(void)
+{
+	struct sigaction sa = { .sa_handler = fsp_sighandler };
+	int              rc;
+
+	sigemptyset(&sa.sa_mask);
+
+	/* Block these signals while the handler runs. */
+	sigaddset(&sa.sa_mask, SIGINT);
+	sigaddset(&sa.sa_mask, SIGTERM);
+
+	rc = sigaction(SIGINT, &sa, NULL) ?: sigaction(SIGTERM, &sa, NULL);
+	return rc == 0 ? 0 : M0_ERR(errno);
+}
+
+static void fsp_print_params(struct m0_fsp_params *params)
+{
+	fprintf(stderr,
+		"Starting params:\n"
+		"  local_ep: %s\n"
+		"  hare_ep : %s\n"
+		"  profile_fid : %s\n"
+		"  process_fid : %s\n"
+		"  plugin_fid  : %s\n",
+		params->spp_local_addr, params->spp_hare_addr,
+		params->spp_profile_fid, params->spp_process_fid,
+		params->spp_fdmi_plugin_fid_s);
+}
+
+int main(int argc, char **argv)
+{
+	int rc = 0;
+
+	if (argc == 1) {
+		fsp_usage();
+		exit(EXIT_FAILURE);
+	}
+
+	rc = fsp_args_parse(&fsp_params, argc, argv);
+	if (rc != 0) {
+		fprintf(stderr, "Args parse failed\n");
+		return M0_ERR(errno);
+	}
+
+	rc = m0_semaphore_init(&fsp_sem, 0);
+	if (rc != 0)
+		return M0_ERR(errno);
+
+	rc = fsp_init(&fsp_params);
+	if (rc != 0) {
+		rc = M0_ERR(errno);
+		goto fini_sem;
+	}
+
+	rc = fsp_sighandler_init();
+	if (rc != 0)
+		goto fini_fsp;
+
+        /* Main thread loop */
+	fsp_print_params(&fsp_params);
+	fprintf(stderr, "fdmi_sample_plugin waiting for signal...\n");
+	m0_semaphore_down(&fsp_sem);
+
+fini_fsp:
+	fsp_fini(&fsp_params);
+fini_sem:
+	m0_semaphore_fini(&fsp_sem);
+	return M0_RC(rc < 0 ? -rc : rc);
+}
+
+#undef M0_TRACE_SUBSYSTEM
+/** @} fdmi_sample_plugin */

--- a/fdmi/source_dock_fom.c
+++ b/fdmi/source_dock_fom.c
@@ -31,6 +31,9 @@
 #include "fdmi/source_dock_internal.h"
 #include "fdmi/fops.h"
 
+#include "fdmi/fol_fdmi_src.h"  /* m0_fol_fdmi_filter_kv_substring */
+
+
 static void fdmi_sd_fom_fini(struct m0_fom *fom);
 static int fdmi_sd_fom_tick(struct m0_fom *fom);
 static size_t fdmi_sd_fom_locality(const struct m0_fom *fom);
@@ -634,22 +637,46 @@ static int node_eval(void                        *data,
 	return src_rec->fsr_src->fs_node_eval(src_rec, value_desc, value);
 }
 
+static struct m0_fdmi_sd_filter_type_handler fdmi_filter_type_handlers[] = {
+	{
+		.ffth_id      = M0_FDMI_FILTER_TYPE_TREE,
+		.ffth_handler = &m0_fdmi_eval_flt,
+	},
+	{
+		.ffth_id      = M0_FDMI_FILTER_TYPE_KV_SUBSTRING,
+		.ffth_handler = &m0_fol_fdmi_filter_kv_substring,
+	},
+};
+
 static int fdmi_filter_calc(struct fdmi_sd_fom         *sd_fom,
 			    struct m0_fdmi_src_rec     *src_rec,
 			    struct m0_conf_fdmi_filter *fdmi_filter)
 {
-	struct m0_fdmi_eval_var_info get_var_info;
+	struct m0_fdmi_sd_filter_type_handler *handler;
+	struct m0_fdmi_eval_var_info           get_var_info;
+	int                                    rc;
+	int                                    i;
 
-	M0_ENTRY("sd_fom %p, src_rec %p, fdmi_filter %p",
+	M0_ENTRY("sd_fom=%p src_rec=%p fdmi_filter=%p",
 		 sd_fom, src_rec, fdmi_filter);
 	M0_PRE(m0_fdmi__record_is_valid(src_rec));
 
 	get_var_info.user_data    = src_rec;
 	get_var_info.get_value_cb = node_eval;
 
-	return M0_RC(m0_fdmi_eval_flt(&sd_fom->fsf_flt_eval,
-				      &fdmi_filter->ff_filter,
-				      &get_var_info));
+	for (i = 0; i < ARRAY_SIZE(fdmi_filter_type_handlers); ++i) {
+		handler = &fdmi_filter_type_handlers[i];
+		if (handler->ffth_id == fdmi_filter->ff_type) {
+			rc = handler->ffth_handler(&sd_fom->fsf_flt_eval,
+						   fdmi_filter,
+						   &get_var_info);
+			return M0_RC_INFO(rc,
+					  "sd_fom=%p src_rec=%p fdmi_filter=%p",
+					  sd_fom, src_rec, fdmi_filter);
+
+		}
+	}
+	return M0_ERR_INFO(-EINVAL, "ff_filter_id=%d", fdmi_filter->ff_type);
 }
 
 static int fdmi_sd_fom_tick(struct m0_fom *fom)

--- a/fdmi/source_dock_internal.h
+++ b/fdmi/source_dock_internal.h
@@ -116,6 +116,23 @@ struct m0_fdmi_src_dock {
 	struct fdmi_sd_fom    fsdc_sd_fom;
 };
 
+/**
+ * A handler for a specific m0_fdmi_filter_type_id.
+ * It is chosen based on m0_conf_fdmi_filter::ff_filter_id.
+ */
+struct m0_fdmi_sd_filter_type_handler {
+	enum m0_fdmi_filter_type_id   ffth_id;
+	/**
+	 * @return <0 - error code
+	 * @return =0 - false
+	 * @return >0 - true
+	 */
+	int                         (*ffth_handler)
+		(struct m0_fdmi_eval_ctx      *ctx,
+		 struct m0_conf_fdmi_filter   *filter,
+		 struct m0_fdmi_eval_var_info *var_info);
+};
+
 /** Function posts new fdmi data for analysis by FDMI source dock. */
 M0_INTERNAL void m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec);
 

--- a/fdmi/ut/filter_eval.c
+++ b/fdmi/ut/filter_eval.c
@@ -28,6 +28,7 @@
 #include "lib/finject.h"
 #include "xcode/xcode.h"
 #include "ut/ut.h"
+#include "conf/obj.h"           /* m0_conf_fdmi_filter */
 
 /* ------------------------------------------------------------------
  * Helper: initialize and eval simple binary operand.
@@ -38,17 +39,18 @@ static int flt_eval_binary_operator(enum m0_fdmi_flt_op_code  op_code,
 				    struct m0_fdmi_flt_node  *opnd2,
 				    struct m0_fdmi_eval_ctx  *eval_ctx)
 {
-	struct m0_fdmi_filter    flt;
-	struct m0_fdmi_flt_node *root;
-	int                      rc;
+	struct m0_conf_fdmi_filter  filter;
+	struct m0_fdmi_flt_node    *root;
+	int                         rc;
 
 	root = m0_fdmi_flt_op_node_create(op_code, opnd1, opnd2);
-	m0_fdmi_filter_init(&flt);
-	m0_fdmi_filter_root_set(&flt, root);
+	m0_fdmi_filter_init(&filter.ff_filter);
+	m0_fdmi_filter_root_set(&filter.ff_filter, root);
+	filter.ff_type = M0_FDMI_FILTER_TYPE_TREE;
 
-	rc = m0_fdmi_eval_flt(eval_ctx, &flt, NULL);
+	rc = m0_fdmi_eval_flt(eval_ctx, &filter, NULL);
 
-	m0_fdmi_filter_fini(&flt);
+	m0_fdmi_filter_fini(&filter.ff_filter);
 
 	return rc;
 }

--- a/fdmi/ut/fol_ut.c
+++ b/fdmi/ut/fol_ut.c
@@ -200,6 +200,21 @@ static void fdmi_fol_test_ops(enum ffs_ut_test_op test_op)
 	M0_UT_ASSERT(betx->t_ref == 1);
 	m0_sm_conf_init(&ffs_ut_sm_conf);
 	m0_sm_init(&betx->t_sm, &ffs_ut_sm_conf, FFS_UT_FOM_INIT, grp);
+	/*
+	 * XXX
+	 * This UT has many flaws and it makes a lot of assumption about what is
+	 * initialised in BE tx and what is not. It must be rewritten in a way
+	 * that properly initialises foms and BE transactions and moves them
+	 * from state to state using interfaces and not just "m0_sm_init() to
+	 * make invariant pass, so this 'test' could 'test' something".
+	 *
+	 * The following assignment is added just because another invariant was
+	 * added and this UT failed, because the UT doesn't use interfaces from
+	 * be/tx.h for BE transaction in the way it should.
+	 *
+	 * This code could be used as an example of how to not to write tests.
+	 */
+	betx->t_sm.sm_state = M0_BTS_LOGGED;
 	m0_fol_rec_init(fol_rec, NULL);
 
 	/* FOM ini */

--- a/fdmi/ut/sd_send_not.c
+++ b/fdmi/ut/sd_send_not.c
@@ -119,6 +119,7 @@ static int filterc_send_notif_get_next(struct m0_filterc_iter      *iter,
 		m0_fdmi_filter_root_set(flt, root);
 
 		M0_ALLOC_ARR(conf_flt->ff_endpoints, 1);
+		conf_flt->ff_type = M0_FDMI_FILTER_TYPE_TREE;
 		conf_flt->ff_endpoints[0] = g_rpc_env.ep_addr_remote;
 		conf_flt->ff_filter_id = g_fid;
 		*out = conf_flt;

--- a/fol/fol.h
+++ b/fol/fol.h
@@ -168,6 +168,13 @@ struct m0_fol_rec_header {
 	 * @note The update might be for a different node.
 	 */
 	struct m0_update_id rh_self;
+	/** BE lsn for the record. @see m0_be_tx::t_lsn */
+	uint64_t            rh_lsn;
+	/**
+	 * @see m0_be_tx::t_lsn_discarded and
+	 * fdmi/fol_fdmi_src.c:"FDMI FOL records pruning on plugin side".
+	 */
+	uint64_t            rh_lsn_discarded;
 	uint64_t            rh_magic;
 } M0_XCA_RECORD;
 

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -41,6 +41,7 @@
 /m0rpcping-altogether
 /m0rwlock
 /m0stats
+/fdmi_sample_plugin
 /m0t1fs_*_test_helper
 /m0t1fs_io_file_pattern
 /m0t1fs_test


### PR DESCRIPTION
The patch allows sending del FDMI events and to filter them by value.
- performs the lookup of the value on the del operation, makes key/value available in the FDMI record
- fixes the FDMI plugin st script to fail in case that kv operation is failing.

PS. It would also be nice to fail the test if the plugin is not showing put or del events.