### PR TITLE
EOS-22704: Re-Analyze small objects Read throughput with MD cache patch

### DIFF
--- a/motr/idx.c
+++ b/motr/idx.c
@@ -227,7 +227,7 @@ static int idx_op_init(struct m0_idx *idx, int opcode,
 		oi->oi_dtx = NULL;
 
 	if (opcode == M0_EO_CREATE && entity->en_type == M0_ET_IDX &&
-	    oi->oi_flags & M0_ENF_META) {
+	    entity->en_flags & M0_ENF_META) {
 		rc = idx_pool_version_get(oi);
 		if (rc != 0)
 			return M0_ERR(rc);


### PR DESCRIPTION
Client(s3server) will store the pool version and layout type if the  MO_ENF_META flag is set while index creation. Motr will store the pool version and layout type if the M0_ENF_META flag is not set while index creation.

As per initial design, we have to add M0_ENF_META flag in to object index flags. Later it was changed to entity flags to support MD and DATA path. It was found while re-analyzing small object performance.

Modified M0_ENF_META flag validation to improve small object performance.

Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>