### PR TITLE
lib: fix bogus warnings about thread migration

### DIFF
--- a/fop/fom.c
+++ b/fop/fom.c
@@ -135,6 +135,7 @@
 
 enum {
 	LOC_IDLE_NR = 1,
+	LOCM_CHECK_PERIOD_SEC = 10*60,
 	HUNG_FOP_SEC_PERIOD   = 5,
 	HUNG_FOP_TIME_SEC_MAX = 2*60,
 	HUNG_FOP_TIME_SEC_IEM = 5*60,
@@ -197,6 +198,8 @@ static int loc_thr_create(struct m0_fom_locality *loc);
 
 static void hung_foms_notify(struct m0_locality_chore *chore,
 			     struct m0_locality *loc, void *place);
+static void locm_warn_notify(struct m0_locality_chore *chore,
+			     struct m0_locality *loc, void *place);
 
 static struct m0_sm_conf fom_states_conf0;
 M0_INTERNAL struct m0_sm_conf fom_states_conf;
@@ -214,6 +217,14 @@ static struct m0_fom_domain_ops m0_fom_dom_ops = {
  */
 static const struct m0_locality_chore_ops hung_foms_chore_ops = {
 	.co_tick = hung_foms_notify
+};
+
+/**
+ * Chore which checks and warns about migrated locality threads.
+ * (Locality threads should not migrate to another CPU core.)
+ */
+static const struct m0_locality_chore_ops locm_warn_chore_ops = {
+	.co_tick = locm_warn_notify
 };
 
 static void group_lock(struct m0_fom_locality *loc)
@@ -1170,6 +1181,18 @@ static void hung_foms_notify(struct m0_locality_chore *chore,
 			   dom->fd_ops->fdo_time_is_out(dom, fom));
 }
 
+static void locm_warn_notify(struct m0_locality_chore *chore,
+			     struct m0_locality *loc, void *place)
+{
+	struct m0_thread_tls *tls = m0_thread_tls();
+
+	if (tls->tls_loci != m0_processor_id_get()) {
+		M0_LOG(M0_WARN, "locality thread migrated to another CPU core"
+		       " (was %d, now %d), it might affect performance",
+		       (int)tls->tls_loci, (int)m0_processor_id_get());
+	}
+}
+
 M0_INTERNAL int m0_fom_domain_init(struct m0_fom_domain **out)
 {
 	struct m0_fom_domain   *dom;
@@ -1239,6 +1262,11 @@ M0_INTERNAL int m0_fom_domain_init(struct m0_fom_domain **out)
 				       NULL,
 				       M0_MKTIME(HUNG_FOP_SEC_PERIOD, 0),
 				       0);
+				m0_locality_chore_init(&dom->fd_locm_warn_chore,
+				       &locm_warn_chore_ops,
+				       NULL,
+				       M0_MKTIME(LOCM_CHECK_PERIOD_SEC, 0),
+				       0);
 			}
 		} else
 			result = M0_ERR(-ENOMEM);
@@ -1258,6 +1286,7 @@ M0_INTERNAL void m0_fom_domain_fini(struct m0_fom_domain *dom)
 	int i;
 
 	m0_locality_chore_fini(&dom->fd_hung_foms_chore);
+	m0_locality_chore_fini(&dom->fd_locm_warn_chore);
 	if (dom->fd_localities != NULL) {
 		for (i = dom->fd_localities_nr - 1; i >= 0; --i) {
 			if (dom->fd_localities[i] != NULL)

--- a/fop/fom.c
+++ b/fop/fom.c
@@ -1258,15 +1258,12 @@ M0_INTERNAL int m0_fom_domain_init(struct m0_fom_domain **out)
 				}
 
 				m0_locality_chore_init(&dom->fd_hung_foms_chore,
-				       &hung_foms_chore_ops,
-				       NULL,
-				       M0_MKTIME(HUNG_FOP_SEC_PERIOD, 0),
-				       0);
+				       &hung_foms_chore_ops, NULL,
+				       M0_MKTIME(HUNG_FOP_SEC_PERIOD, 0), 0);
+
 				m0_locality_chore_init(&dom->fd_locm_warn_chore,
-				       &locm_warn_chore_ops,
-				       NULL,
-				       M0_MKTIME(LOCM_CHECK_PERIOD_SEC, 0),
-				       0);
+				       &locm_warn_chore_ops, NULL,
+				       M0_MKTIME(LOCM_CHECK_PERIOD_SEC, 0), 0);
 			}
 		} else
 			result = M0_ERR(-ENOMEM);
@@ -1285,8 +1282,8 @@ M0_INTERNAL void m0_fom_domain_fini(struct m0_fom_domain *dom)
 {
 	int i;
 
-	m0_locality_chore_fini(&dom->fd_hung_foms_chore);
 	m0_locality_chore_fini(&dom->fd_locm_warn_chore);
+	m0_locality_chore_fini(&dom->fd_hung_foms_chore);
 	if (dom->fd_localities != NULL) {
 		for (i = dom->fd_localities_nr - 1; i >= 0; --i) {
 			if (dom->fd_localities[i] != NULL)

--- a/fop/fom.h
+++ b/fop/fom.h
@@ -335,6 +335,8 @@ struct m0_fom_domain {
 	const struct m0_fom_domain_ops *fd_ops;
 	/** Long living foms detecting chore. */
 	struct m0_locality_chore        fd_hung_foms_chore;
+	/** Locality migration warning chore. */
+	struct m0_locality_chore        fd_locm_warn_chore;
 	struct m0_addb2_sys            *fd_addb2_sys;
 };
 

--- a/fop/fom.h
+++ b/fop/fom.h
@@ -335,7 +335,7 @@ struct m0_fom_domain {
 	const struct m0_fom_domain_ops *fd_ops;
 	/** Long living foms detecting chore. */
 	struct m0_locality_chore        fd_hung_foms_chore;
-	/** Locality migration warning chore. */
+	/** Locality thread migration warning chore. */
 	struct m0_locality_chore        fd_locm_warn_chore;
 	struct m0_addb2_sys            *fd_addb2_sys;
 };

--- a/lib/locality.c
+++ b/lib/locality.c
@@ -305,18 +305,9 @@ void m0_locality_chore_fini(struct m0_locality_chore *chore)
 M0_INTERNAL void m0_locality_chores_run(struct m0_locality *locality)
 {
 	struct chore_local   *chloc;
-	struct m0_thread_tls *tls;
 
 	M0_PRE(m0_sm_group_is_locked(locality->lo_grp));
 	M0_ASSERT(locality == m0_locality_here());
-
-	tls = m0_thread_tls();
-	if (tls->tls_loci != m0_processor_id_get() && !tls->tls_warned) {
-		M0_LOG(M0_WARN, "thread migrated to another CPU core: "
-		       "was %d, now %d", (int)tls->tls_loci,
-		       (int)m0_processor_id_get());
-		tls->tls_warned = true;
-	}
 
 	m0_tl_for(chore_l, &locality->lo_chores, chloc) {
 		struct m0_locality_chore *chore = chloc->lo_chore;

--- a/lib/locality.c
+++ b/lib/locality.c
@@ -304,7 +304,7 @@ void m0_locality_chore_fini(struct m0_locality_chore *chore)
 
 M0_INTERNAL void m0_locality_chores_run(struct m0_locality *locality)
 {
-	struct chore_local   *chloc;
+	struct chore_local *chloc;
 
 	M0_PRE(m0_sm_group_is_locked(locality->lo_grp));
 	M0_ASSERT(locality == m0_locality_here());

--- a/lib/locality.h
+++ b/lib/locality.h
@@ -81,7 +81,7 @@ M0_INTERNAL void m0_locality_fini(struct m0_locality *loc);
  * Returns locality corresponding to the CPU core the thread (from which
  * the call is made) was initially run on.
  *
- * Locality threads are bind to the cores (unless the affinity
+ * Locality threads are bound to the cores (unless the affinity
  * is not reset externally, for example, by numad), see loc_thr_init().
  * All the rest threads might change their CPU cores over time. In any case,
  * the returned locality is always the same and corresponds to the CPU core

--- a/lib/locality.h
+++ b/lib/locality.h
@@ -78,7 +78,17 @@ M0_INTERNAL void m0_locality_init(struct m0_locality *loc,
 M0_INTERNAL void m0_locality_fini(struct m0_locality *loc);
 
 /**
- * Returns locality corresponding to the core the call is made on.
+ * Returns locality corresponding to the CPU core the thread (from which
+ * the call is made) was initially run on.
+ *
+ * Locality threads are bind to the cores (unless the affinity
+ * is not reset externally, for example, by numad), see loc_thr_init().
+ * All the rest threads might change their CPU cores over time. In any case,
+ * the returned locality is always the same and corresponds to the CPU core
+ * the thread was run the very first time.
+ *
+ * If the call is made from the global fallback locality thread, returns the
+ * fallback locality (lg_fallback), regardless of the CPU core it runs on.
  *
  * @post result->lo_grp != NULL
  */

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -68,7 +68,6 @@ int m0_thread_init(struct m0_thread *q, int (*init)(void *),
 	 * of `q'. */
 	q->t_tls.tls_m0_instance = m0_get();
 	q->t_tls.tls_self = q;
-	q->t_tls.tls_loci = m0_processor_id_get();
 
 	result = m0_thread_init_impl(q, q->t_namebuf);
 	if (result != 0)
@@ -108,6 +107,7 @@ M0_INTERNAL void *m0_thread_trampoline(void *arg)
 	M0_PRE(t->t_tls.tls_m0_instance != NULL);
 	M0_PRE(t->t_tls.tls_self == t);
 
+	t->t_tls.tls_loci = m0_processor_id_get();
 	m0_set(t->t_tls.tls_m0_instance);
 	m0_addb2_global_thread_enter();
 	if (t->t_init != NULL) {

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -75,8 +75,6 @@ struct m0_thread_tls {
 	 *       say, numad service.
 	 */
 	m0_processor_nr_t          tls_loci;
-	/** Warned about the thread migration to another CPU. */
-	bool                       tls_warned;
 	struct m0_addb2_sensor     tls_clock;
 	/** Platform specific part of tls. Defined in lib/PLATFORM/thread.h. */
 	struct m0_thread_arch_tls  tls_arch;


### PR DESCRIPTION
After commit 4c27187 the spurious warnings started appearing:

    [lib/locality.c:157:m0_locality_here]  thread migrated to another CPU core

The warnings were meant for the locality threads only, who are confined to a specific CPU cores. But they appear now for any thread created in Motr process.

Solution: add the warning code as a locality chore which runs once in 10 mins.

Also, set the initial value of tls_loci at m0_thread_trampoline() which is called from the new thread already, rather than at m0_thread_init() which is called from the parent-thread. As we use m0_processor_id_get() for the initial value, this seems to be more appropriate.