### PR TITLE
Revert "lib: fix bogus warnings about thread migration"

### DIFF
--- a/fop/fom.c
+++ b/fop/fom.c
@@ -135,7 +135,6 @@
 
 enum {
 	LOC_IDLE_NR = 1,
-	LOCM_CHECK_PERIOD_SEC = 10*60,
 	HUNG_FOP_SEC_PERIOD   = 5,
 	HUNG_FOP_TIME_SEC_MAX = 2*60,
 	HUNG_FOP_TIME_SEC_IEM = 5*60,
@@ -198,8 +197,6 @@ static int loc_thr_create(struct m0_fom_locality *loc);
 
 static void hung_foms_notify(struct m0_locality_chore *chore,
 			     struct m0_locality *loc, void *place);
-static void locm_warn_notify(struct m0_locality_chore *chore,
-			     struct m0_locality *loc, void *place);
 
 static struct m0_sm_conf fom_states_conf0;
 M0_INTERNAL struct m0_sm_conf fom_states_conf;
@@ -217,14 +214,6 @@ static struct m0_fom_domain_ops m0_fom_dom_ops = {
  */
 static const struct m0_locality_chore_ops hung_foms_chore_ops = {
 	.co_tick = hung_foms_notify
-};
-
-/**
- * Chore which checks and warns about migrated locality threads.
- * (Locality threads should not migrate to another CPU core.)
- */
-static const struct m0_locality_chore_ops locm_warn_chore_ops = {
-	.co_tick = locm_warn_notify
 };
 
 static void group_lock(struct m0_fom_locality *loc)
@@ -1181,18 +1170,6 @@ static void hung_foms_notify(struct m0_locality_chore *chore,
 			   dom->fd_ops->fdo_time_is_out(dom, fom));
 }
 
-static void locm_warn_notify(struct m0_locality_chore *chore,
-			     struct m0_locality *loc, void *place)
-{
-	struct m0_thread_tls *tls = m0_thread_tls();
-
-	if (tls->tls_loci != m0_processor_id_get()) {
-		M0_LOG(M0_WARN, "locality thread migrated to another CPU core"
-		       " (was %d, now %d), it might affect performance",
-		       (int)tls->tls_loci, (int)m0_processor_id_get());
-	}
-}
-
 M0_INTERNAL int m0_fom_domain_init(struct m0_fom_domain **out)
 {
 	struct m0_fom_domain   *dom;
@@ -1258,12 +1235,10 @@ M0_INTERNAL int m0_fom_domain_init(struct m0_fom_domain **out)
 				}
 
 				m0_locality_chore_init(&dom->fd_hung_foms_chore,
-				       &hung_foms_chore_ops, NULL,
-				       M0_MKTIME(HUNG_FOP_SEC_PERIOD, 0), 0);
-
-				m0_locality_chore_init(&dom->fd_locm_warn_chore,
-				       &locm_warn_chore_ops, NULL,
-				       M0_MKTIME(LOCM_CHECK_PERIOD_SEC, 0), 0);
+				       &hung_foms_chore_ops,
+				       NULL,
+				       M0_MKTIME(HUNG_FOP_SEC_PERIOD, 0),
+				       0);
 			}
 		} else
 			result = M0_ERR(-ENOMEM);
@@ -1282,7 +1257,6 @@ M0_INTERNAL void m0_fom_domain_fini(struct m0_fom_domain *dom)
 {
 	int i;
 
-	m0_locality_chore_fini(&dom->fd_locm_warn_chore);
 	m0_locality_chore_fini(&dom->fd_hung_foms_chore);
 	if (dom->fd_localities != NULL) {
 		for (i = dom->fd_localities_nr - 1; i >= 0; --i) {

--- a/fop/fom.h
+++ b/fop/fom.h
@@ -335,8 +335,6 @@ struct m0_fom_domain {
 	const struct m0_fom_domain_ops *fd_ops;
 	/** Long living foms detecting chore. */
 	struct m0_locality_chore        fd_hung_foms_chore;
-	/** Locality thread migration warning chore. */
-	struct m0_locality_chore        fd_locm_warn_chore;
 	struct m0_addb2_sys            *fd_addb2_sys;
 };
 

--- a/lib/locality.c
+++ b/lib/locality.c
@@ -146,11 +146,19 @@ M0_INTERNAL void m0_locality_fini(struct m0_locality *loc)
 M0_INTERNAL struct m0_locality *m0_locality_here(void)
 {
 	struct locality_global *glob = loc_glob();
+	struct m0_thread_tls   *tls;
 
 	if (glob->lg_dom == NULL || m0_thread_self() == &glob->lg_ast_thread)
 		return &glob->lg_fallback;
-	else
-		return m0_locality_get(m0_thread_tls()->tls_loci);
+	else {
+		tls = m0_thread_tls();
+		if (tls->tls_loci != m0_processor_id_get() &&
+		    !tls->tls_warned) {
+			M0_LOG(M0_WARN, "thread migrated to another CPU core");
+			tls->tls_warned = true;
+		}
+		return m0_locality_get(tls->tls_loci);
+	}
 }
 
 M0_INTERNAL struct m0_locality *m0_locality_get(uint64_t value)

--- a/lib/locality.h
+++ b/lib/locality.h
@@ -78,17 +78,7 @@ M0_INTERNAL void m0_locality_init(struct m0_locality *loc,
 M0_INTERNAL void m0_locality_fini(struct m0_locality *loc);
 
 /**
- * Returns locality corresponding to the CPU core the thread (from which
- * the call is made) was initially run on.
- *
- * Locality threads are bound to the cores (unless the affinity
- * is not reset externally, for example, by numad), see loc_thr_init().
- * All the rest threads might change their CPU cores over time. In any case,
- * the returned locality is always the same and corresponds to the CPU core
- * the thread was run the very first time.
- *
- * If the call is made from the global fallback locality thread, returns the
- * fallback locality (lg_fallback), regardless of the CPU core it runs on.
+ * Returns locality corresponding to the core the call is made on.
  *
  * @post result->lo_grp != NULL
  */

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -68,6 +68,7 @@ int m0_thread_init(struct m0_thread *q, int (*init)(void *),
 	 * of `q'. */
 	q->t_tls.tls_m0_instance = m0_get();
 	q->t_tls.tls_self = q;
+	q->t_tls.tls_loci = m0_processor_id_get();
 
 	result = m0_thread_init_impl(q, q->t_namebuf);
 	if (result != 0)
@@ -107,7 +108,6 @@ M0_INTERNAL void *m0_thread_trampoline(void *arg)
 	M0_PRE(t->t_tls.tls_m0_instance != NULL);
 	M0_PRE(t->t_tls.tls_self == t);
 
-	t->t_tls.tls_loci = m0_processor_id_get();
 	m0_set(t->t_tls.tls_m0_instance);
 	m0_addb2_global_thread_enter();
 	if (t->t_init != NULL) {

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -75,6 +75,8 @@ struct m0_thread_tls {
 	 *       say, numad service.
 	 */
 	m0_processor_nr_t          tls_loci;
+	/** Warned about the thread migration to another CPU. */
+	bool                       tls_warned;
 	struct m0_addb2_sensor     tls_clock;
 	/** Platform specific part of tls. Defined in lib/PLATFORM/thread.h. */
 	struct m0_thread_arch_tls  tls_arch;


### PR DESCRIPTION
Reverts Seagate/cortx-motr#970. Need to test this on a feature branch for its performance impact.