### PR TITLE
Fix race with opertion cancellation.

### DIFF
--- a/dix/req.c
+++ b/dix/req.c
@@ -2541,6 +2541,7 @@ M0_INTERNAL void m0_dix_req_fini(struct m0_dix_req *req)
 	uint32_t i;
 
 	M0_PRE(m0_dix_req_is_locked(req));
+	M0_PRE(req->dr_ast.sa_next == NULL);
 	for (i = 0; i < req->dr_indices_nr; i++)
 		m0_dix_fini(&req->dr_indices[i]);
 	m0_free(req->dr_indices);

--- a/motr/idx.c
+++ b/motr/idx.c
@@ -399,6 +399,7 @@ static void idx_op_cb_fini(struct m0_op_common *oc)
 
 	oi = bob_of(oc, struct m0_op_idx, oi_oc, &oi_bobtype);
 	M0_PRE(m0__idx_op_invariant(oi));
+	M0_PRE(oi->oi_ast.sa_next == NULL);
 
 	m0_op_common_bob_fini(&oi->oi_oc);
 	m0_ast_rc_bob_fini(&oi->oi_ar);


### PR DESCRIPTION
Cancellation of index operations posts an ast in
idx_op_cb_cancel()->m0__idx_cancel(). There is no any synchronization with this
ast execution and as a result, m0_op_fini() might finalise the operation while
the ast is still in the fork queue. This leads to crashes in locality
m0_sm_asts_run().

The only thing the ast is doing is cancellation of the rpc items. There is no
good reason to do this in an ast, this can be done synchronously in
m0__idx_cancel().

Also, add a few checks that ast-s are completed when operations are finalised.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>