### PR TITLE
Check for invalid tree open

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -2195,7 +2195,7 @@ static int64_t node_get(struct node_op *op, struct td *tree,
 	 * restart the tick funcions.
 	 */
 	if (!segaddr_header_isvalid(addr)) {
-		op->no_op.o_sm.sm_rc = M0_ERR(-ECHILD);
+		op->no_op.o_sm.sm_rc = M0_ERR(-EINVAL);
 		m0_rwlock_write_unlock(&list_lock);
 		return nxt;
 	}
@@ -9947,7 +9947,7 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 					      m0_btree_open(rnode,
 							    1024, &tree,
 							    seg, &b_op));
-		M0_ASSERT(rc == -ECHILD);
+		M0_ASSERT(rc == -EINVAL);
 	}
 
 	m0_atomic64_dec(&threads_running);
@@ -10455,7 +10455,7 @@ static void ut_btree_persistence(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 				      m0_btree_open(rnode, rnode_sz, &tree, seg,
 						    &b_op));
-	M0_ASSERT(rc == -ECHILD);
+	M0_ASSERT(rc == -EINVAL);
 
 
 	/** Delete temp node space which was used as root node for the tree. */

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -10449,12 +10449,12 @@ static void ut_btree_persistence(void)
 	 *  is coded to return error when a root node with invalid contents
 	 *  is passed.
 	 */
-#if 0
+
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 				      m0_btree_open(rnode, rnode_sz, &tree, seg,
 						    &b_op));
-	M0_ASSERT(rc == 0);
-#endif
+	M0_ASSERT(rc == -ECHILD);
+
 
 	/** Delete temp node space which was used as root node for the tree. */
 	cred = M0_BE_TX_CREDIT(0, 0);

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -9941,6 +9941,13 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 		M0_ASSERT(rc == 0);
 		m0_be_tx_close_sync(tx);
 		m0_be_tx_fini(tx);
+
+		/** Error Case */
+		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					      m0_btree_open(rnode,
+							    1024, &tree,
+							    seg, &b_op));
+		M0_ASSERT(rc == -ECHILD);
 	}
 
 	m0_atomic64_dec(&threads_running);
@@ -10444,11 +10451,6 @@ static void ut_btree_persistence(void)
 	M0_ASSERT(rc == -1 && errno == ENOMEM); /** Assert BE segment unmapped*/
 	m0_be_seg_open(ut_seg->bus_seg);
 
-	/**
-	 *  The following #if 0 is to be removed once m0_btree_open function
-	 *  is coded to return error when a root node with invalid contents
-	 *  is passed.
-	 */
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 				      m0_btree_open(rnode, rnode_sz, &tree, seg,


### PR DESCRIPTION
This changes are meant to enhance the invalid case of UT where we cannot open a tree after it is destroyed.