### PR TITLE
Calling m0_btree_mod_init() from init subsystem.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7510,14 +7510,12 @@ static bool                     btree_ut_initialised = false;
 static void btree_ut_init(void)
 {
 	if (!btree_ut_initialised) {
-		m0_btree_mod_init();
 		btree_ut_initialised = true;
 	}
 }
 
 static void btree_ut_fini(void)
 {
-	m0_btree_mod_fini();
 	btree_ut_initialised = false;
 }
 

--- a/motr/init.c
+++ b/motr/init.c
@@ -63,6 +63,7 @@
 #else
 #  include "be/tx_service.h"    /* m0_be_txs_register */
 #  include "be/be.h"            /* m0_backend_init */
+#  include "btree/btree.h"      /* m0_btree_mod_init */
 #  include "conf/confd.h"       /* m0_confd_register */
 #  include "mdstore/mdstore.h"  /* m0_mdstore_mod_init */
 #endif
@@ -206,6 +207,7 @@ struct init_fini_call subsystem[] = {
 #ifdef __KERNEL__
 	{ &m0t1fs_init,         &m0t1fs_fini,         "m0t1fs" },
 #else
+	{ &m0_btree_mod_init,   &m0_btree_mod_fini,   "btree" },
 	{ &m0_backend_init,     &m0_backend_fini,     "be" },
 	{ &m0_be_txs_register,  &m0_be_txs_unregister, "be-tx-service" },
 	{ &m0_confd_register,   &m0_confd_unregister, "confd" },


### PR DESCRIPTION
With this change the btree module init and fini will get called similar to other
modules thus removing the need to call these explicitly in every ut.

Signed-off-by: Shashank Parulekar <shashank.parulekar@seagate.com>