### PR TITLE
Rectify tree ops

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -2398,7 +2398,7 @@ static int64_t node_alloc(struct node_op *op, struct td *tree, int shift,
 	op->no_tree = tree;
 
 	nxt_state = node_init(&op->no_addr, ksize, vsize, nt,
-			      tree->t_seg->bs_gen, tree->t_fid, nxt);
+			       tree->t_seg->bs_gen, tree->t_fid, nxt);
 	/**
 	 * TODO: Consider adding a state here to return in case we might need to
 	 * visit node_init() again to complete its execution.
@@ -7638,6 +7638,7 @@ void get_key_at_index(struct nd *node, int idx, uint64_t *key)
 static void ut_basic_tree_oper_cp(void)
 {
 	struct m0_btree         btree = {};
+	struct m0_btree         btree_2 = {};
 	struct m0_btree        *temp_btree;
 	struct m0_btree_type    btree_type = {  .tt_id = M0_BT_UT_KV_OPS,
 						.ksize = 8,
@@ -7673,12 +7674,13 @@ static void ut_basic_tree_oper_cp(void)
 	temp_btree = b_op.bo_arbor;
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_open(temp_node, 1024,
-							   &btree, seg,
+							   &btree_2, seg,
 							   &b_op));
 	M0_ASSERT(rc == 0);
 
-	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(&btree, &b_op));
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(&btree_2, &b_op));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree_2);
 	b_op.bo_arbor = temp_btree;
 
 	m0_btree_destroy_credit(b_op.bo_arbor, &cred);
@@ -7853,6 +7855,7 @@ static void ut_basic_tree_oper_icp(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(b_op.bo_arbor,
 							    &b_op));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(b_op.bo_arbor,
 							    &b_op));

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7672,6 +7672,7 @@ static void ut_basic_tree_oper_cp(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(b_op.bo_arbor,
 							      &b_op, tx));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 	m0_free_aligned(temp_node, (1024 + sizeof(struct nd)), 10);
 
 	/**
@@ -7694,6 +7695,7 @@ static void ut_basic_tree_oper_cp(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(b_op.bo_arbor,
 							      &b_op, tx));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 	m0_free_aligned(temp_node, (1024 + sizeof(struct nd)), 10);
 
 	/**
@@ -7716,6 +7718,7 @@ static void ut_basic_tree_oper_cp(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 				      m0_btree_close(b_op.bo_arbor, &b_op));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_open(temp_node, 1024,
 							   b_op.bo_arbor,
@@ -7727,6 +7730,7 @@ static void ut_basic_tree_oper_cp(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(b_op.bo_arbor,
 							      &b_op, tx));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 	m0_free_aligned(temp_node, (1024 + sizeof(struct nd)), 10);
 
 	btree_ut_fini();
@@ -7809,6 +7813,7 @@ static void ut_basic_tree_oper_icp(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(b_op.bo_arbor,
 							      &b_op, tx));
 	M0_ASSERT(rc == -EPERM);
+	M0_SET0(&btree);
 	m0_free_aligned(temp_node, (1024 + sizeof(struct nd)), 10);
 
 	/**
@@ -7838,6 +7843,7 @@ static void ut_basic_tree_oper_icp(void)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(b_op.bo_arbor,
 							    &b_op));
 	M0_ASSERT(rc == -EINVAL);
+	M0_SET0(&btree);
 
 	m0_free_aligned(temp_node, (1024 + sizeof(struct nd)), 10);
 	btree_ut_fini();
@@ -8246,6 +8252,7 @@ static void ut_basic_kv_oper(void)
 	m0_btree_destroy_credit(b_op.bo_arbor, &cred);
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(tree, &b_op, tx));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	btree_ut_fini();
 }
@@ -8650,6 +8657,7 @@ static void ut_multi_stream_kv_oper(void)
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(tree, &b_op, tx));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	/** Delete temp node space which was used as root node for the tree. */
 	buf = M0_BUF_INIT(rnode_sz, rnode);
@@ -9746,7 +9754,7 @@ static void btree_ut_kv_oper(int32_t thread_count, int32_t tree_count,
 					      m0_btree_destroy(ut_trees[i],
 							       &b_op, tx));
 		M0_ASSERT(rc == 0);
-
+		M0_SET0(&btree[i]);
 		buf = M0_BUF_INIT(rnode_sz, rnode);
 		M0_BE_FREE_ALIGN_BUF_SYNC(&buf, rnode_sz_shift, seg, tx);
 		m0_be_tx_close_sync(tx);
@@ -9939,6 +9947,7 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					      m0_btree_close(tree, &b_op));
 		M0_ASSERT(rc == 0);
+		M0_SET0(&btree);
 
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					      m0_btree_open(rnode, rnode_sz,
@@ -9961,6 +9970,7 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					      m0_btree_close(tree, &b_op));
 		M0_ASSERT(rc == 0);
+		M0_SET0(&btree);
 
 		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					      m0_btree_open(rnode,
@@ -10002,6 +10012,8 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 					      m0_btree_destroy(tree,
 							       &b_op, tx));
 		M0_ASSERT(rc == 0);
+		M0_SET0(&btree);
+
 		m0_be_tx_close_sync(tx);
 		m0_be_tx_fini(tx);
 
@@ -10252,6 +10264,7 @@ static void ut_btree_persistence(void)
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(tree, &b_op));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	/** Re-map the BE segment.*/
 	m0_be_seg_close(ut_seg->bus_seg);
@@ -10313,6 +10326,7 @@ static void ut_btree_persistence(void)
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(tree, &b_op));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	/** Re-map the BE segment.*/
 	m0_be_seg_close(ut_seg->bus_seg);
@@ -10398,6 +10412,7 @@ static void ut_btree_persistence(void)
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(tree, &b_op));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	/** Re-map the BE segment.*/
 	m0_be_seg_close(ut_seg->bus_seg);
@@ -10459,6 +10474,7 @@ static void ut_btree_persistence(void)
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_close(tree, &b_op));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	/** Re-map the BE segment.*/
 	m0_be_seg_close(ut_seg->bus_seg);
@@ -10505,6 +10521,7 @@ static void ut_btree_persistence(void)
 
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(tree, &b_op, tx));
 	M0_ASSERT(rc == 0);
+	M0_SET0(&btree);
 
 	m0_be_tx_close_sync(tx);
 	m0_be_tx_fini(tx);

--- a/btree/btree.h
+++ b/btree/btree.h
@@ -182,7 +182,7 @@ void m0_btree_destroy_credit(struct m0_btree *tree,
  *
  * @return 0 if successful.
  */
-int  m0_btree_open(void *addr, int nob, struct m0_btree **out,
+int  m0_btree_open(void *addr, int nob, struct m0_btree *out,
 		   struct m0_be_seg *seg, struct m0_btree_op *bop);
 
 /**
@@ -219,8 +219,9 @@ void m0_btree_close(struct m0_btree *arbor, struct m0_btree_op *bop);
  * @param tx pointer to the transaction struture to capture BE segment changes.
  */
 void m0_btree_create(void *addr, int nob, const struct m0_btree_type *bt,
-		     struct m0_btree_op *bop, struct m0_be_seg *seg,
-		     const struct m0_fid *fid, struct m0_be_tx *tx);
+		     struct m0_btree_op *bop, struct m0_btree *tree,
+		     struct m0_be_seg *seg, const struct m0_fid *fid,
+		     struct m0_be_tx *tx);
 
 /**
  * Destroys the opened or created tree represented by arbor. Once the destroy


### PR DESCRIPTION
Modify tree_create() and tree_open() to accept tree from the user and assigning it to bop.bo_arbor instead of allocating memory for bop.bo_arbor in tree_create()