### PR TITLE
Integration of new BTree with the COB module of Motr.

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -3011,10 +3011,12 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 {
 	struct cob_action        *ca = container_of(act, struct cob_action,
 						    coa_act);
-	struct m0_be_btree       *ios_ns = &act->a_builder->b_ios_cdom->
+#ifdef NEW_BTREE_INTEGRATION_COMPLETE
+	struct m0_btree          *ios_ns = act->a_builder->b_ios_cdom->
 								cd_namespace;
-	struct m0_be_btree       *mds_ns = &act->a_builder->b_mds_cdom->
+	struct m0_btree          *mds_ns = act->a_builder->b_mds_cdom->
 								cd_namespace;
+#endif
 	struct m0_cob             cob = {};
 	struct m0_cob_nskey      *nskey = ca->coa_key.b_addr;
 	struct m0_cob_nsrec      *nsrec = ca->coa_val.b_addr;
@@ -3028,12 +3030,14 @@ static void cob_act(struct action *act, struct m0_be_tx *tx)
 
 	m0_mutex_lock(&beck_builder.b_coblock);
 
+#ifdef NEW_BTREE_INTEGRATION_COMPLETE
 	if (m0_fid_eq(&ca->coa_fid, &ios_ns->bb_backlink.bli_fid))
 		m0_cob_init(act->a_builder->b_ios_cdom, &cob);
 	else if (m0_fid_eq(&ca->coa_fid, &mds_ns->bb_backlink.bli_fid))
 		m0_cob_init(act->a_builder->b_mds_cdom, &cob);
 	else
 		rc = -ENODATA;
+#endif
 
 	cob.co_nsrec = *nsrec;
 	rc = rc ?: m0_cob_name_add(&cob, nskey, nsrec, tx);

--- a/be/tool/main.c
+++ b/be/tool/main.c
@@ -85,12 +85,11 @@ void track_cob_btrees(struct m0_cob_domain *cdom, bool print_btree)
 {
 	if (print_btree) {
 		M0_LOG(M0_ALWAYS, "cd_object_index ");
-		btree_dbg_print(&cdom->cd_object_index);
+		btree_dbg_print((struct m0_be_btree *)cdom->cd_object_index);
 		M0_LOG(M0_ALWAYS, "cd_namespace ");
-		btree_dbg_print(&cdom->cd_namespace);
+		btree_dbg_print((struct m0_be_btree *)cdom->cd_namespace);
 		M0_LOG(M0_ALWAYS, "cd_fileattr_basic ");
-		btree_dbg_print(&cdom->
-				cd_fileattr_basic);
+		btree_dbg_print((struct m0_be_btree *)cdom->cd_fileattr_basic);
 	} else
 		M0_LOG(M0_ALWAYS,"M0_BE:COB "
 				"cd_object_index btree = %p "

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3530,7 +3530,7 @@ static void fkvv_make_leaf(struct slot *slot)
 {
 	struct fkvv_head *h = fkvv_data(slot->s_node);
 	uint32_t         *curr_val_offset;
-	uint32_t         *prev_val_offset;
+	uint32_t         *prev_val_offset   = NULL;
 	uint32_t         *last_val_offset;
 	uint32_t          new_val_offset;
 	void             *key_addr;
@@ -5333,13 +5333,10 @@ void m0_btree_destroy_credit(struct m0_btree *tree,
 			       m0_vec_count(&__src_rec ->r_val.ov_vec));       \
 	})
 
-#define REC_INIT(pp_key, p_ksize, pp_val, p_vsize)                             \
+#define REC_INIT(p_rec, pp_key, p_ksz, pp_val, p_vsz)                          \
 	({                                                                     \
-		struct m0_btree_rec __rec;                                     \
-									       \
-		__rec.r_key.k_data = M0_BUFVEC_INIT_BUF((pp_key), (p_ksize));  \
-		__rec.r_val        = M0_BUFVEC_INIT_BUF((pp_val), (p_vsize));  \
-		__rec;                                                         \
+		(p_rec)->r_key.k_data = M0_BUFVEC_INIT_BUF((pp_key), (p_ksz)); \
+		(p_rec)->r_val        = M0_BUFVEC_INIT_BUF((pp_val), (p_vsz)); \
 	})
 
 /** Insert operation section start point: */
@@ -5655,7 +5652,7 @@ static int64_t btree_put_root_split_handle(struct m0_btree_op *bop,
 
 	/* M0_ASSERT(node_isfit(&node_slot)) */
 	node_make(&node_slot);
-	node_slot.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+	REC_INIT(&node_slot.s_rec, &p_key, &ksize, &p_val, &vsize);
 	node_rec(&node_slot);
 	COPY_RECORD(&node_slot.s_rec, &bop->bo_rec);
 	/* if we need to update vec_count for node, update here */
@@ -5675,7 +5672,7 @@ static int64_t btree_put_root_split_handle(struct m0_btree_op *bop,
 	node_slot.s_idx  = 1;
 	node_slot.s_rec = bop->bo_rec;
 	node_make(&node_slot);
-	node_slot.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+	REC_INIT(&node_slot.s_rec, &p_key, &ksize, &p_val, &vsize);
 	node_rec(&node_slot);
 	COPY_VALUE(&node_slot.s_rec, &bop->bo_rec);
 	/* if we need to update vec_count for root slot, update at this place */
@@ -5741,7 +5738,7 @@ static void btree_put_split_and_find(struct nd *allocated_node,
 	/*2) Find appropriate slot for given record */
 
 	right_slot.s_idx = 0;
-	right_slot.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+	REC_INIT(&right_slot.s_rec, &p_key, &ksize, &p_val, &vsize);
 	node_key(&right_slot);
 
 	m0_bufvec_cursor_init(&cur_1, &rec->r_key.k_data);
@@ -5758,7 +5755,7 @@ static void btree_put_split_and_find(struct nd *allocated_node,
 	 */
 	if (node_level(tgt->s_node) > 0 && tgt->s_node == left_slot.s_node) {
 		left_slot.s_idx = node_count(left_slot.s_node);
-		left_slot.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+		REC_INIT(&left_slot.s_rec, &p_key, &ksize, &p_val, &vsize);
 		node_key(&left_slot);
 		m0_bufvec_cursor_init(&cur_2, &left_slot.s_rec.r_key.k_data);
 		diff = m0_bufvec_cursor_cmp(&cur_1, &cur_2);
@@ -5820,11 +5817,11 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 	if (bop->bo_opc == M0_BO_PUT) {
 		tgt.s_rec = bop->bo_rec;
 		node_make (&tgt);
-		tgt.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+		REC_INIT(&tgt.s_rec, &p_key, &ksize, &p_val, &vsize);
 		node_rec(&tgt);
 	} else {
 		/* bop->bo_opc == M0_BO_UPDATE */
-		tgt.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+		REC_INIT(&tgt.s_rec, &p_key, &ksize, &p_val, &vsize);
 		node_rec(&tgt);
 		vsize_diff = m0_vec_count(&bop->bo_rec.r_val.ov_vec) -
 			     m0_vec_count(&tgt.s_rec.r_val.ov_vec);
@@ -5874,7 +5871,7 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 	/* Initialized new record which will get inserted at parent */
 	node_slot.s_node = lev->l_node;
 	node_slot.s_idx = 0;
-	node_slot.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+	REC_INIT(&node_slot.s_rec, &p_key, &ksize, &p_val, &vsize);
 	node_key(&node_slot);
 	new_rec.r_key = node_slot.s_rec.r_key;
 
@@ -5892,7 +5889,7 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 			node_lock(lev->l_node);
 
 			node_make(&node_slot);
-			node_slot.s_rec = REC_INIT(&p_key_1, &ksize_1,
+			REC_INIT(&node_slot.s_rec, &p_key_1, &ksize_1,
 						   &p_val_1, &vsize_1);
 			node_rec(&node_slot);
 			rec = &new_rec;
@@ -5922,7 +5919,7 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 
 		tgt.s_rec = new_rec;
 		node_make(&tgt);
-		tgt.s_rec = REC_INIT(&p_key_1, &ksize_1, &p_val_1, &vsize_1);
+		REC_INIT(&tgt.s_rec, &p_key_1, &ksize_1, &p_val_1, &vsize_1);
 		node_rec(&tgt);
 		COPY_RECORD(&tgt.s_rec,  &new_rec);
 
@@ -5944,7 +5941,7 @@ static int64_t btree_put_makespace_phase(struct m0_btree_op *bop)
 
 		node_slot.s_node = lev->l_alloc;
 		node_slot.s_idx = node_count(node_slot.s_node);
-		node_slot.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+		REC_INIT(&node_slot.s_rec, &p_key, &ksize, &p_val, &vsize);
 		node_key(&node_slot);
 		new_rec.r_key = node_slot.s_rec.r_key;
 		newv_ptr = &(lev->l_alloc->n_addr);
@@ -6237,7 +6234,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 			int                  new_vsize;
 			int                  old_vsize;
 
-			node_slot.s_rec  = REC_INIT(&p_key, &ksize,
+			REC_INIT(&node_slot.s_rec, &p_key, &ksize,
 						    &p_val, &vsize);
 			node_rec(&node_slot);
 
@@ -6272,7 +6269,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 		node_slot.s_node = lev->l_node;
 		node_slot.s_idx  = lev->l_idx;
 
-		node_slot.s_rec = REC_INIT(&p_key, &ksize, &p_val, &vsize);
+		REC_INIT(&node_slot.s_rec, &p_key, &ksize, &p_val, &vsize);
 		node_rec(&node_slot);
 
 		/**
@@ -6981,8 +6978,8 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 
 		s.s_node        = lev->l_node;
 		s.s_idx         = lev->l_idx;
-		s.s_rec	        = REC_INIT(&pkey, &ksize, &pval, &vsize);
 		s.s_rec.r_flags = M0_BSC_SUCCESS;
+		REC_INIT(&s.s_rec, &pkey, &ksize, &pval, &vsize);
 
 		count = node_count(s.s_node);
 		/**
@@ -7327,7 +7324,7 @@ int64_t btree_iter_kv_tick(struct m0_sm_op *smop)
 
 		lev = &oi->i_level[oi->i_used];
 
-		s.s_rec	        = REC_INIT(&pkey, &ksize, &pval, &vsize);
+		REC_INIT(&s.s_rec, &pkey, &ksize, &pval, &vsize);
 		s.s_rec.r_flags = M0_BSC_SUCCESS;
 
 		/* Return record if idx fit in the node. */
@@ -7828,7 +7825,7 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 			m0_bcount_t          vsize;
 			void                *p_val;
 
-			node_slot.s_rec  = REC_INIT(&p_key, &ksize,
+			REC_INIT(&node_slot.s_rec, &p_key, &ksize,
 						    &p_val, &vsize);
 			node_rec(&node_slot);
 			node_slot.s_rec.r_flags = M0_BSC_SUCCESS;

--- a/btree/internal.h
+++ b/btree/internal.h
@@ -74,7 +74,6 @@ struct m0_btree {
 	struct td                  *t_desc;
 };
 
-
 /** @} end of btree group */
 #endif /* __MOTR_BTREE_INTERNAL_H__ */
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -912,7 +912,7 @@ static int cob_table_delete(struct m0_btree *tree, struct m0_be_tx *tx,
 }
 
 
-static int btree_update_callback(struct m0_btree_cb  *cb,
+static int cob_table_update_callback(struct m0_btree_cb  *cb,
 				 struct m0_btree_rec *rec)
 {
 	struct m0_btree_rec     *datum = cb->c_datum;
@@ -935,7 +935,7 @@ static int cob_table_update(struct m0_btree *tree, struct m0_be_tx *tx,
 			   .r_key.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 			   .r_val        = M0_BUFVEC_INIT_BUF( &v_ptr, &vsize),
 			};
-	struct m0_btree_cb   ut_put_cb = {.c_act = btree_update_callback,
+	struct m0_btree_cb   ut_put_cb = {.c_act = cob_table_update_callback,
 					  .c_datum = &rec,
 					  };
 
@@ -944,7 +944,7 @@ static int cob_table_update(struct m0_btree *tree, struct m0_be_tx *tx,
 							&kv_op, tx));
 }
 
-static int btree_insert_callback(struct m0_btree_cb  *cb,
+static int cob_table_insert_callback(struct m0_btree_cb  *cb,
 				 struct m0_btree_rec *rec)
 {
 	struct m0_btree_rec     *datum = cb->c_datum;
@@ -969,7 +969,7 @@ static int cob_table_insert(struct m0_btree *tree, struct m0_be_tx *tx,
 			   .r_key.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 			   .r_val        = M0_BUFVEC_INIT_BUF(&v_ptr, &vsize),
 			};
-	struct m0_btree_cb   insert_cb = {.c_act = btree_insert_callback,
+	struct m0_btree_cb   insert_cb = {.c_act = cob_table_insert_callback,
 					  .c_datum = &rec,
 					 };
 
@@ -978,7 +978,7 @@ static int cob_table_insert(struct m0_btree *tree, struct m0_be_tx *tx,
 						     &kv_op, tx));
 }
 
-static int btree_lookup_callback(struct m0_btree_cb  *cb,
+static int cob_table_lookup_callback(struct m0_btree_cb  *cb,
 				 struct m0_btree_rec *rec)
 {
 	struct m0_btree_rec     *datum = cb->c_datum;
@@ -1001,7 +1001,7 @@ static int cob_table_lookup(struct m0_btree *tree, struct m0_buf *key,
 			    .r_key.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 			    .r_val        = M0_BUFVEC_INIT_BUF(&v_ptr, &vsize),
 			};
-	struct m0_btree_cb   lookup_cb = {.c_act = btree_lookup_callback,
+	struct m0_btree_cb   lookup_cb = {.c_act = cob_table_lookup_callback,
 					  .c_datum = &rec,
 					 };
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -543,35 +543,35 @@ void m0_cob_domain_fini(struct m0_cob_domain *dom)
 	if (dom->cd_object_index != NULL) {
 		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					 m0_btree_close(dom->cd_object_index,
-							       &b_op));
+							&b_op));
 		m0_free0(&dom->cd_object_index);
 	}
 
 	if (dom->cd_namespace != NULL) {
 		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					 m0_btree_close(dom->cd_namespace,
-							       &b_op));
+							&b_op));
 		m0_free0(&dom->cd_namespace);
 	}
 
 	if (dom->cd_fileattr_basic != NULL) {
 		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					 m0_btree_close(dom->cd_fileattr_basic,
-							       &b_op));
+							&b_op));
 		m0_free0(&dom->cd_fileattr_basic);
 	}
 
 	if (dom->cd_fileattr_omg != NULL) {
 		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					 m0_btree_close(dom->cd_fileattr_omg,
-							       &b_op));
+							&b_op));
 		m0_free0(&dom->cd_fileattr_omg);
 	}
 
 	if (dom->cd_fileattr_ea != NULL) {
 		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 					 m0_btree_close(dom->cd_fileattr_ea,
-							       &b_op));
+							&b_op));
 		m0_free0(&dom->cd_fileattr_ea);
 	}
 }
@@ -689,9 +689,9 @@ int m0_cob_domain_create_prepared(struct m0_cob_domain          **out,
 	M0_ASSERT(rc == 0);
 
 	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_NAMESPACE,
-		.ksize = -1,
-		.vsize = -1,
-	};
+				    .ksize = -1,
+				    .vsize = -1,
+				   };
 	fid = M0_FID_TINIT('b', M0_BBT_COB_NAMESPACE, cdid->id);
 	M0_ALLOC_PTR(dom->cd_namespace);
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -44,7 +44,7 @@
 #include "cob/cob.h"
 
 #include "be/domain.h"
-#include "be/btree.h"
+#include "btree/btree.h"
 #include "be/seg0.h"
 #include "be/tx.h"
 
@@ -471,34 +471,104 @@ M0_UNUSED static char *cob_dom_id_make(char *buf, const struct m0_cob_domain_id 
 }
 
 /**
-   Set up a new cob domain
-
-   Tables are identified by the domain id, which must be set before calling
-   this function.
+ * Load the COB trees.
  */
 int m0_cob_domain_init(struct m0_cob_domain *dom, struct m0_be_seg *seg)
 {
+	int                     rc;
+	struct m0_btree_op      b_op = {};
+
 	M0_ENTRY("dom=%p id=%"PRIx64"", dom, dom != NULL ? dom->cd_id.id : 0);
 
 	M0_PRE(dom != NULL);
 	M0_PRE(dom->cd_id.id != 0);
 
-	m0_be_btree_init(&dom->cd_object_index,   seg, &cob_oi_ops);
-	m0_be_btree_init(&dom->cd_namespace,	  seg, &cob_ns_ops);
-	m0_be_btree_init(&dom->cd_fileattr_basic, seg, &cob_fab_ops);
-	m0_be_btree_init(&dom->cd_fileattr_omg,   seg, &cob_omg_ops);
-	m0_be_btree_init(&dom->cd_fileattr_ea,    seg, &cob_ea_ops);
+	M0_ALLOC_PTR(dom->cd_object_index);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_open(dom->cd_oi_node,
+						    sizeof dom->cd_oi_node,
+						    dom->cd_object_index, seg,
+						    &b_op));
+	M0_ASSERT(rc == 0);
+
+	M0_ALLOC_PTR(dom->cd_namespace);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_open(&dom->cd_ns_node,
+						    sizeof dom->cd_ns_node,
+						    dom->cd_namespace, seg,
+						    &b_op));
+	M0_ASSERT(rc == 0);
+
+	M0_ALLOC_PTR(dom->cd_fileattr_basic);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_open(&dom->cd_fa_basic_node,
+						    sizeof dom->cd_fa_basic_node,
+						    dom->cd_fileattr_basic, seg,
+						    &b_op));
+	M0_ASSERT(rc == 0);
+
+	M0_ALLOC_PTR(dom->cd_fileattr_omg);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_open(&dom->cd_fa_omg_node,
+						    sizeof dom->cd_fa_omg_node,
+						    dom->cd_fileattr_omg, seg,
+						    &b_op));
+	M0_ASSERT(rc == 0);
+
+	M0_ALLOC_PTR(dom->cd_fileattr_ea);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_open(&dom->cd_fa_ea_node,
+						    sizeof dom->cd_fa_ea_node,
+						    dom->cd_fileattr_ea, seg,
+						    &b_op));
+	M0_ASSERT(rc == 0);
 
 	return M0_RC(0);
 }
 
 void m0_cob_domain_fini(struct m0_cob_domain *dom)
 {
-	m0_be_btree_fini(&dom->cd_fileattr_ea);
-	m0_be_btree_fini(&dom->cd_fileattr_omg);
-	m0_be_btree_fini(&dom->cd_fileattr_basic);
-	m0_be_btree_fini(&dom->cd_object_index);
-	m0_be_btree_fini(&dom->cd_namespace);
+	struct m0_btree_op b_op = {};
+
+	M0_ENTRY("dom=%p id=%"PRIx64"", dom, dom != NULL ? dom->cd_id.id : 0);
+
+	M0_PRE(dom != NULL);
+	M0_PRE(dom->cd_id.id != 0);
+
+	if (dom->cd_object_index != NULL) {
+		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					 m0_btree_close(dom->cd_object_index,
+							       &b_op));
+		m0_free0(&dom->cd_object_index);
+	}
+
+	if (dom->cd_namespace != NULL) {
+		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					 m0_btree_close(dom->cd_namespace,
+							       &b_op));
+		m0_free0(&dom->cd_namespace);
+	}
+
+	if (dom->cd_fileattr_basic != NULL) {
+		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					 m0_btree_close(dom->cd_fileattr_basic,
+							       &b_op));
+		m0_free0(&dom->cd_fileattr_basic);
+	}
+
+	if (dom->cd_fileattr_omg != NULL) {
+		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					 m0_btree_close(dom->cd_fileattr_omg,
+							       &b_op));
+		m0_free0(&dom->cd_fileattr_omg);
+	}
+
+	if (dom->cd_fileattr_ea != NULL) {
+		M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					 m0_btree_close(dom->cd_fileattr_ea,
+							       &b_op));
+		m0_free0(&dom->cd_fileattr_ea);
+	}
 }
 
 static void cob_domain_id2str(char **s, const struct m0_cob_domain_id *cdid)
@@ -512,16 +582,46 @@ M0_INTERNAL int m0_cob_domain_credit_add(struct m0_cob_domain          *dom,
 				         const struct m0_cob_domain_id *cdid,
 				         struct m0_be_tx_credit        *cred)
 {
-	char                *cdid_str;
-	struct m0_buf        data = {}; /*XXX*/
-	struct m0_be_btree   dummy = { .bb_seg = seg }; /* XXX */
+	char                 *cdid_str;
+	struct m0_buf         data = {}; /*XXX*/
+	struct m0_btree_type  bt;
 
 	cob_domain_id2str(&cdid_str, cdid);
 	if (cdid_str == NULL)
 		return M0_ERR(-ENOMEM);
 	m0_be_0type_add_credit(bedom, &m0_be_cob0, cdid_str, &data, cred);
 	M0_BE_ALLOC_CREDIT_PTR(dom, seg, cred);
-	m0_be_btree_create_credit(&dummy, 5 /* XXX */, cred);
+
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_OBJECT_INDEX,
+				    .ksize = sizeof(struct m0_cob_oikey),
+				    .vsize = m0_cob_max_nskey_size(),
+				   };
+	m0_btree_create_credit(&bt, cred); /** Tree cd_object_index */
+
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_NAMESPACE,
+				    .ksize = m0_cob_max_nskey_size(),
+				    .vsize = sizeof(struct m0_cob_nsrec),
+				   };
+	m0_btree_create_credit(&bt, cred); /** Tree cd_namespace */
+
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_FILEATTR_BASIC,
+				    .ksize = sizeof(struct m0_cob_fabkey),
+				    .vsize = m0_cob_max_fabrec_size(),
+				   };
+	m0_btree_create_credit(&bt, cred); /** Tree cd_fileattr_basic */
+
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_FILEATTR_OMG,
+				    .ksize = sizeof (struct m0_cob_omgkey),
+				    .vsize = sizeof (struct m0_cob_omgrec),
+				   };
+	m0_btree_create_credit(&bt, cred); /** Tree cd_fileattr_omg */
+
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_FILEATTR_EA,
+				    .ksize = m0_cob_max_eakey_size(),
+				    .vsize = m0_cob_max_earec_size(),
+				   };
+	m0_btree_create_credit(&bt, cred); /** Tree cd_fileattr_ea */
+
 	m0_free(cdid_str);
 	return M0_RC(0);
 }
@@ -538,12 +638,15 @@ int m0_cob_domain_create_prepared(struct m0_cob_domain          **out,
 	char                 *cdid_str;
 	struct m0_buf         data = {}; /*XXX*/
 	int                   rc;
+	struct m0_btree_type  bt;
+	struct m0_btree_op    b_op = {};
+	struct m0_fid         fid;
 
 	cob_domain_id2str(&cdid_str, cdid);
 	if (cdid_str == NULL)
 		return M0_ERR(-ENOMEM);
 
-	M0_BE_ALLOC_PTR_SYNC(dom, seg, tx);
+	M0_BE_ALLOC_ALIGN_PTR_SYNC(dom, 10, seg, tx);
 	if (dom == NULL) {
 		m0_free(cdid_str);
 		return M0_ERR(-ENOMEM);
@@ -560,34 +663,75 @@ int m0_cob_domain_create_prepared(struct m0_cob_domain          **out,
 	m0_format_footer_update(dom);
 	M0_BE_TX_CAPTURE_PTR(seg, tx, dom);
 
-	rc = m0_cob_domain_init(dom, seg);
-	M0_ASSERT(rc == 0); /* XXX */
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_OBJECT_INDEX,
+		.ksize = sizeof(struct m0_cob_oikey),
+		.vsize = -1,
+	};
+	fid = M0_FID_TINIT('b', M0_BBT_COB_OBJECT_INDEX, cdid->id);
+	M0_ALLOC_PTR(dom->cd_object_index);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_create(&dom->cd_oi_node,
+						      sizeof dom->cd_oi_node,
+						      &bt, &b_op,
+						      dom->cd_object_index, seg,
+						      &fid, tx));
+	M0_ASSERT(rc == 0);
 
-	M0_BE_OP_SYNC(o,
-		      m0_be_btree_create(&dom->cd_object_index, tx, &o,
-					 &M0_FID_TINIT('b',
-						       M0_BBT_COB_OBJECT_INDEX,
-						       cdid->id)));
-	M0_BE_OP_SYNC(o,
-		      m0_be_btree_create(&dom->cd_namespace, tx, &o,
-					 &M0_FID_TINIT('b',
-						       M0_BBT_COB_NAMESPACE,
-						       cdid->id)));
-	M0_BE_OP_SYNC(o,
-		      m0_be_btree_create(&dom->cd_fileattr_basic, tx, &o,
-					 &M0_FID_TINIT('b',
-						      M0_BBT_COB_FILEATTR_BASIC,
-						       cdid->id)));
-	M0_BE_OP_SYNC(o,
-		      m0_be_btree_create(&dom->cd_fileattr_omg, tx, &o,
-					 &M0_FID_TINIT('b',
-						       M0_BBT_COB_FILEATTR_OMG,
-						       cdid->id)));
-	M0_BE_OP_SYNC(o,
-		      m0_be_btree_create(&dom->cd_fileattr_ea, tx, &o,
-					 &M0_FID_TINIT('b',
-						       M0_BBT_COB_FILEATTR_EA,
-						       cdid->id)));
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_NAMESPACE,
+		.ksize = -1,
+		.vsize = -1,
+	};
+	fid = M0_FID_TINIT('b', M0_BBT_COB_NAMESPACE, cdid->id);
+	M0_ALLOC_PTR(dom->cd_namespace);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_create(&dom->cd_ns_node,
+						      sizeof dom->cd_ns_node,
+						      &bt, &b_op,
+						      dom->cd_namespace, seg,
+						      &fid, tx));
+	M0_ASSERT(rc == 0);
+
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_FILEATTR_BASIC,
+		.ksize = sizeof(struct m0_cob_fabkey),
+		.vsize = -1,
+	};
+	fid = M0_FID_TINIT('b', M0_BBT_COB_FILEATTR_BASIC, cdid->id);
+	M0_ALLOC_PTR(dom->cd_fileattr_basic);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_create(&dom->cd_fa_basic_node,
+						      sizeof dom->cd_fa_basic_node,
+						      &bt, &b_op,
+						      dom->cd_fileattr_basic,
+						      seg, &fid, tx));
+	M0_ASSERT(rc == 0);
+
+	bt = (struct m0_btree_type){ .tt_id = M0_BT_COB_FILEATTR_OMG,
+				     .ksize = sizeof (struct m0_cob_omgkey),
+				     .vsize = sizeof (struct m0_cob_omgrec),
+				   };
+	fid = M0_FID_TINIT('b', M0_BBT_COB_FILEATTR_OMG, cdid->id);
+	M0_ALLOC_PTR(dom->cd_fileattr_omg);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_create(&dom->cd_fa_omg_node,
+						      sizeof dom->cd_fa_omg_node,
+						      &bt, &b_op,
+						      dom->cd_fileattr_omg, seg,
+						      &fid, tx));
+	M0_ASSERT(rc == 0);
+
+	bt = (struct m0_btree_type){.tt_id = M0_BT_COB_FILEATTR_EA,
+		.ksize = -1,
+		.vsize = -1,
+	};
+	fid = M0_FID_TINIT('b', M0_BBT_COB_FILEATTR_EA, cdid->id);
+	M0_ALLOC_PTR(dom->cd_fileattr_ea);
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+				      m0_btree_create(&dom->cd_fa_ea_node,
+						      sizeof dom->cd_fa_ea_node,
+						      &bt, &b_op,
+						      dom->cd_fileattr_ea, seg,
+						      &fid, tx));
+	M0_ASSERT(rc == 0);
 
 	data = M0_BUF_INIT_PTR(&dom);
 	rc = m0_be_0type_add(&m0_be_cob0, bedom, tx, cdid_str, &data);
@@ -630,15 +774,23 @@ tx_fini:
 	return M0_RC(rc);
 }
 
+static int cob_table_delete(struct m0_btree *tree, struct m0_be_tx *tx,
+			    struct m0_buf *key);
+
 int m0_cob_domain_destroy(struct m0_cob_domain *dom,
 			  struct m0_sm_group   *grp,
 			  struct m0_be_domain  *bedom)
 {
-	struct m0_be_tx_credit cred  = {};
-	struct m0_be_seg      *seg;
-	char                  *cdid_str;
-	struct m0_be_tx       *tx;
-	int rc;
+	struct m0_be_tx_credit  cred  = {};
+	struct m0_be_seg       *seg;
+	char                   *cdid_str;
+	struct m0_be_tx        *tx;
+	int                     rc;
+	struct m0_btree_op      b_op  = {};
+	struct m0_cob_omgkey    omgkey = {};
+	struct m0_cob_nskey    *nskey;
+	struct m0_buf           key;
+	struct m0_cob          *cob;
 
 	M0_PRE(dom != NULL);
 
@@ -652,31 +804,65 @@ int m0_cob_domain_destroy(struct m0_cob_domain *dom,
 		return M0_ERR(-ENOMEM);
 	}
 
-	seg = m0_be_domain_seg(bedom, dom);
-	m0_be_0type_del_credit(bedom, &m0_be_cob0, cdid_str, &cred);
-	M0_BE_FREE_CREDIT_PTR(dom, seg, &cred);
-
-	m0_be_btree_destroy_credit(&dom->cd_object_index,   &cred);
-	m0_be_btree_destroy_credit(&dom->cd_namespace,      &cred);
-	m0_be_btree_destroy_credit(&dom->cd_fileattr_basic, &cred);
-	m0_be_btree_destroy_credit(&dom->cd_fileattr_omg,   &cred);
-	m0_be_btree_destroy_credit(&dom->cd_fileattr_ea,    &cred);
-
-
+	/**
+	 *  Delete entries which were created by mkfs. No need to check if the
+	 *  delete functions succeed as we anyway need to proceed to delete the
+	 *  trees.
+	 */
+	m0_cob_tx_credit(dom, M0_COB_OP_DOMAIN_MKFS, &cred);
 	m0_be_tx_init(tx, 0, bedom, grp, NULL, NULL, NULL, NULL);
 	m0_be_tx_prep(tx, &cred);
 	rc = m0_be_tx_exclusive_open_sync(tx);
 	if (rc != 0)
 		goto tx_fini_return;
 
+	omgkey.cok_omgid = ~0ULL;
+	m0_buf_init(&key, &omgkey, sizeof omgkey);
+	cob_table_delete(dom->cd_fileattr_omg, tx, &key);
+
+	rc = m0_cob_nskey_make(&nskey, &M0_COB_ROOT_FID, M0_COB_ROOT_NAME,
+			       strlen(M0_COB_ROOT_NAME));
+	rc = m0_cob_lookup(dom, nskey, M0_CA_NSKEY_FREE, &cob);
+	m0_cob_delete(cob, tx);
+
+	m0_be_tx_close_sync(tx);
+	m0_be_tx_fini(tx);
+
+	seg = m0_be_domain_seg(bedom, dom);
+	m0_be_0type_del_credit(bedom, &m0_be_cob0, cdid_str, &cred);
+	M0_BE_FREE_CREDIT_PTR(dom, seg, &cred);
+	m0_btree_destroy_credit(dom->cd_object_index,   &cred);
+	m0_btree_destroy_credit(dom->cd_namespace,      &cred);
+	m0_btree_destroy_credit(dom->cd_fileattr_basic, &cred);
+	m0_btree_destroy_credit(dom->cd_fileattr_omg,   &cred);
+	m0_btree_destroy_credit(dom->cd_fileattr_ea,    &cred);
+
+	M0_SET0(tx);
+	m0_be_tx_init(tx, 0, bedom, grp, NULL, NULL, NULL, NULL);
+	m0_be_tx_prep(tx, &cred);
+	m0_be_tx_exclusive_open_sync(tx);
+	if (rc != 0)
+		goto tx_fini_return;
+
 	rc = m0_be_0type_del(&m0_be_cob0, bedom, tx, cdid_str);
 	M0_ASSERT(rc == 0);
 
-	M0_BE_OP_SYNC(o, m0_be_btree_destroy(&dom->cd_object_index,   tx, &o));
-	M0_BE_OP_SYNC(o, m0_be_btree_destroy(&dom->cd_namespace,      tx, &o));
-	M0_BE_OP_SYNC(o, m0_be_btree_destroy(&dom->cd_fileattr_basic, tx, &o));
-	M0_BE_OP_SYNC(o, m0_be_btree_destroy(&dom->cd_fileattr_omg,   tx, &o));
-	M0_BE_OP_SYNC(o, m0_be_btree_destroy(&dom->cd_fileattr_ea,    tx, &o));
+	M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(dom->cd_object_index,
+							 &b_op, tx));
+	M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(dom->cd_namespace,
+							 &b_op, tx));
+	M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(dom->cd_fileattr_basic,
+							 &b_op, tx));
+	M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(dom->cd_fileattr_omg,
+							 &b_op, tx));
+	M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(dom->cd_fileattr_ea,
+							 &b_op, tx));
+
+	m0_free0(&dom->cd_object_index);
+	m0_free0(&dom->cd_namespace);
+	m0_free0(&dom->cd_fileattr_basic);
+	m0_free0(&dom->cd_fileattr_omg);
+	m0_free0(&dom->cd_fileattr_ea);
 
 	m0_cob_domain_fini(dom);
 
@@ -699,36 +885,119 @@ tx_fini_return:
 #define MKFS_ROOT_BLKSIZE       4096
 #define MKFS_ROOT_BLOCKS        16
 
-static int cob_table_delete(struct m0_be_btree *tree, struct m0_be_tx *tx,
-			     struct m0_buf *key)
+static int cob_table_delete(struct m0_btree *tree, struct m0_be_tx *tx,
+			    struct m0_buf *key)
 {
-	return M0_BE_OP_SYNC_RET(op, m0_be_btree_delete(tree, tx, &op, key),
-	                         bo_u.u_btree.t_rc);
+	struct m0_btree_op   kv_op        = {};
+	void                *k_ptr = key->b_addr;
+	m0_bcount_t          ksize = key->b_nob;
+	struct m0_btree_key  r_key = {
+				  .k_data  = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+				};
+
+	return M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+					m0_btree_del(tree, &r_key, NULL,
+							&kv_op, tx));
 }
 
 
-static int cob_table_update(struct m0_be_btree *tree, struct m0_be_tx *tx,
+static int btree_update_callback(struct m0_btree_cb  *cb,
+				 struct m0_btree_rec *rec)
+{
+	struct m0_btree_rec     *datum = cb->c_datum;
+
+	/** Only update the Value to the location indicated in rec. */
+	m0_bufvec_copy(&rec->r_val, &datum->r_val,
+		       m0_vec_count(&datum->r_val.ov_vec));
+	return 0;
+}
+
+static int cob_table_update(struct m0_btree *tree, struct m0_be_tx *tx,
 			     struct m0_buf *key, struct m0_buf *val)
 {
-	return M0_BE_OP_SYNC_RET(op,
-				 m0_be_btree_update(tree, tx, &op, key, val),
-	                         bo_u.u_btree.t_rc);
+	struct m0_btree_op   kv_op        = {};
+	void                *k_ptr = key->b_addr;
+	void                *v_ptr = val->b_addr;
+	m0_bcount_t          ksize = key->b_nob;
+	m0_bcount_t          vsize = val->b_nob;
+	struct m0_btree_rec  rec = {
+			   .r_key.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+			   .r_val        = M0_BUFVEC_INIT_BUF( &v_ptr, &vsize),
+			};
+	struct m0_btree_cb   ut_put_cb = {.c_act = btree_update_callback,
+					  .c_datum = &rec,
+					  };
+
+	return M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+					m0_btree_update(tree, &rec, &ut_put_cb,
+							&kv_op, tx));
 }
 
-static int cob_table_insert(struct m0_be_btree *tree, struct m0_be_tx *tx,
+static int btree_insert_callback(struct m0_btree_cb  *cb,
+				 struct m0_btree_rec *rec)
+{
+	struct m0_btree_rec     *datum = cb->c_datum;
+
+	/** Write the Key and Value to the location indicated in rec. */
+	m0_bufvec_copy(&rec->r_key.k_data,  &datum->r_key.k_data,
+		       m0_vec_count(&datum->r_key.k_data.ov_vec));
+	m0_bufvec_copy(&rec->r_val, &datum->r_val,
+		       m0_vec_count(&rec->r_val.ov_vec));
+	return 0;
+}
+
+static int cob_table_insert(struct m0_btree *tree, struct m0_be_tx *tx,
 			     struct m0_buf *key, struct m0_buf *val)
 {
-	return M0_BE_OP_SYNC_RET(op,
-				 m0_be_btree_insert(tree, tx, &op, key, val),
-				 bo_u.u_btree.t_rc);
+	struct m0_btree_op   kv_op        = {};
+	void                *k_ptr = key->b_addr;
+	void                *v_ptr = val->b_addr;
+	m0_bcount_t          ksize = key->b_nob;
+	m0_bcount_t          vsize = val->b_nob;
+	struct m0_btree_rec  rec = {
+			   .r_key.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+			   .r_val        = M0_BUFVEC_INIT_BUF(&v_ptr, &vsize),
+			};
+	struct m0_btree_cb   ut_put_cb = {.c_act = btree_insert_callback,
+					  .c_datum = &rec,
+					 };
+
+	return M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+					m0_btree_put(tree, &rec, &ut_put_cb,
+						     &kv_op, tx));
 }
 
-static int cob_table_lookup(struct m0_be_btree *tree, struct m0_buf *key,
+static int btree_lookup_callback(struct m0_btree_cb  *cb,
+				 struct m0_btree_rec *rec)
+{
+	struct m0_btree_rec     *datum = cb->c_datum;
+
+	/** Only copy the Value for the caller. */
+	m0_bufvec_copy(&datum->r_val, &rec->r_val,
+		       m0_vec_count(&rec->r_val.ov_vec));
+	return 0;
+}
+
+static int cob_table_lookup(struct m0_btree *tree, struct m0_buf *key,
 			    struct m0_buf *out)
 {
-	return M0_BE_OP_SYNC_RET(op,
-	                         m0_be_btree_lookup(tree, &op, key, out),
-	                         bo_u.u_btree.t_rc);
+	struct m0_btree_op   kv_op     = {};
+	void                *k_ptr     = key->b_addr;
+	void                *v_ptr     = out->b_addr;
+	m0_bcount_t          ksize     = key->b_nob;
+	m0_bcount_t          vsize     = out->b_nob;
+	struct m0_btree_rec  rec       = {
+			    .r_key.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+			    .r_val        = M0_BUFVEC_INIT_BUF(&v_ptr, &vsize),
+			};
+	struct m0_btree_cb   ut_get_cb = {.c_act = btree_lookup_callback,
+					  .c_datum = &rec,
+					 };
+
+	return M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+					m0_btree_get(tree, &rec.r_key,
+						     &ut_get_cb,
+						     BOF_EQUAL, &kv_op));
 }
 
 
@@ -741,8 +1010,8 @@ M0_INTERNAL int m0_cob_domain_mkfs(struct m0_cob_domain *dom,
 				   const struct m0_fid *rootfid,
 				   struct m0_be_tx *tx)
 {
-	struct m0_cob_nskey  *nskey = NULL;
-	struct m0_cob_nsrec   nsrec = {};
+	struct m0_cob_nskey  *nskey  = NULL;
+	struct m0_cob_nsrec   nsrec  = {};
 	struct m0_cob_omgkey  omgkey = {};
 	struct m0_cob_omgrec  omgrec = {};
 	struct m0_cob_fabrec *fabrec = NULL;
@@ -758,7 +1027,7 @@ M0_INTERNAL int m0_cob_domain_mkfs(struct m0_cob_domain *dom,
 
 	m0_buf_init(&key, &omgkey, sizeof omgkey);
 	m0_buf_init(&rec, &omgrec, sizeof omgrec);
-	cob_table_insert(&dom->cd_fileattr_omg, tx, &key, &rec);
+	cob_table_insert(dom->cd_fileattr_omg, tx, &key, &rec);
 
 	/**
 	   Create root cob where all namespace is stored.
@@ -897,7 +1166,7 @@ static int cob_ns_lookup(struct m0_cob *cob)
 	m0_buf_init(&key, cob->co_nskey, m0_cob_nskey_size(cob->co_nskey));
 	m0_buf_init(&val, &cob->co_nsrec, sizeof cob->co_nsrec);
 
-	rc = cob_table_lookup(&cob->co_dom->cd_namespace, &key, &val);
+	rc = cob_table_lookup(cob->co_dom->cd_namespace, &key, &val);
 	if (rc == 0) {
 		cob->co_flags |= M0_CA_NSREC;
 		M0_ASSERT(cob->co_nsrec.cnr_linkno > 0 ||
@@ -915,14 +1184,18 @@ static int cob_ns_lookup(struct m0_cob *cob)
  */
 static int cob_oi_lookup(struct m0_cob *cob)
 {
-	struct m0_be_btree_cursor cursor;
-	struct m0_buf		  start;
-	struct m0_buf		  key;
-	struct m0_buf		  val;
-	struct m0_cob_oikey       oldkey;
-	struct m0_cob_oikey      *oikey;
-	struct m0_cob_nskey      *nskey;
-	int                       rc;
+	struct m0_btree_cursor  cursor;
+	m0_bcount_t             ksize  = sizeof cob->co_oikey;
+	void                   *k_ptr  = &cob->co_oikey;
+	struct m0_btree_key     start = {
+				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+				};
+	struct m0_buf           key;
+	struct m0_buf           val;
+	struct m0_cob_oikey     oldkey;
+	struct m0_cob_oikey    *oikey;
+	struct m0_cob_nskey    *nskey;
+	int                     rc;
 
 	if (cob->co_flags & M0_CA_NSKEY)
 		return 0;
@@ -939,20 +1212,19 @@ static int cob_oi_lookup(struct m0_cob *cob)
 	 * is out of scope outside of this function, but the record is good
 	 * until m0_db_pair_fini.
 	 */
-	m0_buf_init(&start, &cob->co_oikey, sizeof cob->co_oikey);
 
 	/*
 	 * We use cursor here because in some situations we need
 	 * to find most suitable position instead of exact location.
 	 */
-	m0_be_btree_cursor_init(&cursor, &cob->co_dom->cd_object_index);
-	rc = m0_be_btree_cursor_get_sync(&cursor, &start, true);
+	m0_btree_cursor_init(&cursor, cob->co_dom->cd_object_index);
+	rc = m0_btree_cursor_get(&cursor, &start, true);
 	if (rc != 0) {
 		M0_LOG(M0_DEBUG, "btree_cursor_get_sync() failed with %d", rc);
 		goto out;
 	}
 
-	m0_be_btree_cursor_kv_get(&cursor, &key, &val);
+	m0_btree_cursor_kv_get(&cursor, &key, &val);
 	nskey = (struct m0_cob_nskey *)val.b_addr;
 	oikey = (struct m0_cob_oikey *)key.b_addr;
 
@@ -976,7 +1248,7 @@ static int cob_oi_lookup(struct m0_cob *cob)
 			       m0_bitstring_len_get(&nskey->cnk_name));
 	cob->co_flags |= (M0_CA_NSKEY | M0_CA_NSKEY_FREE);
 out:
-	m0_be_btree_cursor_fini(&cursor);
+	m0_btree_cursor_fini(&cursor);
 	return M0_RC(rc);
 }
 
@@ -988,7 +1260,7 @@ out:
  */
 static int cob_fab_lookup(struct m0_cob *cob)
 {
-	struct m0_cob_fabkey fabkey;
+	struct m0_cob_fabkey fabkey = {};
 	struct m0_buf        key;
 	struct m0_buf        val;
 	int                  rc;
@@ -1004,7 +1276,7 @@ static int cob_fab_lookup(struct m0_cob *cob)
 	m0_buf_init(&key, &fabkey, sizeof fabkey);
 	m0_buf_init(&val, cob->co_fabrec, m0_cob_max_fabrec_size());
 
-	rc = cob_table_lookup(&cob->co_dom->cd_fileattr_basic, &key, &val);
+	rc = cob_table_lookup(cob->co_dom->cd_fileattr_basic, &key, &val);
 	if (rc == 0)
 		cob->co_flags |= M0_CA_FABREC;
 	else
@@ -1019,7 +1291,7 @@ static int cob_fab_lookup(struct m0_cob *cob)
  */
 static int cob_omg_lookup(struct m0_cob *cob)
 {
-	struct m0_cob_omgkey omgkey;
+	struct m0_cob_omgkey omgkey = {};
 	struct m0_buf        key;
 	struct m0_buf        val;
 	int                  rc;
@@ -1032,7 +1304,7 @@ static int cob_omg_lookup(struct m0_cob *cob)
 	m0_buf_init(&key, &omgkey, sizeof omgkey);
 	m0_buf_init(&val, &cob->co_omgrec, sizeof cob->co_omgrec);
 
-	rc = cob_table_lookup(&cob->co_dom->cd_fileattr_omg, &key, &val);
+	rc = cob_table_lookup(cob->co_dom->cd_fileattr_omg, &key, &val);
 	if (rc == 0)
 		cob->co_flags |= M0_CA_OMGREC;
 	else
@@ -1166,28 +1438,32 @@ M0_INTERNAL int m0_cob_iterator_init(struct m0_cob *cob,
 	if (rc != 0)
 		return M0_RC(rc);
 
-	m0_be_btree_cursor_init(&it->ci_cursor, &cob->co_dom->cd_namespace);
+	m0_btree_cursor_init(&it->ci_cursor, cob->co_dom->cd_namespace);
 	it->ci_cob = cob;
 	return M0_RC(rc);
 }
 
 M0_INTERNAL void m0_cob_iterator_fini(struct m0_cob_iterator *it)
 {
-	m0_be_btree_cursor_fini(&it->ci_cursor);
+	m0_btree_cursor_fini(&it->ci_cursor);
 	m0_free(it->ci_key);
 }
 
 M0_INTERNAL int m0_cob_iterator_get(struct m0_cob_iterator *it)
 {
         struct m0_cob_nskey *nskey;
-	struct m0_buf key;
-	int rc;
+	m0_bcount_t          ksize  = m0_cob_nskey_size(it->ci_key);
+	void                *k_ptr  = it->ci_key;
+	struct m0_btree_key  find_key = {
+				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+				};
+	struct m0_buf        key;
+	int                  rc;
 
 	M0_COB_NSKEY_LOG(ENTRY, "[%lx:%lx]/%.*s", it->ci_key);
-	m0_buf_init(&key, it->ci_key, m0_cob_nskey_size(it->ci_key));
-	rc = m0_be_btree_cursor_get_sync(&it->ci_cursor, &key, true);
+	rc = m0_btree_cursor_get(&it->ci_cursor, &find_key, true);
 	if (rc == 0) {
-		m0_be_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
+		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
 		nskey = (struct m0_cob_nskey *)key.b_addr;
 
                 /**
@@ -1213,9 +1489,9 @@ M0_INTERNAL int m0_cob_iterator_next(struct m0_cob_iterator *it)
 	int rc;
 
 	M0_COB_NSKEY_LOG(ENTRY, "[%lx:%lx]/%.*s", it->ci_key);
-	rc = m0_be_btree_cursor_next_sync(&it->ci_cursor);
+	rc = m0_btree_cursor_next(&it->ci_cursor);
 	if (rc == 0) {
-		m0_be_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
+		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
 		nskey = (struct m0_cob_nskey *)key.b_addr;
 
                 /**
@@ -1254,21 +1530,25 @@ M0_INTERNAL int m0_cob_ea_iterator_init(struct m0_cob *cob,
 		return M0_RC(rc);
         }
 
-	m0_be_btree_cursor_init(&it->ci_cursor, &cob->co_dom->cd_fileattr_ea);
+	m0_btree_cursor_init(&it->ci_cursor, cob->co_dom->cd_fileattr_ea);
 	it->ci_cob = cob;
 	return M0_RC(rc);
 }
 
 M0_INTERNAL int m0_cob_ea_iterator_get(struct m0_cob_ea_iterator *it)
 {
-	int rc;
-	struct m0_buf key;
+	int                  rc;
+	m0_bcount_t          ksize  = m0_cob_eakey_size(it->ci_key);
+	void                *k_ptr  = it->ci_key;
+	struct m0_btree_key  find_key = {
+				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+				};
+	struct m0_buf        key;
         struct m0_cob_eakey *eakey;
 
-	m0_buf_init(&key, it->ci_key, m0_cob_eakey_size(it->ci_key));
-	rc = m0_be_btree_cursor_get_sync(&it->ci_cursor, &key, true);
+	rc = m0_btree_cursor_get(&it->ci_cursor, &find_key, true);
 	if (rc == 0) {
-		m0_be_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
+		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
                 eakey = (struct m0_cob_eakey *)key.b_addr;
 
                 /**
@@ -1293,9 +1573,9 @@ M0_INTERNAL int m0_cob_ea_iterator_next(struct m0_cob_ea_iterator *it)
 	struct m0_buf key;
         struct m0_cob_eakey *eakey;
 
-	rc = m0_be_btree_cursor_next_sync(&it->ci_cursor);
+	rc = m0_btree_cursor_next(&it->ci_cursor);
 	if (rc == 0) {
-		m0_be_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
+		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
                 eakey = (struct m0_cob_eakey *)key.b_addr;
 
                 /**
@@ -1330,14 +1610,19 @@ static bool m0_cob_is_valid(struct m0_cob *cob)
 
 M0_INTERNAL int m0_cob_alloc_omgid(struct m0_cob_domain *dom, uint64_t *omgid)
 {
-	struct m0_be_btree_cursor cursor;
-	struct m0_cob_omgkey      omgkey;
-	struct m0_buf             kbuf;
-	int                       rc;
+	struct m0_btree_cursor cursor;
+	struct m0_cob_omgkey   omgkey = {};
+	m0_bcount_t            ksize  = sizeof omgkey;
+	void                  *k_ptr  = &omgkey;
+	struct m0_btree_key    find_key = {
+				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+				};
+	struct m0_buf          kbuf;
+	int                    rc;
 
 	M0_ENTRY();
 
-	m0_be_btree_cursor_init(&cursor, &dom->cd_fileattr_omg);
+	m0_btree_cursor_init(&cursor, dom->cd_fileattr_omg);
 
 	/*
 	 * Look for ~0ULL terminator record and do a step back to find last
@@ -1345,20 +1630,19 @@ M0_INTERNAL int m0_cob_alloc_omgid(struct m0_cob_domain *dom, uint64_t *omgid)
 	 * init time (mkfs or else).
 	 */
 	omgkey.cok_omgid = ~0ULL;
-	m0_buf_init(&kbuf, &omgkey, sizeof omgkey);
-	rc = m0_be_btree_cursor_get_sync(&cursor, &kbuf, true);
+	rc = m0_btree_cursor_get(&cursor, &find_key, true);
 
 	/*
 	 * In case of error, most probably due to no terminator record found,
 	 * one needs to run mkfs.
 	 */
 	if (rc == 0) {
-                rc = m0_be_btree_cursor_prev_sync(&cursor);
+                rc = m0_btree_cursor_prev(&cursor);
 		if (omgid != NULL) {
 			if (rc == 0) {
 				/* We found last allocated omgid.
 				 * Bump it by one. */
-				m0_be_btree_cursor_kv_get(&cursor, &kbuf, NULL);
+				m0_btree_cursor_kv_get(&cursor, &kbuf, NULL);
 				omgkey = *(struct m0_cob_omgkey*)kbuf.b_addr;
 				*omgid = ++omgkey.cok_omgid;
 			} else {
@@ -1370,7 +1654,7 @@ M0_INTERNAL int m0_cob_alloc_omgid(struct m0_cob_domain *dom, uint64_t *omgid)
 		rc = 0;
 	}
 
-	m0_be_btree_cursor_fini(&cursor);
+	m0_btree_cursor_fini(&cursor);
 	return M0_RC(rc);
 }
 
@@ -1384,9 +1668,12 @@ M0_INTERNAL int m0_cob_create(struct m0_cob *cob,
 {
 	struct m0_buf         key;
 	struct m0_buf         val;
-	struct m0_cob_omgkey  omgkey;
-	struct m0_cob_fabkey  fabkey;
+	struct m0_cob_omgkey  omgkey = {};
+	struct m0_cob_fabkey  fabkey = {};
 	int                   rc;
+	uint64_t              old_omgid    = nsrec->cnr_omgid;
+	uint32_t              old_cnr_cntr = nsrec->cnr_cntr;
+
 
 	M0_PRE(cob != NULL);
 	M0_PRE(nskey != NULL);
@@ -1426,8 +1713,12 @@ M0_INTERNAL int m0_cob_create(struct m0_cob *cob,
 	 * Let's create name, statdata and object index.
 	 */
 	rc = m0_cob_name_add(cob, nskey, nsrec, tx);
-	if (rc != 0)
+	if (rc != 0) {
+		cob->co_nsrec.cnr_omgid = old_omgid;
+		nsrec->cnr_omgid        = old_omgid;
+		nsrec->cnr_cntr         = old_cnr_cntr;
 		goto out;
+	}
 	cob->co_flags |= M0_CA_NSKEY_FREE;
 
 	if (fabrec != NULL) {
@@ -1447,7 +1738,7 @@ M0_INTERNAL int m0_cob_create(struct m0_cob *cob,
 		m0_buf_init(&key, &fabkey, sizeof fabkey);
 		m0_buf_init(&val, cob->co_fabrec,
 			    m0_cob_fabrec_size(cob->co_fabrec));
-		cob_table_insert(&cob->co_dom->cd_fileattr_basic, tx, &key,
+		cob_table_insert(cob->co_dom->cd_fileattr_basic, tx, &key,
 		                                                      &val);
 		cob->co_flags |= M0_CA_FABREC;
 	}
@@ -1469,10 +1760,10 @@ M0_INTERNAL int m0_cob_create(struct m0_cob *cob,
 		 */
 		m0_buf_init(&key, &omgkey, sizeof omgkey);
 		m0_buf_init(&val, &cob->co_omgrec, sizeof cob->co_omgrec);
-		rc = cob_table_lookup(&cob->co_dom->cd_fileattr_omg, &key,
+		rc = cob_table_lookup(cob->co_dom->cd_fileattr_omg, &key,
 		                                                     &val);
 		if (rc == -ENOENT)
-			cob_table_insert(&cob->co_dom->cd_fileattr_omg, tx,
+			cob_table_insert(cob->co_dom->cd_fileattr_omg, tx,
 					 &key, &val);
 		else
 			M0_LOG(M0_DEBUG, "the same omgkey: %"PRIx64" is being "
@@ -1485,9 +1776,9 @@ out:
 
 M0_INTERNAL int m0_cob_delete(struct m0_cob *cob, struct m0_be_tx *tx)
 {
-	struct m0_cob_fabkey fabkey;
-	struct m0_cob_omgkey omgkey;
-	struct m0_cob_oikey  oikey;
+	struct m0_cob_fabkey fabkey = {};
+	struct m0_cob_omgkey omgkey = {};
+	struct m0_cob_oikey  oikey  = {};
 	struct m0_buf        key;
 	struct m0_cob       *sdcob;
 	bool                 sdname;
@@ -1524,7 +1815,7 @@ M0_INTERNAL int m0_cob_delete(struct m0_cob *cob, struct m0_be_tx *tx)
 		 * Ignore errors; it's a dangling table entry but causes
 		 * no harm.
 		 */
-		cob_table_delete(&cob->co_dom->cd_fileattr_basic, tx, &key);
+		cob_table_delete(cob->co_dom->cd_fileattr_basic, tx, &key);
 
 		/*
 		 * @todo: Omgrec may be shared between multiple objects.
@@ -1541,7 +1832,7 @@ M0_INTERNAL int m0_cob_delete(struct m0_cob *cob, struct m0_be_tx *tx)
 		 * Ignore errors; it's a dangling table entry but causes
 		 * no harm.
 		 */
-		cob_table_delete(&cob->co_dom->cd_fileattr_omg, tx, &key);
+		cob_table_delete(cob->co_dom->cd_fileattr_omg, tx, &key);
 	}
 out:
 	return M0_RC(rc);
@@ -1560,8 +1851,8 @@ M0_INTERNAL int m0_cob_update(struct m0_cob *cob,
 			      struct m0_cob_omgrec *omgrec,
 			      struct m0_be_tx *tx)
 {
-	struct m0_cob_omgkey  omgkey;
-	struct m0_cob_fabkey  fabkey;
+	struct m0_cob_omgkey  omgkey = {};
+	struct m0_cob_fabkey  fabkey = {};
 	struct m0_buf         key;
 	struct m0_buf         val;
 	int                   rc = 0;
@@ -1579,7 +1870,7 @@ M0_INTERNAL int m0_cob_update(struct m0_cob *cob,
 		/* Update footer before record becomes persistant */
 		m0_format_footer_update(&cob->co_nsrec);
 		m0_buf_init(&val, &cob->co_nsrec, sizeof cob->co_nsrec);
-		rc = cob_table_update(&cob->co_dom->cd_namespace,
+		rc = cob_table_update(cob->co_dom->cd_namespace,
 				      tx, &key, &val);
 	}
 
@@ -1595,7 +1886,7 @@ M0_INTERNAL int m0_cob_update(struct m0_cob *cob,
 
 		m0_buf_init(&key, &fabkey, sizeof fabkey);
 		m0_buf_init(&val,cob->co_fabrec, m0_cob_fabrec_size(cob->co_fabrec));
-		rc = cob_table_update(&cob->co_dom->cd_fileattr_basic,
+		rc = cob_table_update(cob->co_dom->cd_fileattr_basic,
 				      tx, &key, &val);
 	}
 
@@ -1611,7 +1902,7 @@ M0_INTERNAL int m0_cob_update(struct m0_cob *cob,
 
 		m0_buf_init(&key, &omgkey, sizeof omgkey);
 		m0_buf_init(&val, &cob->co_omgrec, sizeof cob->co_omgrec);
-		rc = cob_table_update(&cob->co_dom->cd_fileattr_omg,
+		rc = cob_table_update(cob->co_dom->cd_fileattr_omg,
 				      tx, &key, &val);
 	}
 
@@ -1623,7 +1914,7 @@ M0_INTERNAL int m0_cob_name_add(struct m0_cob *cob,
 				struct m0_cob_nsrec *nsrec,
 				struct m0_be_tx *tx)
 {
-	struct m0_cob_oikey  oikey;
+	struct m0_cob_oikey  oikey = {};
 	struct m0_buf        key;
 	struct m0_buf        val;
 	int                  rc;
@@ -1637,7 +1928,7 @@ M0_INTERNAL int m0_cob_name_add(struct m0_cob *cob,
 
 	m0_buf_init(&key, &oikey, sizeof oikey);
 	m0_buf_init(&val, nskey, m0_cob_nskey_size(nskey));
-	rc = cob_table_insert(&cob->co_dom->cd_object_index, tx, &key, &val);
+	rc = cob_table_insert(cob->co_dom->cd_object_index, tx, &key, &val);
 	if (rc != 0)
 		return M0_RC_INFO(rc, "fid="FID_F" cntr=%u",
 				  FID_P(&nsrec->cnr_fid),
@@ -1647,10 +1938,10 @@ M0_INTERNAL int m0_cob_name_add(struct m0_cob *cob,
 	/* Update footer before record becomes persistant */
 	m0_format_footer_update(nsrec);
 	m0_buf_init(&val, nsrec, sizeof *nsrec);
-	rc = cob_table_insert(&cob->co_dom->cd_namespace, tx, &key, &val);
+	rc = cob_table_insert(cob->co_dom->cd_namespace, tx, &key, &val);
 	if (rc != 0) {
 		m0_buf_init(&key, &oikey, sizeof oikey);
-		cob_table_delete(&cob->co_dom->cd_object_index, tx, &key);
+		cob_table_delete(cob->co_dom->cd_object_index, tx, &key);
 		return M0_RC_INFO(rc, "parent="FID_F" name='%*s'",
 				  FID_P(&nskey->cnk_pfid),
 				  nskey->cnk_name.b_len,
@@ -1664,8 +1955,8 @@ M0_INTERNAL int m0_cob_name_del(struct m0_cob *cob,
 				struct m0_cob_nskey *nskey,
 				struct m0_be_tx *tx)
 {
-	struct m0_cob_oikey oikey;
-	struct m0_cob_nsrec nsrec;
+	struct m0_cob_oikey oikey = {};
+	struct m0_cob_nsrec nsrec = {};
 	struct m0_buf       key;
 	struct m0_buf       val;
 	int                 rc;
@@ -1679,11 +1970,11 @@ M0_INTERNAL int m0_cob_name_del(struct m0_cob *cob,
 	m0_buf_init(&key, nskey, m0_cob_nskey_size(nskey));
 	m0_buf_init(&val, &nsrec, sizeof nsrec);
 
-	rc = cob_table_lookup(&cob->co_dom->cd_namespace, &key, &val);
+	rc = cob_table_lookup(cob->co_dom->cd_namespace, &key, &val);
 	if (rc != 0)
 		goto out;
 
-	rc = cob_table_delete(&cob->co_dom->cd_namespace, tx, &key);
+	rc = cob_table_delete(cob->co_dom->cd_namespace, tx, &key);
 	if (rc != 0)
 		goto out;
 
@@ -1692,7 +1983,7 @@ M0_INTERNAL int m0_cob_name_del(struct m0_cob *cob,
 	 */
 	m0_cob_oikey_make(&oikey, m0_cob_fid(cob), nsrec.cnr_linkno);
 	m0_buf_init(&key, &oikey, sizeof oikey);
-	rc = cob_table_delete(&cob->co_dom->cd_object_index, tx, &key);
+	rc = cob_table_delete(cob->co_dom->cd_object_index, tx, &key);
 
 out:
 	return M0_RC(rc);
@@ -1703,7 +1994,7 @@ M0_INTERNAL int m0_cob_name_update(struct m0_cob *cob,
 				   struct m0_cob_nskey *tgtkey,
 				   struct m0_be_tx *tx)
 {
-	struct m0_cob_oikey  oikey;
+	struct m0_cob_oikey  oikey = {};
 	struct m0_buf        key;
 	struct m0_buf        val;
 	int                  rc;
@@ -1715,27 +2006,27 @@ M0_INTERNAL int m0_cob_name_update(struct m0_cob *cob,
 	 * Insert new record with nsrec found with srckey.
 	 */
 	m0_buf_init(&key, srckey, m0_cob_nskey_size(srckey));
-	rc = cob_table_lookup(&cob->co_dom->cd_namespace, &key, &val);
+	rc = cob_table_lookup(cob->co_dom->cd_namespace, &key, &val);
 	if (rc != 0)
 		goto out;
 
 	m0_buf_init(&key, tgtkey, m0_cob_nskey_size(tgtkey));
 	/* here @val consists value to insert */
-	cob_table_insert(&cob->co_dom->cd_namespace, tx, &key, &val);
+	cob_table_insert(cob->co_dom->cd_namespace, tx, &key, &val);
 
 	/*
 	 * Kill old record. Error will be returned if
 	 * nothing found.
 	 */
 	m0_buf_init(&key, srckey, m0_cob_nskey_size(srckey));
-	rc = cob_table_delete(&cob->co_dom->cd_namespace, tx, &key);
+	rc = cob_table_delete(cob->co_dom->cd_namespace, tx, &key);
 	if (rc != 0)
 		goto out;
 
 	/* Update object index */
 	m0_buf_init(&key, &oikey, sizeof oikey);
 	m0_buf_init(&val, tgtkey, m0_cob_nskey_size(tgtkey));
-	rc = cob_table_update(&cob->co_dom->cd_object_index, tx, &key, &val);
+	rc = cob_table_update(cob->co_dom->cd_object_index, tx, &key, &val);
 	if (rc != 0)
 		goto out;
 
@@ -1765,7 +2056,7 @@ M0_INTERNAL void m0_cob_nsrec_init(struct m0_cob_nsrec *nsrec)
 M0_INTERNAL int m0_cob_setattr(struct m0_cob *cob, struct m0_cob_attr *attr,
 			       struct m0_be_tx *tx)
 {
-	struct m0_cob_nsrec   nsrec_prev;
+	struct m0_cob_nsrec   nsrec_prev = {};
 	struct m0_cob_nsrec  *nsrec = NULL;
 	struct m0_cob_fabrec *fabrec = NULL;
 	struct m0_cob_omgrec *omgrec = NULL;
@@ -1860,7 +2151,7 @@ M0_INTERNAL int m0_cob_ea_get(struct m0_cob *cob,
 
 	m0_buf_init(&key, eakey, m0_cob_eakey_size(eakey));
 	m0_buf_init(&val, out, m0_cob_max_earec_size());
-	rc = cob_table_lookup(&cob->co_dom->cd_fileattr_ea, &key, &val);
+	rc = cob_table_lookup(cob->co_dom->cd_fileattr_ea, &key, &val);
 
 	return M0_RC(rc);
 }
@@ -1882,7 +2173,7 @@ M0_INTERNAL int m0_cob_ea_set(struct m0_cob *cob,
 
 	m0_buf_init(&key, eakey, m0_cob_eakey_size(eakey));
 	m0_buf_init(&val, earec, m0_cob_earec_size(earec));
-	cob_table_insert(&cob->co_dom->cd_fileattr_ea, tx, &key, &val);
+	cob_table_insert(cob->co_dom->cd_fileattr_ea, tx, &key, &val);
 
 	return 0;
 }
@@ -1897,7 +2188,7 @@ M0_INTERNAL int m0_cob_ea_del(struct m0_cob *cob,
 	M0_PRE(m0_cob_is_valid(cob));
 
 	m0_buf_init(&key, eakey, m0_cob_eakey_size(eakey));
-	rc = cob_table_delete(&cob->co_dom->cd_fileattr_ea, tx, &key);
+	rc = cob_table_delete(cob->co_dom->cd_fileattr_ea, tx, &key);
 	return M0_RC(rc);
 }
 
@@ -1915,9 +2206,9 @@ enum cob_table_kvtype {
 	COB_KVTYPE_OI,
 };
 
-static void cob_table_tx_credit(struct m0_be_btree *tree,
-				enum cob_table_optype t_optype,
-				enum cob_table_kvtype t_kvtype,
+static void cob_table_tx_credit(struct m0_btree        *tree,
+				enum cob_table_optype   t_optype,
+				enum cob_table_kvtype   t_kvtype,
 				struct m0_be_tx_credit *accum)
 {
 	const struct {
@@ -1957,13 +2248,13 @@ static void cob_table_tx_credit(struct m0_be_btree *tree,
 
 	switch (t_optype) {
 	case COB_TABLE_DELETE:
-		m0_be_btree_delete_credit(tree, 1, ksize, vsize, accum);
+		m0_btree_del_credit(tree, 1, ksize, vsize, accum);
 		break;
 	case COB_TABLE_UPDATE:
-		m0_be_btree_update_credit(tree, 1, vsize, accum);
+		m0_btree_put_credit(tree, 1, ksize, vsize, accum);
 		break;
 	case COB_TABLE_INSERT:
-		m0_be_btree_insert_credit(tree, 1, ksize, vsize, accum);
+		m0_btree_put_credit(tree, 1, ksize, vsize, accum);
 		break;
 	default:
 		M0_IMPOSSIBLE("Impossible cob btree optype");
@@ -1982,7 +2273,7 @@ M0_INTERNAL void m0_cob_tx_credit(struct m0_cob_domain *dom,
 
 	switch (optype) {
 	case M0_COB_OP_DOMAIN_MKFS:
-		TCREDIT(&dom->cd_fileattr_omg, INSERT, OMG, accum);
+		TCREDIT(dom->cd_fileattr_omg, INSERT, OMG, accum);
 		for (i = 0; i < 2; ++i)
 			m0_cob_tx_credit(dom, M0_COB_OP_CREATE, accum);
 		break;
@@ -1992,41 +2283,41 @@ M0_INTERNAL void m0_cob_tx_credit(struct m0_cob_domain *dom,
 		break;
 	case M0_COB_OP_CREATE:
 		m0_cob_tx_credit(dom, M0_COB_OP_NAME_ADD, accum);
-		TCREDIT(&dom->cd_fileattr_basic, INSERT, FAB, accum);
-		TCREDIT(&dom->cd_fileattr_omg, INSERT, OMG, accum);
+		TCREDIT(dom->cd_fileattr_basic, INSERT, FAB, accum);
+		TCREDIT(dom->cd_fileattr_omg, INSERT, OMG, accum);
 		break;
 	case M0_COB_OP_DELETE:
 	case M0_COB_OP_DELETE_PUT:
 		m0_cob_tx_credit(dom, M0_COB_OP_LOCATE, accum);
 		m0_cob_tx_credit(dom, M0_COB_OP_NAME_DEL, accum);
-		TCREDIT(&dom->cd_fileattr_basic, DELETE, FAB, accum);
-		TCREDIT(&dom->cd_fileattr_omg, DELETE, FAB, accum);
+		TCREDIT(dom->cd_fileattr_basic, DELETE, FAB, accum);
+		TCREDIT(dom->cd_fileattr_omg, DELETE, FAB, accum);
 		break;
 	case M0_COB_OP_UPDATE:
-		TCREDIT(&dom->cd_namespace, UPDATE, NS, accum);
-		TCREDIT(&dom->cd_fileattr_basic, UPDATE, FAB, accum);
-		TCREDIT(&dom->cd_fileattr_omg, UPDATE, OMG, accum);
+		TCREDIT(dom->cd_namespace, UPDATE, NS, accum);
+		TCREDIT(dom->cd_fileattr_basic, UPDATE, FAB, accum);
+		TCREDIT(dom->cd_fileattr_omg, UPDATE, OMG, accum);
 		break;
 	case M0_COB_OP_FEA_SET:
-		TCREDIT(&dom->cd_fileattr_ea, DELETE, FEA, accum);
-		TCREDIT(&dom->cd_fileattr_ea, INSERT, FEA, accum);
+		TCREDIT(dom->cd_fileattr_ea, DELETE, FEA, accum);
+		TCREDIT(dom->cd_fileattr_ea, INSERT, FEA, accum);
 		break;
 	case M0_COB_OP_FEA_DEL:
-		TCREDIT(&dom->cd_fileattr_ea, DELETE, FEA, accum);
+		TCREDIT(dom->cd_fileattr_ea, DELETE, FEA, accum);
 		break;
 	case M0_COB_OP_NAME_ADD:
-		TCREDIT(&dom->cd_object_index, INSERT, OI, accum);
-		TCREDIT(&dom->cd_object_index, DELETE, OI, accum);
-		TCREDIT(&dom->cd_namespace, INSERT, NS, accum);
+		TCREDIT(dom->cd_object_index, INSERT, OI, accum);
+		TCREDIT(dom->cd_object_index, DELETE, OI, accum);
+		TCREDIT(dom->cd_namespace, INSERT, NS, accum);
 		break;
 	case M0_COB_OP_NAME_DEL:
-		TCREDIT(&dom->cd_namespace, DELETE, NS, accum);
-		TCREDIT(&dom->cd_object_index, DELETE, OI, accum);
+		TCREDIT(dom->cd_namespace, DELETE, NS, accum);
+		TCREDIT(dom->cd_object_index, DELETE, OI, accum);
 		break;
 	case M0_COB_OP_NAME_UPDATE:
-		TCREDIT(&dom->cd_namespace, INSERT, NS, accum);
-		TCREDIT(&dom->cd_namespace, DELETE, NS, accum);
-		TCREDIT(&dom->cd_object_index, UPDATE, OI, accum);
+		TCREDIT(dom->cd_namespace, INSERT, NS, accum);
+		TCREDIT(dom->cd_namespace, DELETE, NS, accum);
+		TCREDIT(dom->cd_object_index, UPDATE, OI, accum);
 		break;
 	default:
 		M0_IMPOSSIBLE("Impossible cob optype");

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -33,7 +33,7 @@
 #include "lib/bitstring_xc.h"
 #include "fid/fid.h"
 #include "mdservice/md_fid.h"
-#include "be/btree.h"
+#include "btree/btree.h"
 #include "be/btree_xc.h"
 
 /* import */
@@ -267,11 +267,22 @@ struct m0_cob_domain {
 	 * m0_be_btree has it's own volatile-only fields, so it can't be placed
 	 * before the m0_format_footer, where only persistent fields allowed
 	 */
-	struct m0_be_btree      cd_object_index;
-	struct m0_be_btree      cd_namespace;
-	struct m0_be_btree      cd_fileattr_basic;
-	struct m0_be_btree      cd_fileattr_omg;
-	struct m0_be_btree      cd_fileattr_ea;
+	struct m0_btree *cd_object_index;
+	struct m0_btree *cd_namespace;
+	struct m0_btree *cd_fileattr_basic;
+	struct m0_btree *cd_fileattr_omg;
+	struct m0_btree *cd_fileattr_ea;
+	uint8_t          cd_oi_node[1024] __attribute__((aligned(1024)));
+	uint8_t          cd_ns_node[1024] __attribute__((aligned(1024)));
+	uint8_t          cd_fa_basic_node[1024] __attribute__((aligned(1024)));
+	uint8_t          cd_fa_omg_node[1024] __attribute__((aligned(1024)));
+	uint8_t          cd_fa_ea_node[1024] __attribute__((aligned(1024)));
+#if 0
+	uint8_t  cd_object_index[1024] __attribute__ ((aligned(1024)));
+	uint8_t  cd_namespace[1024]__attribute__ ((aligned(1024)));
+	uint8_t  cd_fileattr_basic[1024]__attribute__ ((aligned(1024)));
+	uint8_t  cd_fileattr_ea[1024]__attribute__ ((aligned(1024)));
+#endif
 } M0_XCA_RECORD M0_XCA_DOMAIN(be);
 
 enum m0_cob_domain_format_version {
@@ -600,7 +611,7 @@ struct m0_rdpg {
  */
 struct m0_cob_iterator {
 	struct m0_cob            *ci_cob;      /**< the cob we iterate */
-	struct m0_be_btree_cursor ci_cursor;   /**< cob iterator cursor */
+	struct m0_btree_cursor    ci_cursor;   /**< cob iterator cursor */
 	struct m0_cob_nskey      *ci_key;      /**< current iterator pos */
 };
 
@@ -609,7 +620,7 @@ struct m0_cob_iterator {
  */
 struct m0_cob_ea_iterator {
 	struct m0_cob            *ci_cob;      /**< the cob we iterate */
-	struct m0_be_btree_cursor ci_cursor;   /**< cob iterator cursor */
+	struct m0_btree_cursor    ci_cursor;   /**< cob iterator cursor */
 	struct m0_cob_eakey      *ci_key;      /**< current iterator pos */
 	struct m0_cob_earec      *ci_rec;      /**< current iterator rec */
 };

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -231,6 +231,17 @@ enum {
 };
 
 /**
+ *  If the following define is made an enum then the compiler throws an error,
+ *  hence using it as a #define constant.
+ */
+#define M0_COB_ROOT_NODE_ALIGN (4 * 1024)
+
+enum {
+	M0_COB_ROOT_NODE_SIZE = (8 * 1024),
+
+	/** This should align to Block size on the storage. Change as needed */
+};
+/**
    Unique cob domain identifier.
 
    A cob_domain identifier distinguishes domains within a single
@@ -263,26 +274,33 @@ struct m0_cob_domain {
 	struct m0_format_header cd_header;
 	struct m0_cob_domain_id cd_id;
 	struct m0_format_footer cd_footer;
-	/*
-	 * m0_be_btree has it's own volatile-only fields, so it can't be placed
-	 * before the m0_format_footer, where only persistent fields allowed
+	/**
+	 * The new BTree does not have a tree structure persistent on BE seg.
+	 * Instead we have the root node occupying the same location where the
+	 * old m0_be_btree used to be placed. To minimize the changes to the
+	 * code we have the pointers to m0_btree (new BTree) placed here and the
+	 * root nodes follow them aligned to a Block boundary.
 	 */
-	struct m0_btree *cd_object_index;
-	struct m0_btree *cd_namespace;
-	struct m0_btree *cd_fileattr_basic;
-	struct m0_btree *cd_fileattr_omg;
-	struct m0_btree *cd_fileattr_ea;
-	uint8_t          cd_oi_node[1024] __attribute__((aligned(1024)));
-	uint8_t          cd_ns_node[1024] __attribute__((aligned(1024)));
-	uint8_t          cd_fa_basic_node[1024] __attribute__((aligned(1024)));
-	uint8_t          cd_fa_omg_node[1024] __attribute__((aligned(1024)));
-	uint8_t          cd_fa_ea_node[1024] __attribute__((aligned(1024)));
-#if 0
-	uint8_t  cd_object_index[1024] __attribute__ ((aligned(1024)));
-	uint8_t  cd_namespace[1024]__attribute__ ((aligned(1024)));
-	uint8_t  cd_fileattr_basic[1024]__attribute__ ((aligned(1024)));
-	uint8_t  cd_fileattr_ea[1024]__attribute__ ((aligned(1024)));
-#endif
+	struct m0_btree *cd_object_index;   /** Pointer to OI tree. */
+	struct m0_btree *cd_namespace;      /** Pointer to namespace tree */
+	struct m0_btree *cd_fileattr_basic; /** Pointer to fileattr_ba tree */
+	struct m0_btree *cd_fileattr_omg;   /** Pointer to fileattr_omg tree */
+	struct m0_btree *cd_fileattr_ea;    /** Pointer to fileattr_ea tree */
+
+	/**
+	 *  Root nodes for the above trees follow here. These root nodes
+	 *  are aligned to Block boundary for performance reasons.
+	 */
+	uint8_t          cd_oi_node[M0_COB_ROOT_NODE_SIZE]
+			      __attribute__((aligned(M0_COB_ROOT_NODE_ALIGN)));
+	uint8_t          cd_ns_node[M0_COB_ROOT_NODE_SIZE]
+			      __attribute__((aligned(M0_COB_ROOT_NODE_ALIGN)));
+	uint8_t          cd_fa_basic_node[M0_COB_ROOT_NODE_SIZE]
+			      __attribute__((aligned(M0_COB_ROOT_NODE_ALIGN)));
+	uint8_t          cd_fa_omg_node[M0_COB_ROOT_NODE_SIZE]
+			      __attribute__((aligned(M0_COB_ROOT_NODE_ALIGN)));
+	uint8_t          cd_fa_ea_node[M0_COB_ROOT_NODE_SIZE]
+			      __attribute__((aligned(M0_COB_ROOT_NODE_ALIGN)));
 } M0_XCA_RECORD M0_XCA_DOMAIN(be);
 
 enum m0_cob_domain_format_version {

--- a/cob/ns_iter.h
+++ b/cob/ns_iter.h
@@ -76,7 +76,7 @@ M0_INTERNAL int m0_cob_ns_iter_next(struct m0_cob_fid_ns_iter *iter,
 				    struct m0_fid *gfid,
 				    struct m0_cob_nsrec **nsrec);
 
-M0_INTERNAL int m0_cob_ns_rec_of(struct m0_be_btree *cob_namespace,
+M0_INTERNAL int m0_cob_ns_rec_of(struct m0_btree *cob_namespace,
 				 const struct m0_fid *key_gfid,
 				 struct m0_fid *next_gfid,
 				 struct m0_cob_nsrec **nsrec);

--- a/cob/ut/cob.c
+++ b/cob/ut/cob.c
@@ -131,7 +131,7 @@ static void test_init(void)
 
 static void test_fini(void)
 {
-	int                     rc;
+	int rc;
 
 	grp = m0_be_ut_backend_sm_group_lookup(&ut_be);
 	rc = m0_cob_domain_destroy(dom, grp, &ut_be.but_dom);
@@ -142,15 +142,15 @@ static void test_fini(void)
 
 static void test_create(void)
 {
-	struct m0_be_tx_credit	accum = {};
+	struct m0_be_tx_credit  accum = {};
 	struct m0_cob_nskey    *key;
-	struct m0_cob_nsrec	nsrec = {};
-	struct m0_cob_fabrec  *fabrec;
-	struct m0_cob_omgrec	omgrec = {};
-	struct m0_fid		pfid;
-	struct m0_be_tx		tx_;
+	struct m0_cob_nsrec     nsrec = {};
+	struct m0_cob_fabrec   *fabrec;
+	struct m0_cob_omgrec    omgrec = {};
+	struct m0_fid           pfid;
+	struct m0_be_tx         tx_;
 	struct m0_be_tx	       *tx = &tx_;
-	int			rc;
+	int                     rc;
 
 	M0_SET0(&nsrec);
 	M0_SET0(&omgrec);
@@ -189,11 +189,11 @@ static void test_create(void)
 static void test_add_name(void)
 {
 	struct m0_cob_nskey    *nskey;
-	struct m0_fid		pfid;
-	struct m0_be_tx		tx_;
+	struct m0_fid           pfid;
+	struct m0_be_tx         tx_;
 	struct m0_be_tx	       *tx = &tx_;
-	int			rc;
-	struct m0_be_tx_credit	accum = {};
+	int                     rc;
+	struct m0_be_tx_credit  accum = {};
 
 	/* pfid, filename */
 	m0_fid_set(&pfid, 0x123, 0x456);
@@ -232,11 +232,11 @@ static void test_add_name(void)
 static void test_del_name(void)
 {
 	struct m0_cob_nskey    *nskey;
-	struct m0_fid		pfid;
-	struct m0_be_tx		tx_;
-	struct m0_be_tx	       *tx = &tx_;
-	int			rc;
-	struct m0_be_tx_credit	accum = {};
+	struct m0_fid           pfid;
+	struct m0_be_tx         tx_;
+	struct m0_be_tx        *tx = &tx_;
+	int                     rc;
+	struct m0_be_tx_credit  accum = {};
 
 	/* pfid, filename */
 	m0_fid_set(&pfid, 0x123, 0x456);
@@ -315,10 +315,10 @@ static void test_locate(void)
 
 static void test_delete(void)
 {
-	struct m0_be_tx		tx_;
+	struct m0_be_tx         tx_;
 	struct m0_be_tx	       *tx = &tx_;
-	int		        rc;
-	struct m0_be_tx_credit	accum = {};
+	int                     rc;
+	struct m0_be_tx_credit  accum = {};
 
 	/* gets ref */
 	rc = _locate(0xabc, 0xdef);

--- a/cob/ut/cob.c
+++ b/cob/ut/cob.c
@@ -64,7 +64,7 @@ static void ut_tx_open(struct m0_be_tx *tx, struct m0_be_tx_credit *credit)
 static int _locate(int c, int k)
 {
 	struct m0_fid       fid;
-	struct m0_cob_oikey oikey;
+	struct m0_cob_oikey oikey = {};
 	int                 rc;
 
 	m0_fid_set(&fid, c, k);
@@ -131,7 +131,7 @@ static void test_init(void)
 
 static void test_fini(void)
 {
-	int rc;
+	int                     rc;
 
 	grp = m0_be_ut_backend_sm_group_lookup(&ut_be);
 	rc = m0_cob_domain_destroy(dom, grp, &ut_be.but_dom);
@@ -144,9 +144,9 @@ static void test_create(void)
 {
 	struct m0_be_tx_credit	accum = {};
 	struct m0_cob_nskey    *key;
-	struct m0_cob_nsrec	nsrec;
+	struct m0_cob_nsrec	nsrec = {};
 	struct m0_cob_fabrec  *fabrec;
-	struct m0_cob_omgrec	omgrec;
+	struct m0_cob_omgrec	omgrec = {};
 	struct m0_fid		pfid;
 	struct m0_be_tx		tx_;
 	struct m0_be_tx	       *tx = &tx_;

--- a/sns/cm/ag.c
+++ b/sns/cm/ag.c
@@ -116,7 +116,7 @@ static bool _is_fid_valid(struct m0_sns_cm_ag_iter *ai, struct m0_fid *fid)
 
 	if (!m0_sns_cm_fid_is_valid(scm, fid))
 		return false;
-	rc = m0_cob_ns_rec_of(&cdom->cd_namespace, fid, &fid_out, &nsrec);
+	rc = m0_cob_ns_rec_of(cdom->cd_namespace, fid, &fid_out, &nsrec);
 	if (rc == 0 && m0_fid_eq(fid, &fid_out))
 		return true;
 	return false;
@@ -241,7 +241,7 @@ static int ai_pm_set(struct m0_sns_cm_ag_iter *ai, struct m0_fid *pv_id)
 
 	pver_id = pv_id;
 	if (pver_id == NULL) {
-		rc = m0_cob_ns_rec_of(&scm->sc_cob_dom->cd_namespace,
+		rc = m0_cob_ns_rec_of(scm->sc_cob_dom->cd_namespace,
 				      &ai->ai_fid, &fid, &nsrec);
 		if (rc == 0)
 			pver_id = &nsrec->cnr_pver;
@@ -289,7 +289,7 @@ static int ai_fid_next(struct m0_sns_cm_ag_iter *ai)
 
 	do {
 		M0_CNT_INC(fid_curr.f_key);
-		rc = m0_cob_ns_rec_of(&scm->sc_cob_dom->cd_namespace,
+		rc = m0_cob_ns_rec_of(scm->sc_cob_dom->cd_namespace,
 				      &fid_curr, &fid, &nsrec);
 		fid_curr = fid;
 	} while (rc == 0 &&


### PR DESCRIPTION
With the changes in this commit the COB module now uses the new BTree. The
changes still need to be verified on a cluster, but with the code in this commit
all the COB ut's are working.

Signed-off-by: Shashank Parulekar <shashank.parulekar@seagate.com>