### PR TITLE
EOS-20623: Remove Galois code compilation and usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "extra-libs/galois"]
-	path = extra-libs/galois
-	url = ../cortx-motr-galois
-	ignore = untracked

--- a/Kbuild.in
+++ b/Kbuild.in
@@ -4,7 +4,7 @@
 # global vars ----------------------------------------- {{{1
 #
 
-KBUILD_EXTRA_SYMBOLS := @LUSTRE_SYMVERS@ @GALOIS_SYMVERS@
+KBUILD_EXTRA_SYMBOLS := @LUSTRE_SYMVERS@
 
 ccflags-y := -DHAVE_CONFIG_H -iquote . @M0_KCPPFLAGS@ @M0_KCFLAGS@ @KCFLAGS@
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,9 +78,6 @@ AM_CPPFLAGS  = @M0_CPPFLAGS@
 AM_CFLAGS    = @M0_CFLAGS@
 AM_LDFLAGS   = @M0_LDFLAGS@
 
-GALOIS_DIR   = extra-libs/galois
-SUBDIRS = $(GALOIS_DIR)
-
 ################################################################################
 #                               Global variables                            {{{1
 ################################################################################
@@ -1514,17 +1511,10 @@ libmotr-ut: pre-all
 .PHONY: __libmotr-ut
 __libmotr-ut: config.h Makefile ut/libmotr-ut.la $(HEADERS)
 
-# galois ---------------------------------------------- {{{3
-
-.PHONY: galois
-galois:
-	@echo 'Building galois'
-	@cd $(GALOIS_DIR) && $(MAKE) $(AM_MAKEFLAGS)
-
 # quick ----------------------------------------------- {{{3
 
 .PHONY: quick
-quick: generate-files galois
+quick: generate-files
 	@echo 'Building user-space Unit Tests'
 	@$(MAKE) $(AM_MAKEFLAGS) __quick
 
@@ -1535,12 +1525,12 @@ __quick: __libmotr __libmotr-ut ut/m0ut
 # kuick ----------------------------------------------- {{{3
 
 .PHONY: kuick
-kuick: generate-files galois
+kuick: generate-files
 	@echo 'Building kernel-space Unit Tests'
 	@$(MAKE) $(AM_MAKEFLAGS) build-kernel-modules M0_BUILD_KERNEL_UT_ONLY=yes
 
 .PHONY: motr_st
-motr_st: generate-files galois
+motr_st: generate-files
 	@echo 'Building motr for motr system test.'
 	@$(MAKE) $(AM_MAKEFLAGS) build-kernel-modules M0_BUILD_ST=yes
 
@@ -1578,7 +1568,7 @@ clean-local: $(KERNEL_MODULES_CLEAN) clean-doc
 #   $(MAKE) -C $(KDIR) M=$(PWD) $(AM_MAKEFLAGS) clean
 # because it's a bit dummy - it uses `find` to recursively delete all *.o, *.a
 # and *.ko files, which will mess up our user-space build in .libs/ directories
-# and delete library files under extra-libs/ and galois.ko module;
+# and delete library files under extra-libs/;
 # instead we use our own `find` command, which excludes some paths we need to
 # keep, to clean up kernel build
 .PHONY: clean-kernel-modules
@@ -1627,7 +1617,6 @@ endif
 install-exec-local: $(KERNEL_MODULES_INSTALL)
 
 install-tests:
-	@$(MAKE) -C extra-libs/galois install
 	@$(MAKE) INSTALL_MOD_DIR=kernel/fs/motr/tests $(KERNEL_MODULES_INSTALL) \
 		 install-binPROGRAMS install-sbinPROGRAMS install-binSCRIPTS \
 		 install-sbinSCRIPTS
@@ -1837,7 +1826,6 @@ help:
 	@echo '  quick           - build only user-space UT'
 	@echo '  kuick           - build only kernel-space UT'
 	@echo ''
-	@echo '  galois          - build only libgalois.so and galois.ko'
 	@echo '  libmotr         - build only libmotr library'
 	@echo '  libmotr-ut      - build only libmotr-ut library'
 	@echo '  libmotr-altogether - build only libmotr library'

--- a/Makefile.am
+++ b/Makefile.am
@@ -99,7 +99,6 @@ noinst_LTLIBRARIES =
 man_MANS   =
 
 EXTRA_DIST  = autogen.sh cortx-motr.spec.in README.rst LICENCE .gdbinit
-EXTRA_DIST += extra-libs/.gitignore
 CLEANFILES  =
 DISTCLEANFILES = @LUSTRE_CONFIG_LINK@ utils/ub.sh
 MAN_PAGES  =
@@ -1567,8 +1566,7 @@ clean-local: $(KERNEL_MODULES_CLEAN) clean-doc
 # we don't want to use the default kernel clean command, i.e.:
 #   $(MAKE) -C $(KDIR) M=$(PWD) $(AM_MAKEFLAGS) clean
 # because it's a bit dummy - it uses `find` to recursively delete all *.o, *.a
-# and *.ko files, which will mess up our user-space build in .libs/ directories
-# and delete library files under extra-libs/;
+# and *.ko files, which will mess up our user-space build in .libs/ directories;
 # instead we use our own `find` command, which excludes some paths we need to
 # keep, to clean up kernel build
 .PHONY: clean-kernel-modules
@@ -1578,7 +1576,7 @@ clean-kernel-modules:
 	@rm -vf $(top_builddir)/Module.markers
 	@rm -vf $(top_builddir)/modules.order
 	@find $(top_builddir) \
-		\( -name .git -o -name .libs -o -name extra-libs \) -prune \
+		\( -name .git -o -name .libs \) -prune \
 		-o \( -name '*.o' -o -name '*.ko' -o -name '.*.cmd' \
 		      -o -name '*.ko.*' -o -name '.*.d' -o -name '.*.tmp' \
 		      -o -name '*.mod.c' \

--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -40,7 +40,6 @@
 package mio
 
 // #cgo CFLAGS: -I/usr/include/motr
-// #cgo CFLAGS: -I../../.. -I../../../extra-libs/galois/include
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #cgo CFLAGS: -Wno-attributes
 // #cgo LDFLAGS: -L../../../motr/.libs -Wl,-rpath=../../../motr/.libs -lmotr

--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -40,6 +40,7 @@
 package mio
 
 // #cgo CFLAGS: -I/usr/include/motr
+// #cgo CFLAGS: -I../../..
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #cgo CFLAGS: -Wno-attributes
 // #cgo LDFLAGS: -L../../../motr/.libs -Wl,-rpath=../../../motr/.libs -lmotr

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -23,6 +23,7 @@
 package mio
 
 // #cgo CFLAGS: -I/usr/include/motr
+// #cgo CFLAGS: -I../../..
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #include <errno.h> /* EEXIST */
 // #include "motr/client.h"

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -23,7 +23,6 @@
 package mio
 
 // #cgo CFLAGS: -I/usr/include/motr
-// #cgo CFLAGS: -I../../.. -I../../../extra-libs/galois/include
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #include <errno.h> /* EEXIST */
 // #include "motr/client.h"

--- a/configure.ac
+++ b/configure.ac
@@ -887,21 +887,6 @@ OLD_CFLAGS=$CFLAGS
 LIBS=""
 CFLAGS=""
 
-# Checking galois --------------------------------------------------------- {{{1
-
-GALOIS_REL_PATH="extra-libs/galois"
-GALOIS_SRC="$SRCDIR/$GALOIS_REL_PATH"
-GALOIS_ABS_SRC="$ABS_SRCDIR/$GALOIS_REL_PATH"
-GALOIS_INCLUDES="-I$GALOIS_ABS_SRC/include"
-KGALOIS_INCLUDES="-I$GALOIS_ABS_SRC/include"
-GALOIS_LIBS="$GALOIS_ABS_SRC/src/libgalois.la"
-
-AC_SUBST([GALOIS_SYMVERS], [$GALOIS_ABS_SRC/src/linux_kernel/Module.symvers])
-
-AS_IF([! test -x $GALOIS_SRC/configure],
-      [ test -x $GALOIS_SRC/autogen.sh && ( cd $GALOIS_SRC; ./autogen.sh ) ]
-)
-
 # Checking libyaml -------------------------------------------------------- {{{1
 
 AS_IF([test x$enable_system_libs = xyes],
@@ -922,8 +907,6 @@ AS_IF([test x$enable_system_libs = xyes],
 LIBS=$OLD_LIBS
 CFLAGS=$OLD_CFLAGS
 
-AC_SUBST([GALOIS_ABS_SRC])
-AC_SUBST([GALOIS_LIBS])
 AC_SUBST([YAML_LIBS])
 
 #
@@ -978,7 +961,7 @@ AS_IF([test x$enable_mcheck = xyes],
 # Set up build variables -------------------------------------------------- {{{1
 #
 
-M0_CPPFLAGS="$GALOIS_INCLUDES $YAML_INCLUDES $M0_CPPFLAGS $LUSTRE_INCLUDES"
+M0_CPPFLAGS="$YAML_INCLUDES $M0_CPPFLAGS $LUSTRE_INCLUDES"
 
 # _GNU_SOURCE for asprintf(3), open(2) O_DIRECT flag
 M0_CPPFLAGS="-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern \
@@ -1006,7 +989,7 @@ M0_KCPPFLAGS="-DM0_INTERNAL='' -DM0_EXTERN=extern \
               -include'$ABS_BUILDDIR/config.h' \
               -iquote '$ABS_BUILDDIR' \
               -iquote '$ABS_SRCDIR' \
-              $LUSTRE_INCLUDES $KGALOIS_INCLUDES $M0_KCPPFLAGS"
+              $LUSTRE_INCLUDES $M0_KCPPFLAGS"
 
 M0_KCFLAGS="-Wall -Werror -Wno-attributes $M0_KCFLAGS"
 
@@ -1057,8 +1040,6 @@ AC_CONFIG_FILES([net/test/demo/demo-config.sh], [chmod +x net/test/demo/demo-con
 AC_CONFIG_FILES([utils/modload-all.sh], [chmod +x utils/modload-all.sh])
 AC_CONFIG_FILES([scripts/systemtap/kem/Makefile])
 
-AC_CONFIG_SUBDIRS([extra-libs/galois])
-
 AC_OUTPUT
 
 #
@@ -1096,7 +1077,6 @@ echo "PTHREAD_LIBS   :  \"$PTHREAD_LIBS\""
 echo "AIO_LIBS       :  \"$AIO_LIBS\""
 echo "RT_LIBS        :  \"$RT_LIBS\""
 echo "PROFILER_LIBS  :  \"$PROFILER_LIBS\""
-echo "GALOIS_LIBS    :  \"$GALOIS_LIBS\""
 echo "YAML_LIBS      :  \"$YAML_LIBS\""
 echo "UUID_LIBS      :  \"$UUID_LIBS\""
 echo "ISAL_LIBS      :  \"$ISAL_LIBS\""

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -215,7 +215,7 @@ find %{buildroot} -type f | sed -e 's#^%{buildroot}##' | sort |
 
 make DESTDIR=%{buildroot} install-tests
 
-find %{buildroot} -name m0tr.ko -o -name m0ut.ko -o -name galois.ko \
+find %{buildroot} -name m0tr.ko -o -name m0ut.ko -o \
 	     | sed -e 's#^%{buildroot}##' > tests-ut.files
 
 find %{buildroot} \
@@ -226,8 +226,7 @@ find %{buildroot} \
         -o -name m0gentestds \
         -o -name 'm0kut*' \
         -o -name 'libtestlib*.so*' \
-        -o -name 'libmotr*.so*' \
-        -o -name 'libgalois*.so*' |
+        -o -name 'libmotr*.so*' |
     sed -e 's#^%{buildroot}##' >> tests-ut.files
 
 sort -o tests-ut.files tests-ut.files

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -17,18 +17,6 @@ GitHub
 
    A: Try https://help.github.com/en/github/authenticating-to-github/authorizing-an-ssh-key-for-use-with-saml-single-sign-on.
 
-#. Q: How to set correct ``galois`` submodule URL after updating the URL for
-   Motr repo?
-
-   A: _::
-
-        > git submodule sync
-        Synchronizing submodule url for 'extra-libs/galois'
-        > grep -A 2 extra-libs .git/config
-        [submodule "extra-libs/galois"]
-       active = true
-       url = git@github.com:Seagate/cortx-motr-galois
-
 #. Q: How to add ssh key that could be used with GitHub?
 
    A: Go to https://github.com/settings/keys, then generate and add ssh key as

--- a/doc/test-coverage
+++ b/doc/test-coverage
@@ -23,7 +23,7 @@ Make sure in the output of configure script, that CFLAGS has --coverage option
 and LDFLAGS has '-lgcov' option present.
 
 LIBS   :  ""
-CFLAGS :  "-Wall -Werror -D_REENTRANT -D_GNU_SOURCE -fno-strict-aliasing -I/laptop/motr/coverage/motr/extra-libs/galois -I/laptop/motr/coverage/motr/extra-libs/yaml/include -I. -I/laptop/motr/coverage/motr/core --coverage -g -O0"
+CFLAGS :  "-Wall -Werror -D_REENTRANT -D_GNU_SOURCE -fno-strict-aliasing -I/laptop/motr/coverage/motr/extra-libs/yaml/include -I. -I/laptop/motr/coverage/motr/core --coverage -g -O0"
 KCFLAGS:  "-Wall -Werror -g -O0"
 LDFLAGS:  "-rdynamic -lgcov"
 
@@ -138,7 +138,7 @@ Run scripts/coverage/gcov-gen-html to collect stats, as specified in above secti
 
 [root@xyralab_02 scripts]# ls ~/lcov/kernel/
 addb       dtm          fop        index.html         ioservice  pool      snow.png    xcode
-amber.png  m0t1fs                emerald.png  galois     index-sort-b.html  layout     rpc       sns
+amber.png  m0t1fs                emerald.png  index-sort-b.html  layout     rpc       sns
 app1.info  cob                   fid          gcov.css   index-sort-f.html  lib        ruby.png  stob
 app.info   db                    fol          glass.png  index-sort-l.html  net        sm        updown.png
 

--- a/motr/examples/example1.c
+++ b/motr/examples/example1.c
@@ -28,9 +28,8 @@
  * Please change the dir according to you development environment.
  *
  * How to build:
- * gcc -I/work/cortx-motr -I/work/cortx-motr/extra-libs/galois/include \
- *     -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes               \
- *     -L/work/cortx-motr/motr/.libs -lmotr                            \
+ * gcc -I/work/cortx-motr -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes   \
+ *     -L/work/cortx-motr/motr/.libs -lmotr                                   \
  *     example1.c -o example1
  *
  * Please change the configuration according to you development environment.

--- a/motr/examples/example2.c
+++ b/motr/examples/example2.c
@@ -28,9 +28,8 @@
  * Please change the dir according to you development environment.
  *
  * How to build:
- * gcc -I/work/cortx-motr -I/work/cortx-motr/extra-libs/galois/include \
- *     -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes               \
- *     -L/work/cortx-motr/motr/.libs -lmotr                            \
+ * gcc -I/work/cortx-motr -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes   \
+ *     -L/work/cortx-motr/motr/.libs -lmotr                                   \
  *     example2.c -o example2
  *
  * Please change the configuration according to you development environment.

--- a/scripts/addb-py/chronometry/s3server_integration/s3srv_build_prepare
+++ b/scripts/addb-py/chronometry/s3server_integration/s3srv_build_prepare
@@ -34,7 +34,6 @@ INCLUDE_DIR="/usr/include"
 MOTR_LIBS="${MOTR_SRC_DIR}/motr/.libs/*.so*"
 MOTR_HELPERS_LIBS="${MOTR_SRC_DIR}/helpers/.libs/*.so*"
 MOTR_EXTRA_LIBS="${MOTR_SRC_DIR}/extra-libs/gf-complete/src/.libs/*.so*"
-GALOIS_INCLUDE_DIR="${MOTR_SRC_DIR}/extra-libs/galois/include/galois"
 
 function create_symlinks() {
     for file_path in $@
@@ -48,9 +47,6 @@ function create_symlinks() {
 function create_include_symlink() {
     echo "creating symlink for ${MOTR_SRC_DIR}"
     ln -s "${MOTR_SRC_DIR}" "${INCLUDE_DIR}/motr"
-
-    echo "creating symlink for ${GALOIS_INCLUDE_DIR}"
-    ln -s "${GALOIS_INCLUDE_DIR}" "${INCLUDE_DIR}/galois"
 }
 
 function delete_symlinks() {
@@ -64,7 +60,7 @@ function delete_symlinks() {
 
 function delete_include_symlink() {
     local link_path=""
-    for p in "${MOTR_SRC_DIR}" "${GALOIS_INCLUDE_DIR}"; do
+    for p in "${MOTR_SRC_DIR}"; do
         link_path=`find ${INCLUDE_DIR} -lname ${p}`
         echo "DEBUG: delete link_path $p"
         if [[ -n "$link_path" ]]; then

--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -87,29 +87,27 @@ static void fail_idx_xor_recover(struct m0_parity_math *math,
 				 const uint32_t failure_index);
 
 /**
- * Below are some functions which has two separate implementations for using
- * Galois and Intel ISA library. At a time any one of the function is
- * called depending on whether Intel ISA library is present or not. If
- * Intel ISA library is present, it will use implementation specific to Intel
- * ISA and use Intel ISA APIs for encoding and recovery, else it will use
- * Galois library arithmetic functions.
+ * Below are some functions which has two separate implementations for user
+ * space and kernel space. Intel ISA library is used in user space only. Hence
+ * implementation of these functions in kernel space are empty for now and will
+ * be removed once kernel space compilation is removed.
  */
 
 /**
  * This function initialize fields required to use Reed Solomon algorithm.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  */
 static int reed_solomon_init(struct m0_parity_math *math);
 
 /**
  * This function clears fields used by Reed Solomon algorithm.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  */
 static void reed_solomon_fini(struct m0_parity_math *math);
 
 /**
  * This function calculates parity fields using Reed Solomon algorithm.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  */
 static void reed_solomon_encode(struct m0_parity_math *math,
 				const struct m0_buf *data,
@@ -117,7 +115,7 @@ static void reed_solomon_encode(struct m0_parity_math *math,
 
 /**
  * This function calculates differential parity using Reed Solomon algorithm.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  */
 static int reed_solomon_diff(struct m0_parity_math *math,
 			     struct m0_buf         *old,
@@ -127,8 +125,8 @@ static int reed_solomon_diff(struct m0_parity_math *math,
 
 /**
  * This function recovers failed data and/or parity using Reed Solomon
- * algorithm. It has two separate implementations for using Galois and Intel
- * ISA library.
+ * algorithm.  * It has two separate implementations for user space and kernel
+ * space for now.
  */
 static int reed_solomon_recover(struct m0_parity_math *math,
 				struct m0_buf *data,
@@ -139,7 +137,7 @@ static int reed_solomon_recover(struct m0_parity_math *math,
 /**
  * Recovers data or parity units partially or fully depending on the parity
  * calculation algorithm, given the failure index.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  */
 static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
 					  struct m0_buf *data,
@@ -149,7 +147,7 @@ static void fail_idx_reed_solomon_recover(struct m0_parity_math *math,
 /**
  * Initialize fields, specific to Reed Solomon implementation, which are
  * required for incremental recovery.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  * @param[in]  math    - Pointer to parity math structure.
  * @param[out] ir      - Pointer to incremental recovery structure.
  */
@@ -157,7 +155,7 @@ static void ir_rs_init(const struct m0_parity_math *math, struct m0_sns_ir *ir);
 
 /**
  * This function registers failed index.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  * @param[in, out] ir           - pointer to incremental recovery structure.
  * @param[in]      failed_index - index of the failed block in a parity group.
  */
@@ -167,7 +165,7 @@ static void ir_failure_register(struct m0_sns_ir *ir,
 /**
  * Computes data-recovery matrix. Populates dependency bitmaps for failed
  * blocks.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  * @param[in, out] ir       - pointer to incremental recovery structure.
  * @retval         0          on success.
  * @retval         -ENOMEM    on failure to acquire memory.
@@ -177,7 +175,7 @@ static int ir_mat_compute(struct m0_sns_ir *ir);
 
 /**
  * Core routine to recover failed block using current alive block.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  * @param[in] ir           - Pointer to incremental recovery structure.
  * @param[in] alive_block  - Pointer to the alive block.
  * @retval    0            - success otherwise failure
@@ -186,7 +184,7 @@ static int ir_recover(struct m0_sns_ir *ir, struct m0_sns_ir_block *alive_block)
 
 /**
  * Returns last usable block index.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * It has two separate implementations for user space and kernel space for now.
  */
 static uint32_t last_usable_block_id(const struct m0_sns_ir *ir,
 				     uint32_t block_idx);
@@ -285,9 +283,8 @@ static int isal_gen_recov_coeff_tbl(uint32_t data_count, uint32_t parity_count,
 /**
  * Recovery of each failed block depends upon subset of alive blocks.
  * This routine prepares a bitmap indicating this dependency. If a bit at
- *  location 'x' is set 'true' then it implies that f_block has no dependency
- *  on block with index 'x'.
- * It has two separate implementations for using Galois and Intel ISA library.
+ * location 'x' is set 'true' then it implies that f_block has no dependency
+ * on block with index 'x'.
  */
 static void dependency_bitmap_prepare(struct m0_sns_ir_block *f_block,
 				      struct m0_sns_ir *ir);

--- a/utils/spiel/setup.py
+++ b/utils/spiel/setup.py
@@ -21,7 +21,7 @@ from distutils.core import setup, Extension
 
 motr = Extension('motr',
                  define_macros=[('M0_INTERNAL', ''), ('M0_EXTERN', 'extern')],
-                 include_dirs=['../../', '../../extra-libs/galois/include/'],
+                 include_dirs=['../../'],
                  sources=['motr.c'],
                  extra_compile_args=['-w'])
 


### PR DESCRIPTION
- Removed Galois code compilation.
- Removed Galois code entry as Motr sub-module.
- Removed remaining occurrences of Galois.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>