### PR TITLE
[EOS-24924] UUID parser change

### DIFF
--- a/lib/ut/uuid.c
+++ b/lib/ut/uuid.c
@@ -28,6 +28,7 @@
 static char *nil_uuid = "00000000-0000-0000-0000-000000000000"; /* nil UUID */
 static char *uuid1    = "abcdef01-2345-6789-abcd-ef0123456789"; /* lc */
 static char *uuid2    = "98765432-10AB-CDEF-FEDC-BA0123456789"; /* uc */
+static char *uuid3    = "9876543210ABCDEFFEDCBA0123456789"; /* uc */
 static char *bad1     = "bad1";
 static char *bad_uuids_len_ok[] = { /* len ok in all cases */
 	"abcdef0101-2345-6789-abcd-0123456789", /* field lengths wrong */
@@ -82,6 +83,12 @@ void m0_test_lib_uuid(void)
 	M0_UT_ASSERT(u.u_hi == 0);
 	M0_UT_ASSERT(u.u_lo == 0);
 	M0_UT_ASSERT(test_identity_op(nil_uuid));
+
+    rc = m0_uuid_parse(uuid3, &u);
+    M0_UT_ASSERT(rc == 0);
+    M0_UT_ASSERT(u.u_hi == 0x9876543210abcdef);
+    M0_UT_ASSERT(u.u_lo == 0xfedcba0123456789);
+    M0_UT_ASSERT(test_identity_op(uuid3));
 
 	rc = m0_uuid_parse(uuid1, &u);
 	M0_UT_ASSERT(rc == 0);

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -89,8 +89,15 @@ M0_INTERNAL int m0_uuid_parse(const char *str, struct m0_uint128 *val)
 	    parse_hex(&str[14],  4, &h3) < 0 || str[18] != '-' ||
 	    parse_hex(&str[19],  4, &h4) < 0 || str[23] != '-' ||
 	    parse_hex(&str[24], 12, &h5) < 0 || str[36] != '\0')
-		return M0_ERR(-EINVAL);
-	val->u_hi = h1 << 32 | h2 << 16 | h3;
+	    
+        if (parse_hex(&str[0],   8, &h1) < 0 ||
+            parse_hex(&str[8],   4, &h2) < 0 ||
+            parse_hex(&str[12],  4, &h3) < 0 ||
+            parse_hex(&str[16],  4, &h4) < 0 ||
+            parse_hex(&str[20], 12, &h5) < 0 || str[32] != '\0')
+                return M0_ERR(-EINVAL);
+
+    val->u_hi = h1 << 32 | h2 << 16 | h3;
 	val->u_lo = h4 << 48 | h5;
 	/* no validation of adherence to standard version formats */
 	return 0;


### PR DESCRIPTION
   accessing both uuidgen and /etc/machine-id formats

Signed-off-by: JugalPatil <jugal.patil@seagate.com>