### PR TITLE
mio: drop duplicate CFLAGS from mkv.go

### DIFF
--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -39,8 +39,8 @@
 // For the usage example, refer to mcp utility.
 package mio
 
-// #cgo CFLAGS: -I/usr/include/motr
 // #cgo CFLAGS: -I../../.. -I../../../extra-libs/galois/include
+// #cgo CFLAGS: -I/usr/include/motr
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #cgo CFLAGS: -Wno-attributes
 // #cgo LDFLAGS: -L../../../motr/.libs -Wl,-rpath=../../../motr/.libs -lmotr

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -22,9 +22,6 @@
 
 package mio
 
-// #cgo CFLAGS: -I/usr/include/motr
-// #cgo CFLAGS: -I../../.. -I../../../extra-libs/galois/include
-// #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #include <errno.h> /* EEXIST */
 // #include "motr/client.h"
 // #include "motr/layout.h" /* m0c_pools_common */


### PR DESCRIPTION
Drop duplicate CFLAGS settings from mio/mkv.go - they are
already set at mio/mio.go. Also, give priority to the local
headers from the sources tree first over the installed ones,
this allows to build the utilities from the more recent
sources tree than the installed motr packages.