### PR TITLE
EOS-24521: [POC} create SEG0 and SEG1 on the same device

### DIFF
--- a/be/seg.c
+++ b/be/seg.c
@@ -225,17 +225,23 @@ M0_INTERNAL int m0_be_seg_create(struct m0_be_seg *seg,
 				 m0_bcount_t size,
 				 void *addr)
 {
-	struct m0_be_seg_geom geom[] = {
-		[0] = {
-			.sg_size = size,
-			.sg_addr = addr,
-			.sg_offset = 0ULL,
-			.sg_id = seg->bs_id,
-			.sg_gen = seg->bs_gen = m0_time_now()
-		},
+	struct m0_be_seg_geom geom[2];
 
-		[1] = M0_BE_SEG_GEOM0,
-	};
+	if (seg->bs_id == 42) {
+		geom[0].sg_size = size;
+		geom[0].sg_addr = addr;
+		geom[0].sg_offset = 1048576;
+		geom[0].sg_id = seg->bs_id;
+		geom[0].sg_gen = seg->bs_gen = m0_time_now();
+		geom[1] = M0_BE_SEG_GEOM0;
+	} else {
+		geom[0].sg_size = size;
+		geom[0].sg_addr = addr;
+		geom[0].sg_offset = 0ULL;
+		geom[0].sg_id = seg->bs_id;
+		geom[0].sg_gen = seg->bs_gen = m0_time_now();
+		geom[1] = M0_BE_SEG_GEOM0;
+	}
 
 	return m0_be_seg_create_multiple(seg->bs_stob, geom);
 }
@@ -337,8 +343,13 @@ M0_INTERNAL int m0_be_seg_open(struct m0_be_seg *seg)
 	if (hdr == NULL)
 		return M0_ERR(-ENOMEM);
 
-	rc = m0_be_io_single(seg->bs_stob, SIO_READ,
-			     hdr, M0_BE_SEG_HEADER_OFFSET, be_seg_hdr_size());
+	if (seg->bs_id == 41) {
+		rc = m0_be_io_single(seg->bs_stob, SIO_READ,
+			     	hdr, M0_BE_SEG_HEADER_OFFSET, be_seg_hdr_size());
+	} else {
+		rc = m0_be_io_single(seg->bs_stob, SIO_READ,
+			     	hdr, M0_BE_SEG_HEADER_OFFSET + 1048576, be_seg_hdr_size());
+	}
 	if (rc != 0) {
 		m0_free(hdr);
 		return M0_ERR(rc);

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -2179,6 +2179,7 @@ static int _args_parse(struct m0_motr *cctx, int argc, char **argv)
 				LAMBDA(void, (const char *s)
 				{
 					rctx->rc_be_seg_path = s;
+					rctx->rc_be_seg0_path = s;
 				})),
 			M0_NUMBERARG('z', "BE primary segment size",
 				LAMBDA(void, (int64_t size)

--- a/scripts/install/etc/sysconfig/motr
+++ b/scripts/install/etc/sysconfig/motr
@@ -80,6 +80,8 @@ MOTR_M0D_BESEG_SIZE=8589934592
 
 # Backend segment size (in bytes) for IO service. Default is 4 GiB.
 #MOTR_M0D_IOS_BESEG_SIZE=4294967296
+MOTR_M0D_IOS_BESEG_SIZE=1073741824
+
 
 # Backend transactions group configuration parameters.
 #MOTR_M0D_BETXGR_TX_NR_MAX=128


### PR DESCRIPTION
Analysis:
Presently Seg0 is created on the file system and Seg1 is created on the
device. LC will not support Seg0 on the file system. So create Seg0 and
Seg1 on the same device.

Solution:
Created Seg0 and Seg1 on the same device.

Co-authored-by: Vidyadhar Pinglikar <Vidyadhar.Pinglikar@seagate.com>
Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>