### PR TITLE
EOS-24489 dtm0: implement a script for s3 custom setup

### DIFF
--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -104,36 +104,27 @@ function expected_trace_lines_num()
     return 0
 }
 
-function addb_dump()
+function addb2_dump()
 {
-    local outdir="${ADDB_DUMP_DIR}"
-    local outfile
-    local inpfile
-    local fid
-    local a2d=$MOTR_ROOT/utils/m0addb2dump
+    rm -fR "${ADDB_DUMP_DIR}"
+    mkdir "${ADDB_DUMP_DIR}"
 
-    rm -fR "${outdir}"
-    mkdir "${outdir}"
+    _info "Dumping ADDB2..."
 
-    for i in ${!DTM0_IT_M0D_PIDS[@]} ; do
-        fid=$(echo "${DTM0_IT_M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
-        outfile="${outdir}/addb_${fid}.dump"
-        inpfile="${M0D_DIR_COMMON}${DTM0_IT_M0D_FIDS_HEX[i]}/addb-stobs-${DTM0_IT_M0D_PIDS[i]}/o/100000000000000:2"
-        _info "Dumping ${inpfile} -> ${outfile} ..."
-        $a2d -f "${inpfile}" > "${outfile}"
-    done
-
-    inpfile="$PWD/addb_${CLIENT_PID}/o/100000000000000:2"
-    fid=$(echo "$DTM0_IT_CLI_FID_HEX" | awk -F'x' '{ print $2; }')
-    outfile="${outdir}/addb_${fid}.dump"
-    _info "Dumping ${inpfile} -> ${outfile} ..."
-    $a2d -f "${inpfile}" > "${outfile}"
+    dtm0_it_m0ds_addb2_dump "${ADDB_DUMP_DIR}" \
+        "${MOTR_ROOT}/utils/m0addb2dump" \
+        "${M0D_DIR_COMMON}"
+    dtm0_it_cli_addb2_dump "${ADDB_DUMP_DIR}" \
+        "${MOTR_ROOT}/utils/m0addb2dump" \
+        "${PWD}/addb_${CLIENT_PID}/o/100000000000000:2"
 }
 
 function traces_dump()
 {
     local fid
     local out
+
+    _info "Dumping traces..."
 
     for i in ${!DTM0_IT_M0D_PIDS[@]} ; do
         fid=$(echo "${DTM0_IT_M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
@@ -192,8 +183,7 @@ function main()
 
     stop_cluster
 
-    addb_dump
-    _info "Dumping traces..."
+    addb2_dump
     traces_dump
 
     _info "Checking processes exit status..."

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -16,16 +16,10 @@ CLIENT_PID=
 M0D_DIR_COMMON=$MOTR_VAR_DIR/m0d-0x720000000000000
 ADDB_DUMP_DIR="/tmp/a2a-addb-out"
 
-M0D_ENDPOINTS=()
-M0D_FIDS_DEC=()
-M0D_FIDS_HEX=()
-M0D_PIDS=()
-M0D_CLI_FID_DEC=
-M0D_CLI_FID_HEX=
-
 POOL_WIDTH=4
 IPOOL_WIDTH=2
 
+. ../helpers
 . ${MOTR_ROOT}/scripts/addb-py/chronometry/common/common_funcs
 
 
@@ -37,20 +31,6 @@ function stop_cluster()
 function bootstrap_cluster()
 {
     hctl bootstrap --mkfs $CURRENT_CDF
-}
-
-function get_m0d_pids()
-{
-    local pids=""
-    local pid
-
-    for fid in ${M0D_FIDS_HEX[@]} ; do
-        pid=$(ps ax | grep m0d | grep $fid | awk '{ print $1; }')
-        M0D_PIDS+=($pid)
-        pids+="$pid "
-    done
-
-    _info "m0d PIDs: $pids"
 }
 
 function create_m0crate_cfg()
@@ -72,28 +52,16 @@ function create_m0crate_cfg()
     mv $M0CRATE_CFG_TMP $M0CRATE_CFG
 }
 
-function get_params_for_ha_msgs()
-{
-    local svcs_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[]')
-    local svc_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("ioservice"))')
-    local cli_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("m0_client"))')
-    M0D_ENDPOINTS=($(echo $svc_json_out | jq -r '.ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
-    M0D_FIDS_HEX=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
-    M0D_FIDS_DEC=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
-    M0D_CLI_FID_DEC=$(echo $cli_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e')
-    M0D_CLI_FID_HEX=$(echo $cli_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/')
-}
-
 function ha_msg_send_transient()
 {
     # Here we send "TRANSIENT" messages to trigger start of
     # HA messages handling on the m0d side as dtm0 doesn't
     # handle them until "TRANSIENT" received due to incomplete
     # implementation on the Hare side.
-    for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
-        for j in $(seq 0 $((${#M0D_FIDS_DEC[@]}-1))) ; do
+    for i in $(seq 0 $((${#DTM0_IT_M0D_ENDPOINTS[@]}-1))) ; do
+        for j in $(seq 0 $((${#DTM0_IT_M0D_FIDS_DEC[@]}-1))) ; do
             if [[ $i -ne $j ]]; then
-                $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_FIDS_DEC[$j]}" "transient"
+                $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${DTM0_IT_M0D_ENDPOINTS[$i]}" "^r|${DTM0_IT_M0D_FIDS_DEC[$j]}" "transient"
                 break
             fi
         done
@@ -103,10 +71,10 @@ function ha_msg_send_transient()
 function ha_msg_send_online()
 {
     # Here we send "ONLINE" messages to trigger connections logic.
-    for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
-        for j in $(seq 0 $((${#M0D_FIDS_DEC[@]}-1))) ; do
+    for i in $(seq 0 $((${#DTM0_IT_M0D_ENDPOINTS[@]}-1))) ; do
+        for j in $(seq 0 $((${#DTM0_IT_M0D_FIDS_DEC[@]}-1))) ; do
             if [[ $i -ne $j ]]; then
-                $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_FIDS_DEC[$j]}" "online"
+                $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${DTM0_IT_M0D_ENDPOINTS[$i]}" "^r|${DTM0_IT_M0D_FIDS_DEC[$j]}" "online"
             fi
         done
     done
@@ -115,8 +83,8 @@ function ha_msg_send_online()
 function ha_msg_send_cli_online()
 {
     # Here we send "ONLINE" messages to connect servers to client.
-    for i in $(seq 0 $((${#M0D_ENDPOINTS[@]}-1))) ; do
-        $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${M0D_ENDPOINTS[$i]}" "^r|${M0D_CLI_FID_DEC}" "online"
+    for i in $(seq 0 $((${#DTM0_IT_M0D_ENDPOINTS[@]}-1))) ; do
+        $MOTR_ST_UTILS_DIR/ha_msg_send.sh "${DTM0_IT_M0D_ENDPOINTS[$i]}" "^r|${DTM0_IT_CLI_FID_DEC}" "online"
     done
 }
 
@@ -126,8 +94,8 @@ function expected_trace_lines_num()
     local exp_cnt=$2
     local cnt
 
-    for i in ${!M0D_PIDS[@]} ; do
-        cnt=$($MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/m0trace.${M0D_PIDS[i]}" | grep "$pattern" | wc -l)
+    for i in ${!DTM0_IT_M0D_PIDS[@]} ; do
+        cnt=$($MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${DTM0_IT_M0D_FIDS_HEX[i]}/m0trace.${DTM0_IT_M0D_PIDS[i]}" | grep "$pattern" | wc -l)
         if [[ $cnt -ne $exp_cnt ]]; then
             return 1
         fi
@@ -147,16 +115,16 @@ function addb_dump()
     rm -fR "${outdir}"
     mkdir "${outdir}"
 
-    for i in ${!M0D_PIDS[@]} ; do
-        fid=$(echo "${M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
+    for i in ${!DTM0_IT_M0D_PIDS[@]} ; do
+        fid=$(echo "${DTM0_IT_M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
         outfile="${outdir}/addb_${fid}.dump"
-        inpfile="${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/addb-stobs-${M0D_PIDS[i]}/o/100000000000000:2"
+        inpfile="${M0D_DIR_COMMON}${DTM0_IT_M0D_FIDS_HEX[i]}/addb-stobs-${DTM0_IT_M0D_PIDS[i]}/o/100000000000000:2"
         _info "Dumping ${inpfile} -> ${outfile} ..."
         $a2d -f "${inpfile}" > "${outfile}"
     done
 
     inpfile="$PWD/addb_${CLIENT_PID}/o/100000000000000:2"
-    fid=$(echo "$M0D_CLI_FID_HEX" | awk -F'x' '{ print $2; }')
+    fid=$(echo "$DTM0_IT_CLI_FID_HEX" | awk -F'x' '{ print $2; }')
     outfile="${outdir}/addb_${fid}.dump"
     _info "Dumping ${inpfile} -> ${outfile} ..."
     $a2d -f "${inpfile}" > "${outfile}"
@@ -167,11 +135,11 @@ function traces_dump()
     local fid
     local out
 
-    for i in ${!M0D_PIDS[@]} ; do
-        fid=$(echo "${M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
+    for i in ${!DTM0_IT_M0D_PIDS[@]} ; do
+        fid=$(echo "${DTM0_IT_M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
         out="m0trace_${fid}.dump"
         _info "Dumping ${out}..."
-        $MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/m0trace.${M0D_PIDS[i]}" > "${out}"
+        $MOTR_ROOT/utils/trace/m0trace -i "${M0D_DIR_COMMON}${DTM0_IT_M0D_FIDS_HEX[i]}/m0trace.${DTM0_IT_M0D_PIDS[i]}" > "${out}"
     done
 
     out="m0trace_${CLIENT_PID}.dump"
@@ -183,7 +151,7 @@ function processes_status_check()
 {
     local rc=0
 
-    for fid in ${M0D_FIDS_HEX[@]} ; do
+    for fid in ${DTM0_IT_M0D_FIDS_HEX[@]} ; do
         svc_name="m0d@0x720000000000000${fid}.service"
         systemctl is-failed $svc_name > /dev/null && {
             _err "Process $svc_name failed"
@@ -209,8 +177,8 @@ function main()
     _info "Bootstrapping the cluster using Hare..."
     bootstrap_cluster
 
-    get_params_for_ha_msgs
-    get_m0d_pids
+    dtm0_it_fids_get
+    dtm0_it_pids_get
 
     _info "Create m0crate configuration..."
     create_m0crate_cfg

--- a/dtm0/it/helpers
+++ b/dtm0/it/helpers
@@ -26,9 +26,84 @@ function dtm0_it_fids_get()
 
 function dtm0_it_pids_get()
 {
+    local pids=""
+    local pid
+
     for fid in ${DTM0_IT_M0D_FIDS_HEX[@]} ; do
-        DTM0_IT_M0D_PIDS+=($(ps ax | grep m0d | grep $fid | awk '{ print $1; }'))
+        pid=$(ps ax | grep m0d | grep $fid | awk '{ print $1; }')
+        DTM0_IT_M0D_PIDS+=($pid)
+        pids+="$pid "
     done
 
-    DTM0_IT_S3_PID=$(ps ax | grep s3server | grep $DTM0_IT_S3_FID_HEX | awk '{ print $1; }')
+    echo "m0d PIDs: $pids"
+
+    if [[ ! -z $DTM0_IT_S3_FID_HEX ]]; then
+        DTM0_IT_S3_PID=$(ps ax | grep s3server | grep $DTM0_IT_S3_FID_HEX | awk '{ print $1; }')
+        echo "s3server PID: $DTM0_IT_S3_PID"
+    fi
+}
+
+# Should be called after dtm0_it_[pids|fids]_get() functions to have PIDs and FIDs filled
+#
+# $1 - addb2 dump output dir
+# $2 - path to m0addb2dump binary
+# $3 - m0d common var directory pattern like "/var/motr/m0d-0x720000000000000"
+function dtm0_it_m0ds_addb2_dump()
+{
+    local outdir=$1
+    local a2d=$2
+    local m0d_dir_common=$3
+    local outfile
+    local inpfile
+    local fid
+
+    for i in ${!DTM0_IT_M0D_PIDS[@]} ; do
+        fid=$(echo "${DTM0_IT_M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
+        outfile="${outdir}/addb_${fid}.dump"
+        inpfile="${m0d_dir_common}${DTM0_IT_M0D_FIDS_HEX[i]}/addb-stobs-${DTM0_IT_M0D_PIDS[i]}/o/100000000000000:2"
+        echo "Dumping ${inpfile} -> ${outfile} ..."
+        $a2d -f "${inpfile}" > "${outfile}"
+    done
+}
+
+# Should be called after dtm0_it_[pids|fids]_get() functions to have PIDs and FIDs filled
+#
+# $1 - addb2 dump output dir
+# $2 - path to m0addb2dump binary
+# $3 - path to addb2 stob
+function dtm0_it_cli_addb2_dump()
+{
+    local outdir=$1
+    local a2d=$2
+    local inpfile=$3
+    local outfile
+    local fid
+
+    fid=$(echo "$DTM0_IT_CLI_FID_HEX" | awk -F'x' '{ print $2; }')
+    outfile="${outdir}/addb_${fid}.dump"
+    echo "Dumping ${inpfile} -> ${outfile} ..."
+    $a2d -f "${inpfile}" > "${outfile}"
+}
+
+# Should be called after dtm0_it_[pids|fids]_get() functions to have PIDs and FIDs filled
+#
+# $1 - addb2 dump output dir
+# $2 - path to m0addb2dump binary
+# $3 - s3 common var directory pattern like "/var/log/seagate/motr/s3server-0x720000000000000"
+# $4 - path to s3 addb2 plugin
+function dtm0_it_s3_addb2_dump()
+{
+    local outdir=$1
+    local a2d=$2
+    local s3_dir_common=$3
+    local s3_addbplugin_lib=$4
+    local outfile
+    local inpfile
+    local fid
+
+    fid=$(echo "${DTM0_IT_S3_FID_HEX}" | awk -F'x' '{ print $2; }')
+    outfile="${outdir}/addb_${fid}.dump"
+    inpfile="${s3_dir_common}${DTM0_IT_S3_FID_HEX}/addb_${DTM0_IT_S3_PID}/o/100000000000000:2"
+    echo "Dumping ${inpfile} -> ${outfile} ..."
+    $a2d -p $s3_addbplugin_lib -f "${inpfile}" > "${outfile}"
 }

--- a/dtm0/it/helpers
+++ b/dtm0/it/helpers
@@ -1,0 +1,34 @@
+DTM0_IT_M0D_PIDS=()
+DTM0_IT_S3_PID=
+
+DTM0_IT_M0D_ENDPOINTS=()
+DTM0_IT_M0D_FIDS_HEX=()
+DTM0_IT_M0D_FIDS_DEC=()
+DTM0_IT_CLI_FID_HEX=
+DTM0_IT_CLI_FID_DEC=
+DTM0_IT_S3_FID_HEX=
+DTM0_IT_S3_FID_DEC=
+
+function dtm0_it_fids_get()
+{
+    local svcs_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[]')
+    local svc_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("ioservice"))')
+    local cli_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("m0_client"))')
+    local s3_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("s3server"))')
+    DTM0_IT_M0D_ENDPOINTS=($(echo $svc_json_out | jq -r '.ep' | sed -E 's/.*@tcp[:](.*)/\1/'))
+    DTM0_IT_M0D_FIDS_HEX=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
+    DTM0_IT_M0D_FIDS_DEC=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e'))
+    DTM0_IT_CLI_FID_HEX=$(echo $cli_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/')
+    DTM0_IT_CLI_FID_DEC=$(echo $cli_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e')
+    DTM0_IT_S3_FID_HEX=$(echo $s3_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/')
+    DTM0_IT_S3_FID_DEC=$(echo $s3_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:])(0x[A-Za-z0-9]+)/printf "%s%d" \1 \2/e')
+}
+
+function dtm0_it_pids_get()
+{
+    for fid in ${DTM0_IT_M0D_FIDS_HEX[@]} ; do
+        DTM0_IT_M0D_PIDS+=($(ps ax | grep m0d | grep $fid | awk '{ print $1; }'))
+    done
+
+    DTM0_IT_S3_PID=$(ps ax | grep s3server | grep $DTM0_IT_S3_FID_HEX | awk '{ print $1; }')
+}

--- a/dtm0/it/s3setup/README.md
+++ b/dtm0/it/s3setup/README.md
@@ -1,0 +1,70 @@
+# About
+
+The script s3setup.sh sets up the S3 stack with custom
+builds of hare and motr to test and fix integrational
+issues.
+The script works on top of the setup deployed by the
+Cortx deployment pipeline for a single CentOS-7.9 VM.
+When the setup is deployed on a target VM the script
+can be run to substitude hare and motr with development
+versions built from sources locally and dev-installed.
+Now the DTM0 dev branches are used to build hare and motr.
+
+# How to use this piece of masterpeace?
+
+First of all you need to navigate to
+https://ssc-cloud.colo.seagate.com/ui/service/catalogs
+and order a VM "G1 - LDRr2 - CentOS-7.9" with the following
+recommended parameters:
+- 8 CPUs
+
+- 16GB RAM
+
+- 5 additional disks
+
+- 50GB disk size
+
+The second step is to set root password for the target VM
+and run the following deployment pipeline:
+http://eos-jenkins.mero.colo.seagate.com/job/Cortx-Deployment/job/VM-Deployment-1Node-CentOS-7.9/
+
+When the pipeline is comleted copy the directory
+$MOTR_DIR/dtm0/it or simply clone motr repo (NOTE: do not
+use the path /root/cortx/cortx-motr as it is reserved
+by the script) to the VM. Now the s3setup.sh can be run.
+
+# What the s3setup.sh script does?
+
+By default (without passed options) the script does the
+following steps:
+- Create the directory /root/cortx and clone there hare
+  and motr repos, checkout DTM0 branches.
+
+- Stop the cluster using Pacemaker (as it is left running
+  by the deployment pipeline).
+
+- Backup configuration files as they will be overwritten
+  duuring further dev-install.
+
+- Remove motr and hare RPMs.
+
+- Build and dev-install motr and hare.
+
+- Restore configuration files, patch the CDF to have 3 IOs.
+
+- Get s3bench utility.
+
+- Bootstrap the cluster using hare.
+
+There are several options that modify default behavior:
+- --no-bootstrap: do all steps listed above but do not
+  bootstrap the cluster;
+
+- --s3bench: in addition to default steps run s3bench as an
+  S3 client, stop the cluster and gather ADDB2 data;
+
+- --s3workload: do not do default steps, the only done steps
+  are bootstrap the cluster, run s3bench, stop the cluster
+  and gather ADDB2 data (i.e. development/debugging mode),
+  NOTE: the cluster should be shut down before calling this
+  script with that option.

--- a/dtm0/it/s3setup/cluster_yaml.patch
+++ b/dtm0/it/s3setup/cluster_yaml.patch
@@ -1,0 +1,59 @@
+--- /var/lib/hare/cluster.yaml_bak	2021-09-15 13:04:51.953340466 +0000
++++ /var/lib/hare/cluster.yaml	2021-09-16 15:29:31.016555983 +0000
+@@ -22,10 +22,39 @@
+     node: srvnode-1.data.private
+   - path: /dev/sdc4
+     node: srvnode-1.data.private
++  - path: /dev/sdd
++    node: srvnode-1.data.private
+   type: sns
++- allowed_failures:
++    disk: 1
++    ctrl: 1
++    encl: 0
++    rack: 0
++    site: 0
++  spare_units: 0
++  name: storage-set-1__dix
++  data_units: 1
++  parity_units: 2
++  disk_refs:
++  - path: /dev/sdb2
++    node: srvnode-1.data.private
++  - path: /dev/sdb3
++    node: srvnode-1.data.private
++  - path: /dev/sdb4
++    node: srvnode-1.data.private
++  - path: /dev/sdc2
++    node: srvnode-1.data.private
++  - path: /dev/sdc3
++    node: srvnode-1.data.private
++  - path: /dev/sdc4
++    node: srvnode-1.data.private
++  - path: /dev/sdd
++    node: srvnode-1.data.private
++  type: dix
+ profiles:
+ - pools:
+   - storage-set-1__sns
++  - storage-set-1__dix
+   name: Profile_the_pool
+ nodes:
+ - m0_servers:
+@@ -44,12 +73,15 @@
+       meta_data: /dev/vg_srvnode-1_md2/lv_raw_md2
+     runs_confd: false
+   - io_disks:
++      data:
++      - /dev/sdd
++  - io_disks:
+       data: []
+       meta_data: null
+     runs_confd: true
+   data_iface: eth3
+   hostname: srvnode-1.data.private
+   m0_clients:
+-    other: 2
++    other: 0
+     s3: 1
+   data_iface_type: tcp

--- a/dtm0/it/s3setup/hare.patch
+++ b/dtm0/it/s3setup/hare.patch
@@ -1,0 +1,22 @@
+diff --git a/cfgen/cfgen b/cfgen/cfgen
+index aede6c3..8468f83 100755
+--- a/cfgen/cfgen
++++ b/cfgen/cfgen
+@@ -810,7 +810,7 @@ class ConfProcess(ToDhall):
+         Currently client stores volatile DTM0 log, server stores
+         persistent DTM0 log.
+         """
+-        if proc_t is ProcT.m0_client_other:
++        if proc_t in [ProcT.m0_client_other, ProcT.m0_client_s3]:
+             params = ["origin:in-volatile"]
+         if proc_t is ProcT.m0_server:
+             params = ["origin:in-persistent"]
+@@ -864,7 +864,7 @@ def service_types(proc_t: ProcT,
+     if proc_t is ProcT.hax:
+         ts.append(SvcT.M0_CST_HA)
+     ts.append(SvcT.M0_CST_RMS)
+-    if proc_t is ProcT.m0_client_other:
++    if proc_t in [ProcT.m0_client_other, ProcT.m0_client_s3]:
+         ts.append(SvcT.M0_CST_DTM0)
+     if proc_t is ProcT.m0_server:
+         assert proc_desc is not None

--- a/dtm0/it/s3setup/s3setup.sh
+++ b/dtm0/it/s3setup/s3setup.sh
@@ -138,7 +138,7 @@ function s3bench_run()
     read ak sk <<< $(ldapsearch -b "ou=accesskeys,dc=s3,dc=seagate,dc=com" -x -w $sgiam_pass -D "cn=sgiamadmin,dc=seagate,dc=com" "(&(objectclass=accesskey))" | egrep "^ak:|^sk:" | awk '{ print $2; }')
 
     # Run s3bench.
-    $S3BENCH_BIN -accessKey $ak -accessSecret "${sk}" -bucket test1 -endpoint http://127.0.0.1  -numClients 4 -numSamples 4 -objectSize 1Mb
+    $S3BENCH_BIN -accessKey $ak -accessSecret "${sk}" -bucket test1 -endpoint http://127.0.0.1  -numClients 4 -numSamples 4 -objectSize 1Mb -skipCleanup
 }
 
 function addb2_dump()

--- a/dtm0/it/s3setup/s3setup.sh
+++ b/dtm0/it/s3setup/s3setup.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+
+set -e
+#set -x
+
+DEVEL_DIR="/root/cortx"
+MOTR_DIR="${DEVEL_DIR}/cortx-motr"
+HARE_DIR="${DEVEL_DIR}/cortx-hare"
+M0_SRC_DIR=$MOTR_DIR
+
+CLUSTER_YAML="/var/lib/hare/cluster.yaml"
+CLUSTER_YAML_BAK="${CLUSTER_YAML}_bak"
+
+MOTR_SYSCONFIG="/etc/sysconfig/motr"
+MOTR_SYSCONFIG_BAK="${MOTR_SYSCONFIG}_bak"
+
+LNET_CONF="/etc/modprobe.d/lnet.conf"
+LNET_CONF_BAK="${LNET_CONF}_bak"
+
+PIP_CONF="/etc/pip.conf"
+PIP_CONF_BAK="${PIP_CONF}_bak"
+
+MOTR_MAKE_OPTS="-j32"
+MOTR_CONFIGURE_OPTS="--enable-dtm0 --disable-altogether-mode --enable-debug --with-trace-ubuf-size=64"
+
+CLUSTER_YAML_PATCH="${PWD}/cluster_yaml.patch"
+HARE_PATCH="${PWD}/hare.patch"
+
+MOTR_VAR_DIR="/var/motr"
+M0D_DIR_COMMON="${MOTR_VAR_DIR}/m0d-0x720000000000000"
+S3_VAR_DIR="/var/log/seagate/motr"
+S3_DIR_COMMON="${S3_VAR_DIR}/s3server-0x720000000000000"
+ADDB_DUMP_DIR="/tmp/s3it-addb-out"
+
+ADDB2DUMP_S3="/usr/sbin/m0addb2dump_s3"
+
+S3BENCH_URL="https://github.com/Seagate/s3bench/releases/download/v2021-06-28/s3bench.2021-06-28"
+
+M0D_FIDS_HEX=()
+M0D_PIDS=()
+S3_FID_HEX=
+S3_PID=
+
+NO_BOOTSTRAP=0
+RUN_S3BENCH=0
+RUN_S3WORKLOAD=0
+
+function repos_clone()
+{
+    ssh-keygen -F github.com || ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+    pushd $DEVEL_DIR
+
+    git clone --recurse-submodules https://github.com/Seagate/cortx-motr.git
+    pushd cortx-motr
+    git checkout dtm0-main
+    popd
+
+    git clone https://github.com/Seagate/cortx-hare.git
+    pushd cortx-hare
+    git checkout dtm-0
+    popd
+
+    popd
+}
+
+function cfgs_backup()
+{
+    cp $CLUSTER_YAML $CLUSTER_YAML_BAK
+    cp $MOTR_SYSCONFIG $MOTR_SYSCONFIG_BAK
+    cp $LNET_CONF $LNET_CONF_BAK
+    mv $PIP_CONF $PIP_CONF_BAK
+}
+
+function cfgs_restore()
+{
+    cp $CLUSTER_YAML_BAK $CLUSTER_YAML
+    cp $MOTR_SYSCONFIG_BAK $MOTR_SYSCONFIG
+    cp $LNET_CONF_BAK $LNET_CONF
+    # Uncomment and change MOTR_DEVEL_WORKDIR_PATH in motr sysconfig
+    # to use development files.
+    sed -i "s|^#MOTR_DEVEL_WORKDIR_PATH=.*|MOTR_DEVEL_WORKDIR_PATH=${MOTR_DIR}|" $MOTR_SYSCONFIG
+    patch $CLUSTER_YAML < $CLUSTER_YAML_PATCH
+}
+
+function motr_build()
+{
+    pushd $MOTR_DIR
+    ./scripts/install-build-deps
+    MAKE_OPTS=$MOTR_MAKE_OPTS CONFIGURE_OPTS=$MOTR_CONFIGURE_OPTS ./scripts/m0 rebuild
+    popd
+}
+
+function hare_build()
+{
+    pushd $HARE_DIR
+    patch -p1 < $HARE_PATCH
+    make
+    popd
+}
+
+function motr_install()
+{
+    pushd $MOTR_DIR
+    ./scripts/install-motr-service -l
+    rm -f /usr/lib64/libmotr-helpers.so.0 /usr/lib64/libmotr.so.2
+    ln -s "${MOTR_DIR}/helpers/.libs/libmotr-helpers.so.0" /usr/lib64/libmotr-helpers.so.0
+    ln -s "${MOTR_DIR}/motr/.libs/libmotr.so.2" /usr/lib64/libmotr.so.2
+    ln -s "${MOTR_DIR}/extra-libs/galois/src/.libs/libgalois-0.1.so" /usr/lib64/libgalois-0.1.so
+    popd
+}
+
+function hare_install()
+{
+    pushd $HARE_DIR
+    make devinstall    
+    popd
+}
+
+function cluster_bootstrap()
+{
+    hctl bootstrap --mkfs $CLUSTER_YAML
+}
+
+function cluster_stop()
+{
+    hctl shutdown
+}
+
+function s3bench_run()
+{
+    local ak
+    local sk
+    local sgiam_pass
+
+    # Generate password.
+    sgiam_pass=$(s3cipher decrypt --data="$(s3confstore properties:///opt/seagate/cortx/auth/resources/authserver.properties getkey --key ldapLoginPW)" --key="$(s3cipher generate_key --const_key cortx)")
+
+    # Fetch the user from ldap, copy access key (ak) and secret key (sk) from output.
+    read ak sk <<< $(ldapsearch -b "ou=accesskeys,dc=s3,dc=seagate,dc=com" -x -w $sgiam_pass -D "cn=sgiamadmin,dc=seagate,dc=com" "(&(objectclass=accesskey))" | egrep "^ak:|^sk:" | awk '{ print $2; }')
+
+    # Get s3bench.
+    if [[ ! -e ./s3bench ]]; then
+        wget $S3BENCH_URL -O ./s3bench
+        chmod +x ./s3bench
+    fi
+
+    # Run s3bench.
+    ./s3bench -accessKey $ak -accessSecret "${sk}" -bucket test1 -endpoint http://127.0.0.1  -numClients 4 -numSamples 4 -objectSize 1Mb
+}
+
+function fids_hex_get()
+{
+    local svcs_json_out=$(hctl status --json | jq -r '.nodes[] | .svcs[]')
+    local svc_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("ioservice"))')
+    local s3_json_out=$(echo $svcs_json_out | jq -r 'select( .name | contains("s3server"))')
+    M0D_FIDS_HEX=($(echo $svc_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/'))
+    S3_FID_HEX=$(echo $s3_json_out | jq -r '.fid' | sed -E 's/0x720+([0-9][:]0x[A-Za-z0-9]+)/\1/')
+}
+
+function pids_get()
+{
+    local pids=""
+    local pid
+
+    for fid in ${M0D_FIDS_HEX[@]} ; do
+        pid=$(ps ax | grep m0d | grep $fid | awk '{ print $1; }')
+        M0D_PIDS+=($pid)
+        pids+="$pid "
+    done
+
+    S3_PID=$(ps ax | grep s3server | grep $S3_FID_HEX | awk '{ print $1; }')
+
+    echo "m0d PIDs: $pids"
+    echo "s3server PID: $S3_PID"
+}
+
+function addb_dump()
+{
+    local outdir="${ADDB_DUMP_DIR}"
+    local outfile
+    local inpfile
+    local fid
+    local a2d="${MOTR_DIR}/utils/m0addb2dump"
+
+    rm -fR "${outdir}"
+    mkdir "${outdir}"
+
+    # Dumping addb2 of m0ds
+    for i in ${!M0D_PIDS[@]} ; do
+        fid=$(echo "${M0D_FIDS_HEX[i]}" | awk -F'x' '{ print $2; }')
+        outfile="${outdir}/addb_${fid}.dump"
+        inpfile="${M0D_DIR_COMMON}${M0D_FIDS_HEX[i]}/addb-stobs-${M0D_PIDS[i]}/o/100000000000000:2"
+        echo "Dumping ${inpfile} -> ${outfile} ..."
+        $a2d -f "${inpfile}" > "${outfile}"
+    done
+
+    # Dumping addb2 of s3server
+    fid=$(echo "${S3_FID_HEX}" | awk -F'x' '{ print $2; }')
+    outfile="${outdir}/addb_${fid}.dump"
+    inpfile="${S3_DIR_COMMON}${S3_FID_HEX}/addb_${S3_PID}/o/100000000000000:2"
+    echo "Dumping ${inpfile} -> ${outfile} ..."
+    $ADDB2DUMP_S3 -f "${inpfile}" > "${outfile}"
+}
+
+function s3workload()
+{
+    cluster_bootstrap
+
+    fids_hex_get
+    pids_get
+
+    s3bench_run
+
+    cluster_stop
+
+    addb_dump
+}
+
+function s3setup()
+{
+    if [[ -e $DEVEL_DIR ]]; then
+        echo "Development directory '$DEVEL_DIR' exists, exiting"
+        exit 1
+    fi
+
+    mkdir $DEVEL_DIR
+
+    repos_clone
+
+    pcs cluster stop --force
+
+    cfgs_backup
+
+    # We need to have original m0addb2dump utility to
+    # dump addb2 stob created by s3server.
+    cp /usr/sbin/m0addb2dump $ADDB2DUMP_S3
+
+    rpm -e --nodeps cortx-motr cortx-hare
+
+    motr_build
+    hare_build
+
+    motr_install
+    hare_install
+
+    cfgs_restore
+
+    systemctl start haproxy
+    /bin/sh -x /opt/seagate/cortx/auth/startauth.sh &
+
+    if [[ $NO_BOOTSTRAP == 1 ]]; then
+        echo "Done."
+        exit 0
+    fi
+
+    cluster_bootstrap
+
+    if [[ $RUN_S3BENCH == 0 ]]; then
+        echo "Done."
+        exit 0
+    fi
+
+    fids_hex_get
+    pids_get
+
+    s3bench_run
+
+    cluster_stop
+
+    addb_dump
+}
+
+function main()
+{
+    if [[ $RUN_S3WORKLOAD -eq 0 ]]; then
+        s3setup
+    else
+        s3workload
+    fi
+}
+
+function usage()
+{
+    echo "Usage: $0 <option>"
+    echo ""
+    echo "Without option the script sets up S3 stack (means replacing of motr/hare with"
+    echo "custom builds, change configs to have 3-nodes setup etc.) and bootstraps the"
+    echo "cluster."
+    echo "Run s3bench means: get s3bench if not done yet, run s3bench, stop the cluster"
+    echo "and gather addb2 dumps."
+    echo ""
+    echo "Options:"
+    echo "    --no-bootstrap - setup S3 stack but no bootstrap the cluster"
+    echo "    --s3bench      - setup S3 stack, bootstrap the cluster and run s3bench"
+    echo "    --s3workload   - bootstrap the cluster and run s3bench"
+}
+
+if [[ $# > 1 ]]; then
+    usage
+    exit 1
+fi
+
+HELP=0
+
+if [[ $# == 1 ]]; then
+case $1 in
+    -h|--help)
+            HELP=1 ;;
+    --no-bootstrap)
+            NO_BOOTSTRAP=1 ;;
+    --s3bench)
+            RUN_S3BENCH=1 ;;
+    --s3workload)
+            RUN_S3WORKLOAD=1 ;;
+    *)
+            usage
+            exit 1 ;;
+esac
+fi
+
+if [[ $HELP -eq 1 ]]; then
+    usage
+    exit 0
+fi
+
+main


### PR DESCRIPTION
The script is implemented to minimize amount of manual work
to get the development s3 setup. The script is used on top
of the S3 setup made by 1Node deployment pipeline for CentOS7.9,
so it is required to run this pipeline before running the
script.

The steps done by the script:
 - stop running cluster using Pacemaker
 - backup configs
 - clone, checkout dtm0 branch and build motr/hare
 - dev-install motr/hare
 - restore and patch configs
 - OPTIONAL: bootstrap the cluster using hare
 - OPTIONAL: run s3bench and gather addb2 data

Also there is an option to run the following cycle that may be
useful for debugging (works when the custom setup is ready):
bootstrap the cluster, run s3bench, stop the cluster, gather
addb2 data.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>