### PR TITLE
Fixes to COB BTree integration for running m0cp/m0cat.

### DIFF
--- a/ioservice/cob_foms.c
+++ b/ioservice/cob_foms.c
@@ -919,7 +919,7 @@ static int cob_attr_get(struct m0_cob        *cob,
 
 static int cob_locate(const struct m0_fom *fom, struct m0_cob **cob_out)
 {
-	struct m0_cob_oikey   oikey;
+	struct m0_cob_oikey   oikey = {};
 	struct m0_cob_domain *cdom;
 	struct m0_fid         fid;
 	struct m0_fom_cob_op *cob_op;

--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -954,7 +954,7 @@ M0_INTERNAL int m0_io_cob_stob_create(struct m0_fom *fom,
 				      bool crow,
 				      struct m0_cob **out)
 {
-	struct m0_cob_oikey   oikey;
+	struct m0_cob_oikey   oikey = {};
 	struct m0_cob        *cob;
 	struct m0_stob_id     stob_id;
 	bool                  cob_recreate = false;
@@ -1088,7 +1088,7 @@ static int align_bufvec(struct m0_fom    *fom,
 static int fom_cob_locate(struct m0_fom *fom)
 {
 	struct m0_io_fom_cob_rw *fom_obj;
-	struct m0_cob_oikey      oikey;
+	struct m0_cob_oikey      oikey = {};
 	struct m0_fop_cob_rw    *rwfop;
 	int                      rc;
 

--- a/ioservice/ut/bulkio_ut.c
+++ b/ioservice/ut/bulkio_ut.c
@@ -1068,7 +1068,7 @@ static int bulkio_stob_create_fom_tick(struct m0_fom *fom)
 	struct m0_fom_cob_op	      cc;
 	struct m0_reqh_io_service    *ios;
 	struct m0_cob_attr            attr = { {0, } };
-	struct m0_cob_oikey           oikey;
+	struct m0_cob_oikey           oikey = {};
 	struct m0_cob                *cob;
 
 	cob_attr_default_fill(&attr);

--- a/mdstore/mdstore.c
+++ b/mdstore/mdstore.c
@@ -170,7 +170,7 @@ M0_INTERNAL int m0_mdstore_dir_nlink_update(struct m0_mdstore   *md,
 					    struct m0_be_tx     *tx)
 {
 	struct m0_cob         *cob;
-	struct m0_cob_oikey    oikey;
+	struct m0_cob_oikey    oikey = {};
 	int                    rc;
 
 	M0_ENTRY("%+d nlinks for dir "FID_F, inc, FID_P(fid));
@@ -393,7 +393,7 @@ M0_INTERNAL int m0_mdstore_unlink(struct m0_mdstore     *md,
 {
 	struct m0_cob         *ncob;
 	struct m0_cob_nskey   *nskey = NULL;
-	struct m0_cob_oikey    oikey;
+	struct m0_cob_oikey    oikey = {};
 	time_t                 now;
 	int                    rc;
 
@@ -821,7 +821,7 @@ M0_INTERNAL int m0_mdstore_locate(struct m0_mdstore     *md,
 				  struct m0_cob        **cob,
 				  int                    flags)
 {
-	struct m0_cob_oikey oikey;
+	struct m0_cob_oikey oikey = {};
 	int                 rc;
 
 	M0_ENTRY(FID_F, FID_P(fid));

--- a/sns/cm/cm_utils.c
+++ b/sns/cm/cm_utils.c
@@ -152,7 +152,7 @@ M0_INTERNAL int m0_sns_cm_cob_locate(struct m0_cob_domain *cdom,
 				     const struct m0_fid *cob_fid)
 {
 	struct m0_cob        *cob;
-	struct m0_cob_oikey   oikey;
+	struct m0_cob_oikey   oikey = {};
 	int                   rc;
 
 	M0_ENTRY("dom=%p cob="FID_F, cdom, FID_P(cob_fid));

--- a/sns/cm/repair/ut/cm.c
+++ b/sns/cm/repair/ut/cm.c
@@ -236,7 +236,7 @@ M0_INTERNAL void cob_delete(struct m0_cob_domain *cdom,
 	struct m0_cob        *cob;
 	struct m0_fid         cob_fid;
 	struct m0_dtx         tx = {};
-	struct m0_cob_oikey   oikey;
+	struct m0_cob_oikey   oikey = {};
 	int                   rc;
 
 	m0_fid_convert_gob2cob(gfid, &cob_fid, cont);

--- a/sns/cm/storage.c
+++ b/sns/cm/storage.c
@@ -343,7 +343,7 @@ M0_INTERNAL int m0_sns_cm_cp_io_wait(struct m0_cm_cp *cp)
 	struct m0_sns_cm_cp  *sns_cp = cp2snscp(cp);
 	struct m0_stob_io    *stio;
 	struct m0_cob        *cob;
-	struct m0_cob_oikey   oikey;
+	struct m0_cob_oikey   oikey = {};
 	struct m0_cob_domain *cdom;
 	struct m0_be_tx      *betx;
 	uint64_t              io_size;


### PR DESCRIPTION
Since the new BTree does not yet support accepting comparison functions from
the BTree consumer the COB code needs to zero-out the Keys before inserting them
or searching for them in the btree or else the memcmp fails.

Signed-off-by: Shashank Parulekar <Shashank.Parulekar@seagate.com>