### PR TITLE
EOS-24883: cas-client  FAILED with -ETIMEOUT

### DIFF
--- a/motr/init.c
+++ b/motr/init.c
@@ -185,10 +185,10 @@ struct init_fini_call subsystem[] = {
 	{ &m0_fom_generic_init, &m0_fom_generic_fini, "fom-generic" },
 	/* addb2-net must be after rpc, because it initialises a fop type. */
 	{ &m0_addb2_net_module_init, &m0_addb2_net_module_fini, "addb2-net" },
+	{ &m0_net_lnet_init,    &m0_net_lnet_fini,    "net/lnet" },
 #ifndef __KERNEL__
 	{ &m0_net_sock_mod_init, &m0_net_sock_mod_fini, "net/sock" },
 #endif
-	{ &m0_net_lnet_init,    &m0_net_lnet_fini,    "net/lnet" },
 	{ &m0_mem_xprt_init,    &m0_mem_xprt_fini,    "bulk/mem" },
 	{ &m0_cob_mod_init,     &m0_cob_mod_fini,     "cob" },
 	{ &m0_stob_mod_init,    &m0_stob_mod_fini,    "stob" },


### PR DESCRIPTION
Root cause : Reordering of the initialization sequence of transports
caused the issue. sock was put before lnet, because of this cas_client
in UT is trying to use very first transport(sock) while the server is
using the transport based on the endpoint format(lnet). That is why we
see ETIMEDOUT. Client cannot connect to server because they are using
different transport

Fix: Changed the transport order back to lnet first and then sock next

Signed-off-by: Naga Kishore Kommuri <nagakishore.kommuri@seagate.com>
