### PR TITLE
EOS-24863: FDMI Test scripts modified to have multiple FDMI filters

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -638,8 +638,19 @@ Tests:
     dir      : src/dix/cm/st/
     executor : Xperior::Executor::MotrTest
     sandbox  : /var/motr/sandbox.62dix-repair-st
+    groupname: 03motr-single-node
     polltime : 30
     timeout  : 1800
+
+  - id       : 65fdmi-plugin-multi-filters
+    script   : fdmi_plugin_st.sh
+    dir      : src/fdmi/plugins/
+    executor : Xperior::Executor::MotrTest
+    sandbox  : /var/motr/sandbox.65fdmi-plugin-multi-filters
+    groupname: 02motr-single-node
+    polltime : 30
+    timeout  : 600
+
 
 
 # 25 min

--- a/conf/objs/fdmi_filter.c
+++ b/conf/objs/fdmi_filter.c
@@ -165,10 +165,10 @@ static bool fdmi_filter_match(const struct m0_conf_obj *cached,
 
 	M0_PRE(xobj->xf_endpoints.ab_count != 0);
 
-	return m0_bufs_streq(&xobj->xf_endpoints, obj->ff_endpoints) &&
-		m0_bufs_streq(&xobj->xf_substrings, obj->ff_substrings) &&
-		m0_fid_eq(&obj->ff_node->cn_obj.co_id, &xobj->xf_node) &&
-		m0_fid_eq(&obj->ff_dix_pver->pv_obj.co_id, &xobj->xf_dix_pver);
+	return m0_bufs_streq(&xobj->xf_endpoints,  obj->ff_endpoints)     &&
+	       m0_bufs_streq(&xobj->xf_substrings, obj->ff_substrings)    &&
+	       m0_fid_eq(&xobj->xf_node,     &obj->ff_node->cn_obj.co_id) &&
+	       m0_fid_eq(&xobj->xf_dix_pver, &obj->ff_dix_pver->pv_obj.co_id);
 }
 
 static void fdmi_filter_delete(struct m0_conf_obj *obj)

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -33,6 +33,8 @@ TOPDIR=$(dirname "$0")/../../
 
 
 export MOTR_CLIENT_ONLY=1
+export ENABLE_FDMI_FILTERS=YES
+interactive=false
 
 wait_and_exit()
 {
@@ -55,18 +57,46 @@ do_some_kv_operations()
 			    -h ${lnet_nid}:$HA_EP -p $PROF_OPT \
 			    -f $M0T1FS_PROC_ID -s "
 
+		echo "Let's create an index and put {somekey:somevalue}"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
 					index create "$DIX_FID"                            \
 					      put    "$DIX_FID" "somekey" "somevalue"      \
 					      get    "$DIX_FID" "somekey"                  \
-					      put    "$DIX_FID" "key1" "something1 anotherstring2 YETanotherstring3"      \
+				 || {
+			rc=$?
+			echo "m0kv failed"
+		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
+		echo "Let put {key1: ***}"
+		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+					index put    "$DIX_FID" "key1" "something1 anotherstring2 YETanotherstring3"      \
 					      get    "$DIX_FID" "key1"                     \
-					      put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
+				 || {
+			rc=$?
+			echo "m0kv failed"
+		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
+		echo "Let put {key2: ***}"
+		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+					index put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
 					      get    "$DIX_FID" "key2"                     \
 				 || {
 			rc=$?
 			echo "m0kv failed"
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
+		echo "Let put {key3: ***}"
+		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+					index put    "$DIX_FID" "key3" "{Bucket-Name:SomeBucket, Object-Name:Someobject, x-amz-meta-replication:Pending}"      \
+					      get    "$DIX_FID" "key3"                     \
+				 || {
+			rc=$?
+			echo "m0kv failed"
+		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 		echo "Now, let's delete 'key2' from this index. The plugin must show the del op coming"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
@@ -75,14 +105,17 @@ do_some_kv_operations()
 			rc=$?
 			echo "m0kv index del failed"
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 		echo "Now, let's get 'key2' from this index again. It should fail."
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
-				index get    "$DIX_FID" "key2"                     \
+					index get    "$DIX_FID" "key2"                     \
 				 && {
 			rc=22 # EINVAL to indicate the test is failed
 			echo "m0kv index get expected to fail, but did not."
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
 		sleep 1
 		echo "Now, let's delete 'key2' from this index again."
 		echo "It should fail, and the plugin must NOT show the del op coming."
@@ -92,6 +125,7 @@ do_some_kv_operations()
                     rc=22 # EINVAL to indicate the test is failed
                     echo "m0kv index del should fail, but did not"
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 	done
 	return $rc
@@ -99,15 +133,28 @@ do_some_kv_operations()
 
 start_fdmi_plugin()
 {
+	local fdmi_filter_fid=$1
+	local fdmi_plugin_ep=$2
+	local fdmi_output_file="${fdmi_filter_fid}.txt"
 	local rc=0
 
 	# We are using FDMI_PLUGIN_EP
-	MOTR_PARAM="-l ${lnet_nid}:$FDMI_PLUGIN_EP        \
+	MOTR_PARAM="-l ${lnet_nid}:$fdmi_plugin_ep        \
 		    -h ${lnet_nid}:$HA_EP -p $PROF_OPT    \
 		    -f $M0T1FS_PROC_ID                    "
 
-	"$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin" $MOTR_PARAM -g $FDMI_FILTER_FID &
-	sleep 5
+	PLUGIN_CMD="$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g $fdmi_filter_fid -s"
+
+	if $interactive ; then
+		echo "Please use another terminal and run this command:"
+		echo sudo $PLUGIN_CMD
+		echo "Then switch back to this terminal and press ENTER"
+		read
+	else
+		echo "Please check fdmi plugin output from this file: `pwd`/${fdmi_output_file}"
+		($PLUGIN_CMD 2>&1 |& tee ${fdmi_output_file} ) &
+		sleep 5
+	fi
 
 	# Checking for the pid of the started plugin process
 	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
@@ -121,12 +168,24 @@ start_fdmi_plugin()
 
 stop_fdmi_plugin()
 {
-	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
-	if test "x$pid" != x; then
-		echo "Terminating ${pid}"
-		kill -TERM "${pid}"
-		wait "${pid}"
+	local pids=$(pgrep -f "lt-fdmi_sample_plugin")
+	if test "x$pids" != x; then
+		for pid in $pids; do
+			echo "Terminating ${pid}"
+			kill -KILL "${pid}"
+		done
 	fi
+	if ! $interactive ; then
+		echo "The output of $FDMI_FILTER_FID  filter are:"
+		echo "==================>>>======================"
+		cat ${FDMI_FILTER_FID}.txt
+		echo "==================<<<======================"
+		echo "The output of $FDMI_FILTER_FID2 filter are:"
+		echo "==================>>>======================"
+		cat ${FDMI_FILTER_FID2}.txt
+		echo "==================<<<======================"
+	fi
+
 	return 0
 }
 
@@ -148,10 +207,13 @@ motr_fdmi_plugin_test()
 	echo "Process fid    : $M0T1FS_PROC_ID              "
 	echo "FDMI plugin ep : ${lnet_nid}:$FDMI_PLUGIN_EP  "
 	echo "FDMI filter fid: $FDMI_FILTER_FID             "
+	echo "FDMI plugin ep : ${lnet_nid}:$FDMI_PLUGIN_EP2 "
+	echo "FDMI filter fid: $FDMI_FILTER_FID2            "
 	echo
 	echo
 
-	start_fdmi_plugin && {
+	start_fdmi_plugin $FDMI_FILTER_FID $FDMI_PLUGIN_EP &&
+	start_fdmi_plugin $FDMI_FILTER_FID2 $FDMI_PLUGIN_EP2 && {
 	    do_some_kv_operations || {
 		# Make the rc available for the caller and fail the test
 		# if kv operations fail.
@@ -166,6 +228,19 @@ motr_fdmi_plugin_test()
 	stop_fdmi_plugin
 	return $rc
 }
+
+parse_cli_options()
+{
+    while true ; do
+        case "$1" in
+            -i|--interactive)  interactive=true; shift ;;
+
+            *)             break ;;
+        esac
+    done
+}
+
+parse_cli_options "$@"
 
 main()
 {

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -147,12 +147,12 @@ start_fdmi_plugin()
 
 	if $interactive ; then
 		echo "Please use another terminal and run this command:"
-		echo sudo $PLUGIN_CMD
+		echo sudo ${PLUGIN_CMD}
 		echo "Then switch back to this terminal and press ENTER"
 		read
 	else
-		echo "Please check fdmi plugin output from this file: `pwd`/${fdmi_output_file}"
-		($PLUGIN_CMD 2>&1 |& tee ${fdmi_output_file} ) &
+		echo "Please check fdmi plugin output from this file: $(pwd)/${fdmi_output_file}"
+		(${PLUGIN_CMD} 2>&1 |& tee "${fdmi_output_file}" ) &
 		sleep 5
 	fi
 
@@ -168,21 +168,25 @@ start_fdmi_plugin()
 
 stop_fdmi_plugin()
 {
-	local pids=$(pgrep -f "lt-fdmi_sample_plugin")
-	if test "x$pids" != x; then
-		for pid in $pids; do
-			echo "Terminating ${pid}"
-			kill -KILL "${pid}"
-		done
-	fi
-	if ! $interactive ; then
+	if $interactive ; then
+		echo "Please switch to the plugin terminals and press Ctrl+C "
+		echo "When both plugin applications are terminated, come back"
+		echo "Please press Enter to continue ..." && read
+	else
+		local pids=$(pgrep -f "lt-fdmi_sample_plugin")
+		if test "x$pids" != x; then
+			for pid in $pids; do
+				echo "Terminating ${pid}"
+				kill -KILL "${pid}"
+			done
+		fi
 		echo "The output of $FDMI_FILTER_FID  filter are:"
 		echo "==================>>>======================"
-		cat ${FDMI_FILTER_FID}.txt
+		cat "${FDMI_FILTER_FID}.txt"
 		echo "==================<<<======================"
 		echo "The output of $FDMI_FILTER_FID2 filter are:"
 		echo "==================>>>======================"
-		cat ${FDMI_FILTER_FID2}.txt
+		cat "${FDMI_FILTER_FID2}.txt"
 		echo "==================<<<======================"
 	fi
 
@@ -212,8 +216,8 @@ motr_fdmi_plugin_test()
 	echo
 	echo
 
-	start_fdmi_plugin $FDMI_FILTER_FID $FDMI_PLUGIN_EP &&
-	start_fdmi_plugin $FDMI_FILTER_FID2 $FDMI_PLUGIN_EP2 && {
+	start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
+	start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" && {
 	    do_some_kv_operations || {
 		# Make the rc available for the caller and fail the test
 		# if kv operations fail.

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -288,12 +288,15 @@ function dix_pver_build()
 	# Number of parity units (replication factor) for distributed indices.
 	# Calculated automatically as maximum possible parity for the given
 	# number of disks.
-	# If we have SPARE=PARITY, then we will use:
-	#local DIX_PARITY=$(((DIX_DEVS_NR - 1) / 2))
-	#local DIX_SPARE=$DIX_PARITY
-	# If we have SPARE=0, then we can have any number between [1, DIX_DEVS_NR - 1]
-	local DIX_PARITY=$((DIX_DEVS_NR - 1))
-	local DIX_SPARE=0
+	if [ x$ENABLE_FDMI_FILTERS == xYES ] ; then
+		# If we have SPARE=0, then we can have any number between [1, DIX_DEVS_NR - 1]
+		local DIX_PARITY=$((DIX_DEVS_NR - 1))
+		local DIX_SPARE=0
+	else
+		# If we have SPARE=PARITY, then we will use:
+		local DIX_PARITY=$(((DIX_DEVS_NR - 1) / 2))
+		local DIX_SPARE=$DIX_PARITY
+	fi
 
 	# conf objects for disks
 	for ((i=0; i < $DIX_DEVS_NR; i++)); do

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -96,8 +96,12 @@ SNS_MOTR_CLI_EP="12345:33:1000"
 POOL_MACHINE_CLI_EP="12345:33:1001"
 SNS_QUIESCE_CLI_EP="12345:33:1002"
 M0HAM_CLI_EP="12345:33:1003"
-FDMI_PLUGIN_EP="12345:33:1004"
+
+FDMI_PLUGIN_EP="12345:33:601"
+FDMI_PLUGIN_EP2="12345:33:602"
+
 FDMI_FILTER_FID="6c00000000000001:0"
+FDMI_FILTER_FID2="6c00000000000002:0"
 
 SNS_CLI_EP="12345:33:400"
 
@@ -122,7 +126,7 @@ MAX_RPC_MSG_SIZE=65536
 XPT=lnet
 PVERID='^v|1:10'
 MDPVERID='^v|2:10'
-M0T1FS_PROC_ID='<0x7200000000000001:64>'
+M0T1FS_PROC_ID='0x7200000000000001:64'
 
 # Single node configuration.
 SINGLE_NODE=0
@@ -240,7 +244,7 @@ unprepare()
 	return $rc
 }
 
-PROF_OPT='<0x7000000000000001:0>'
+PROF_OPT='0x7000000000000001:0'
 
 . `dirname ${BASH_SOURCE[0]}`/common_service_fids_inc.sh
 
@@ -284,7 +288,12 @@ function dix_pver_build()
 	# Number of parity units (replication factor) for distributed indices.
 	# Calculated automatically as maximum possible parity for the given
 	# number of disks.
-	local DIX_PARITY=$(((DIX_DEVS_NR - 1) / 2))
+	# If we have SPARE=PARITY, then we will use:
+	#local DIX_PARITY=$(((DIX_DEVS_NR - 1) / 2))
+	#local DIX_SPARE=$DIX_PARITY
+	# If we have SPARE=0, then we can have any number between [1, DIX_DEVS_NR - 1]
+	local DIX_PARITY=$((DIX_DEVS_NR - 1))
+	local DIX_SPARE=0
 
 	# conf objects for disks
 	for ((i=0; i < $DIX_DEVS_NR; i++)); do
@@ -303,7 +312,7 @@ function dix_pver_build()
 	done
 	# conf objects for DIX pool version
 	local DIX_POOL="{0x6f| (($DIX_POOLID), 0, [1: $DIX_PVERID])}"
-	local DIX_PVER="{0x76| (($DIX_PVERID), {0| (1, $DIX_PARITY, $DIX_PARITY,
+	local DIX_PVER="{0x76| (($DIX_PVERID), {0| (1, $DIX_PARITY, $DIX_SPARE,
                                                     $DIX_DEVS_NR,
                                                     [5: 0, 0, 0, 0, $DIX_PARITY],
                                                     [1: $DIX_SITEVID])})}"
@@ -418,12 +427,27 @@ function build_conf()
 	PROC_NAMES="$PROC_NAMES${PROC_NAMES:+, }$M0T1FS_PROCID"
 
 	local FDMI_GROUP_ID="^g|1:0"
-	local FDMI_FILTER_ID="^l|1:0"
+	local FDMI_FILTER_ID="^l|1:0"   #Please refer to $FDMI_FILTER_FID
+	local FDMI_FILTER_ID2="^l|2:0"  #Please refer to $FDMI_FILTER_FID2
+
 	local FDMI_FILTER_STRINGS="\"something1\", \"anotherstring2\", \"YETanotherstring3\""
-	local FDMI_GROUP="{0x67| (($FDMI_GROUP_ID), 0x1000, [1: $FDMI_FILTER_ID])}"
-	#local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 1, (11, 11), \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, (0, 0), [0], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])}"
-	local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 2, $FDMI_FILTER_ID, \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, $DIX_PVERID, [3: $FDMI_FILTER_STRINGS], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])}"
-	local FDMI_ITEMS_NR=2
+	local FDMI_FILTER_STRINGS2="\"Bucket-Name\", \"Object-Name\", \"x-amz-meta-replication\""
+
+	if [ x$ENABLE_FDMI_FILTERS == xYES ] ; then
+		local FDMI_GROUP_DESC="1: $FDMI_GROUP_ID"
+		local FDMI_ITEMS_NR=3
+		# Please NOTE the ending comma at the end of each string here
+		local FDMI_GROUP="{0x67| (($FDMI_GROUP_ID), 0x1000, [2: $FDMI_FILTER_ID, $FDMI_FILTER_ID2])},"
+		#local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 1, (11, 11), \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, (0, 0), [0], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])},"
+		local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 2, $FDMI_FILTER_ID, \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, $DIX_PVERID, [3: $FDMI_FILTER_STRINGS], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])},"
+		local FDMI_FILTER2="{0x6c| (($FDMI_FILTER_ID2), 2, $FDMI_FILTER_ID2, \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, $DIX_PVERID, [3: $FDMI_FILTER_STRINGS2], [1: \"$lnet_nid:$FDMI_PLUGIN_EP2\"])},"
+	else
+		local FDMI_GROUP_DESC="0"
+		local FDMI_ITEMS_NR=0
+		local FDMI_GROUP=""
+		local FDMI_FILTER=""
+		local FDMI_FILTER2=""
+	fi
 
 	local i
 	for ((i=0; i < ${#ioservices[*]}; i++, M0D++)); do
@@ -638,7 +662,7 @@ function build_conf()
 	  [$node_count: $NODES],
 	  [$site_count: $SITES],
 	  [$pool_count: $POOLS],
-	  [1: $PROF], [1: $FDMI_GROUP_ID])},
+	  [1: $PROF], [$FDMI_GROUP_DESC])},
   {0x70| (($PROF), [$pool_count: $POOLS])},
   {0x6e| (($NODE), 16000, 2, 3, 2, [$(($M0D + 1)): ${PROC_NAMES[@]}])},
   $PROC_OBJS,
@@ -646,8 +670,9 @@ function build_conf()
   {0x73| (($HA_SVC_ID), @M0_CST_HA, [1: $HA_ENDPOINT], [0], [0])},
   {0x73| (($FIS_SVC_ID), @M0_CST_FIS, [1: $HA_ENDPOINT], [0], [0])},
   $M0T1FS_RM,
-  $FDMI_GROUP,
-  $FDMI_FILTER,
+  $FDMI_GROUP
+  $FDMI_FILTER
+  $FDMI_FILTER2
   $MDS_OBJS,
   $IOS_OBJS,
   $RM_OBJS,

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -97,11 +97,11 @@ POOL_MACHINE_CLI_EP="12345:33:1001"
 SNS_QUIESCE_CLI_EP="12345:33:1002"
 M0HAM_CLI_EP="12345:33:1003"
 
-FDMI_PLUGIN_EP="12345:33:601"
-FDMI_PLUGIN_EP2="12345:33:602"
+export FDMI_PLUGIN_EP="12345:33:601"
+export FDMI_PLUGIN_EP2="12345:33:602"
 
-FDMI_FILTER_FID="6c00000000000001:0"
-FDMI_FILTER_FID2="6c00000000000002:0"
+export FDMI_FILTER_FID="6c00000000000001:0"
+export FDMI_FILTER_FID2="6c00000000000002:0"
 
 SNS_CLI_EP="12345:33:400"
 
@@ -126,7 +126,7 @@ MAX_RPC_MSG_SIZE=65536
 XPT=lnet
 PVERID='^v|1:10'
 MDPVERID='^v|2:10'
-M0T1FS_PROC_ID='0x7200000000000001:64'
+export M0T1FS_PROC_ID='0x7200000000000001:64'
 
 # Single node configuration.
 SINGLE_NODE=0
@@ -244,7 +244,7 @@ unprepare()
 	return $rc
 }
 
-PROF_OPT='0x7000000000000001:0'
+export PROF_OPT='0x7000000000000001:0'
 
 . `dirname ${BASH_SOURCE[0]}`/common_service_fids_inc.sh
 
@@ -288,7 +288,7 @@ function dix_pver_build()
 	# Number of parity units (replication factor) for distributed indices.
 	# Calculated automatically as maximum possible parity for the given
 	# number of disks.
-	if [ x$ENABLE_FDMI_FILTERS == xYES ] ; then
+	if [ "x$ENABLE_FDMI_FILTERS" == "xYES" ] ; then
 		# If we have SPARE=0, then we can have any number between [1, DIX_DEVS_NR - 1]
 		local DIX_PARITY=$((DIX_DEVS_NR - 1))
 		local DIX_SPARE=0
@@ -436,7 +436,7 @@ function build_conf()
 	local FDMI_FILTER_STRINGS="\"something1\", \"anotherstring2\", \"YETanotherstring3\""
 	local FDMI_FILTER_STRINGS2="\"Bucket-Name\", \"Object-Name\", \"x-amz-meta-replication\""
 
-	if [ x$ENABLE_FDMI_FILTERS == xYES ] ; then
+	if [ "x$ENABLE_FDMI_FILTERS" == "xYES" ] ; then
 		local FDMI_GROUP_DESC="1: $FDMI_GROUP_ID"
 		local FDMI_ITEMS_NR=3
 		# Please NOTE the ending comma at the end of each string here

--- a/scripts/st.d/67fdmi-plugin-multi-filters
+++ b/scripts/st.d/67fdmi-plugin-multi-filters
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+
+exec $SUDO "$M0_SRC_DIR/fdmi/plugins/fdmi_plugin_st.sh"


### PR DESCRIPTION
Features included:
  * FDMI_ENABLE_FILTERS to control if FDMI is enabled
  * Explain the DIX_PARITY and DIX_SPARE when generating DIX conf
  * Interactive mode for this ST.
  * Switch for output as string or as hex. Useful when doing manual testing.

Add fdmi st into jenkins tests

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Coding
-  [X] Coding conventions are followed and code is consistent

# Testing 
- [X] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Review Checklist 
- [ ] PR is self reviewed
- [ ] JIRA number/GitHub Issue added to PR
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [N]: 
