### PR TITLE
EOS-24831: Object deletion gives return code as ENOENT 

### DIFF
--- a/motr/cob.c
+++ b/motr/cob.c
@@ -1810,7 +1810,7 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 	struct cob_req         *cr;
 	struct m0_pool_version *pv;
 	struct m0_op           *op;
-	bool                    skip_meta_data;
+	bool                    skip_meta_data = false;
 
 	M0_ENTRY();
 	M0_PRE(oo != NULL);
@@ -1853,21 +1853,18 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 
 	/** Skip meta-data lookup if obj.ob_attr.oa_pver is not empty.
 	 * pver is not empty that means  calling application has
-	 * capability to store meta-data(pver, LID) and has sent pver
-	 * to open entity.
+	 * capability to store meta-data(pver) and has sent pver
+	 * to open/delete entity.
 	 */
-	skip_meta_data = false;
 	obj = m0__obj_entity(oo->oo_oc.oc_op.op_entity);
-	if ((cr->cr_opcode == M0_EO_GETATTR) &&
-	     m0_fid_is_set(&obj->ob_attr.oa_pver) &&
-	     m0_fid_is_valid(&obj->ob_attr.oa_pver)) {
+	if ((M0_IN(cr->cr_opcode, (M0_EO_GETATTR, M0_EO_DELETE))) &&
+	     (obj->ob_entity.en_flags & M0_ENF_META))
 		skip_meta_data = true;
-	}
 
 	/* Set layout id and pver for CREATE op.*/
 	if (cr->cr_opcode == M0_EO_CREATE) {
 		cr->cr_cob_attr->ca_lid = obj->ob_attr.oa_layout_id;
-		 if (obj->ob_entity.en_flags == M0_ENF_META) {
+		 if (obj->ob_entity.en_flags & M0_ENF_META) {
 			/* For create operation setting up pool version locally
 			* found in pools common, so cob lookup call to server
 			* can be skipped */
@@ -1876,7 +1873,7 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 		 }
 	}
 
-	if (! skip_meta_data ) {
+	if (!skip_meta_data) {
 	/* Send requests to services. */
 		rc = cob_req_send(cr);
 		if (rc != 0) {
@@ -1885,16 +1882,29 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 			m0_sm_ast_post(cr->cr_op_sm_grp, &cr->cr_ar.ar_ast);
 		}
 	} else {
-		M0_LOG(M0_DEBUG, "skipped lookup, obj pver is :"FID_F,
-		       FID_P(&obj->ob_attr.oa_pver));
-		/* We are skipping meta-data lookup here as we have received pver
-		 * and LID from application, and hence need to move op state
-		 * LAUNCHED, EXECUTED and STABLE explicitly */
-		m0_sm_move(&cr->cr_op->op_sm, 0, M0_OS_LAUNCHED);
-		m0_sm_group_unlock(&cr->cr_op->op_sm_group);
-		cob_complete_op(cr->cr_op);
-		m0_sm_group_lock(&cr->cr_op->op_sm_group);
-		rc = MOTR_MDCOB_LOOKUP_SKIP;
+		M0_LOG(M0_DEBUG, "skipped lookup, obj pver is:"FID_F"cr->cr_opcode:%d",
+		       FID_P(&obj->ob_attr.oa_pver), cr->cr_opcode);
+		if (cr->cr_opcode == M0_EO_DELETE) {
+			/**
+			 * For DELETE entity we skipped md cob if M0_ENF_META
+			 * is set, but we still wants to send data cob. This
+			 * case is handled here by posting cob_ast_ios_io_send
+			 * AST.
+			 */
+                        cr->cr_ar.ar_ast.sa_cb = &cob_ast_ios_io_send;
+                        cr->cr_ar.ar_rc = 0;
+                        m0_sm_ast_post(cr->cr_op_sm_grp, &cr->cr_ar.ar_ast);
+                        rc = 0;
+		} else {
+			/* We are skipping meta-data lookup here as we have received
+			 * pver from application, and hence need to move op state
+			 * LAUNCHED, EXECUTED and STABLE explicitly */
+			m0_sm_move(&cr->cr_op->op_sm, 0, M0_OS_LAUNCHED);
+			m0_sm_group_unlock(&cr->cr_op->op_sm_group);
+			cob_complete_op(cr->cr_op);
+			m0_sm_group_lock(&cr->cr_op->op_sm_group);
+			rc = MOTR_MDCOB_LOOKUP_SKIP;
+		}
 	}
 
 	return M0_RC(rc);


### PR DESCRIPTION
Problem:
1. Handling of skip md cob lookup case was not handled properly in motr
   code for DELETE opcode. Also we did not receive the M0_ENF_META flag
   from S3 which was allowing us to send a cob lookup call to motr server
   during delete_entity.But on server particular cob entry is not present
   as we had skipped while creating object which we are trying to delete
   now. This resulted in an ENOENT error from motr server.

2. There was one more problem that even though we skip md cob lookup in
   case of object delete, it was also skipping data delete cob
   (M0_IOSERVICE_COB_DELETE_OPCODE) as well, and because of that it was
   not freeing up the disk space.

Solution:
1. Skipped md cob_lookup for entity_delete() operation if M0_ENF_META flag
   is set by application.
2. second problem addressed by posting cob_ast_ios_io_send AST explicitly
   if we skip md cob lookup in case of DELETE entity.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
