### PR TITLE
EOS-24271: Remove Galois code from Motr

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "extra-libs/galois"]
-	path = extra-libs/galois
-	url = ../cortx-motr-galois
+[submodule "extra-libs/test"]
+	path = extra-libs/test
+	url =
 	ignore = untracked

--- a/Kbuild.in
+++ b/Kbuild.in
@@ -4,7 +4,7 @@
 # global vars ----------------------------------------- {{{1
 #
 
-KBUILD_EXTRA_SYMBOLS := @LUSTRE_SYMVERS@ @GALOIS_SYMVERS@
+KBUILD_EXTRA_SYMBOLS := @LUSTRE_SYMVERS@
 
 ccflags-y := -DHAVE_CONFIG_H -iquote . @M0_KCPPFLAGS@ @M0_KCFLAGS@ @KCFLAGS@
 
@@ -157,7 +157,6 @@ include $(src)/stob/ut/Kbuild.sub
 include $(src)/ut/Kbuild.sub
 include $(src)/xcode/ut/Kbuild.sub
 include $(src)/be/ut/Kbuild.sub
-include $(src)/sns/ut/Kbuild.sub
 include $(src)/ha/ut/Kbuild.sub
 
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,9 +78,6 @@ AM_CPPFLAGS  = @M0_CPPFLAGS@
 AM_CFLAGS    = @M0_CFLAGS@
 AM_LDFLAGS   = @M0_LDFLAGS@
 
-GALOIS_DIR   = extra-libs/galois
-SUBDIRS = $(GALOIS_DIR)
-
 ################################################################################
 #                               Global variables                            {{{1
 ################################################################################
@@ -102,7 +99,6 @@ noinst_LTLIBRARIES =
 man_MANS   =
 
 EXTRA_DIST  = autogen.sh cortx-motr.spec.in README.rst LICENCE .gdbinit
-EXTRA_DIST += extra-libs/.gitignore
 CLEANFILES  =
 DISTCLEANFILES = @LUSTRE_CONFIG_LINK@ utils/ub.sh
 MAN_PAGES  =
@@ -188,16 +184,8 @@ motr_libmotr_la_CPPFLAGS  = -DM0_TARGET='libmotr' $(AM_CPPFLAGS)
 motr_libmotr_la_LDFLAGS   = -version-info @LT_VERSION@ -pthread $(AM_LDFLAGS)
 motr_libmotr_la_LIBADD    = @MATH_LIBS@ @PTHREAD_LIBS@ @AIO_LIBS@ @RT_LIBS@ \
                             @YAML_LIBS@ @PROFILER_LIBS@ @UUID_LIBS@ \
-                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@ @OPENSSL_LIBS@
-
-if HAVE_ISAL
-motr_libmotr_la_LIBADD += @ISAL_LIBS@
-else
-motr_libmotr_la_LIBADD += @GALOIS_LIBS@
-# override is needed to allow user to provide some additional options in
-# RPMBUILD_FLAGS variable in command line
-override RPMBUILD_FLAGS += --without isal
-endif
+                            @DL_LIBS@ @CASSANDRA_LIBS@ @UV_LIBS@ @ISAL_LIBS@ \
+			    @OPENSSL_LIBS@
 
 # install directory for public libmotr headers
 motr_includedir             = $(includedir)/motr
@@ -1165,7 +1153,6 @@ EXTRA_DIST += \
               sm/Kbuild.sub \
               sm/ut/Kbuild.sub \
               sns/Kbuild.sub \
-              sns/ut/Kbuild.sub \
               spiel/Kbuild.sub \
               sss/Kbuild.sub \
               stats/Kbuild.sub \
@@ -1534,17 +1521,10 @@ libmotr-ut: pre-all
 .PHONY: __libmotr-ut
 __libmotr-ut: config.h Makefile ut/libmotr-ut.la $(HEADERS)
 
-# galois ---------------------------------------------- {{{3
-
-.PHONY: galois
-galois:
-	@echo 'Building galois'
-	@cd $(GALOIS_DIR) && $(MAKE) $(AM_MAKEFLAGS)
-
 # quick ----------------------------------------------- {{{3
 
 .PHONY: quick
-quick: generate-files galois
+quick: generate-files
 	@echo 'Building user-space Unit Tests'
 	@$(MAKE) $(AM_MAKEFLAGS) __quick
 
@@ -1555,12 +1535,12 @@ __quick: __libmotr __libmotr-ut ut/m0ut
 # kuick ----------------------------------------------- {{{3
 
 .PHONY: kuick
-kuick: generate-files galois
+kuick: generate-files
 	@echo 'Building kernel-space Unit Tests'
 	@$(MAKE) $(AM_MAKEFLAGS) build-kernel-modules M0_BUILD_KERNEL_UT_ONLY=yes
 
 .PHONY: motr_st
-motr_st: generate-files galois
+motr_st: generate-files
 	@echo 'Building motr for motr system test.'
 	@$(MAKE) $(AM_MAKEFLAGS) build-kernel-modules M0_BUILD_ST=yes
 
@@ -1597,8 +1577,7 @@ clean-local: $(KERNEL_MODULES_CLEAN) clean-doc
 # we don't want to use the default kernel clean command, i.e.:
 #   $(MAKE) -C $(KDIR) M=$(PWD) $(AM_MAKEFLAGS) clean
 # because it's a bit dummy - it uses `find` to recursively delete all *.o, *.a
-# and *.ko files, which will mess up our user-space build in .libs/ directories
-# and delete library files under extra-libs/ and galois.ko module;
+# and *.ko files, which will mess up our user-space build in .libs/ directories;
 # instead we use our own `find` command, which excludes some paths we need to
 # keep, to clean up kernel build
 .PHONY: clean-kernel-modules
@@ -1608,7 +1587,7 @@ clean-kernel-modules:
 	@rm -vf $(top_builddir)/Module.markers
 	@rm -vf $(top_builddir)/modules.order
 	@find $(top_builddir) \
-		\( -name .git -o -name .libs -o -name extra-libs \) -prune \
+		\( -name .git -o -name .libs \) -prune \
 		-o \( -name '*.o' -o -name '*.ko' -o -name '.*.cmd' \
 		      -o -name '*.ko.*' -o -name '.*.d' -o -name '.*.tmp' \
 		      -o -name '*.mod.c' \
@@ -1647,7 +1626,6 @@ endif
 install-exec-local: $(KERNEL_MODULES_INSTALL)
 
 install-tests:
-	@$(MAKE) -C extra-libs/galois install
 	@$(MAKE) INSTALL_MOD_DIR=kernel/fs/motr/tests $(KERNEL_MODULES_INSTALL) \
 		 install-binPROGRAMS install-sbinPROGRAMS install-binSCRIPTS \
 		 install-sbinSCRIPTS
@@ -1857,7 +1835,6 @@ help:
 	@echo '  quick           - build only user-space UT'
 	@echo '  kuick           - build only kernel-space UT'
 	@echo ''
-	@echo '  galois          - build only libgalois.so and galois.ko'
 	@echo '  libmotr         - build only libmotr library'
 	@echo '  libmotr-ut      - build only libmotr-ut library'
 	@echo '  libmotr-altogether - build only libmotr library'

--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -40,7 +40,7 @@
 package mio
 
 // #cgo CFLAGS: -I/usr/include/motr
-// #cgo CFLAGS: -I../../.. -I../../../extra-libs/galois/include
+// #cgo CFLAGS: -I../../..
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #cgo CFLAGS: -Wno-attributes
 // #cgo LDFLAGS: -L../../../motr/.libs -Wl,-rpath=../../../motr/.libs -lmotr

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -23,7 +23,7 @@
 package mio
 
 // #cgo CFLAGS: -I/usr/include/motr
-// #cgo CFLAGS: -I../../.. -I../../../extra-libs/galois/include
+// #cgo CFLAGS: -I../../..
 // #cgo CFLAGS: -DM0_EXTERN=extern -DM0_INTERNAL=
 // #include <errno.h> /* EEXIST */
 // #include "motr/client.h"

--- a/conf/st
+++ b/conf/st
@@ -216,7 +216,7 @@ Usage: ${0##*/} [COMMAND]
 
 Supported commands:
   run      run system tests (default command)
-  insmod   insert Motr kernel modules: m0tr.ko, galois.ko
+  insmod   insert Motr kernel modules: m0tr.ko
   rmmod    remove Motr kernel modules
   sstart   start Motr user-space services
   sstop    stop Motr user-space services

--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,6 @@ AH_TEMPLATE([HAVE_MALLINFO],          [Have mallinfo() function])
 AH_TEMPLATE([HAVE_MALLOC_SIZE],       [Have malloc_size() function])
 AH_TEMPLATE([HAVE_BACKTRACE],         [Have backtrace(3) function])
 AH_TEMPLATE([HAVE_SYSTEMD],           [Have systemd available])
-AH_TEMPLATE([HAVE_ISAL],              [Have Intel ISA-L available])
 
 # enable/disable options ------------------------------ {{{2
 
@@ -834,40 +833,14 @@ AS_IF([test x$with_lustre != xno],[
 #
 # Checking Intel ISA library --------------------------------------------------------- {{{1
 #
-AC_ARG_ENABLE([isal],
-        [AS_HELP_STRING([--disable-isal],
-                        [Disable use Intel ISA. Instead use Galois library.])],
-        [],[enable_isal=yes]
+MOTR_SEARCH_LIBS([ec_encode_data], [c isal], [ISAL_LIBS],
+        [ec_encode_data cannot be found! Try to install Intel ISA library package.]
 )
-
-AM_CONDITIONAL([HAVE_ISAL],
-               [test "x$enable_isal" = xyes])
-
-
-AS_IF([test x$enable_isal = xyes],
-      [
-              AC_CHECK_HEADERS([isa-l.h],
-              [
-                      # check for isa library
-                      MOTR_SEARCH_LIBS(
-                              [ec_encode_data], [c isal], [ISAL_LIBS],
-                              [ec_encode_data cannot be found! \
-                               Try to install Intel ISA library package.]
-                      )
-                      AC_SUBST([ISAL_LIBS])
-
-                      # define MACROs
-                      AC_DEFINE([HAVE_ISAL])
-                      # AM_CONDITIONAL([HAVE_ISAL], [true])
-                      AC_MSG_NOTICE([INTEL ISA-L Headers Available])
-              ],
-              [
-                      AM_CONDITIONAL([HAVE_ISAL], [false])
-                      AC_MSG_NOTICE([No INTEL ISA-L Headers])
-              ])
-      ]
+AC_SUBST([ISAL_LIBS])
+AC_CHECK_HEADERS([isa-l.h],
+                 [AC_MSG_NOTICE([INTEL ISA-L Headers Available])],
+                 [AC_MSG_ERROR([No INTEL ISA-L Headers])]
 )
-
 
 #
 # Checking Lustre --------------------------------------------------------- {{{1
@@ -915,21 +888,6 @@ OLD_CFLAGS=$CFLAGS
 LIBS=""
 CFLAGS=""
 
-# Checking galois --------------------------------------------------------- {{{1
-
-GALOIS_REL_PATH="extra-libs/galois"
-GALOIS_SRC="$SRCDIR/$GALOIS_REL_PATH"
-GALOIS_ABS_SRC="$ABS_SRCDIR/$GALOIS_REL_PATH"
-GALOIS_INCLUDES="-I$GALOIS_ABS_SRC/include"
-KGALOIS_INCLUDES="-I$GALOIS_ABS_SRC/include"
-GALOIS_LIBS="$GALOIS_ABS_SRC/src/libgalois.la"
-
-AC_SUBST([GALOIS_SYMVERS], [$GALOIS_ABS_SRC/src/linux_kernel/Module.symvers])
-
-AS_IF([! test -x $GALOIS_SRC/configure],
-      [ test -x $GALOIS_SRC/autogen.sh && ( cd $GALOIS_SRC; ./autogen.sh ) ]
-)
-
 # Checking libyaml -------------------------------------------------------- {{{1
 
 AS_IF([test x$enable_system_libs = xyes],
@@ -950,8 +908,6 @@ AS_IF([test x$enable_system_libs = xyes],
 LIBS=$OLD_LIBS
 CFLAGS=$OLD_CFLAGS
 
-AC_SUBST([GALOIS_ABS_SRC])
-AC_SUBST([GALOIS_LIBS])
 AC_SUBST([YAML_LIBS])
 
 #
@@ -1006,7 +962,7 @@ AS_IF([test x$enable_mcheck = xyes],
 # Set up build variables -------------------------------------------------- {{{1
 #
 
-M0_CPPFLAGS="$GALOIS_INCLUDES $YAML_INCLUDES $M0_CPPFLAGS $LUSTRE_INCLUDES"
+M0_CPPFLAGS="$YAML_INCLUDES $M0_CPPFLAGS $LUSTRE_INCLUDES"
 
 # _GNU_SOURCE for asprintf(3), open(2) O_DIRECT flag
 M0_CPPFLAGS="-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern \
@@ -1034,7 +990,7 @@ M0_KCPPFLAGS="-DM0_INTERNAL='' -DM0_EXTERN=extern \
               -include'$ABS_BUILDDIR/config.h' \
               -iquote '$ABS_BUILDDIR' \
               -iquote '$ABS_SRCDIR' \
-              $LUSTRE_INCLUDES $KGALOIS_INCLUDES $M0_KCPPFLAGS"
+              $LUSTRE_INCLUDES $M0_KCPPFLAGS"
 
 M0_KCFLAGS="-Wall -Werror -Wno-attributes $M0_KCFLAGS"
 
@@ -1085,8 +1041,6 @@ AC_CONFIG_FILES([net/test/demo/demo-config.sh], [chmod +x net/test/demo/demo-con
 AC_CONFIG_FILES([utils/modload-all.sh], [chmod +x utils/modload-all.sh])
 AC_CONFIG_FILES([scripts/systemtap/kem/Makefile])
 
-AC_CONFIG_SUBDIRS([extra-libs/galois])
-
 AC_OUTPUT
 
 #
@@ -1124,12 +1078,9 @@ echo "PTHREAD_LIBS   :  \"$PTHREAD_LIBS\""
 echo "AIO_LIBS       :  \"$AIO_LIBS\""
 echo "RT_LIBS        :  \"$RT_LIBS\""
 echo "PROFILER_LIBS  :  \"$PROFILER_LIBS\""
-echo "GALOIS_LIBS    :  \"$GALOIS_LIBS\""
 echo "YAML_LIBS      :  \"$YAML_LIBS\""
 echo "UUID_LIBS      :  \"$UUID_LIBS\""
-AS_IF([test x$enable_isal = xyes],[
 echo "ISAL_LIBS      :  \"$ISAL_LIBS\""
-])
 echo "OPENSSL_LIBS   :  \"$OPENSSL_LIBS\""
 echo ""
 echo "Gcc            :  \"$BUILD_GCC\""

--- a/console/st/console-st.sh
+++ b/console/st/console-st.sh
@@ -42,12 +42,11 @@ CONF_FILE_PATH=$M0_SRC_DIR/ut/diter.xc
 CONF_PROFILE='<0x7000000000000001:0>'
 
 NODE_UUID=02e94b88-19ab-4166-b26b-91b51f22ad91  # required by `common.sh'
-. $M0_SRC_DIR/m0t1fs/linux_kernel/st/common.sh  # modload_galois
+. $M0_SRC_DIR/m0t1fs/linux_kernel/st/common.sh  # modload
 
 start_server()
 {
 	modprobe lnet
-	modload_galois
 	echo 8 >/proc/sys/kernel/printk
 	modload
 
@@ -132,7 +131,6 @@ stop_server()
 {
 	{ pkill $(basename "$SERVER") && wait; } || true
 	modunload
-	modunload_galois
 }
 
 check_reply()

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -4,12 +4,6 @@
 %bcond_with cassandra
 %bcond_with ivt
 
-# Below line will enable the isal by default. This will add Intel ISA as
-# dependency by default. User can override this by using '--without isal'
-# in makefile to disable it. To change the default value i.e. to disable
-# Intel ISA dependency by default, use '%bcond_with isal'.
-%bcond_without isal
-
 # configure options
 %define with_linux  %( test -n "$kernel_src" && echo "--with-linux=$kernel_src" )
 %define with_lustre %( test -n "$lustre_src" && echo "--with-lustre=$lustre_src" )
@@ -45,14 +39,11 @@
 %if %{with cassandra}
 %define  configure_cassandra_opts   --with-cassandra
 %endif
-%if !%{with isal}
-%define  configure_isal_opts   --disable-isal
-%endif
 
 %if %{with ivt} || %{with ut}
-%define  configure_opts  %{configure_ut_opts} %{?configure_cassandra_opts} %{?configure_isal_opts}
+%define  configure_opts  %{configure_ut_opts} %{?configure_cassandra_opts}
 %else
-%define  configure_opts  %{configure_release_opts} %{?configure_cassandra_opts} %{?configure_isal_opts}
+%define  configure_opts  %{configure_release_opts} %{?configure_cassandra_opts}
 %endif
 
 Name:           @PACKAGE@
@@ -115,9 +106,7 @@ BuildRequires:  python-devel
 BuildRequires:  python2-devel
 %endif
 BuildRequires:  libedit-devel
-%if %{with isal}
 BuildRequires:  isa-l
-%endif
 %if %{with cassandra}
 BuildRequires:  libcassandra
 BuildRequires:  libuv
@@ -147,9 +136,7 @@ Requires:       facter
 Requires:       rubygem-net-ssh
 Requires:       python36-ply
 Requires:       libedit
-%if %{with isal}
 Requires:       isa-l
-%endif
 Requires(pre):  shadow-utils
 Requires(post): findutils
 
@@ -228,7 +215,7 @@ find %{buildroot} -type f | sed -e 's#^%{buildroot}##' | sort |
 
 make DESTDIR=%{buildroot} install-tests
 
-find %{buildroot} -name m0tr.ko -o -name m0ut.ko -o -name galois.ko \
+find %{buildroot} -name m0tr.ko -o -name m0ut.ko -o \
 	     | sed -e 's#^%{buildroot}##' > tests-ut.files
 
 find %{buildroot} \
@@ -239,8 +226,7 @@ find %{buildroot} \
         -o -name m0gentestds \
         -o -name 'm0kut*' \
         -o -name 'libtestlib*.so*' \
-        -o -name 'libmotr*.so*' \
-        -o -name 'libgalois*.so*' |
+        -o -name 'libmotr*.so*' |
     sed -e 's#^%{buildroot}##' >> tests-ut.files
 
 sort -o tests-ut.files tests-ut.files

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -17,18 +17,6 @@ GitHub
 
    A: Try https://help.github.com/en/github/authenticating-to-github/authorizing-an-ssh-key-for-use-with-saml-single-sign-on.
 
-#. Q: How to set correct ``galois`` submodule URL after updating the URL for
-   Motr repo?
-
-   A: _::
-
-        > git submodule sync
-        Synchronizing submodule url for 'extra-libs/galois'
-        > grep -A 2 extra-libs .git/config
-        [submodule "extra-libs/galois"]
-       active = true
-       url = git@github.com:Seagate/cortx-motr-galois
-
 #. Q: How to add ssh key that could be used with GitHub?
 
    A: Go to https://github.com/settings/keys, then generate and add ssh key as

--- a/doc/test-coverage
+++ b/doc/test-coverage
@@ -23,7 +23,7 @@ Make sure in the output of configure script, that CFLAGS has --coverage option
 and LDFLAGS has '-lgcov' option present.
 
 LIBS   :  ""
-CFLAGS :  "-Wall -Werror -D_REENTRANT -D_GNU_SOURCE -fno-strict-aliasing -I/laptop/motr/coverage/motr/extra-libs/galois -I/laptop/motr/coverage/motr/extra-libs/yaml/include -I. -I/laptop/motr/coverage/motr/core --coverage -g -O0"
+CFLAGS :  "-Wall -Werror -D_REENTRANT -D_GNU_SOURCE -fno-strict-aliasing -I/laptop/motr/coverage/motr/extra-libs/yaml/include -I. -I/laptop/motr/coverage/motr/core --coverage -g -O0"
 KCFLAGS:  "-Wall -Werror -g -O0"
 LDFLAGS:  "-rdynamic -lgcov"
 
@@ -138,7 +138,7 @@ Run scripts/coverage/gcov-gen-html to collect stats, as specified in above secti
 
 [root@xyralab_02 scripts]# ls ~/lcov/kernel/
 addb       dtm          fop        index.html         ioservice  pool      snow.png    xcode
-amber.png  m0t1fs                emerald.png  galois     index-sort-b.html  layout     rpc       sns
+amber.png  m0t1fs                emerald.png  index-sort-b.html  layout     rpc       sns
 app1.info  cob                   fid          gcov.css   index-sort-f.html  lib        ruby.png  stob
 app.info   db                    fol          glass.png  index-sort-l.html  net        sm        updown.png
 

--- a/m0t1fs/linux_kernel/file.c
+++ b/m0t1fs/linux_kernel/file.c
@@ -3091,6 +3091,8 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
+
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioreq),
@@ -3098,6 +3100,8 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
+#endif /* NA_FOR_INTEL_ISA */
+
 	/* Populates data and failed buffers. */
 	for (row = 0; row < rows_nr(play); ++row) {
 		for (col = 0; col < layout_n(play); ++col) {
@@ -3121,9 +3125,12 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 			goto end;
 	}
 
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioreq)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioreq));
+#endif /* NA_FOR_INTEL_ISA */
+
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/m0t1fs/linux_kernel/st/common.sh.in
+++ b/m0t1fs/linux_kernel/st/common.sh.in
@@ -39,6 +39,9 @@ LIBISAL_TESTS_SKIPLIST=(
 	"sns-repair-abort"
 	"sns-repair-ios-fail"
 	"sns-repair-abort-repair-quiesce-rebalance-quiesce"
+	# Temporary skip
+	"m0t1fs"
+	"degraded-mode-IO"
 )
 
 abort()
@@ -51,21 +54,6 @@ abort()
 modprobe_lnet()
 {
 	modprobe lnet || abort "Error probing lnet."
-}
-
-modload_galois()
-{
-	BASE=@GALOIS_ABS_SRC@
-	if [ -z "$BASE" ]; then
-		modprobe galois
-	else
-		insmod $BASE/src/linux_kernel/galois.ko
-	fi
-}
-
-modunload_galois()
-{
-	rmmod galois &> /dev/null
 }
 
 modload()

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -215,7 +215,6 @@ unload_motr_ctl_module()
 
 prepare()
 {
-	modload_galois >& /dev/null
 	echo 8 > /proc/sys/kernel/printk
 	load_kernel_module || return $?
 	sysctl -w vm.max_map_count=30000000 || return $?
@@ -235,7 +234,6 @@ unprepare()
 	if lsmod | grep m0tr; then
 		unload_kernel_module || rc=$?
 	fi
-	modunload_galois || rc=$?
 	## The absence of `sandbox_fini' is intentional.
 	return $rc
 }

--- a/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
@@ -46,6 +46,8 @@ blk_size=$((stride * 1024))
 half_blk=$((blk_size / 2))
 OOSTORE=${1-1}
 
+testname="degraded-mode-IO"
+
 valid_count_get()
 {
 	local j=$((RANDOM%9))
@@ -877,6 +879,8 @@ failure_modes_test()
 
 main()
 {
+	check_test_skip_list $testname || return 0
+
 	sandbox_init
 
 	echo '*********************************************************'
@@ -979,4 +983,4 @@ main()
 
 trap unprepare EXIT
 main
-report_and_exit degraded-mode-IO $?
+report_and_exit $testname $?

--- a/m0t1fs/linux_kernel/st/m0t1fs_test.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_test.sh
@@ -24,6 +24,8 @@
 . `dirname $0`/m0t1fs_client_inc.sh
 . `dirname $0`/m0t1fs_server_inc.sh
 
+testname="m0t1fs"
+
 m0t1fs_test()
 {
 	NODE_UUID=`uuidgen`
@@ -66,6 +68,9 @@ m0t1fs_test()
 main()
 {
 	local rc=0
+
+	check_test_skip_list $testname || return $rc
+
 	echo "System tests start:"
 	echo "Test log will be stored in $MOTR_TEST_LOGFILE."
 
@@ -85,4 +90,4 @@ main()
 
 trap unprepare EXIT
 main
-report_and_exit m0t1fs $?
+report_and_exit $testname $?

--- a/motr/examples/example1.c
+++ b/motr/examples/example1.c
@@ -28,9 +28,8 @@
  * Please change the dir according to you development environment.
  *
  * How to build:
- * gcc -I/work/cortx-motr -I/work/cortx-motr/extra-libs/galois/include \
- *     -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes               \
- *     -L/work/cortx-motr/motr/.libs -lmotr                            \
+ * gcc -I/work/cortx-motr -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes   \
+ *     -L/work/cortx-motr/motr/.libs -lmotr                                   \
  *     example1.c -o example1
  *
  * Please change the configuration according to you development environment.

--- a/motr/examples/example2.c
+++ b/motr/examples/example2.c
@@ -28,9 +28,8 @@
  * Please change the dir according to you development environment.
  *
  * How to build:
- * gcc -I/work/cortx-motr -I/work/cortx-motr/extra-libs/galois/include \
- *     -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes               \
- *     -L/work/cortx-motr/motr/.libs -lmotr                            \
+ * gcc -I/work/cortx-motr -DM0_EXTERN=extern -DM0_INTERNAL= -Wno-attributes   \
+ *     -L/work/cortx-motr/motr/.libs -lmotr                                   \
  *     example2.c -o example2
  *
  * Please change the configuration according to you development environment.

--- a/motr/init.c
+++ b/motr/init.c
@@ -1,6 +1,6 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ * Copyright (c) 2013-2021 Seagate Technology LLC and/or its Affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,7 +227,9 @@ struct init_fini_call subsystem[] = {
 	{ &m0_fdms_register,    &m0_fdms_unregister,  "fdmi-service" },
 #endif /* __KERNEL__ */
 	{ &m0_cas_module_init,  &m0_cas_module_fini,  "cas" },
+#if 0 /* NA_FOR_INTEL_ISA */
 	{ &m0_parity_init,      &m0_parity_fini,      "parity_math" },
+#endif /* NA_FOR_INTEL_ISA */
 	{ &m0_dtm_global_init,  &m0_dtm_global_fini,  "dtm" },
 	{ &m0_ha_mod_init,      &m0_ha_mod_fini,      "ha" },
 	{ &m0_client_global_init, &m0_client_global_fini, "client" },

--- a/motr/io_pargrp.c
+++ b/motr/io_pargrp.c
@@ -2039,6 +2039,8 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		rc = -EIO;
 		goto end;
 	}
+
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON) {
 		rc = m0_parity_recov_mat_gen(parity_math(map->pi_ioo),
@@ -2046,6 +2048,7 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 		if (rc != 0)
 			goto end;
 	}
+#endif /* NA_FOR_INTEL_ISA */
 
 	/* Populates data and failed buffers. */
 	for (row = 0; row < rows_nr(play, ioo->ioo_obj); ++row) {
@@ -2073,9 +2076,12 @@ static int pargrp_iomap_dgmode_recover(struct pargrp_iomap *map)
 			goto end;
 	}
 
+#if 0 /* NA_FOR_INTEL_ISA */
 	if (parity_math(map->pi_ioo)->pmi_parity_algo ==
 	    M0_PARITY_CAL_ALGO_REED_SOLOMON)
 		m0_parity_recov_mat_destroy(parity_math(map->pi_ioo));
+#endif /* NA_FOR_INTEL_ISA */
+
 end:
 	m0_free(data);
 	m0_free(parity);

--- a/net/lnet/st/linux_kernel/m0lnetping.sh
+++ b/net/lnet/st/linux_kernel/m0lnetping.sh
@@ -211,11 +211,9 @@ unload_all() {
     echo "Aborted! Unloading kernel modules..."
     rmmod $STMOD
     modunload
-    modunload_galois
 }
 trap unload_all EXIT
 
-modload_galois || exit $?
 modload || exit $?
 
 insmod $STMOD.ko $OPARM $SPARM $CPARM
@@ -231,7 +229,6 @@ if [ $? -eq 0 ] ; then
 fi
 
 modunload
-modunload_galois
 
 trap "" EXIT
 

--- a/net/test/demo/demo-test-run.sh
+++ b/net/test/demo/demo-test-run.sh
@@ -37,7 +37,6 @@ STOP_TIME_S=1
 DIR_SCRIPT=${0%/*}
 TOP_SCRDIR="$DIR_SCRIPT/../../.."
 # TODO hardcoded for now
-MOD_GALOIS="$TOP_SCRDIR/extra-libs/galois/src/linux_kernel/galois.ko"
 MOD_M0KV="$TOP_SCRDIR/m0tr.ko"
 PARAMS_M0KV="node_uuid=00000000-0000-0000-0000-000000000000"
 
@@ -124,7 +123,6 @@ host_pre()
 	local ssh_credentials="$1"
 	ssh_sudo "$ssh_credentials" modprobe lnet
 	ssh_sudo "$ssh_credentials" lctl network up
-	ssh_sudo "$ssh_credentials" insmod "$MOD_GALOIS"
 	ssh_sudo "$ssh_credentials" insmod "$MOD_M0KV" "$PARAMS_M0KV"
 	[ $TRACE_RM -eq 1 ] && ssh_sudo "$ssh_credentials" "rm -rf m0.trace.*"
 }
@@ -133,7 +131,6 @@ host_post()
 {
 	local ssh_credentials="$1"
 	ssh_sudo "$ssh_credentials" rmmod m0tr
-	ssh_sudo "$ssh_credentials" rmmod galois
 }
 
 node_host_pre()

--- a/net/test/m0nettest.sh.in
+++ b/net/test/m0nettest.sh.in
@@ -15,12 +15,10 @@ NODE_UUID="abcdef01-2345-6789-0123-456789ABCDEF"
 
 unload_all() {
     modunload
-    modunload_galois
 }
 trap unload_all EXIT
 
 modprobe_lnet
-modload_galois
 modload || exit $?
 
 @abs_top_srcdir@/net/test/user_space/m0nettest "$@"

--- a/net/test/m0nettestd.sh.in
+++ b/net/test/m0nettestd.sh.in
@@ -15,12 +15,10 @@ NODE_UUID="abcdef01-2345-6789-0123-456789ABCDEF"
 
 unload_all() {
     modunload
-    modunload_galois
 }
 trap unload_all EXIT
 
 modprobe_lnet
-modload_galois
 modload || exit $?
 
 @abs_top_srcdir@/net/test/user_space/m0nettestd "$@"

--- a/net/test/st/st.sh
+++ b/net/test/st/st.sh
@@ -42,13 +42,11 @@ role_space()
 
 unload_all() {
 	modunload
-	modunload_galois
 }
 trap unload_all EXIT
 
 modprobe_lnet
 lctl network up > /dev/null
-modload_galois
 modload || exit $?
 
 sandbox_init

--- a/net/test/test-user.sh.in
+++ b/net/test/test-user.sh.in
@@ -33,12 +33,10 @@ fi
 
 unload_all() {
     modunload
-    modunload_galois
 }
 trap unload_all EXIT
 
 modprobe_lnet
-modload_galois
 modload || exit $?
 
 JOB_IDS=

--- a/net/test/test.sh
+++ b/net/test/test.sh
@@ -44,11 +44,9 @@ fi
 tailseek=$(( $(stat -c %s "$log") + 1 ))
 
 # currently, kernel UT runs as part of loading m0ut module
-modload_galois
 modload
 insmod $MODMAIN $*
 rmmod $MODMAIN
 modunload
-modunload_galois
 
 tail -c+$tailseek "$log" | grep ' kernel: '

--- a/scripts/addb-py/chronometry/io_workload
+++ b/scripts/addb-py/chronometry/io_workload
@@ -66,7 +66,7 @@ function stop_hare_cluster()
     hctl shutdown || {
         _warn "Cluster stop FAILED! Trying to go further."
     }
-    
+
     $EX_SRV systemctl reset-failed hare-hax
     set -e
 }
@@ -97,7 +97,6 @@ function cleanup_cluster()
     $EX_SRV lsmod | grep -q m0ctl && ( rmmod m0ctl || echo "Failed to unload m0ctl module" )
     $EX_SRV lsmod | grep -q m0tr && ( rmmod m0tr || echo "Failed to unload m0tr module" )
     $EX_SRV lsmod | grep -q m0gf && ( rmmod m0gf || echo "Failed to unload m0gf module" )
-    $EX_SRV lsmod | grep -q galois && ( rmmod galois || echo "Failed to unload galois module" )
     set -e
 
     $EX_SRV 'rm -rf /var/motr/*'
@@ -114,7 +113,7 @@ function setup_ha()
         $EX_SRV systemctl stop halond
         $EX_SRV systemctl start motr-cleanup
         $EX_SRV systemctl start halon-cleanup
-         
+
    else
         _info "setup Hare"
         CURRENT_CDF="/tmp/cdf.yaml"
@@ -151,7 +150,7 @@ function setup_m0_configs()
 
 function setup_ha_configs()
 {
-   # TODO: Add support for dev VMs.   
+   # TODO: Add support for dev VMs.
    if [[ "$HA_TYPE" == "halon" ]]; then
         _info "setup Halon configs"
         # halon_facts.yaml
@@ -261,10 +260,10 @@ function save_motr_artifacts() {
     fi
 
     mkdir -p $configs_dir
-    
+
     pushd $configs_dir
     cp $MOTR_CONF_FILE ./
-    
+
     if [[ "$HA_TYPE" == "halon" ]]; then
         #Halon configs
         cp $HALOND_CONF_FILE ./
@@ -554,7 +553,7 @@ function run_tests() {
     popd #m0cli_dir
 
     set +e
-    
+
     if [[ "$HA_TYPE" == "halon" ]]; then
        hctl motr status > hctl-motr-status.stop
        hctl motr stop || {

--- a/scripts/addb-py/chronometry/run_corruption_task
+++ b/scripts/addb-py/chronometry/run_corruption_task
@@ -188,7 +188,6 @@ function check_and_stop_cluster()
     $EX_SRV lsmod | grep -q m0ctl && ( rmmod m0ctl || echo "Failed to unload m0ctl module" )
     $EX_SRV lsmod | grep -q m0tr && ( rmmod m0tr || echo "Failed to unload m0tr module" )
     $EX_SRV lsmod | grep -q m0gf && ( rmmod m0gf || echo "Failed to unload m0gf module" )
-    $EX_SRV lsmod | grep -q galois && ( rmmod galois || echo "Failed to unload galois module" )
     set -e
 }
 

--- a/scripts/addb-py/chronometry/run_s3_corruption
+++ b/scripts/addb-py/chronometry/run_s3_corruption
@@ -263,7 +263,6 @@ function check_and_stop_cluster()
     $EX_SRV lsmod | grep -q m0ctl && ( rmmod m0ctl || echo "Failed to unload m0ctl module" )
     $EX_SRV lsmod | grep -q m0tr && ( rmmod m0tr || echo "Failed to unload m0tr module" )
     $EX_SRV lsmod | grep -q m0gf && ( rmmod m0gf || echo "Failed to unload m0gf module" )
-    $EX_SRV lsmod | grep -q galois && ( rmmod galois || echo "Failed to unload galois module" )
     set -e
 
 }

--- a/scripts/addb-py/chronometry/run_s3_task
+++ b/scripts/addb-py/chronometry/run_s3_task
@@ -237,7 +237,6 @@ function check_and_stop_cluster() {
     $EX_SRV lsmod | grep -q m0ctl && ( rmmod m0ctl || echo "Failed to unload m0ctl module" )
     $EX_SRV lsmod | grep -q m0tr && ( rmmod m0tr || echo "Failed to unload m0tr module" )
     $EX_SRV lsmod | grep -q m0gf && ( rmmod m0gf || echo "Failed to unload m0gf module" )
-    $EX_SRV lsmod | grep -q galois && ( rmmod galois || echo "Failed to unload galois module" )
     set -e
 
 }

--- a/scripts/addb-py/chronometry/run_task
+++ b/scripts/addb-py/chronometry/run_task
@@ -172,7 +172,6 @@ function check_and_stop_cluster() {
     $EX_SRV lsmod | grep -q m0ctl && ( rmmod m0ctl || echo "Failed to unload m0ctl module" )
     $EX_SRV lsmod | grep -q m0tr && ( rmmod m0tr || echo "Failed to unload m0tr module" )
     $EX_SRV lsmod | grep -q m0gf && ( rmmod m0gf || echo "Failed to unload m0gf module" )
-    $EX_SRV lsmod | grep -q galois && ( rmmod galois || echo "Failed to unload galois module" )
     set -e
 }
 

--- a/scripts/addb-py/chronometry/s3_corruption_workload
+++ b/scripts/addb-py/chronometry/s3_corruption_workload
@@ -145,7 +145,6 @@ function cleanup_cluster()
     $EX_SRV lsmod | grep -q m0ctl && ( rmmod m0ctl || echo "Failed to unload m0ctl module" )
     $EX_SRV lsmod | grep -q $M0TR_KERNEL_MODULE && ( rmmod $M0TR_KERNEL_MODULE || echo "Failed to unload $M0TR_KERNEL_MODULE module" )
     $EX_SRV lsmod | grep -q m0gf && ( rmmod m0gf || echo "Failed to unload m0gf module" )
-    $EX_SRV lsmod | grep -q galois && ( rmmod galois || echo "Failed to unload galois module" )
     set -e
 
     $EX_SRV 'rm -rf /var/motr/*'
@@ -684,7 +683,7 @@ function run_tests()
     cp $MOTR_SRC_DIR/motr/.libs/lt-m0d ./
     cp /opt/seagate/cortx/s3/bin/s3server ./
     popd
-    
+
     mkdir -p $s3cli_dir
     pushd $s3cli_dir
     prepare_client

--- a/scripts/addb-py/chronometry/s3_workload
+++ b/scripts/addb-py/chronometry/s3_workload
@@ -120,7 +120,6 @@ function cleanup_cluster()
     $EX_SRV "pushd $HARE_SRC_DIR && make uninstall && popd"
     $EX_SRV rmmod m0tr
     $EX_SRV rmmod m0gf
-    $EX_SRV rmmod galois
     set -e
 
     $EX_SRV 'rm -rf /var/motr/*'
@@ -621,7 +620,7 @@ function run_tests() {
         app=${APPS[((i))]}
         conf=${CONFS[((i))]}
 
-        echo "app: "$app 
+        echo "app: "$app
         echo "conf: "$conf
 
         # In some cases conf may be empty

--- a/scripts/addb-py/chronometry/s3server_integration/s3srv_build_prepare
+++ b/scripts/addb-py/chronometry/s3server_integration/s3srv_build_prepare
@@ -34,7 +34,6 @@ INCLUDE_DIR="/usr/include"
 MOTR_LIBS="${MOTR_SRC_DIR}/motr/.libs/*.so*"
 MOTR_HELPERS_LIBS="${MOTR_SRC_DIR}/helpers/.libs/*.so*"
 MOTR_EXTRA_LIBS="${MOTR_SRC_DIR}/extra-libs/gf-complete/src/.libs/*.so*"
-GALOIS_INCLUDE_DIR="${MOTR_SRC_DIR}/extra-libs/galois/include/galois"
 
 function create_symlinks() {
     for file_path in $@
@@ -48,9 +47,6 @@ function create_symlinks() {
 function create_include_symlink() {
     echo "creating symlink for ${MOTR_SRC_DIR}"
     ln -s "${MOTR_SRC_DIR}" "${INCLUDE_DIR}/motr"
-
-    echo "creating symlink for ${GALOIS_INCLUDE_DIR}"
-    ln -s "${GALOIS_INCLUDE_DIR}" "${INCLUDE_DIR}/galois"
 }
 
 function delete_symlinks() {
@@ -64,7 +60,7 @@ function delete_symlinks() {
 
 function delete_include_symlink() {
     local link_path=""
-    for p in "${MOTR_SRC_DIR}" "${GALOIS_INCLUDE_DIR}"; do
+    for p in "${MOTR_SRC_DIR}"; do
         link_path=`find ${INCLUDE_DIR} -lname ${p}`
         echo "DEBUG: delete link_path $p"
         if [[ -n "$link_path" ]]; then

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -25,7 +25,6 @@ readonly SELF="$(readlink -f $0)"
 readonly TOP_SRCDIR="${SELF%/*/*}"
 dry_run=
 install_epel=true
-install_isal=true
 
 #
 # Usage
@@ -48,8 +47,6 @@ Usage: $PROG_NAME [-h|--help] [-n|--dry-run]
 
        --no-epel        Skip EPEL repository installation.
 
-       --no-isal        Skip Intel ISA library installtion
-
     -h|--help           Print this help screen.
 USAGE_END
 }
@@ -64,7 +61,7 @@ parse_cli_options()
     # Note that we use `"$@"' to let each command-line parameter expand to a
     # separate word. The quotes around `$@' are essential!
     # We need TEMP as the `eval set --' would nuke the return value of getopt.
-    TEMP=$( getopt -o hn --long help,dry-run,no-epel,no-isal -n "$PROG_NAME" -- "$@" )
+    TEMP=$( getopt -o hn --long help,dry-run,no-epel -n "$PROG_NAME" -- "$@" )
 
     [[ $? != 0 ]] && help
 
@@ -76,7 +73,6 @@ parse_cli_options()
             -h|--help)          help stdout ;;
             -n|--dry-run)       dry_run=--dry-run ; shift ;;
                --no-epel)       install_epel=false ; shift ;;
-               --no-isal)       install_isal=false ; shift ;;
             --)                 shift; break ;;
             *)                  echo 'getopt: internal error...'; exit 1 ;;
         esac
@@ -143,10 +139,6 @@ fi
 
 if ! $install_epel ; then
     skip_tags+=,epel
-fi
-
-if ! $install_isal ; then
-    skip_tags+=,isa-l
 fi
 
 $TOP_SRCDIR/scripts/setup-node localhost \

--- a/scripts/install/usr/libexec/cortx-motr/motr-service.functions
+++ b/scripts/install/usr/libexec/cortx-motr/motr-service.functions
@@ -102,7 +102,6 @@ _trap_munge()
 declare -rA _path_inside_workdir=(
     [m0tr.ko]='m0tr.ko'
     [m0ctl.ko]='m0ctl.ko'
-    [galois.ko]='extra-libs/galois/src/linux_kernel/galois.ko'
     [m0d]='motr/m0d'
     [m0mkfs]='utils/mkfs/m0mkfs'
     [m0traced]='utils/trace/m0traced'
@@ -185,11 +184,7 @@ m0_load_modules()
     fi
 
     if [ -n "$MOTR_DEVEL_WORKDIR_PATH" ] ; then
-        insmod $(m0_path_to galois.ko) || m0_exit "Failed to load galois module"
-        _trap_munge "rmmod $(m0_path_to galois.ko)" ERR
-
         insmod $(m0_path_to m0tr.ko) $m0tr_params || {
-            rmmod $(m0_path_to galois.ko)
             m0_exit "Failed to load m0tr module"
         }
         _trap_munge "rmmod $(m0_path_to m0tr.ko)" ERR
@@ -197,7 +192,6 @@ m0_load_modules()
         insmod $(m0_path_to m0ctl.ko) || {
             # FIXME: looks wrong, should be able to use `rmmod m0tr`
             rmmod $(m0_path_to m0tr.ko)
-            rmmod $(m0_path_to galois.ko)
             m0_exit "Failed to load m0ctl module"
         }
         _trap_munge "rmmod $(m0_path_to m0ctl.ko)" ERR
@@ -216,7 +210,6 @@ m0_unload_modules()
 
     if [ -n "$MOTR_DEVEL_WORKDIR_PATH" ] ; then
         rmmod m0tr || m0_exit "Failed to unload m0tr module"
-        rmmod galois || m0_exit "Failed to unload galois module"
     else
         modprobe -r m0tr
     fi

--- a/sns/cm/st/repair_test.sh
+++ b/sns/cm/st/repair_test.sh
@@ -51,7 +51,7 @@ cleanup()
 		sleep 2;
 	done
 
-	rmmod m0tr galois
+	rmmod m0tr
 }
 
 main()

--- a/sns/parity_defs.h
+++ b/sns/parity_defs.h
@@ -26,7 +26,7 @@
 /**
  *  Define the condition here to use Intel ISA library.
  */
-#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__) && defined(HAVE_ISAL))
+#define ISAL_ENCODE_ENABLED	(!defined(__KERNEL__))
 
 /* __MOTR_SNS_PARITY_DEFS_H__ */
 #endif

--- a/sns/parity_math.h
+++ b/sns/parity_math.h
@@ -85,7 +85,7 @@ struct m0_sns_ir_block {
 	 * blocks required for its recovery.
 	 */
 	struct m0_bitmap	     sib_bitmap;
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	/* Column associated with the block within
 	 * m0_parity_math::pmi_data_recovery_mat. This field is meaningful
 	 * when status of a block is M0_SI_BLOCK_ALIVE.
@@ -95,12 +95,11 @@ struct m0_sns_ir_block {
 	 * The field is meaningful when status of a block is M0_SI_BLOCK_FAILED.
 	 */
 	uint32_t		     sib_recov_mat_row;
-#endif /* !ISAL_ENCODE_ENABLED */
+#endif /* NA_FOR_INTEL_ISA */
 	/* Indicates whether a block is available, failed or restored. */
 	enum m0_sns_ir_block_status  sib_status;
 };
 
-#if ISAL_ENCODE_ENABLED
 /**
  * Holds information specific to Reed Solomon implementation using Intel ISA.
  */
@@ -129,7 +128,6 @@ struct m0_reed_solomon {
 	 * recovery. */
 	uint8_t		**rs_bufs_out;
 };
-#endif /* ISAL_ENCODE_ENABLED */
 
 /**
    Holds information about system configuration i.e., data and parity units
@@ -140,7 +138,7 @@ struct m0_parity_math {
 
 	uint32_t		     pmi_data_count;
 	uint32_t		     pmi_parity_count;
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	/* structures used for parity calculation and recovery */
 	struct m0_matvec	     pmi_data;
 	struct m0_matvec	     pmi_parity;
@@ -155,9 +153,8 @@ struct m0_parity_math {
 	struct m0_linsys	     pmi_sys;
 	/* Data recovery matrix that's inverse of pmi_sys_mat. */
 	struct m0_matrix	     pmi_recov_mat;
-#else
+#endif /* NA_FOR_INTEL_ISA */
 	struct m0_reed_solomon	     pmi_rs;
-#endif /* ISAL_ENCODE_ENABLED */
 };
 
 /* Holds information essential for incremental recovery. */
@@ -170,7 +167,7 @@ struct m0_sns_ir {
 	uint32_t		si_local_nr;
 	/* Array holding all blocks */
 	struct m0_sns_ir_block *si_blocks;
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	uint32_t		si_failed_data_nr;
 	/* Vandermonde matrix used during RS encoding */
 	struct m0_matrix	si_vandmat;
@@ -180,9 +177,8 @@ struct m0_sns_ir {
 	 * math::pmi_vandmat_parity_slice.
 	 */
 	struct m0_matrix	si_parity_recovery_mat;
-#else
+#endif /* NA_FOR_INTEL_ISA */
 	struct m0_reed_solomon	si_rs;
-#endif /* !ISAL_ENCODE_ENABLED */
 };
 
 /**
@@ -240,10 +236,12 @@ M0_INTERNAL void m0_parity_math_refine(struct m0_parity_math *math,
 				       struct m0_buf *parity,
 				       uint32_t data_ind_changed);
 
+#if 0 /* NA_FOR_INTEL_ISA */
 M0_INTERNAL int m0_parity_recov_mat_gen(struct m0_parity_math *math,
 					uint8_t *fail);
 
 M0_INTERNAL void m0_parity_recov_mat_destroy(struct m0_parity_math *math);
+#endif /* NA_FOR_INTEL_ISA */
 
 /**
  * Recovers data units' data words from single or multiple errors.

--- a/sns/parity_ops.c
+++ b/sns/parity_ops.c
@@ -27,6 +27,7 @@
 #include "lib/assert.h"
 #include "sns/parity_ops.h"
 
+#if 0 /* NA_FOR_INTEL_ISA */
 M0_INTERNAL void m0_parity_fini(void)
 {
 #if !ISAL_ENCODE_ENABLED
@@ -42,6 +43,7 @@ M0_INTERNAL int m0_parity_init(void)
 #endif /* !ISAL_ENCODE_ENABLED */
 	return 0;
 }
+#endif /* NA_FOR_INTEL_ISA */
 
 M0_INTERNAL m0_parity_elem_t m0_parity_pow(m0_parity_elem_t x,
 					   m0_parity_elem_t p)

--- a/sns/parity_ops.h
+++ b/sns/parity_ops.h
@@ -29,8 +29,6 @@
 
 #if ISAL_ENCODE_ENABLED
 #include <isa-l.h>
-#else
-#include "galois/galois.h"
 #endif /* ISAL_ENCODE_ENABLED */
 #include "lib/assert.h"
 
@@ -39,8 +37,10 @@
 
 typedef int m0_parity_elem_t;
 
+#if 0 /* NA_FOR_INTEL_ISA */
 M0_INTERNAL int m0_parity_init(void);
 M0_INTERNAL void m0_parity_fini(void);
+#endif /* NA_FOR_INTEL_ISA */
 
 M0_INTERNAL m0_parity_elem_t m0_parity_pow(m0_parity_elem_t x,
 					   m0_parity_elem_t p);
@@ -60,8 +60,7 @@ static inline m0_parity_elem_t m0_parity_mul(m0_parity_elem_t x, m0_parity_elem_
 #if ISAL_ENCODE_ENABLED
 	return gf_mul(x, y);
 #else
-	/* return galois_single_multiply(x, y, M0_PARITY_GALOIS_W); */
-	return galois_multtable_multiply(x, y, M0_PARITY_GALOIS_W);
+	return 0;
 #endif /* ISAL_ENCODE_ENABLED */
 }
 
@@ -70,8 +69,7 @@ static inline m0_parity_elem_t m0_parity_div(m0_parity_elem_t x, m0_parity_elem_
 #if ISAL_ENCODE_ENABLED
 	return gf_mul(x, gf_inv(y));
 #else
-	/* return galois_single_divide(x, y, M0_PARITY_GALOIS_W); */
-	return galois_multtable_divide(x, y, M0_PARITY_GALOIS_W);
+	return 0;
 #endif /* ISAL_ENCODE_ENABLED */
 }
 

--- a/sns/ut/Kbuild.sub
+++ b/sns/ut/Kbuild.sub
@@ -1,1 +1,0 @@
-m0ut_objects += sns/ut/parity_math_ut.o

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -818,15 +818,14 @@ static void direct_recover(struct m0_parity_math *math,  struct m0_bufvec *x,
 	ret = m0_sns_ir_mat_compute(&ir);
 	M0_UT_ASSERT(ret == 0);
 
-#if !ISAL_ENCODE_ENABLED
+#if 0 /* NA_FOR_INTEL_ISA */
 	M0_UT_ASSERT(ergo(ir.si_failed_data_nr != 0,
 			  ir.si_data_recovery_mat.m_width ==
 			  ir.si_data_nr));
 
 	ret = m0_matvec_init(&r, ir.si_failed_data_nr);
-#else
+#endif /* NA_FOR_INTEL_ISA */
 	ret = m0_matvec_init(&r, ir.si_rs.rs_failed_nr);
-#endif /* !ISAL_ENCODE_ENABLED */
 	M0_UT_ASSERT(ret == 0);
 
 	reconstruct(&ir, &b, &r);
@@ -902,7 +901,6 @@ static void rhs_prepare(const struct m0_sns_ir *ir, struct m0_matvec *des,
 	}
 }
 
-#if ISAL_ENCODE_ENABLED
 static void reconstruct(const struct m0_sns_ir *ir, const struct m0_matvec *b,
 			struct m0_matvec *r)
 {
@@ -945,7 +943,8 @@ static bool compare(const struct m0_sns_ir *ir, const uint32_t *failed_arr,
 
 	return true;
 }
-#else
+
+#if 0 /* NA_FOR_INTEL_ISA */
 static void reconstruct(const struct m0_sns_ir *ir, const struct m0_matvec *b,
 			struct m0_matvec *r)
 {
@@ -976,7 +975,7 @@ static bool compare(const struct m0_sns_ir *ir, const uint32_t *failed_arr,
 
 	return true;
 }
-#endif /* ISAL_ENCODE_ENABLED */
+#endif /* NA_FOR_INTEL_ISA */
 
 static void test_incr_recov(void)
 {

--- a/spiel/st/m0t1fs_spiel_st.sh
+++ b/spiel/st/m0t1fs_spiel_st.sh
@@ -560,7 +560,7 @@ Usage: ${0##*/} [COMMAND]
 
 Supported commands:
   run      run system tests (default command)
-  insmod   insert Motr kernel modules: m0tr.ko, galois.ko
+  insmod   insert Motr kernel modules: m0tr.ko
   rmmod    remove Motr kernel modules
   sstart   start Motr user-space services
   sstop    stop Motr user-space services

--- a/ut/linux_kernel/m0ut_main.c
+++ b/ut/linux_kernel/m0ut_main.c
@@ -1,7 +1,7 @@
 /* -*- C -*- */
 /*
- * Copyright (c) 2012-2020 Seagate Technology LLC and/or its Affiliates
- * 
+ * Copyright (c) 2012-2021 Seagate Technology LLC and/or its Affiliates
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -73,7 +73,6 @@ extern struct m0_ut_suite ha_ut;
 extern struct m0_ut_suite layout_ut;
 extern struct m0_ut_suite ms_fom_ut;
 extern struct m0_ut_suite packet_encdec_ut;
-extern struct m0_ut_suite parity_math_ut;
 extern struct m0_ut_suite parity_math_ssse3_ut;
 extern struct m0_ut_suite reqh_service_ut;
 extern struct m0_ut_suite rpc_mc_ut;
@@ -122,7 +121,6 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &layout_ut, true);
 	m0_ut_add(m, &ms_fom_ut, true);
 	m0_ut_add(m, &packet_encdec_ut, true);
-	m0_ut_add(m, &parity_math_ut, true);
 	m0_ut_add(m, &reqh_service_ut, true);
 	m0_ut_add(m, &rm_ut, true);
 	m0_ut_add(m, &rpc_mc_ut, true);

--- a/ut/m0kut
+++ b/ut/m0kut
@@ -156,12 +156,10 @@ load_modules()
         source $top_srcdir/m0t1fs/linux_kernel/st/common.sh
         MODLIST="$top_srcdir/m0ut.ko"
         modprobe_lnet
-        modload_galois
         # currently, kernel UT runs as part of loading m0ut module
         modload
         run_lut_helper
         modunload
-        modunload_galois
     else
         local lnet_status=$(service lnet status)
         if [[ $lnet_status != running ]] ; then

--- a/utils/functions
+++ b/utils/functions
@@ -61,9 +61,6 @@ opcode() {
 }
 
 m0_modules_insert() {
-    insmod $M0_SRC_DIR/extra-libs/galois/src/linux_kernel/galois.ko ||
-        die 'Inserting galois.ko failed'
-
     insmod $M0_SRC_DIR/m0tr.ko \
     local_addr=${M0T1FS_ENDPOINT%:*}: \
     max_rpc_msg_size=$MAX_RPC_MSG_SIZE \
@@ -72,12 +69,10 @@ m0_modules_insert() {
     ${M0_TRACE_LEVEL:+trace_level=$M0_TRACE_LEVEL} \
     ${M0_TRACE_PRINT_CONTEXT:+trace_print_context=$M0_TRACE_PRINT_CONTEXT} \
     || {
-        rmmod galois
         die 'Inserting m0tr.ko failed'
     }
     insmod $M0_SRC_DIR/m0ctl.ko || {
         rmmod m0tr
-        rmmod galois
         die 'inserting m0ctl failed'
     }
 }
@@ -85,7 +80,6 @@ m0_modules_insert() {
 m0_modules_remove() {
     rmmod m0ctl || true
     rmmod m0tr || true
-    rmmod galois || true
 }
 
 lnet_up() {

--- a/utils/m0mount
+++ b/utils/m0mount
@@ -171,14 +171,12 @@ if [ $0 = "/usr/bin/m0mount" ]; then
 	M0LAYOUT=/usr/sbin/m0layout
 	SUMFILE=$M0D
 	MOTR_KO_LOAD_CMD="modprobe m0tr"
-	GALOIS_KO_LOAD_CMD="modprobe galois"
 else
 	M0D=$M0_SRC_DIR/motr/m0d
 	M0MKFS=$M0_SRC_DIR/utils/mkfs/m0mkfs
 	M0LAYOUT=$M0_SRC_DIR/utils/m0layout
 	SUMFILE=$M0_SRC_DIR/motr/.libs/m0d
 	MOTR_KO_LOAD_CMD="insmod $M0_SRC_DIR/m0tr.ko"
-	GALOIS_KO_LOAD_CMD="insmod $M0_SRC_DIR/extra-libs/galois/src/linux_kernel/galois.ko"
 fi
 
 #
@@ -292,17 +290,11 @@ function setup_host ()
 		echo  ERROR: Unable to configure LNet
 		return 1
 	fi
-	$RUN rmmod m0tr galois 2>/dev/null
-	$RUN $GALOIS_KO_LOAD_CMD
-	if [ $? -ne 0 ]; then
-		echo ERROR: Failed to load galois module on $H
-		return 1
-	fi
+	$RUN rmmod m0tr 2>/dev/null
 	$RUN $MOTR_KO_LOAD_CMD local_addr=$KEP $XPT_PARAM $KTRACE_FLAGS \
 		node_uuid=${NODE_UUID[$H]} trace_buf_size=$((128 * 1024 * 1024))
 	if [ $? -ne 0 ]; then
 		echo ERROR: Failed to load m0tr module on $H
-		$RUN rmmod galois
 		return 1
 	fi
 	return 0
@@ -336,7 +328,7 @@ function teardown_host ()
 	else
 		RUN=l_run
 	fi
-	$RUN rmmod m0tr galois
+	$RUN rmmod m0tr
 	return 0
 }
 
@@ -841,16 +833,11 @@ main()
 
 	LSUM=$(sum $SUMFILE)
 
-	rmmod m0tr galois &> /dev/null
+	rmmod m0tr &> /dev/null
 
 	#ldemo now needs kernel module loaded for some reason...
-	l_do $GALOIS_KO_LOAD_CMD || {
-		echo ERROR: Failed to load galois module
-		exit 1
-	}
 	l_do $MOTR_KO_LOAD_CMD || {
 		echo ERROR: Failed to load m0tr module
-		rmmod galois
 		exit 1
 	}
 

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -126,7 +126,7 @@ main() {
     done >>$REPORT
 
     # Collects compressed core generated in /var/crash and /var/log/crash
-    for IN_DIR in  ${CORE_DIRS[@]}; do 
+    for IN_DIR in  ${CORE_DIRS[@]}; do
         [[ -d $IN_DIR ]] || {
                 warn "$IN_DIR: no such directory"
                 continue
@@ -415,7 +415,6 @@ _path_rpm() {
         libmotr-ut.so|libmotr-xcode-ff2c.so)
             ## Provided by motr-devel-*.rpm (optional).
             echo "?/usr/lib64/$name.0.0.0";;
-        libgalois.so) echo "/usr/lib64/libgalois-0.1.so";;
         python) type -p python;;
         *) die "${FUNCNAME[0]}: Unsupported argument: $name";;
     esac
@@ -450,8 +449,6 @@ _path_src() {
         m0beck|m0betool) echo "$src/be/tool/.libs/$name";;
         libmotr-ut.so) echo "$src/ut/.libs/$name.0.0.0";;
         libmotr-xcode-ff2c.so) echo "$src/xcode/ff2c/.libs/$name.0.0.0";;
-        libgalois.so)
-            echo "$src/extra-libs/galois/src/.libs//libgalois-0.1.so";;
         lt-m0rwlock) echo "$src/rm/st/.libs/lt-m0rwlock";;
         python) type -p python;;
         *) die "${FUNCNAME[0]}: Unsupported argument: $name";;
@@ -642,7 +639,6 @@ binaries() {
         libmotr.so
         libmotr-xcode-ff2c.so
         libmotr-ut.so
-        libgalois.so
     )
     local f s
 
@@ -872,7 +868,7 @@ optparse() {
             --nr-boots) NR_BOOTS_MAX=$2; shift;;
             -p|--path)
                 for f in m0mkfs m0d m0tracedump m0addb2dump m0beck m0betool \
-                         m0tr.ko libmotr{,-xcode-ff2c,-ut}.so libgalois.so; do
+                         m0tr.ko libmotr{,-xcode-ff2c,-ut}.so; do
                     path $f
                 done
                 exit 0;;
@@ -905,7 +901,7 @@ exit
 ### 2020-10-05 0.52    Removed halon related things since we are not using
 ###                    it.Removed collection of kernel buffer because we lack
 ###                    of debugfs support.Removed collection of m0traces of
-###                    s3server and hax. Added 'df -h' to probe info. 
+###                    s3server and hax. Added 'df -h' to probe info.
 ###
 ### 2020-10-02 0.51    Added /var/log/crash to CORE_DIRS list since on
 ###                    provisioner deployed setup, core would be in /var/log/crash

--- a/utils/m0run
+++ b/utils/m0run
@@ -289,7 +289,7 @@ load_modules()
         # and don't unload them as well (EXIT trap is not set)
         # unless '-f' option was used
         local loaded=false
-        if lsmod | grep -Eq 'm0|galois' ; then
+        if lsmod | grep -Eq 'm0' ; then
             log 'Motr kernel modules are already loaded'
             loaded=true
             if $force_modules_reload ; then

--- a/utils/modload-all.sh.in
+++ b/utils/modload-all.sh.in
@@ -12,11 +12,9 @@ NODE_UUID="abcdef01-2345-6789-0123-456789ABCDEF"
 
 unload_all() {
     modunload
-    modunload_galois
 }
 trap unload_all EXIT
 
 modprobe_lnet
-modload_galois
 modload || exit $?
 

--- a/utils/spiel/setup.py
+++ b/utils/spiel/setup.py
@@ -21,7 +21,7 @@ from distutils.core import setup, Extension
 
 motr = Extension('motr',
                  define_macros=[('M0_INTERNAL', ''), ('M0_EXTERN', 'extern')],
-                 include_dirs=['../../', '../../extra-libs/galois/include/'],
+                 include_dirs=['../../'],
                  sources=['motr.c'],
                  extra_compile_args=['-w'])
 


### PR DESCRIPTION
# Problem Statement
- The Galois code is removed from Motr code because of following reasons.
  - In kubernetes environment, we dont want any kernel modules present. In motr, Galois code gets compiled and gets loaded as kernel module. 
  - Also because of licensing issue, we want to remove Galois completely. It is replaced with Intel ISA library.

# Design
-  The design for removing Galois is mention in [Remove Galois code completely from Motr](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/665224248/Integrate+Intel+ISAL+in+Motr+code#Remove-Galois-code-completely-from-Motr) 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
