### PR TITLE
EOS-24863: FDMI Test scripts modified to have multiple FDMI filters

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -643,6 +643,16 @@ Tests:
     polltime : 30
     timeout  : 1800
 
+  - id       : 67fdmi-plugin-multi-filters
+    script   : 'm0 run-st 67fdmi-plugin-multi-filters'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    sandbox  : /var/motr/sandbox.st-67fdmi-plugin-multi-filters
+    groupname: 02motr-single-node
+    polltime : 30
+    timeout  : 600
+
+
 
 # 25 min
 dangerous: 'yes'

--- a/conf/objs/fdmi_filter.c
+++ b/conf/objs/fdmi_filter.c
@@ -165,10 +165,10 @@ static bool fdmi_filter_match(const struct m0_conf_obj *cached,
 
 	M0_PRE(xobj->xf_endpoints.ab_count != 0);
 
-	return m0_bufs_streq(&xobj->xf_endpoints, obj->ff_endpoints) &&
-		m0_bufs_streq(&xobj->xf_substrings, obj->ff_substrings) &&
-		m0_fid_eq(&obj->ff_node->cn_obj.co_id, &xobj->xf_node) &&
-		m0_fid_eq(&obj->ff_dix_pver->pv_obj.co_id, &xobj->xf_dix_pver);
+	return m0_bufs_streq(&xobj->xf_endpoints,  obj->ff_endpoints)     &&
+	       m0_bufs_streq(&xobj->xf_substrings, obj->ff_substrings)    &&
+	       m0_fid_eq(&xobj->xf_node,     &obj->ff_node->cn_obj.co_id) &&
+	       m0_fid_eq(&xobj->xf_dix_pver, &obj->ff_dix_pver->pv_obj.co_id);
 }
 
 static void fdmi_filter_delete(struct m0_conf_obj *obj)

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -33,6 +33,8 @@ TOPDIR=$(dirname "$0")/../../
 
 
 export MOTR_CLIENT_ONLY=1
+export ENABLE_FDMI_FILTERS=YES
+interactive=false
 
 wait_and_exit()
 {
@@ -55,18 +57,46 @@ do_some_kv_operations()
 			    -h ${lnet_nid}:$HA_EP -p $PROF_OPT \
 			    -f $M0T1FS_PROC_ID -s "
 
+		echo "Let's create an index and put {somekey:somevalue}"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
 					index create "$DIX_FID"                            \
 					      put    "$DIX_FID" "somekey" "somevalue"      \
 					      get    "$DIX_FID" "somekey"                  \
-					      put    "$DIX_FID" "key1" "something1 anotherstring2 YETanotherstring3"      \
+				 || {
+			rc=$?
+			echo "m0kv failed"
+		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
+		echo "Let put {key1: ***}"
+		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+					index put    "$DIX_FID" "key1" "something1 anotherstring2 YETanotherstring3"      \
 					      get    "$DIX_FID" "key1"                     \
-					      put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
+				 || {
+			rc=$?
+			echo "m0kv failed"
+		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
+		echo "Let put {key2: ***}"
+		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+					index put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
 					      get    "$DIX_FID" "key2"                     \
 				 || {
 			rc=$?
 			echo "m0kv failed"
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
+		echo "Let put {key3: ***}"
+		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+					index put    "$DIX_FID" "key3" "{Bucket-Name:SomeBucket, Object-Name:Someobject, x-amz-meta-replication:Pending}"      \
+					      get    "$DIX_FID" "key3"                     \
+				 || {
+			rc=$?
+			echo "m0kv failed"
+		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 		echo "Now, let's delete 'key2' from this index. The plugin must show the del op coming"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
@@ -75,14 +105,17 @@ do_some_kv_operations()
 			rc=$?
 			echo "m0kv index del failed"
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 		echo "Now, let's get 'key2' from this index again. It should fail."
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
-				index get    "$DIX_FID" "key2"                     \
+					index get    "$DIX_FID" "key2"                     \
 				 && {
 			rc=22 # EINVAL to indicate the test is failed
 			echo "m0kv index get expected to fail, but did not."
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
 		sleep 1
 		echo "Now, let's delete 'key2' from this index again."
 		echo "It should fail, and the plugin must NOT show the del op coming."
@@ -92,6 +125,7 @@ do_some_kv_operations()
                     rc=22 # EINVAL to indicate the test is failed
                     echo "m0kv index del should fail, but did not"
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 	done
 	return $rc
@@ -99,15 +133,28 @@ do_some_kv_operations()
 
 start_fdmi_plugin()
 {
+	local fdmi_filter_fid=$1
+	local fdmi_plugin_ep=$2
+	local fdmi_output_file="${fdmi_filter_fid}.txt"
 	local rc=0
 
 	# We are using FDMI_PLUGIN_EP
-	MOTR_PARAM="-l ${lnet_nid}:$FDMI_PLUGIN_EP        \
+	MOTR_PARAM="-l ${lnet_nid}:$fdmi_plugin_ep        \
 		    -h ${lnet_nid}:$HA_EP -p $PROF_OPT    \
 		    -f $M0T1FS_PROC_ID                    "
 
-	"$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin" $MOTR_PARAM -g $FDMI_FILTER_FID &
-	sleep 5
+	PLUGIN_CMD="$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g $fdmi_filter_fid -s"
+
+	if $interactive ; then
+		echo "Please use another terminal and run this command:"
+		echo sudo ${PLUGIN_CMD}
+		echo "Then switch back to this terminal and press ENTER"
+		read
+	else
+		echo "Please check fdmi plugin output from this file: $(pwd)/${fdmi_output_file}"
+		(${PLUGIN_CMD} 2>&1 |& tee "${fdmi_output_file}" ) &
+		sleep 5
+	fi
 
 	# Checking for the pid of the started plugin process
 	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
@@ -121,12 +168,28 @@ start_fdmi_plugin()
 
 stop_fdmi_plugin()
 {
-	local pid=$(pgrep -f "lt-fdmi_sample_plugin")
-	if test "x$pid" != x; then
-		echo "Terminating ${pid}"
-		kill -TERM "${pid}"
-		wait "${pid}"
+	if $interactive ; then
+		echo "Please switch to the plugin terminals and press Ctrl+C "
+		echo "When both plugin applications are terminated, come back"
+		echo "Please press Enter to continue ..." && read
+	else
+		local pids=$(pgrep -f "lt-fdmi_sample_plugin")
+		if test "x$pids" != x; then
+			for pid in $pids; do
+				echo "Terminating ${pid}"
+				kill -KILL "${pid}"
+			done
+		fi
+		echo "The output of $FDMI_FILTER_FID  filter are:"
+		echo "==================>>>======================"
+		cat "${FDMI_FILTER_FID}.txt"
+		echo "==================<<<======================"
+		echo "The output of $FDMI_FILTER_FID2 filter are:"
+		echo "==================>>>======================"
+		cat "${FDMI_FILTER_FID2}.txt"
+		echo "==================<<<======================"
 	fi
+
 	return 0
 }
 
@@ -148,10 +211,13 @@ motr_fdmi_plugin_test()
 	echo "Process fid    : $M0T1FS_PROC_ID              "
 	echo "FDMI plugin ep : ${lnet_nid}:$FDMI_PLUGIN_EP  "
 	echo "FDMI filter fid: $FDMI_FILTER_FID             "
+	echo "FDMI plugin ep : ${lnet_nid}:$FDMI_PLUGIN_EP2 "
+	echo "FDMI filter fid: $FDMI_FILTER_FID2            "
 	echo
 	echo
 
-	start_fdmi_plugin && {
+	start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
+	start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" && {
 	    do_some_kv_operations || {
 		# Make the rc available for the caller and fail the test
 		# if kv operations fail.
@@ -166,6 +232,19 @@ motr_fdmi_plugin_test()
 	stop_fdmi_plugin
 	return $rc
 }
+
+parse_cli_options()
+{
+    while true ; do
+        case "$1" in
+            -i|--interactive)  interactive=true; shift ;;
+
+            *)             break ;;
+        esac
+    done
+}
+
+parse_cli_options "$@"
 
 main()
 {

--- a/fdmi/plugins/fdmi_sample_plugin.c
+++ b/fdmi/plugins/fdmi_sample_plugin.c
@@ -42,6 +42,7 @@ struct m0_fsp_params {
 	char          *spp_process_fid;
 	char          *spp_fdmi_plugin_fid_s;
 	struct m0_fid  spp_fdmi_plugin_fid;
+	bool           spp_output_strings;
 };
 
 /**
@@ -97,38 +98,10 @@ const struct m0_fdmi_pd_ops *fsp_pdo;
  */
 static struct m0_reqh_service *fsp_fdmi_service = NULL;
 
-/**
- * Aux buffer, used for data parsing.
- */
-#define MAX_LEN 8192
-static char buffer[MAX_LEN];
-
-static char *to_str(void *addr, int len)
-{
-	if (len > MAX_LEN - 1)
-		len = MAX_LEN - 1;
-	memcpy(buffer, addr, len);
-	buffer[len] = '\0';
-	return buffer;
-}
-
-M0_UNUSED static char *to_hex(void *addr, int len)
-{
-	int i, j;
-	if ((2 * len) > MAX_LEN) {
-		fprintf(stderr, "to_hex() failed with (2 * len) > MAX_LEN\n");
-		return NULL;
-	}
-	for(i = 0, j = 0; i < (2 * len) && j < len; ++j)
-		i += sprintf(buffer + i, "%02x", ((char *)addr)[j]);
-	buffer[2 * len] = '\0';
-	return buffer;
-}
-
 static void dump_fol_rec_to_json(struct m0_fol_rec *rec)
 {
 	struct m0_fol_frag *frag;
-	int i;
+	int i, j;
 
 	m0_tl_for(m0_rec_frag, &rec->fr_frags, frag) {
 		struct m0_fop_fol_frag *fp_frag = frag->rp_data;
@@ -137,27 +110,41 @@ static void dump_fol_rec_to_json(struct m0_fol_rec *rec)
 		struct m0_cas_rec *cr_rec = cg_rec.cr_rec;
 
 		for (i = 0; i < cg_rec.cr_nr; i++) {
-			int len = 0;
+			const char *addr;
+			int len;
 
-			m0_console_printf("{ \"opcode\": \"%d\", ", fp_frag->ffrp_fop_code);
+			printf("{ \"opcode\": \"%d\", ",
+				fp_frag->ffrp_fop_code);
 
-			len = sizeof(struct m0_fid);
-			m0_console_printf("\"fid\": \""FID_F"\", ",
-					  FID_P(&cas_op->cg_id.ci_fid));
+			printf("\"fid\": \""FID_F"\", ",
+				FID_P(&cas_op->cg_id.ci_fid));
 
-			len = cr_rec[i].cr_key.u.ab_buf.b_nob;
-			m0_console_printf("\"cr_key\": \"%s\", ",
-					  to_str(cr_rec[i].cr_key.u.ab_buf.b_addr, len));
-
-			len = cr_rec[i].cr_val.u.ab_buf.b_nob;
-			if (len > 0) {
-				m0_console_printf("\"cr_val\": \"%s\"",
-						  to_str(cr_rec[i].cr_val.u.ab_buf.b_addr, len));
+			len  = cr_rec[i].cr_key.u.ab_buf.b_nob;
+			addr = cr_rec[i].cr_key.u.ab_buf.b_addr;
+			if (fsp_params.spp_output_strings) {
+				printf("\"cr_key\": \"%.*s\", ", len, addr);
 			} else {
-				m0_console_printf("\"cr_val\": \"0\"");
+				printf("\"cr_key\": \"");
+				for (j = 0; j < len; j++)
+					printf("%02x", addr[j]);
+				printf("\", ");
 			}
-			m0_console_printf(" }\n");
-
+			len  = cr_rec[i].cr_val.u.ab_buf.b_nob;
+			addr = cr_rec[i].cr_val.u.ab_buf.b_addr;
+			if (len > 0) {
+				if (fsp_params.spp_output_strings) {
+					printf("\"cr_val\": \"%.*s\"",
+						len, addr);
+				} else {
+					printf("\"cr_val\": \"");
+					for (j = 0; j < len; j++)
+						printf("%02x", addr[j]);
+					printf("\"");
+				}
+			} else {
+				printf("\"cr_val\": \"0\"");
+			}
+			printf(" }\n");
 		}
 	} m0_tl_endfor;
 }
@@ -167,7 +154,7 @@ static void fsp_usage(void)
 	fprintf(stderr,
 		"Usage: fdmi_sample_plugin "
 		"-l local_addr -h ha_addr -p profile_fid -f process_fid "
-		"-g fdmi_plugin_fid\n"
+		"-g fdmi_plugin_fid [-s]\n"
 		"Use -? or -i for more verbose help on common arguments.\n"
 		"Usage example for common arguments: \n"
 		"fdmi_sample_plugin -l 192.168.52.53@tcp:12345:4:1 "
@@ -190,6 +177,7 @@ static int fsp_args_parse(struct m0_fsp_params *params, int argc, char ** argv)
 	params->spp_profile_fid = NULL;
 	params->spp_process_fid = NULL;
 	params->spp_fdmi_plugin_fid_s = NULL;
+	params->spp_output_strings = false;
 
 	rc = M0_GETOPTS("fdmi_sample_plugin", argc, argv,
 			M0_HELPARG('?'),
@@ -218,7 +206,11 @@ static int fsp_args_parse(struct m0_fsp_params *params, int argc, char ** argv)
 				     LAMBDA(void, (const char *str) {
 						     params->spp_fdmi_plugin_fid_s =
 							     (char*)str;
-					     })));
+					     })),
+			M0_VOIDARG('s', "output key/val as string",
+				   LAMBDA(void, (void) {
+						     params->spp_output_strings = true;
+					   })));
 	if (rc != 0)
 		return M0_ERR(rc);
 
@@ -409,10 +401,12 @@ static void fsp_print_params(struct m0_fsp_params *params)
 		"  hare_ep : %s\n"
 		"  profile_fid : %s\n"
 		"  process_fid : %s\n"
-		"  plugin_fid  : %s\n",
+		"  plugin_fid  : %s\n"
+		"  output as string: %s\n",
 		params->spp_local_addr, params->spp_hare_addr,
 		params->spp_profile_fid, params->spp_process_fid,
-		params->spp_fdmi_plugin_fid_s);
+		params->spp_fdmi_plugin_fid_s,
+		params->spp_output_strings? "true":"false");
 }
 
 int main(int argc, char **argv)

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -96,8 +96,12 @@ SNS_MOTR_CLI_EP="12345:33:1000"
 POOL_MACHINE_CLI_EP="12345:33:1001"
 SNS_QUIESCE_CLI_EP="12345:33:1002"
 M0HAM_CLI_EP="12345:33:1003"
-FDMI_PLUGIN_EP="12345:33:1004"
-FDMI_FILTER_FID="6c00000000000001:0"
+
+export FDMI_PLUGIN_EP="12345:33:601"
+export FDMI_PLUGIN_EP2="12345:33:602"
+
+export FDMI_FILTER_FID="6c00000000000001:0"
+export FDMI_FILTER_FID2="6c00000000000002:0"
 
 SNS_CLI_EP="12345:33:400"
 
@@ -122,7 +126,7 @@ MAX_RPC_MSG_SIZE=65536
 XPT=lnet
 PVERID='^v|1:10'
 MDPVERID='^v|2:10'
-M0T1FS_PROC_ID='<0x7200000000000001:64>'
+export M0T1FS_PROC_ID='0x7200000000000001:64'
 
 # Single node configuration.
 SINGLE_NODE=0
@@ -240,7 +244,7 @@ unprepare()
 	return $rc
 }
 
-PROF_OPT='<0x7000000000000001:0>'
+export PROF_OPT='0x7000000000000001:0'
 
 . `dirname ${BASH_SOURCE[0]}`/common_service_fids_inc.sh
 
@@ -284,7 +288,15 @@ function dix_pver_build()
 	# Number of parity units (replication factor) for distributed indices.
 	# Calculated automatically as maximum possible parity for the given
 	# number of disks.
-	local DIX_PARITY=$(((DIX_DEVS_NR - 1) / 2))
+	if [ "x$ENABLE_FDMI_FILTERS" == "xYES" ] ; then
+		# If we have SPARE=0, then we can have any number between [1, DIX_DEVS_NR - 1]
+		local DIX_PARITY=$((DIX_DEVS_NR - 1))
+		local DIX_SPARE=0
+	else
+		# If we have SPARE=PARITY, then we will use:
+		local DIX_PARITY=$(((DIX_DEVS_NR - 1) / 2))
+		local DIX_SPARE=$DIX_PARITY
+	fi
 
 	# conf objects for disks
 	for ((i=0; i < $DIX_DEVS_NR; i++)); do
@@ -303,7 +315,7 @@ function dix_pver_build()
 	done
 	# conf objects for DIX pool version
 	local DIX_POOL="{0x6f| (($DIX_POOLID), 0, [1: $DIX_PVERID])}"
-	local DIX_PVER="{0x76| (($DIX_PVERID), {0| (1, $DIX_PARITY, $DIX_PARITY,
+	local DIX_PVER="{0x76| (($DIX_PVERID), {0| (1, $DIX_PARITY, $DIX_SPARE,
                                                     $DIX_DEVS_NR,
                                                     [5: 0, 0, 0, 0, $DIX_PARITY],
                                                     [1: $DIX_SITEVID])})}"
@@ -418,12 +430,27 @@ function build_conf()
 	PROC_NAMES="$PROC_NAMES${PROC_NAMES:+, }$M0T1FS_PROCID"
 
 	local FDMI_GROUP_ID="^g|1:0"
-	local FDMI_FILTER_ID="^l|1:0"
+	local FDMI_FILTER_ID="^l|1:0"   #Please refer to $FDMI_FILTER_FID
+	local FDMI_FILTER_ID2="^l|2:0"  #Please refer to $FDMI_FILTER_FID2
+
 	local FDMI_FILTER_STRINGS="\"something1\", \"anotherstring2\", \"YETanotherstring3\""
-	local FDMI_GROUP="{0x67| (($FDMI_GROUP_ID), 0x1000, [1: $FDMI_FILTER_ID])}"
-	#local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 1, (11, 11), \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, (0, 0), [0], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])}"
-	local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 2, $FDMI_FILTER_ID, \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, $DIX_PVERID, [3: $FDMI_FILTER_STRINGS], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])}"
-	local FDMI_ITEMS_NR=2
+	local FDMI_FILTER_STRINGS2="\"Bucket-Name\", \"Object-Name\", \"x-amz-meta-replication\""
+
+	if [ "x$ENABLE_FDMI_FILTERS" == "xYES" ] ; then
+		local FDMI_GROUP_DESC="1: $FDMI_GROUP_ID"
+		local FDMI_ITEMS_NR=3
+		# Please NOTE the ending comma at the end of each string here
+		local FDMI_GROUP="{0x67| (($FDMI_GROUP_ID), 0x1000, [2: $FDMI_FILTER_ID, $FDMI_FILTER_ID2])},"
+		#local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 1, (11, 11), \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, (0, 0), [0], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])},"
+		local FDMI_FILTER="{0x6c| (($FDMI_FILTER_ID), 2, $FDMI_FILTER_ID, \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, $DIX_PVERID, [3: $FDMI_FILTER_STRINGS], [1: \"$lnet_nid:$FDMI_PLUGIN_EP\"])},"
+		local FDMI_FILTER2="{0x6c| (($FDMI_FILTER_ID2), 2, $FDMI_FILTER_ID2, \"{2|(0,[2:({1|(3,{2|0})}),({1|(3,{2|0})})])}\", $NODE, $DIX_PVERID, [3: $FDMI_FILTER_STRINGS2], [1: \"$lnet_nid:$FDMI_PLUGIN_EP2\"])},"
+	else
+		local FDMI_GROUP_DESC="0"
+		local FDMI_ITEMS_NR=0
+		local FDMI_GROUP=""
+		local FDMI_FILTER=""
+		local FDMI_FILTER2=""
+	fi
 
 	local i
 	for ((i=0; i < ${#ioservices[*]}; i++, M0D++)); do
@@ -638,7 +665,7 @@ function build_conf()
 	  [$node_count: $NODES],
 	  [$site_count: $SITES],
 	  [$pool_count: $POOLS],
-	  [1: $PROF], [1: $FDMI_GROUP_ID])},
+	  [1: $PROF], [$FDMI_GROUP_DESC])},
   {0x70| (($PROF), [$pool_count: $POOLS])},
   {0x6e| (($NODE), 16000, 2, 3, 2, [$(($M0D + 1)): ${PROC_NAMES[@]}])},
   $PROC_OBJS,
@@ -646,8 +673,9 @@ function build_conf()
   {0x73| (($HA_SVC_ID), @M0_CST_HA, [1: $HA_ENDPOINT], [0], [0])},
   {0x73| (($FIS_SVC_ID), @M0_CST_FIS, [1: $HA_ENDPOINT], [0], [0])},
   $M0T1FS_RM,
-  $FDMI_GROUP,
-  $FDMI_FILTER,
+  $FDMI_GROUP
+  $FDMI_FILTER
+  $FDMI_FILTER2
   $MDS_OBJS,
   $IOS_OBJS,
   $RM_OBJS,

--- a/scripts/st.d/67fdmi-plugin-multi-filters
+++ b/scripts/st.d/67fdmi-plugin-multi-filters
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+set -eu
+
+exec $SUDO "$M0_SRC_DIR/fdmi/plugins/fdmi_plugin_st.sh"


### PR DESCRIPTION
Features included:
  * FDMI_ENABLE_FILTERS to control if FDMI is enabled
  * Explain the DIX_PARITY and DIX_SPARE when generating DIX conf
  * Interactive mode for this ST.
  * Switch for output as string or as hex. Useful when doing manual testing.
  * Added ST to xperior (Jenkins)

Signed-off-by: Hua Huang <hua.huang@seagate.com>
