### PR TITLE
Added M0_NC_DTM_RECOVERING HA state DLD

### DIFF
--- a/conf/ha.h
+++ b/conf/ha.h
@@ -70,6 +70,16 @@ enum m0_conf_ha_process_event {
 	 * from the process.
 	 */
 	M0_CONF_HA_PROCESS_STOPPED,
+	/**
+	 * When the process has completed the iteration of the DTM log and
+	 * there’re no new records to send to the recovering process it sends
+	 * "REDO_END" message. When recovering process receives "REDO_END" from
+	 * all ONLINE and TRANSIENT processes of the cluster it completes the
+	 * recovery and sends M0_CONF_HA_PROCESS_DTM_RECOVERED() to HARE.
+	 * If any process goes PERMANENT during DTM recovery the process being
+	 * recovered shall not wait "REDO_END" from this process.
+	 */
+	M0_CONF_HA_PROCESS_DTM_RECOVERED,
 };
 
 /** Defines the source of the process event */

--- a/ha/halon/interface.c
+++ b/ha/halon/interface.c
@@ -773,6 +773,14 @@ static int halon_interface_level_enter(struct m0_module *module)
 		return M0_RC(0);
 	case M0_HALON_INTERFACE_LEVEL_EVENTS_STARTED:
 		halon_interface_process_event(hii, M0_CONF_HA_PROCESS_STARTED);
+		/*
+		   For HAX daemon, M0_NC_DTM_RECOVERING state is transient,
+		   sending M0_CONF_HA_PROCESS_DTM_RECOVERED just after
+		   M0_CONF_HA_PROCESS_STARTED.
+
+		halon_interface_process_event(hii,
+					      M0_CONF_HA_PROCESS_DTM_RECOVERED);
+		*/
 		return M0_RC(0);
 	case M0_HALON_INTERFACE_LEVEL_STARTED:
 		return M0_ERR(-ENOSYS);

--- a/ha/note.c
+++ b/ha/note.c
@@ -441,6 +441,7 @@ M0_INTERNAL const char *m0_ha_state2str(enum m0_ha_obj_state state)
 	S_CASE(M0_NC_REPAIR);
 	S_CASE(M0_NC_REPAIRED);
 	S_CASE(M0_NC_REBALANCE);
+	S_CASE(M0_NC_DTM_RECOVERING);
 	default:
 		M0_IMPOSSIBLE("Invalid state: %d", state);
 	}

--- a/ha/note.h
+++ b/ha/note.h
@@ -149,6 +149,25 @@ enum m0_ha_obj_state {
 	 * copied from spare space to the replacement storage.
 	 */
 	M0_NC_REBALANCE,
+	/**
+	 * Recovery is triggered by the incoming NC_DTM_RECOVERING HA state
+	 * message. During this state, processes iterate over their DTM logs,
+	 * pack elements of them, TXRs, into REDO messages and send REDO
+	 * messages to corresponding participants of TXR. Any subsequent failure
+	 * of the process in the cluster restarts the recovery process on all
+	 * alive participants.
+	 *
+	 * DTM_RECOVERING state is transitive for client applications and mkfs,
+	 * meaning that transition from NC_DTM_RECOVERING to NC_ONLINE is
+	 * immediate.
+	 *
+	 * For m0ds (CAS-, IO-services) indicates that the process waits for the
+	 * completion of ongoing DTM recovery process. When the client learns
+	 * the process in DTM_RECOVERING state it treats the process as
+	 * read-only, at least for the meta-data, and skips sending modification
+	 * requests to it.
+	 */
+	M0_NC_DTM_RECOVERING,
 
 	M0_NC_NR
 };

--- a/m0t1fs/linux_kernel/super.c
+++ b/m0t1fs/linux_kernel/super.c
@@ -1341,7 +1341,13 @@ static int m0t1fs_fill_super(struct super_block *sb, void *data,
 	M0_SET0(&iommstats);
 
 	m0t1fs_ha_process_event(csb, M0_CONF_HA_PROCESS_STARTED);
+	/*
+	   For m0t1fs client, M0_NC_DTM_RECOVERING state is transient,
+	   sending M0_CONF_HA_PROCESS_DTM_RECOVERED just after
+	   M0_CONF_HA_PROCESS_STARTED.
 
+	   m0t1fs_ha_process_event(csb, M0_CONF_HA_PROCESS_DTM_RECOVERED);
+	*/
 	return M0_RC(0);
 
 m0t1fs_teardown:

--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -1586,6 +1586,14 @@ int m0_client_init(struct m0_client **m0c_p,
 		 * are completed successfully.
 		 */
 		ha_process_event(m0c, M0_CONF_HA_PROCESS_STARTED);
+		/*
+		   For m0crate, s3servers and other client apps,
+		   M0_NC_DTM_RECOVERING state is transient, sending
+		   M0_CONF_HA_PROCESS_DTM_RECOVERED just after
+		   M0_CONF_HA_PROCESS_STARTED.
+
+		   ha_process_event(m0c, M0_CONF_HA_PROCESS_DTM_RECOVERED);
+		*/
 	}
 
 	m0_sm_group_unlock(&m0c->m0c_sm_group);

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -2647,8 +2647,17 @@ static int cs_level_enter(struct m0_module *module)
 		 * XXX STARTED expected even in the error case.
 		 * It should be fixed either here or in Halon.
 		 */
-		if (cctx->cc_mkfs)
+		if (cctx->cc_mkfs) {
 			cs_ha_process_event(cctx, M0_CONF_HA_PROCESS_STARTED);
+			/*
+			For mkfs, M0_NC_DTM_RECOVERING state is transient,
+			sending M0_CONF_HA_PROCESS_DTM_RECOVERED just after
+			M0_CONF_HA_PROCESS_STARTED.
+
+			cs_ha_process_event(cctx,
+			                    M0_CONF_HA_PROCESS_DTM_RECOVERED);
+			*/
+		}
 		return M0_RC(0);
 	case CS_LEVEL_RCONFC_FATAL_CALLBACK:
 		if (!cctx->cc_no_conf) { /* otherwise rconfc did not start */
@@ -2712,6 +2721,14 @@ static int cs_level_enter(struct m0_module *module)
 		return M0_RC(0);
 	case CS_LEVEL_STARTED_EVENT_FOR_M0D:
 		cs_ha_process_event(cctx, M0_CONF_HA_PROCESS_STARTED);
+		/*
+		For m0d, M0_NC_DTM_RECOVERING state is being sent here just for
+		test purposes. The real notification shall be sent inside
+		dtm0_rmsg_fom_tick().
+
+		cs_ha_process_event(cctx,
+				    M0_CONF_HA_PROCESS_DTM_RECOVERED);
+		*/
 		return M0_RC(0);
 	case CS_LEVEL_START:
 		return M0_RC(0);

--- a/pool/pool.c
+++ b/pool/pool.c
@@ -1724,7 +1724,7 @@ M0_INTERNAL int m0_pool_version_append(struct m0_pools_common  *pc,
 		if (rc != 0)
 			return M0_ERR(rc);
 	}
-	M0_ASSERT(cp != NULL); 
+	M0_ASSERT(cp != NULL);
 	p = pool_find(pc, &cp->pl_obj.co_id);
 	M0_ASSERT(p != NULL);
 
@@ -1895,6 +1895,7 @@ M0_INTERNAL uint32_t m0_ha2pm_state_map(enum m0_ha_obj_state hastate)
 		[M0_NC_REPAIR]         = M0_PNDS_SNS_REPAIRING,
 		[M0_NC_REPAIRED]       = M0_PNDS_SNS_REPAIRED,
 		[M0_NC_REBALANCE]      = M0_PNDS_SNS_REBALANCING,
+		[M0_NC_DTM_RECOVERING] = M0_PNDS_ONLINE,
 	};
 	M0_ASSERT (hastate < M0_NC_NR);
 	return ha2pm_statemap[hastate];


### PR DESCRIPTION
 - Added M0_NC_DTM_RECOVERING and corresponding
   M0_CONF_HA_PROCESS_DTM_RECOVERED message.
 - Added REDO FOP/FOM stubs.
 - Added documentation and examples of the use of
   M0_CONF_HA_PROCESS_DTM_RECOVERED message inside the
   code of m0ds, mkfs, clients, hax.
 - Based on pull/1052.
 - jira: EOS-24483

Signed-off-by: Anatoliy Bilenko <anatoliy.bilenko@seagate.com>

# Problem Statement
To implement DTM recovery new motr process states and messages in hax ↔︎ motr process protocol need to be added. Motr process transits through the set of states, overall DTM recovery flow including M0_CONF_HA_PROCESS_* messages and corresponding broadcasting of HA state messages.

# Design
-  https://seagate-systems.atlassian.net/wiki/spaces/~770032066/pages/609880834/DTM+Basic+Recovery+HLD+draft

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [X] Interface change (if any) are documented
- [NA] Side effects on other features (deployment/upgrade)
- [X] Dependencies on other component(s) (review the comments)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [X] Changes done to WIKI / Confluence page / Quick Start Guide
