### PR TITLE
Motr Provisioner integration issue resolved

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -303,7 +303,7 @@ def update_copy_motr_config_file(self):
 def get_md_disks(self, node_info):
     md_disks = []
     cvg_count = node_info['storage']['cvg_count']
-    cvg = self.storage['cvg']
+    cvg = node_info['storage']['cvg']
     for i in range(cvg_count):
         temp_cvg = cvg[i]
         if temp_cvg['devices']['metadata']:


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
- Storage_node keys were expected for control_node while running fsm service

# Design
- fixed the values to fetch appropriate type matching its machine-id from conf store. 

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] cortx_setup cluster bootstrap -c yaml:///etc/cortx/cluster.conf - tested for control node and storage node 
- [ ] Test Cases cover Happy Path


# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
