### PR TITLE
spec: fix rpm deps on CentOS 8

### DIFF
--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -80,7 +80,7 @@ BuildRequires:  libtool
 BuildRequires:  make
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
-%if %{rhel} <= 7
+%if %{rhel} < 8
 BuildRequires:  gccxml
 %else
 BuildRequires:  castxml
@@ -102,14 +102,14 @@ BuildRequires:  libuuid-devel
 BuildRequires:  openssl
 BuildRequires:  openssl-devel
 BuildRequires:  binutils-devel
-%if %{rhel} <= 7
+%if %{rhel} < 8
 BuildRequires:  python36-ply
 %else
 BuildRequires:  python3-ply
 %endif
 BuildRequires:  perl-autodie
 BuildRequires:  systemd-devel
-%if %{rhel} <= 7
+%if %{rhel} < 8
 BuildRequires:  python-devel
 %else
 BuildRequires:  python2-devel
@@ -131,7 +131,7 @@ Requires:       libyaml
 Requires:       openssl
 Requires:       gdb
 Requires:       genders
-%if %{rhel} <= 7
+%if %{rhel} < 8
 Requires:       sysvinit-tools
 %endif
 Requires:       attr
@@ -147,7 +147,7 @@ Requires:       perl-MCE
 Requires:       ruby
 Requires:       facter
 Requires:       rubygem-net-ssh
-%if %{rhel} <= 7
+%if %{rhel} < 8
 Requires:       python36-ply
 %else
 Requires:       python3-ply

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -131,7 +131,9 @@ Requires:       libyaml
 Requires:       openssl
 Requires:       gdb
 Requires:       genders
+%if %{rhel} <= 7
 Requires:       sysvinit-tools
+%endif
 Requires:       attr
 Requires:       perl
 Requires:       perl-YAML-LibYAML
@@ -145,7 +147,11 @@ Requires:       perl-MCE
 Requires:       ruby
 Requires:       facter
 Requires:       rubygem-net-ssh
+%if %{rhel} <= 7
 Requires:       python36-ply
+%else
+Requires:       python3-ply
+%endif
 Requires:       libedit
 %if %{with isal}
 Requires:       isa-l


### PR DESCRIPTION
Fix packages dependencies in rpmbuild spec file on CentOS 8.3:
1) sysvinit-tools package is not available on CentOS 8 anymore;
2) python36-ply is named python3-ply on CentOS 8.