### PR TITLE
Changes to m0_btree_destroy_credit() for accepting m0_btree_type parameter

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -5510,11 +5510,16 @@ M0_INTERNAL void m0_btree_create_credit(const struct m0_btree_type *bt,
 }
 
 M0_INTERNAL void m0_btree_destroy_credit(struct m0_btree *tree,
+					 const struct m0_btree_type *bt,
 					 struct m0_be_tx_credit *accum,
 					 m0_bcount_t nr)
 {
-	int size = tree->t_desc->t_root->n_type->nt_create_delete_credit_size();
-	struct m0_be_tx_credit cred = M0_BE_TX_CREDIT(1, size);
+	const struct node_type *nt   = (tree != NULL) ?
+					tree->t_desc->t_root->n_type :
+					btree_nt_from_bt(bt);
+	int                     size = nt->nt_create_delete_credit_size();
+	struct m0_be_tx_credit  cred = M0_BE_TX_CREDIT(1, size);
+
 	m0_be_tx_credit_add(accum, &cred);
 	m0_be_tx_credit_mac(accum, &cred, nr);
 }
@@ -8838,7 +8843,7 @@ static void ut_basic_tree_oper_icp(void)
 	cred = M0_BE_TX_CREDIT(0, 0);
 	m0_be_allocator_credit(NULL, M0_BAO_FREE_ALIGNED, rnode_sz,
 			       rnode_sz_shift, &cred);
-	m0_btree_destroy_credit(b_op.bo_arbor, &cred, 1);
+	m0_btree_destroy_credit(b_op.bo_arbor, NULL, &cred, 1);
 
 	m0_be_ut_tx_init(tx, ut_be);
 	m0_be_tx_prep(tx, &cred);
@@ -8903,7 +8908,7 @@ static void ut_basic_tree_oper_icp(void)
 	cred = M0_BE_TX_CREDIT(0, 0);
 	m0_be_allocator_credit(NULL, M0_BAO_FREE_ALIGNED, rnode_sz,
 			       rnode_sz_shift, &cred);
-	m0_btree_destroy_credit(b_op.bo_arbor, &cred, 1);
+	m0_btree_destroy_credit(b_op.bo_arbor, NULL, &cred, 1);
 
 	m0_be_ut_tx_init(tx, ut_be);
 	m0_be_tx_prep(tx, &cred);
@@ -9582,7 +9587,7 @@ static void ut_multi_stream_kv_oper(void)
 	cred = M0_BE_TX_CREDIT(0, 0);
 	m0_be_allocator_credit(NULL, M0_BAO_FREE_ALIGNED, rnode_sz,
 			       rnode_sz_shift, &cred);
-	m0_btree_destroy_credit(tree, &cred, 1);
+	m0_btree_destroy_credit(tree, NULL, &cred, 1);
 
 	m0_be_ut_tx_init(tx, ut_be);
 	m0_be_tx_prep(tx, &cred);
@@ -10693,7 +10698,7 @@ static void btree_ut_kv_oper(int32_t thread_count, int32_t tree_count,
 	cred = M0_BE_TX_CB_CREDIT(0, 0, 0);
 	m0_be_allocator_credit(NULL, M0_BAO_FREE_ALIGNED, rnode_sz,
 			       rnode_sz_shift, &cred);
-	m0_btree_destroy_credit(ut_trees[0], &cred, 1);
+	m0_btree_destroy_credit(ut_trees[0], NULL, &cred, 1);
 	for (i = 0; i < tree_count; i++) {
 		m0_be_ut_tx_init(tx, ut_be);
 		m0_be_tx_prep(tx, &cred);
@@ -10953,7 +10958,7 @@ static void btree_ut_tree_oper_thread_handler(struct btree_ut_thread_info *ti)
 		}
 
 		cred = M0_BE_TX_CREDIT(0, 0);
-		m0_btree_destroy_credit(tree, &cred, 1);
+		m0_btree_destroy_credit(tree, NULL, &cred, 1);
 
 		m0_be_ut_tx_init(tx, ut_be);
 		m0_be_tx_prep(tx, &cred);
@@ -11542,7 +11547,7 @@ static void ut_btree_persistence(void)
 	}
 
 	cred = M0_BE_TX_CREDIT(0, 0);
-	m0_btree_destroy_credit(tree, &cred, 1);
+	m0_btree_destroy_credit(tree, NULL, &cred, 1);
 
 	m0_be_ut_tx_init(tx, ut_be);
 	m0_be_tx_prep(tx, &cred);
@@ -11719,7 +11724,7 @@ static void ut_btree_truncate(void)
 	cred = M0_BE_TX_CREDIT(0, 0);
 	m0_be_allocator_credit(NULL, M0_BAO_FREE_ALIGNED, rnode_sz,
 			       rnode_sz_shift, &cred);
-	m0_btree_destroy_credit(tree, &cred, 1);
+	m0_btree_destroy_credit(tree, NULL, &cred, 1);
 
 	m0_be_ut_tx_init(tx, ut_be);
 	m0_be_tx_prep(tx, &cred);

--- a/btree/btree.h
+++ b/btree/btree.h
@@ -157,6 +157,12 @@ enum m0_btree_opflag {
 /**
  * Calculates the credit needed to create tree with @nr nodes and adds this
  * credit to @accum.
+ *
+ * @param bt points to the structure which tells the tree type for whom the
+ *        credit needs to be calculated.
+ * @param accum contains the accumulated credit count.
+ * @param nr is the multiplier which gets the total credits for that many nodes
+ *        of the btree.
  */
 M0_INTERNAL void m0_btree_create_credit(const struct m0_btree_type *bt,
 					struct m0_be_tx_credit *accum,
@@ -165,8 +171,18 @@ M0_INTERNAL void m0_btree_create_credit(const struct m0_btree_type *bt,
 /**
  * Calculates the credit needed to destroy tree with @nr nodes and adds this
  * credit to @accum.
+ * Either tree or bt should be valid (non-NULL). If both are valid then tree is
+ * used to get the credit count.
+ *
+ * @param tree points to the tree for whom the credits need to be calculated.
+ * @param bt points to the structure which tells the tree type for whom the
+ *        credit needs to be calculated.
+ * @param accum contains the accumulated credit count.
+ * @param nr is the multiplier which gets the total credits for that many nodes
+ *        of the btree.
  */
 M0_INTERNAL void m0_btree_destroy_credit(struct m0_btree *tree,
+					 const struct m0_btree_type *bt,
 					 struct m0_be_tx_credit *accum,
 					 m0_bcount_t nr);
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -842,11 +842,11 @@ int m0_cob_domain_destroy(struct m0_cob_domain *dom,
 	seg = m0_be_domain_seg(bedom, dom);
 	m0_be_0type_del_credit(bedom, &m0_be_cob0, cdid_str, &cred);
 	M0_BE_FREE_CREDIT_PTR(dom, seg, &cred);
-	m0_btree_destroy_credit(dom->cd_object_index,   &cred, 1);
-	m0_btree_destroy_credit(dom->cd_namespace,      &cred, 1);
-	m0_btree_destroy_credit(dom->cd_fileattr_basic, &cred, 1);
-	m0_btree_destroy_credit(dom->cd_fileattr_omg,   &cred, 1);
-	m0_btree_destroy_credit(dom->cd_fileattr_ea,    &cred, 1);
+	m0_btree_destroy_credit(dom->cd_object_index,   NULL, &cred, 1);
+	m0_btree_destroy_credit(dom->cd_namespace,      NULL, &cred, 1);
+	m0_btree_destroy_credit(dom->cd_fileattr_basic, NULL, &cred, 1);
+	m0_btree_destroy_credit(dom->cd_fileattr_omg,   NULL, &cred, 1);
+	m0_btree_destroy_credit(dom->cd_fileattr_ea,    NULL, &cred, 1);
 
 	M0_SET0(tx);
 	m0_be_tx_init(tx, 0, bedom, grp, NULL, NULL, NULL, NULL);

--- a/conf/db.c
+++ b/conf/db.c
@@ -445,8 +445,6 @@ M0_INTERNAL void m0_confdb_destroy_credit(struct m0_be_seg *seg,
 					  struct m0_be_tx_credit *accum)
 {
 	uint8_t              *rnode;
-	struct m0_btree       btree;
-	struct m0_btree_op    b_op  = {};
 	int                   rc;
 	struct m0_btree_type  bt    = { .tt_id = M0_BT_CONFDB,
 					.ksize = sizeof (struct m0_fid),
@@ -457,12 +455,9 @@ M0_INTERNAL void m0_confdb_destroy_credit(struct m0_be_seg *seg,
 	M0_ENTRY();
 
 	rc = m0_be_seg_dict_lookup(seg, btree_name, (void **)&rnode);
-	if (rc == 0 &&
-	    M0_BTREE_OP_SYNC_WITH_RC(&b_op,
-				     m0_btree_open(rnode, rnode_sz,
-						   &btree, seg, &b_op)) == 0) {
-		m0_btree_destroy_credit(&btree, accum, 1);
-	} else
+	if (rc == 0)
+		m0_btree_destroy_credit(NULL, &bt, accum, 1);
+	else
 		/** Use the same credit count as btree_create. */
 		m0_btree_create_credit(&bt, accum, 1);
 	m0_be_seg_dict_delete_credit(seg, btree_name, accum);


### PR DESCRIPTION

Current implementation of m0_btree_destroy_credit() used the (m0_btree *)
parameter for getting the correct node-type needed to get the destroy credit
count. In some cases this tree pointer is not available at the code location
where the credit calculations are done. To cover these scenarioes the modified
m0_btree_destroy_credit() also takes m0_btree_type parameter which is used to
find out the node type needed for getting the correct credit count.

Signed-off-by: Shashank Parulekar <Shashank.Parulekar@seagate.com>

