### PR TITLE
EOS-25295 : Fix invocation of m0_default_xprt in utils/functions.

### DIFF
--- a/utils/functions
+++ b/utils/functions
@@ -135,7 +135,7 @@ m0_default_xprt()
 m0_local_nid_get()
 {
     local local_nid
-    XPRT=m0_default_xprt
+    XPRT=$(m0_default_xprt)
     if [ "$XPRT" = "lnet" ]
     then 
         local_nid=`sudo lctl list_nids | head -1`


### PR DESCRIPTION
Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
