### PR TITLE
EOS-25316 : Fix the status reported by xperior for tests in jenkins run

### DIFF
--- a/scripts/m0
+++ b/scripts/m0
@@ -197,7 +197,7 @@ cmd_run_kut() {
     else
         echo 'Libfabric runs in userspace only. Kernel UTs are disabled!'
         . "$M0_SRC_DIR/utils/functions" # sandbox_init, report_and_exit
-        export SANDBOX_DIR=$RUNDIR/sandbox.st-${f##*/}
+        export SANDBOX_DIR=$RUNDIR/sandbox.st-m0kut
         rc=0
         sandbox_init
         sandbox_fini $rc


### PR DESCRIPTION
Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- For some tests in the jenkins run, the status is marked as failed even if the stdout shows  the below message
'status: SUCCESS'
[example](http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Motr/824/testReport/03motr-single-node/06conf/test/)

# Design
-  Along with the status:SUCCESS message on the stdout, the sandbox dir is also checked by the xperior.
Add generation of sandbox directory for such tests.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
