### PR TITLE
EOS-24933: s3server service failing intermittently while executing s3 tests.

### DIFF
--- a/motr/io_req_fop.c
+++ b/motr/io_req_fop.c
@@ -169,20 +169,23 @@ static void application_attribute_copy(struct m0_indexvec *rep_ivec,
 	/* Move rep_cursor on unit boundary */
 	off = rep_index % unit_size;
 	if (off) {
-		if (m0_ivec_cursor_move(&rep_cursor, unit_size - off)) {
+		if (!m0_ivec_cursor_move(&rep_cursor, unit_size - off)) {
 			rep_index = m0_ivec_cursor_index(&rep_cursor);
 		}
 		else {
 			/** invalid cusror position */
-			M0_ASSERT(false);
+			//M0_ASSERT(false);
+			return;
 		}
 	}
 	M0_ASSERT(ti_cob_index <= rep_index);
 
 	/* Move ti index to rep index */
 	if (ti_cob_index != rep_index) 	{
-		M0_ASSERT (m0_ivec_cursor_move(&ti_cob_cursor,  rep_index - ti_cob_index) && 
-		           m0_ivec_cursor_move(&ti_goff_cursor, rep_index - ti_cob_index));
+		if (m0_ivec_cursor_move(&ti_cob_cursor,  rep_index - ti_cob_index) ||
+		    m0_ivec_cursor_move(&ti_goff_cursor, rep_index - ti_cob_index)) {
+			return;
+		}
 	}
 
 	/**

--- a/motr/io_req_fop.c
+++ b/motr/io_req_fop.c
@@ -178,13 +178,13 @@ static void application_attribute_copy(struct m0_indexvec *rep_ivec,
 			return;
 	}
 	off = ti_cob_index % unit_size;
-	if (off) {
+	if (off != 0) {
 		if (!m0_ivec_cursor_move(&ti_cob_cursor, unit_size - off)) {
 			ti_cob_index = m0_ivec_cursor_index(&ti_cob_cursor);
 		}
 	}
 	off = ti_goff_index % unit_size;
-	if (off) {
+	if (off != 0) {
 		if (!m0_ivec_cursor_move(&ti_goff_cursor, unit_size - off)) {
 			ti_goff_index = m0_ivec_cursor_index(&ti_goff_cursor);
 		}
@@ -223,6 +223,7 @@ static void application_attribute_copy(struct m0_indexvec *rep_ivec,
 						      ti_goff_index,
 						      &ioo->ioo_ext,
 						      unit_size, cs_sz);
+                M0_ASSERT(dst != NULL);
 		memcpy(dst, src, cs_sz);
 		src = (char *)src + cs_sz;
 


### PR DESCRIPTION
Signed-off-by: Shipra Gupta <shipra.gupta@seagate.com>

# Problem Statement
s3server service failing intermittently while executing s3 tests.

# Design
1.There was an assumption taken in code that m0_ivec_cursor_move returns false after reaching end of cursor. This assumption is wrong and generated defect.  Changed the code as per correct return value of  m0_ivec_cursor_move. 
2. rep_ivec may contain very less data and it may not be eligible to fetch checksums. In this case simply return, do not assert.
3. Use the correct unit size to move the cursors.


# Testing 
 Tested the fix for different IO sizes on 3 node cluster setup.
Sanity tests performed.
