### PR TITLE
EOS-25285: Checking if fom tx is initialized

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -1140,10 +1140,12 @@ static int op_sync_wait(struct m0_fom *fom)
 	struct m0_be_tx     *tx;
 
 	tx = m0_fom_tx(fom);
-	if (m0_be_tx_state(tx) < M0_BTS_LOGGED) {
-		M0_LOG(M0_DEBUG, "fom wait for tx to be logged");
-		m0_fom_wait_on(fom, &tx->t_sm.sm_chan, &fom->fo_cb);
-		return M0_FSO_WAIT;
+	if (fom->fo_tx.tx_state != M0_DTX_INVALID) {
+		if (m0_be_tx_state(tx) < M0_BTS_LOGGED) {
+			M0_LOG(M0_DEBUG, "fom wait for tx to be logged");
+			m0_fom_wait_on(fom, &tx->t_sm.sm_chan, &fom->fo_cb);
+			return M0_FSO_WAIT;
+		}
 	}
 	return M0_FSO_AGAIN;
 }


### PR DESCRIPTION
In some cases, e.g. the index del operation on a non-existing index,
the fom tx is not initialized.

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
