### PR TITLE
go/mio: fix build after arm64 port

### DIFF
--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -45,6 +45,7 @@ package mio
 // #cgo CFLAGS: -Wno-attributes
 // #cgo LDFLAGS: -L../../../motr/.libs -Wl,-rpath=../../../motr/.libs -lmotr
 // #include <stdlib.h>
+// #include "config.h"
 // #include "lib/types.h"
 // #include "lib/trace.h"   /* m0_trace_set_mmapped_buffer */
 // #include "motr/client.h"

--- a/bindings/go/mio/mkv.go
+++ b/bindings/go/mio/mkv.go
@@ -23,6 +23,7 @@
 package mio
 
 // #include <errno.h> /* EEXIST */
+// #include "config.h"
 // #include "motr/client.h"
 // #include "motr/layout.h" /* m0c_pools_common */
 //


### PR DESCRIPTION
Fix build after commit bc844a8 (ARM64 platform support) by including config.h file.