### PR TITLE
EOS-25418: libfab: increase address string buffer to support long names

### DIFF
--- a/net/libfab/libfab_internal.h
+++ b/net/libfab/libfab_internal.h
@@ -48,7 +48,8 @@ extern struct m0_net_xprt m0_net_libfab_xprt;
 
 #define LIBFAB_ADDR_LEN_MAX	INET6_ADDRSTRLEN
 #define LIBFAB_PORT_LEN_MAX	6
-#define LIBFAB_ADDR_STRLEN_MAX  (LIBFAB_ADDR_LEN_MAX + LIBFAB_PORT_LEN_MAX + 1)
+#define LIBFAB_ADDR_LEN_MISC    100
+#define LIBFAB_ADDR_STRLEN_MAX  (LIBFAB_ADDR_LEN_MAX + LIBFAB_PORT_LEN_MAX + LIBFAB_ADDR_LEN_MISC)
 
 /**
  * Parameters required for libfabric configuration


### PR DESCRIPTION
Signed-off-by: Yeshpal Jain <yeshpal.jain@seagate.com>

# Problem Statement
- motr services are failing because of long libfabric endpoints
  for ex: libfab:inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-1532

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
