### PR TITLE
EOS:25147 Removed __KERNEL__ around function m0_btree_truncate_credit.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -642,6 +642,11 @@ enum {
 		typeof(cb) __cb = (cb);                                      \
 		(__cb) = (__cb);                                             \
 	} while (0)
+
+#define m0_be_engine_tx_size_max(en, cred, payload_size)                     \
+	do {                                                                 \
+		*(cred) = M0_BE_TX_CREDIT(0, 0);                             \
+	} while (0)
 #endif
 
 #if (AVOID_BE_SEGMENT == 1)
@@ -5552,7 +5557,6 @@ M0_INTERNAL void m0_btree_destroy_credit(struct m0_btree *tree,
 	m0_be_tx_credit_mac(accum, &cred, nr);
 }
 
-#ifndef __KERNEL__
 M0_INTERNAL void m0_btree_truncate_credit(struct m0_be_tx        *tx,
 					  struct m0_btree        *tree,
 					  struct m0_be_tx_credit *accum,
@@ -5583,7 +5587,6 @@ M0_INTERNAL void m0_btree_truncate_credit(struct m0_be_tx        *tx,
 
 	m0_be_tx_credit_mac(accum, &cred, *limit);
 }
-#endif
 
 /**
  *  --------------------------------------------


### PR DESCRIPTION

# Coding
-  [x] Coding conventions are followed and code is consistent


# Review Checklist 
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained


Signed-off-by: Shashank Parulekar <Shashank.Parulekar@seagate.com>
