### PR TITLE
EOS-25146: Make m0_btreee_oimpl->i_level variable static.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -1398,7 +1398,7 @@ struct m0_btree_oimpl {
 	unsigned                   i_used;
 
 	/** Array of levels for storing data about each level. **/
-	struct level              *i_level;
+	struct level               i_level[MAX_TREE_HEIGHT];
 
 	/** Level from where sibling nodes needs to be loaded. **/
 	int                        i_pivot;
@@ -5725,11 +5725,6 @@ static void lock_op_unlock(struct td *tree)
 	m0_rwlock_write_unlock(&tree->t_lock);
 }
 
-static void level_alloc(struct m0_btree_oimpl *oi, int height)
-{
-	oi->i_level = m0_alloc(height * (sizeof *oi->i_level));
-}
-
 static void level_put(struct m0_btree_oimpl *oi)
 {
 	int i;
@@ -5794,7 +5789,6 @@ static void level_cleanup(struct m0_btree_oimpl *oi, struct m0_be_tx *tx)
 			oi->i_extra_node = NULL;
 		}
 	}
-	m0_free(oi->i_level);
 }
 
 /**
@@ -6283,12 +6277,7 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
-		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL) {
-			if (lock_acquired)
-				lock_op_unlock(tree);
-			return fail(bop, M0_ERR(-ENOMEM));
-		}
+		memset(&oi->i_level, 0, sizeof oi->i_level);
 		bop->bo_i->i_key_found = false;
 		oi->i_nop.no_op.o_sm.sm_rc = 0;
 		/** Fall through to P_DOWN. */
@@ -7139,12 +7128,7 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
-		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL) {
-			if (lock_acquired)
-				lock_op_unlock(tree);
-			return fail(bop, M0_ERR(-ENOMEM));
-		}
+		memset(&oi->i_level, 0, sizeof oi->i_level);
 		oi->i_nop.no_op.o_sm.sm_rc = 0;
 		/** Fall through to P_DOWN. */
 	case P_DOWN:
@@ -7362,12 +7346,7 @@ static int64_t btree_iter_kv_tick(struct m0_sm_op *smop)
 				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
-		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL) {
-			if (lock_acquired)
-				lock_op_unlock(tree);
-			return fail(bop, M0_ERR(-ENOMEM));
-		}
+		memset(&oi->i_level, 0, sizeof oi->i_level);
 		oi->i_nop.no_op.o_sm.sm_rc = 0;
 		/** Fall through to P_DOWN. */
 	case P_DOWN:
@@ -7933,12 +7912,7 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
-		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL) {
-			if (lock_acquired)
-				lock_op_unlock(tree);
-			return fail(bop, M0_ERR(-ENOMEM));
-		}
+		memset(&oi->i_level, 0, sizeof oi->i_level);
 		bop->bo_i->i_key_found = false;
 		oi->i_nop.no_op.o_sm.sm_rc = 0;
 		/** Fall through to P_DOWN. */
@@ -8215,11 +8189,7 @@ static int64_t btree_truncate_tick(struct m0_sm_op *smop)
 				    bop->bo_arbor->t_desc, P_SETUP);
 	case P_SETUP:
 		oi->i_height = tree->t_height;
-		level_alloc(oi, oi->i_height);
-		if (oi->i_level == NULL) {
-			lock_op_unlock(tree);
-			return fail(bop, M0_ERR(-ENOMEM));
-		}
+		memset(&oi->i_level, 0, sizeof oi->i_level);
 		oi->i_nop.no_op.o_sm.sm_rc = 0;
 		/** Fall through to P_DOWN. */
 	case P_DOWN:


### PR DESCRIPTION
Signed-off-by: Nikhil Kumar Birgade <nikhil.birgade@seagate.com>

# Problem Statement
- Convert m0_btreee_oimpl->i_level variable from dynamic to static.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Unit and System Tests are added


