### PR TITLE
EOS-24872 FDMI events delivering after failure plugin comes back

### DIFF
--- a/fdmi/filter.c
+++ b/fdmi/filter.c
@@ -114,8 +114,10 @@ M0_INTERNAL void m0_fdmi_filter_fini(struct m0_fdmi_filter *flt)
 {
 	M0_ENTRY("flt=%p", flt);
 
-	if (flt->ff_root != NULL)
+	if (flt->ff_root != NULL) {
 		free_flt_node(flt->ff_root);
+		flt->ff_root = NULL;
+	}
 
 	M0_LEAVE();
 }

--- a/fdmi/plugins/fdmi_app
+++ b/fdmi/plugins/fdmi_app
@@ -63,7 +63,7 @@ def str_decode(encoded):
 # move.
 def process_fdmi_record(kv_record):
     kvs = json.loads(kv_record)
-    fid = str_decode(kvs.get('fid'))
+    fid = kvs.get('fid')
     if fid is None:
         print('Invalid fid in kv_record {}'.format(kv_record), file=sys.stderr)
         return

--- a/fdmi/source_dock.c
+++ b/fdmi/source_dock.c
@@ -209,10 +209,21 @@ M0_INTERNAL void m0_fdmi__rec_id_gen(struct m0_fdmi_src_rec *src_rec)
 	M0_LEAVE();
 }
 
-M0_INTERNAL void m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec)
+M0_INTERNAL void m0_fdmi__enqueue(struct m0_fdmi_src_rec *src_rec)
 {
 	struct m0_fdmi_src_dock *src_dock = m0_fdmi_src_dock_get();
 
+	M0_ASSERT(src_rec != NULL && src_rec->fsr_src != NULL);
+
+	m0_mutex_lock(&src_dock->fsdc_list_mutex);
+	fdmi_record_list_tlist_add_tail(
+			&src_dock->fsdc_posted_rec_list, src_rec);
+	m0_fdmi__src_dock_fom_wakeup(&src_dock->fsdc_sd_fom);
+	m0_mutex_unlock(&src_dock->fsdc_list_mutex);
+}
+
+M0_INTERNAL void m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec)
+{
 	M0_ENTRY("src %p, fdmi_data %p, rec_id "U128X_F_SAFE,
 		 (src_rec ? src_rec->fsr_src : (void*)(-1)),
 		 (src_rec ? src_rec->fsr_data : (void*)(-1)),
@@ -226,12 +237,7 @@ M0_INTERNAL void m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec)
 
 	/** @todo Phase 2: Call m0_fdmi__fs_get(), remove inc_ref in FOL
 	 * source */
-
-	m0_mutex_lock(&src_dock->fsdc_list_mutex);
-	fdmi_record_list_tlist_add_tail(
-			&src_dock->fsdc_posted_rec_list, src_rec);
-	m0_fdmi__src_dock_fom_wakeup(&src_dock->fsdc_sd_fom);
-	m0_mutex_unlock(&src_dock->fsdc_list_mutex);
+	m0_fdmi__enqueue(src_rec);
 
 	M0_LEAVE();
 }

--- a/fdmi/source_dock_fom.c
+++ b/fdmi/source_dock_fom.c
@@ -40,8 +40,6 @@ static size_t fdmi_sd_fom_locality(const struct m0_fom *fom);
 static int sd_fom_send_record(struct fdmi_sd_fom *sd_fom,
 			      struct m0_fop      *fop,
 			      const char         *ep);
-static int sd_fom_process_matched_filters(struct m0_fdmi_src_dock *sd_ctx,
-					  struct m0_fdmi_src_rec  *src_rec);
 static int fdmi_filter_calc(struct fdmi_sd_fom         *sd_fom,
 			    struct m0_fdmi_src_rec     *src_rec,
 			    struct m0_conf_fdmi_filter *fdmi_filter);
@@ -388,6 +386,8 @@ static void fdmi_sd_fom_fini(struct m0_fom *fom)
 	M0_LEAVE();
 }
 
+enum { FDMI_RPC_MAX_RETRIES = 60 }; /* @see M0_RPC_MAX_RETRIES */
+
 static int fdmi_post_fop(struct m0_fop *fop, struct m0_rpc_session *session)
 {
 	struct m0_rpc_item *item;
@@ -403,7 +403,8 @@ static int fdmi_post_fop(struct m0_fop *fop, struct m0_rpc_session *session)
 	item->ri_deadline        = M0_TIME_IMMEDIATELY;
 
 	item->ri_resend_interval = m0_time(M0_RPC_ITEM_RESEND_INTERVAL, 0);
-	item->ri_nr_sent_max     = ~(uint64_t)0;
+	item->ri_nr_sent_max     = (uint64_t)FDMI_RPC_MAX_RETRIES;
+	/* timeout val = (item->ri_resend_interval * item->ri_nr_sent_max) */
 
 	return M0_RC(m0_rpc_post(item));
 }
@@ -420,6 +421,7 @@ static bool pending_fop_clink_cb(struct m0_clink *clink)
 	else
 		m0_rpc_conn_pool_put(&pending_fop->sd_fom->fsf_conn_pool,
 				     pending_fop->fti_session);
+	m0_fop_put_lock(pending_fop->fti_fop);
 	m0_mutex_lock(&sd_fom->fsf_pending_fops_lock);
 	pending_fops_tlist_del(pending_fop);
 	m0_mutex_unlock(&sd_fom->fsf_pending_fops_lock);
@@ -461,7 +463,7 @@ static int sd_fom_send_record(struct fdmi_sd_fom *sd_fom, struct m0_fop *fop,
 	int                    rc;
 	struct m0_rpc_session *session;
 
-	M0_ENTRY("sd_fom %p, fop %p, ep %s", sd_fom, fop, ep);
+	M0_LOG(M0_DEBUG, "sd_fom %p, sending fop %p to ep %s", sd_fom, fop, ep);
 	rc = m0_rpc_conn_pool_get_async(&sd_fom->fsf_conn_pool, ep, &session);
 	if (rc == 0)
 		rc = fdmi_post_fop(fop, session);
@@ -751,6 +753,7 @@ static void fdmi_rec_notif_replied(struct m0_rpc_item *item)
 {
 	struct m0_fdmi_src_rec  *src_rec;
 	struct m0_fdmi_src_dock *src_dock;
+	struct m0_rpc_conn_pool *pool;
 	int                      rc;
 
 	M0_ENTRY("item=%p", item);
@@ -761,12 +764,26 @@ static void fdmi_rec_notif_replied(struct m0_rpc_item *item)
 
 	rc = item->ri_error ?: m0_rpc_item_generic_reply_rc(item->ri_reply);
 	if (rc != 0)
-		M0_LOG(M0_ERROR, "FDMI reply error %d item->ri_error %d",
-		       rc, item->ri_error);
+		M0_LOG(M0_ERROR, "FDMI reply error %d item->ri_error %d to %s",
+		       rc, item->ri_error,
+		       m0_rpc_conn_addr(item->ri_session->s_conn));
 
-	m0_fdmi__handle_reply(src_dock, src_rec, rc);
-	m0_rpc_conn_pool_put(&src_dock->fsdc_sd_fom.fsf_conn_pool,
-			     item->ri_session);
+	pool = &src_dock->fsdc_sd_fom.fsf_conn_pool;
+	m0_rpc_conn_pool_put(pool, item->ri_session);
+	if (rc != 0) {
+		m0_rpc_conn_pool_destroy(pool, item->ri_session);
+
+		/*
+		 * The failed fop will be released.
+		 * Now let's enqueue the FDMI record again. It will be
+		 * processed and sent again.
+		 */
+		M0_LOG(M0_DEBUG, "Enqueue fdmi record again %p, ID:"U128X_F,
+				 src_rec, U128_P(&src_rec->fsr_rec_id));
+		m0_fdmi__enqueue(src_rec);
+	} else
+		m0_fdmi__handle_reply(src_dock, src_rec, rc);
+
 	M0_LEAVE();
 }
 

--- a/fdmi/source_dock_internal.h
+++ b/fdmi/source_dock_internal.h
@@ -133,6 +133,8 @@ struct m0_fdmi_sd_filter_type_handler {
 		 struct m0_fdmi_eval_var_info *var_info);
 };
 
+M0_INTERNAL void m0_fdmi__enqueue(struct m0_fdmi_src_rec *src_rec);
+
 /** Function posts new fdmi data for analysis by FDMI source dock. */
 M0_INTERNAL void m0_fdmi__record_post(struct m0_fdmi_src_rec *src_rec);
 

--- a/fdmi/ut/sd_send_not.c
+++ b/fdmi/ut/sd_send_not.c
@@ -291,9 +291,16 @@ void fdmi_sd_send_notif(void)
 	M0_UT_ASSERT(rpc_conn_pool_items_tlist_head(&conn_pool->cp_items) ==
 		     rpc_conn_pool_items_tlist_tail(&conn_pool->cp_items));
 	unprepare_rpc_env(&g_rpc_env);
-	rpc_conn_pool_items_tlink_del_fini(pool_item);
-	m0_free(pool_item);
-	pool_item = NULL;
+
+	/*
+	 * At this moment, the pool_item might have been removed from the list
+	 * and been freed in FDMI notification failure handling.
+	 */
+	if (rpc_conn_pool_items_tlink_is_in(pool_item)) {
+		rpc_conn_pool_items_tlink_del_fini(pool_item);
+		m0_free(pool_item);
+		pool_item = NULL;
+	}
 	fdmi_serv_stop_ut();
 	m0_semaphore_fini(&g_sem1);
 	m0_semaphore_fini(&g_sem2);

--- a/rpc/conn_pool.c
+++ b/rpc/conn_pool.c
@@ -139,7 +139,8 @@ static void conn_pool_item_fini(struct m0_rpc_conn_pool_item *item)
 	m0_clink_fini(&item->cpi_clink);
 	m0_chan_fini_lock(&item->cpi_chan);
 	m0_rpc_link_fini(&item->cpi_rpc_link);
-	rpc_conn_pool_items_tlink_del_fini(item);
+	if (rpc_conn_pool_items_tlink_is_in(item))
+		rpc_conn_pool_items_tlink_del_fini(item);
 	m0_free(item);
 }
 
@@ -367,6 +368,94 @@ M0_INTERNAL void m0_rpc_conn_pool_fini(struct m0_rpc_conn_pool *pool)
 
 	M0_LEAVE();
 }
+
+static void pool_item_disconnected_ast(struct m0_sm_group *grp,
+				       struct m0_sm_ast   *ast)
+{
+	struct m0_rpc_conn_pool_item *item = ast->sa_datum;
+
+	M0_LOG(M0_DEBUG, "item=%p got freed", item);
+	m0_rpc_link_fini(&item->cpi_rpc_link);
+	m0_free(item);
+}
+
+static bool pool_item_disconn_cb(struct m0_clink *link)
+{
+	struct m0_rpc_conn_pool_item *item;
+	struct m0_rpc_conn_pool      *pool;
+	struct m0_rpc_session        *session;
+	struct m0_sm_ast             *ast;
+	struct m0_locality           *loc = m0_locality0_get();
+
+	M0_ENTRY("link %p", link);
+
+	item = container_of(link, struct m0_rpc_conn_pool_item, cpi_clink);
+	pool = item->cpi_pool;
+	session = &item->cpi_rpc_link.rlk_sess;
+
+	m0_mutex_lock(&pool->cp_mutex);
+	M0_LOG(M0_DEBUG, "session established=%d rpc connected=%d",
+			 !!m0_rpc_conn_pool_session_established(session),
+			 !!item->cpi_rpc_link.rlk_connected);
+
+	m0_clink_fini(&item->cpi_clink);
+	m0_chan_fini_lock(&item->cpi_chan);
+	M0_LOG(M0_DEBUG, "Going to free item=%p in an AST", item);
+
+	ast = &pool->cp_ast;
+	ast->sa_cb = pool_item_disconnected_ast;
+	ast->sa_datum = item;
+	m0_sm_ast_post(loc->lo_grp, ast);
+
+	m0_mutex_unlock(&pool->cp_mutex);
+
+	M0_LEAVE();
+	return true;
+}
+
+/**
+ * Destroy this rpc session from this pool.
+ *
+ * First, the connection pool item will be identified by iterating the
+ * connection pool list and removed from the list.
+ * Then, the rpc link will be asynchronously disconnect. In the disconnection
+ * callback, we will destroy this rpc link.
+ */
+M0_INTERNAL void m0_rpc_conn_pool_destroy(struct m0_rpc_conn_pool *pool,
+					  struct m0_rpc_session   *session)
+{
+	struct m0_rpc_conn_pool_item *item;
+
+	M0_ENTRY();
+
+	m0_mutex_lock(&pool->cp_mutex);
+
+	m0_tl_for(rpc_conn_pool_items, &pool->cp_items, item) {
+		if (&item->cpi_rpc_link.rlk_sess != session)
+			continue;
+
+		/* remove this item from pool. */
+		rpc_conn_pool_items_tlink_del_fini(item);
+		break;
+	} m0_tl_endfor;
+
+	if (item != NULL) {
+		/* disconnect the rpc link */
+		M0_LOG(M0_DEBUG, "Async disconnect this rpc. item=%p", item);
+		if (m0_rpc_conn_pool_session_established(session) &&
+		    item->cpi_rpc_link.rlk_connected){
+			m0_clink_init(&item->cpi_clink, pool_item_disconn_cb);
+			item->cpi_clink.cl_is_oneshot = true;
+			m0_rpc_link_disconnect_async(&item->cpi_rpc_link,
+						     m0_time_from_now(10, 0),
+						     &item->cpi_clink);
+		}
+	}
+	m0_mutex_unlock(&pool->cp_mutex);
+
+	M0_LEAVE();
+}
+
 
 #undef M0_TRACE_SUBSYSTEM
 

--- a/rpc/conn_pool.h
+++ b/rpc/conn_pool.h
@@ -50,6 +50,7 @@ struct m0_rpc_conn_pool {
 	struct m0_mutex          cp_ch_mutex;
 	m0_time_t                cp_timeout;
 	uint64_t                 cp_max_rpcs_in_flight;
+	struct m0_sm_ast         cp_ast;
 };
 
 M0_INTERNAL int m0_rpc_conn_pool_init(
@@ -87,6 +88,11 @@ struct m0_chan *m0_rpc_conn_pool_session_chan(struct m0_rpc_session *session);
 M0_INTERNAL bool m0_rpc_conn_pool_session_established(
 		struct m0_rpc_session *session);
 
+/**
+ * Destroy this rpc session from this pool.
+ */
+M0_INTERNAL void m0_rpc_conn_pool_destroy(struct m0_rpc_conn_pool *pool,
+					  struct m0_rpc_session   *session);
 #endif /* __MOTR_RPC_CONN_POOL_H__ */
 
 /*


### PR DESCRIPTION

Signed-off-by: Hua Huang <hua.huang@seagate.com>


# Problem Statement
When a Motr FDMI plguin app failed, the delivery of FDMI notification from source side
to plugin app side will STUCK there, and retrying several times, and eventually failed with timeout.
The fop replied callback is triggered with a failure. In this case, the rpc connection and session
from source side to plugin side is dead.


# Design
On FDMI source side, if FDMI notification fop is failed to send, we remove this RPC link from
the connection pool, and destroy it. The notification fop is released. Now, we post the FDMI record
again so it will be re-sent with a new RPC connection/session. We are using the asynchronously
interfaces to establish and destroy the RPC connection.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
