### PR TITLE
Kubernetes:  Use machine id motr hare keys

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -323,25 +323,24 @@ def get_md_disks(self, node_info):
     return md_disks
 
 # Update metadata disk entries to motr-hare confstore
-def update_to_file(self, index, url, hostname, md_disks):
+def update_to_file(self, index, url, machine_id, md_disks):
     ncvgs = len(md_disks)
     for i in range(ncvgs):
         md = md_disks[i]
         len_md = len(md)
         for j in range(len_md):
             md_disk = md[j]
-            self.logger.info(f"setting key server>{hostname}>cvg[{i}]>m0d[{j}]>md_seg1"
+            self.logger.info(f"setting key server>{machine_id}>cvg[{i}]>m0d[{j}]>md_seg1"
                          f" with value {md_disk} in {url}")
-            Conf.set(index, f"server>{hostname}>cvg[{i}]>m0d[{j}]>md_seg1",f"{md_disk}")
+            Conf.set(index, f"server>{machine_id}>cvg[{i}]>m0d[{j}]>md_seg1",f"{md_disk}")
             Conf.save(index)
 
 def update_motr_hare_keys(self, nodes):
-    # k = machine_id. v = node_info
-    for v in nodes.values():
-        if v['type'] == 'storage_node':
-            md_disks = get_md_disks(self, v)
-            hostname = v['hostname']
-            update_to_file(self, self._index_motr_hare, self._url_motr_hare, hostname, md_disks)
+    # key = machine_id value = node_info
+    for machine_id, node_info in nodes.items():
+        if node_info['type'] == 'storage_node':
+            md_disks = get_md_disks(self, node_info)
+            update_to_file(self, self._index_motr_hare, self._url_motr_hare, machine_id, md_disks)
 
 def motr_config_k8(self):
     if not verify_libfabric(self):


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
- Use machine id key in motr-hare keys file instead of hostname

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
