### PR TITLE
EOS-25421: Add APIs for aligning chunk header.

### DIFF
--- a/be/alloc.c
+++ b/be/alloc.c
@@ -1023,7 +1023,8 @@ M0_INTERNAL void m0_be_alloc_aligned(struct m0_be_allocator *a,
 				     void **ptr,
 				     m0_bcount_t size,
 				     unsigned shift,
-				     uint64_t zonemask)
+				     uint64_t zonemask,
+				     bool chunk_align)
 {
 	enum  m0_be_alloc_zone_type  ztype;
 	struct be_alloc_chunk       *c = NULL;
@@ -1095,7 +1096,12 @@ M0_INTERNAL void m0_be_alloc(struct m0_be_allocator *a,
 			     m0_bcount_t size)
 {
 	m0_be_alloc_aligned(a, tx, op, ptr, size, M0_BE_ALLOC_SHIFT_MIN,
-			    M0_BITS(M0_BAP_NORMAL));
+			    M0_BITS(M0_BAP_NORMAL), false);
+}
+
+M0_INTERNAL size_t m0_be_chunk_header_size(void)
+{
+	return sizeof(struct be_alloc_chunk);
 }
 
 M0_INTERNAL void m0_be_free_aligned(struct m0_be_allocator *a,

--- a/be/alloc.h
+++ b/be/alloc.h
@@ -240,6 +240,9 @@ M0_INTERNAL void m0_be_allocator_credit(struct m0_be_allocator *a,
  * @param zonemask Bit mask of the zones where memory should be allocated.
  *                 The first zone from the bit mask with sufficient space will
  *                 be chosen for allocation, see m0_be_alloc_zone_type.
+ * @param chunk_align Chunk header(be_alloc_chunk) will be aligned to
+ *		      (shift^2)-byte boundary. Memory will follow after chunk
+ *		      header.
  *
  * The memory should be freed using m0_be_free_aligned().
  *
@@ -252,7 +255,8 @@ M0_INTERNAL void m0_be_alloc_aligned(struct m0_be_allocator *a,
 				     void **ptr,
 				     m0_bcount_t size,
 				     unsigned shift,
-				     uint64_t zonemask);
+				     uint64_t zonemask,
+				     bool chunk_align);
 
 /**
  * Allocate memory.
@@ -312,7 +316,10 @@ M0_INTERNAL void m0_be_alloc_stats_credit(struct m0_be_allocator *a,
 M0_INTERNAL void m0_be_alloc_stats_capture(struct m0_be_allocator *a,
                                            struct m0_be_tx        *tx);
 
-
+/**
+ * Returns size of chunk header (be_alloc_chunk).
+ */
+M0_INTERNAL size_t m0_be_chunk_header_size(void);
 /**
  * Allocate array of structures.
  *
@@ -336,7 +343,7 @@ M0_INTERNAL void m0_be_alloc_stats_capture(struct m0_be_allocator *a,
 #define M0_BE_ALLOC_ALIGN_ARR(arr, nr, shift, seg, tx, op)                     \
 		m0_be_alloc_aligned(m0_be_seg_allocator(seg), (tx), (op),      \
 				    (void **)&(arr), (nr) * sizeof((arr)[0]),  \
-				    (shift), M0_BITS(M0_BAP_NORMAL))
+				    (shift), M0_BITS(M0_BAP_NORMAL), false)
 
 #define M0_BE_FREE_ALIGN_ARR(arr, seg, tx, op)                                 \
 		m0_be_free_aligned(m0_be_seg_allocator(seg), (tx), (op), (arr))
@@ -396,7 +403,7 @@ M0_INTERNAL void m0_be_alloc_stats_capture(struct m0_be_allocator *a,
 #define M0_BE_ALLOC_ALIGN_BUF(buf, shift, seg, tx, op)                         \
 		m0_be_alloc_aligned(m0_be_seg_allocator(seg), (tx), (op),      \
 				    &(buf)->b_addr, (buf)->b_nob,              \
-				    shift, M0_BITS(M0_BAP_NORMAL))
+				    shift, M0_BITS(M0_BAP_NORMAL), false)
 
 #define M0_BE_FREE_ALIGN_BUF(buf, shift, seg, tx, op)                          \
 		m0_be_free_aligned(m0_be_seg_allocator(seg), (tx),             \

--- a/be/btree.c
+++ b/be/btree.c
@@ -123,7 +123,7 @@ static inline void *mem_alloc(const struct m0_be_btree *btree,
 		      m0_be_alloc_aligned(tree_allocator(btree),
 					  tx, &op, &p, size,
 					  BTREE_ALLOC_SHIFT,
-					  zonemask));
+					  zonemask, false));
 	M0_ASSERT(p != NULL);
 	return p;
 }

--- a/be/linux_kernel/stubs.c
+++ b/be/linux_kernel/stubs.c
@@ -53,7 +53,8 @@ M0_INTERNAL void m0_be_alloc_aligned(struct m0_be_allocator *a,
 				     void **ptr,
 				     m0_bcount_t size,
 				     unsigned shift,
-				     uint64_t zonemask)
+				     uint64_t zonemask,
+				     bool chunk_align)
 {
 	m0_be_alloc(a, tx, op, ptr, size);
 }

--- a/be/ut/alloc.c
+++ b/be/ut/alloc.c
@@ -110,7 +110,8 @@ static void be_ut_alloc_ptr_handle(struct m0_be_allocator  *a,
 			  (M0_BE_OP_SYNC(op,
 				 m0_be_alloc_aligned(a, tx, &op, p, size,
 						     shift,
-						     M0_BITS(M0_BAP_NORMAL))),
+						     M0_BITS(M0_BAP_NORMAL),
+						     false)),
 			   m0_be_alloc_stats_capture(a, tx)));
 		M0_UT_ASSERT(*p != NULL);
 		M0_UT_ASSERT(m0_addr_is_aligned(*p, shift));
@@ -377,7 +378,8 @@ M0_INTERNAL void m0_be_ut_alloc_spare(void)
 						 m0_be_alloc_aligned(a, tx, &op,
 						     &ptrs[i], size,
 						     BE_UT_ALLOC_SHIFT,
-						     scenario[i].zonemask)),
+						     scenario[i].zonemask,
+						     false)),
 					   m0_be_alloc_stats_capture(a, tx)));
 			M0_UT_ASSERT(
 				(ptrs[i] == NULL) == scenario[i].should_fail);

--- a/motr/m0crate/btree_without_tx_seg.c
+++ b/motr/m0crate/btree_without_tx_seg.c
@@ -75,7 +75,8 @@ M0_INTERNAL void m0_be_alloc_aligned(struct m0_be_allocator *a,
 				     void **ptr,
 				     m0_bcount_t size,
 				     unsigned shift,
-				     uint64_t zonemask)
+				     uint64_t zonemask,
+				     bool chunk_align)
 {
 	*ptr = m0_alloc_aligned(size, shift);
 }
@@ -208,7 +209,7 @@ static inline void *mem_alloc(const struct m0_be_btree *btree,
 		      m0_be_alloc_aligned(tree_allocator(btree),
 					  tx, &op, &p, size,
 					  BTREE_ALLOC_SHIFT,
-					  zonemask));
+					  zonemask, false));
 	M0_ASSERT(p != NULL);
 	return p;
 }


### PR DESCRIPTION
Signed-off-by: Nikhil Kumar Birgade <nikhil.birgade@seagate.com>

# Problem Statement
- Define BE allocator interface to allocate/free BE memory and also provide allocator chunk header size to the caller.


# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent -> Done
