### PR TITLE
EOS-24484: Added DTM0 Log iterator and UTs.

### DIFF
--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -641,6 +641,82 @@ M0_INTERNAL int m0_be_dtm0_plog_prune(struct m0_be_dtm0_log    *log,
 	return 0;
 }
 
+static const struct m0_dtm0_tid dtm0_log_iter_tid0 =
+		(struct m0_dtm0_tid) { .dti_ts = { .dts_phys = ~0 } };
+
+static bool be_dtm0_log_iter_is_first(const struct m0_be_dtm0_log_iter *iter)
+{
+	return memcmp(&iter->dli_current_tid, &dtm0_log_iter_tid0,
+		      sizeof iter->dli_current_tid) == 0;
+}
+
+static bool be_dtm0_log_iter_invariant(const struct m0_be_dtm0_log_iter *iter)
+{
+	return _0C(m0_be_dtm0_log__invariant(iter->dli_log)) &&
+		(be_dtm0_log_iter_is_first(iter)
+		 ? _0C(true)
+		 : _0C(m0_dtm0_tid__invariant(&iter->dli_current_tid)));
+}
+
+M0_INTERNAL void m0_be_dtm0_log_iter_init(struct m0_be_dtm0_log_iter *iter,
+					  struct m0_be_dtm0_log      *log)
+{
+	iter->dli_log = log;
+	iter->dli_current_tid = dtm0_log_iter_tid0;
+	M0_POST(be_dtm0_log_iter_invariant(iter));
+}
+
+M0_INTERNAL void m0_be_dtm0_log_iter_fini(struct m0_be_dtm0_log_iter *iter)
+{
+	M0_POST(be_dtm0_log_iter_invariant(iter));
+}
+
+M0_INTERNAL int m0_be_dtm0_log_iter_next(struct m0_be_dtm0_log_iter *iter,
+					 struct m0_dtm0_log_rec	    *out)
+{
+	struct m0_dtm0_log_rec *rec;
+	int rc;
+
+	M0_PRE(m0_mutex_is_locked(&iter->dli_log->dl_lock));
+	M0_PRE(be_dtm0_log_iter_invariant(iter));
+	M0_ENTRY();
+
+	if (be_dtm0_log_iter_is_first(iter))
+		rec = iter->dli_log->dl_is_persistent
+			? lrec_be_list_head(iter->dli_log->u.dl_persist)
+			: lrec_tlist_head(iter->dli_log->u.dl_inmem);
+	else {
+		rec = m0_be_dtm0_log_find(iter->dli_log,
+					  &iter->dli_current_tid);
+		rec = iter->dli_log->dl_is_persistent
+			? lrec_be_list_next(iter->dli_log->u.dl_persist, rec)
+			: lrec_tlist_next(iter->dli_log->u.dl_inmem, rec);
+	}
+
+	if (rec != NULL) {
+		iter->dli_current_tid = rec->dlr_txd.dtd_id;
+		rc = m0_dtm0_log_rec_copy(out, rec);
+		if (rc != 0)
+			return M0_ERR(rc);
+	}
+
+	return M0_RC(rec == NULL ? 0 : +1);
+}
+
+M0_INTERNAL int m0_dtm0_log_rec_copy(struct m0_dtm0_log_rec       *dst,
+				     const struct m0_dtm0_log_rec *src)
+{
+	M0_SET0(dst);
+	return m0_dtm0_tx_desc_copy(&src->dlr_txd, &dst->dlr_txd) ?:
+		m0_buf_copy(&dst->dlr_payload, &src->dlr_payload);
+}
+
+M0_INTERNAL void m0_dtm0_log_iter_rec_fini(struct m0_dtm0_log_rec *rec)
+{
+	m0_dtm0_tx_desc_fini(&rec->dlr_txd);
+	m0_buf_free(&rec->dlr_payload);
+}
+
 #undef M0_TRACE_SUBSYSTEM
 
 /** @} end of dtm group */

--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -653,9 +653,8 @@ static bool be_dtm0_log_iter_is_first(const struct m0_be_dtm0_log_iter *iter)
 static bool be_dtm0_log_iter_invariant(const struct m0_be_dtm0_log_iter *iter)
 {
 	return _0C(m0_be_dtm0_log__invariant(iter->dli_log)) &&
-		(be_dtm0_log_iter_is_first(iter)
-		 ? _0C(true)
-		 : _0C(m0_dtm0_tid__invariant(&iter->dli_current_tid)));
+	       _0C(be_dtm0_log_iter_is_first(iter) ||
+		   m0_dtm0_tid__invariant(&iter->dli_current_tid));
 }
 
 M0_INTERNAL void m0_be_dtm0_log_iter_init(struct m0_be_dtm0_log_iter *iter,

--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -521,6 +521,44 @@ M0_INTERNAL void m0_be_dtm0_volatile_log_del(struct m0_be_dtm0_log  *log,
 					     struct m0_dtm0_log_rec *rec,
 					     bool                    fini);
 
+
+/**
+ * DTM0 Log iterator
+ *
+ * Provides a way to iterate over the DTM0 Log structure. Today has a very
+ * inefficient implementation and used to glue log related code together with
+ * redo logic and expose interfaces which hopefully will not change.
+ */
+struct m0_be_dtm0_log_iter {
+	struct m0_be_dtm0_log *dli_log;
+	struct m0_dtm0_tid     dli_current_tid;
+};
+
+M0_INTERNAL int m0_dtm0_log_rec_copy(struct m0_dtm0_log_rec       *dst,
+				     const struct m0_dtm0_log_rec *src);
+/**
+ * Used to finalise record returned from the iterator. Could be generalised in
+ * future.
+ */
+M0_INTERNAL void m0_dtm0_log_iter_rec_fini(struct m0_dtm0_log_rec *rec);
+
+M0_INTERNAL void m0_be_dtm0_log_iter_init(struct m0_be_dtm0_log_iter *iter,
+					  struct m0_be_dtm0_log      *log);
+
+M0_INTERNAL void m0_be_dtm0_log_iter_fini(struct m0_be_dtm0_log_iter *iter);
+
+/**
+ * Returns next record of the iterator pointing to the log.
+ *
+ * @param out returned record which is copied and need to be freed with
+ *            m0_dtm0_log_iter_rec_fini()
+ *
+ * @return +1 when the iterator was successfully moved to the next record.
+ * @return  0 when the end of the log has been reached.
+ */
+M0_INTERNAL int m0_be_dtm0_log_iter_next(struct m0_be_dtm0_log_iter *iter,
+					 struct m0_dtm0_log_rec	    *out);
+
 /** @} */ /* end DTM0Internals */
 
 #endif /* __MOTR_BE_DTM0_LOG_H__ */

--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -525,8 +525,8 @@ M0_INTERNAL void m0_be_dtm0_volatile_log_del(struct m0_be_dtm0_log  *log,
 /**
  * DTM0 Log iterator
  *
- * Provides a way to iterate over the DTM0 Log structure. Today has a very
- * inefficient implementation and used to glue log related code together with
+ * Provides a way to iterate over the DTM0 Log structure. Today it has a very
+ * inefficient implementation and is used to glue log related code together with
  * redo logic and expose interfaces which hopefully will not change.
  */
 struct m0_be_dtm0_log_iter {
@@ -550,7 +550,7 @@ M0_INTERNAL void m0_be_dtm0_log_iter_fini(struct m0_be_dtm0_log_iter *iter);
 /**
  * Returns next record of the iterator pointing to the log.
  *
- * @param out returned record which is copied and need to be freed with
+ * @param out returned record which is copied and needs to be freed with
  *            m0_dtm0_log_iter_rec_fini()
  *
  * @return +1 when the iterator was successfully moved to the next record.

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -908,6 +908,8 @@ static void idx_setup(void)
 	m0_idx_init(idx, &realm->co_realm, (struct m0_uint128 *) ifid);
 
 	/* Create the index */
+	if (ENABLE_DTM0)
+		idx->in_entity.en_flags |= M0_ENF_META;
 	rc = m0_entity_create(NULL, &idx->in_entity, &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);


### PR DESCRIPTION
Signed-off-by: Anatoliy Bilenko <anatoliy.bilenko@seagate.com>

# Problem Statement
- added log iterator code as a part of DTM0 recovery algorithm and UT.
# Design
https://seagate-systems.atlassian.net/wiki/spaces/~770032066/pages/609880834/DTM+Basic+Recovery+HLD+draft

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [X] Unit and System Tests are added
- [X] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [not needed] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [X] Interface change (if any) are documented
- [N/A] Side effects on other features (deployment/upgrade)
- [N/A] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [N/A] Changes done to WIKI / Confluence page / Quick Start Guide
