### PR TITLE
EOS-25504: K8s Free space monitor failing on control pods

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -1319,6 +1319,11 @@ def fetch_fid(self, service, idx):
 def start_service(self, service, idx):
     self.logger.info(f"service={service}\nidx={idx}\n")
 
+    if service == "fsm":
+        cmd = f"{MOTR_FSM_SCRIPT_PATH}"
+        execute_command_verbose(self, cmd, set_timeout=False)
+        return
+
     # Copy confd_path to /etc/sysconfig
     # confd_path = MOTR_M0D_CONF_DIR/confd.xc
     confd_path = f"{self.local_path}/motr/sysconfig/{self.machine_id}/confd.xc"
@@ -1330,14 +1335,9 @@ def start_service(self, service, idx):
     cmd = f"cp -v {self.local_path}/motr/sysconfig/{self.machine_id}/motr /etc/sysconfig/"
     execute_command(self, cmd)
 
-    if service != "fsm":
-        fid = fetch_fid(self, service, idx)
-        if fid == -1:
-            return -1
-    if service in ["ioservice", "confd", "cas"]:
-        cmd = f"{MOTR_SERVER_SCRIPT_PATH} m0d-{fid}"
-        execute_command_verbose(self, cmd, set_timeout=False)
-    elif service == "fsm":
-        cmd = f"{MOTR_FSM_SCRIPT_PATH}"
-        execute_command_verbose(self, cmd, set_timeout=False)
+    fid = fetch_fid(self, service, idx)
+    if fid == -1:
+        return -1
+    cmd = f"{MOTR_SERVER_SCRIPT_PATH} m0d-{fid}"
+    execute_command_verbose(self, cmd, set_timeout=False)
     return


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
EOS-25504: K8s Free space monitor failing on control pods

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
