### PR TITLE
spec: fix check for castxml on CentOS 7 aarch64 platform

### DIFF
--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -85,16 +85,17 @@ BuildRequires:  libtool
 BuildRequires:  make
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
-%if %{rhel} < 8 && "%{_arch}" == "aarch64"
-# castxml rpm on rhel 7 is not available, so it has to be
-# built and installed manually.
-#BuildRequires:  castxml
-%else if %{rhel} < 8
-BuildRequires:  gccxml
+%if %{rhel} < 8
+  %if "%{_arch}" == "aarch64"
+    # castxml rpm is not available on rhel 7,
+    # it must be built and installed manually.
+    #BuildRequires:  castxml
+  %else
+    BuildRequires:  gccxml
+  %endif
 %else
-BuildRequires:  castxml
+  BuildRequires:  castxml
 %endif
-
 BuildRequires:  glibc-headers
 BuildRequires:  asciidoc
 BuildRequires:  libyaml-devel


### PR DESCRIPTION
The BuildRequires check for castxml on CentOS 7 aarch64
platform is not working well, it still requires castxml
package to be present:

    error: Failed build dependencies:
          castxml is needed by cortx-motr...

But the check should be skipped because castxml rpm is not
available on CentOS 7.

Solution: fix `%if` directive which does the check, avoid
using `%if else`.