### PR TITLE
cortx-motr.spec: set m0trace to 16M

### DIFF
--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -38,7 +38,7 @@
 %define _use_internal_dependency_generator 0
 
 # configure options
-%define  configure_release_opts     --enable-release --disable-avx --enable-force-ssse3 --with-trace-kbuf-size=256 --with-trace-ubuf-size=64
+%define  configure_release_opts     --enable-release --disable-avx --enable-force-ssse3 --with-trace-kbuf-size=256 --with-trace-ubuf-size=16
 %define  configure_ut_opts          --enable-dev-mode --disable-altogether-mode
 
 %if %{with cassandra}


### PR DESCRIPTION
# Problem Statement
    - s3server can generate multiple m0traces which will add lot of disk
      space which will make local disk full.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
[root@ssc-vm-g3-rhev4-2135 ~]# ls -al /var/motr/m0d-0x7200000000000001\:0x9/m0trace.40* -h
-rwx------ 1 root motr 17M Oct 25 23:54 /var/motr/m0d-0x7200000000000001:0x9/m0trace.40387
-rwx------ 1 root motr 17M Oct 25 23:55 /var/motr/m0d-0x7200000000000001:0x9/m0trace.40883
[root@ssc-vm-g3-rhev4-2135 ~]# ls -la /var/log/seagate/motr/s3server-0x7200000000000001:0x17/m0trace.42216
-rwx------ 1 root root 16842752 Oct 25 23:54 /var/log/seagate/motr/s3server-0x7200000000000001:0x17/m0trace.42216


# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
