### PR TITLE
EOS-25635: Fix Confstr-ut failure with new btree code.

### DIFF
--- a/conf/db.h
+++ b/conf/db.h
@@ -62,6 +62,20 @@ M0_INTERNAL void m0_confdb_destroy_credit(struct m0_be_seg *seg,
 M0_INTERNAL int m0_confdb_destroy(struct m0_be_seg *seg, struct m0_be_tx *tx);
 
 /**
+ * Calculates BE credits in-order to truncate configuration database from
+ * persistent store. Currently it is only used by conf-ut.
+ */
+M0_INTERNAL int m0_confdb_truncate_credit(struct m0_be_seg       *seg,
+					   struct m0_be_tx        *tx,
+					   struct m0_be_tx_credit *accum,
+					   m0_bcount_t            *limit);
+/**
+ * Truncates configuration data base. Currently only used by conf-ut.
+ */
+M0_INTERNAL int m0_confdb_truncate(struct m0_be_seg *seg,
+				   struct m0_be_tx  *tx,
+				   m0_bcount_t       limit);
+/**
  * Creates m0_confx and populates it with data read from a
  * configuration database.
  *

--- a/conf/ut/db.c
+++ b/conf/ut/db.c
@@ -123,6 +123,7 @@ static void test_confdb(void)
 	int                     j;
 	int                     hit;
 	int                     rc;
+	m0_bcount_t             limit;
 	struct {
 		const struct m0_fid *fid;
 		void (*check)(const struct m0_confx_obj *xobj);
@@ -217,6 +218,18 @@ static void test_confdb(void)
 	m0_free(dec->cx__objs);
 	m0_free(dec);
 	m0_confdb_fini(seg);
+	/** 
+	 * Delete all the btree nodes except root node before calling destroy.
+	 */
+	M0_SET0(&accum);
+	rc = m0_confdb_truncate_credit(seg, &tx, &accum, &limit);
+	M0_UT_ASSERT(rc == 0);
+	rc = conf_ut_be_tx_create(&tx, &ut_be, &accum);
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_confdb_truncate(seg, &tx, limit);
+	M0_UT_ASSERT(rc == 0);
+	conf_ut_be_tx_fini(&tx);
+	/** Destroy the btree. */
 	M0_SET0(&accum);
 	m0_confdb_destroy_credit(seg, &accum);
 	rc = conf_ut_be_tx_create(&tx, &ut_be, &accum);


### PR DESCRIPTION
Issue: The tree was non-empty before calling btree_destroy.
Fix: Truncate tree before calling btree_destroy.

Signed-off-by: Nikhil Kumar Birgade <nikhil.birgade@seagate.com>

# Problem Statement
- Confstr-ut failure with new btree code.

# Design
-  Truncate tree before calling btree_destroy.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
 - Confstr-ut passed witht the changes.

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
