### PR TITLE
motr_setup: run logrotate in background to avoid startup delay

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -1380,10 +1380,13 @@ def start_service(self, service, idx):
     fid = fetch_fid(self, service, idx)
     if fid == -1:
         return -1
-    cmd = "/opt/seagate/cortx/motr/libexec/m0trace_logrotate.sh"
+    #Run log rotate in background to avoid delay in startup
+    cmd = "/opt/seagate/cortx/motr/libexec/m0trace_logrotate.sh &"
     execute_command(self, cmd)
-    cmd = "/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh"
+    cmd = "/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh &"
     execute_command(self, cmd)
+
+    #Start motr services
     cmd = f"{MOTR_SERVER_SCRIPT_PATH} m0d-{fid}"
     execute_command_verbose(self, cmd, set_timeout=False)
     return

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -315,10 +315,6 @@ class StartCmd(Cmd):
             self.logger.error(f"Invalid service name({self._services}).")
             return
         if (nargs == 0):
-            if pkg_installed(self, "cortx-hare"):
-                if cluster_up(self):
-                    self.logger.warning("Cluster is already up...Exiting.\n")
-                    return
             svc = self._services
 
             if not self._idx:


### PR DESCRIPTION
- run m0trace and m0addb logrotate in background to avoid startup delay.
- remove hare package installed check which is not required for kubernetes.

Signed-off-by: Yeshpal Jain <yeshpal.jain@seagate.com>

# Problem Statement
- Avoid startup delay because of log rotate running in foreground.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
