### PR TITLE
EOS-24894: Clean up the clink in rconfc_herd_link_fom_wait_on 

### DIFF
--- a/conf/rconfc_link_fom.c
+++ b/conf/rconfc_link_fom.c
@@ -178,7 +178,9 @@ static void rconfc_herd_link_fom_wait_on(struct rconfc_link *lnk,
 		[M0_RLF_SESS_WAIT_IDLE]   = rconfc_link__on_sess_terminated,
 		[M0_RLF_SESS_TERMINATING] = rconfc_link__on_conn_terminated,
 	};
-
+	/*
+	 * Insure that link is cleaned up before next initialization 		
+ 	 */
 	m0_clink_cleanup(&lnk->rl_fom_clink);
 	m0_clink_init(&lnk->rl_fom_clink, cb[phase]);
 	m0_clink_add_lock(chan[phase], &lnk->rl_fom_clink);

--- a/conf/rconfc_link_fom.c
+++ b/conf/rconfc_link_fom.c
@@ -179,7 +179,7 @@ static void rconfc_herd_link_fom_wait_on(struct rconfc_link *lnk,
 		[M0_RLF_SESS_TERMINATING] = rconfc_link__on_conn_terminated,
 	};
 	/*
-	 * Insure that link is cleaned up before next initialization 		
+	 * Ensure that link is cleaned up before next initialization 		
  	 */
 	m0_clink_cleanup(&lnk->rl_fom_clink);
 	m0_clink_init(&lnk->rl_fom_clink, cb[phase]);

--- a/conf/rconfc_link_fom.c
+++ b/conf/rconfc_link_fom.c
@@ -179,6 +179,7 @@ static void rconfc_herd_link_fom_wait_on(struct rconfc_link *lnk,
 		[M0_RLF_SESS_TERMINATING] = rconfc_link__on_conn_terminated,
 	};
 
+	m0_clink_cleanup(&lnk->rl_fom_clink);
 	m0_clink_init(&lnk->rl_fom_clink, cb[phase]);
 	m0_clink_add_lock(chan[phase], &lnk->rl_fom_clink);
 }

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -75,16 +75,17 @@ BuildRequires:  libtool
 BuildRequires:  make
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
-%if %{rhel} < 8 && "%{_arch}" == "aarch64"
-# castxml rpm on rhel 7 is not available, so it has to be
-# built and installed manually.
-#BuildRequires:  castxml
-%else if %{rhel} < 8
+%if %{rhel} < 8
+  %if "%{_arch}" == "aarch64"
+    # castxml rpm is not available on rhel 7,
+    # it must be built and installed manually.
+    # BuildRequires:  castxml
+  %else
 BuildRequires:  gccxml
+  %endif
 %else
 BuildRequires:  castxml
 %endif
-
 BuildRequires:  glibc-headers
 BuildRequires:  asciidoc
 BuildRequires:  libyaml-devel


### PR DESCRIPTION
Clean up the clink in rconfc_herd_link_fom_wait_on before clink initialization.

Signed-off-by: Vidyadhar Pinglikar <vidyadhar.pinglikar@seagate.com>

# Problem Statement
- In rconfc_link_fom_tick, if rconfc_herd_link_fom_wait_on is called in both initial states, (M0_RLF_INIT and M0_RLF_SESS_WAIT_IDLE) then in that case, sess->s_sm.sm_chan is getting initialized twice with link->cl_is_oneshot = false;
- Due to this clink is not getting deleted when signaled but is re-initialized subsequently again in M0_RLF_SESS_WAIT_IDLE where its tlink is also initialized; due this tlink verification assert is getting hit.

# Design
-  As a fix, Clink clean-up API is invoked every-time, its initialized in rconfc_herd_link_fom_wait_on.  

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Existing UT for rconfc is validated and passed. 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
