### PR TITLE
EOS-25506: LC : remove m0provision config from rpm spec files

### DIFF
--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -344,7 +344,6 @@ getent passwd motr >/dev/null || useradd --system --shell /sbin/nologin \
 %post -e
 /sbin/depmod -a
 systemctl daemon-reload
-echo $(date) &> /var/log/motr-rpm-conf-update.log
 
 if [ x%%{?no_trace_logs} != x ] ; then
     /bin/sed -i -r -e "s/(MOTR_TRACED_KMOD=)yes/\1no/" /etc/sysconfig/motr

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -345,7 +345,6 @@ getent passwd motr >/dev/null || useradd --system --shell /sbin/nologin \
 /sbin/depmod -a
 systemctl daemon-reload
 echo $(date) &> /var/log/motr-rpm-conf-update.log
-/usr/sbin/m0provision config &>> /var/log/motr-rpm-conf-update.log
 
 if [ x%%{?no_trace_logs} != x ] ; then
     /bin/sed -i -r -e "s/(MOTR_TRACED_KMOD=)yes/\1no/" /etc/sysconfig/motr


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
During image creation, it applied m0provision config stage which modifies the sysconfig parameter during image creation which is not required, m0provision config was required for R1 to apply the changes when we update the RPM's, with R2 and LC we already have mini provisioner which does the same job this is a redundant and can lead to errors in some environement so better to remove it from rpm spec file to apply config changes.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
