### PR TITLE
lib: include config.h automatically

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -192,7 +192,7 @@ motr_includedir             = $(includedir)/motr
 
 # these variables are populated in the Makefile.sub files of each motr module,
 # which are then included into this top-level makefile
-nobase_motr_include_HEADERS  = config.h
+nobase_motr_include_HEADERS  = config.h motr/config.h
 if ENABLE_LUSTRE
 nobase_motr_include_HEADERS += lustre_config.h
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,15 @@ AC_ARG_VAR([KCFLAGS], [kernel-space CFLAGS])
 AC_ARG_VAR([CXXXML],  [gccxml/castxml command])
 
 # define macros --------------------------------------- {{{2
+#
+# Add include guards to config.h
+#
+AH_TOP([
+#pragma once
+
+#ifndef __MOTR_CONFIG_H__
+#define __MOTR_CONFIG_H__
+])
 AH_TEMPLATE([MOTR_IDX_STORE_CASS],    [Use Cassandra as KVS backend.])
 AH_TEMPLATE([IDX_CASS_DRV_V22],       [Cassandra driver version >= 2.2.])
 AH_TEMPLATE([ENABLE_LUSTRE],          [Enable LNet network stack from Lustre.])
@@ -202,7 +211,9 @@ AH_TEMPLATE([HAVE_BACKTRACE],         [Have backtrace(3) function])
 AH_TEMPLATE([HAVE_SYSTEMD],           [Have systemd available])
 AH_TEMPLATE([CONFIG_X86_64],          [Support for X86_64 platform])
 AH_TEMPLATE([CONFIG_AARCH64],         [Support for AARCH64 platform])
-
+AH_BOTTOM([
+#endif /* __MOTR_CONFIG_H__ */
+])
 
 # enable/disable options ------------------------------ {{{2
 

--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -25,6 +25,7 @@
 #ifndef __MOTR_LIB_ATOMIC_H__
 #define __MOTR_LIB_ATOMIC_H__
 
+#include "motr/config.h"  /* CONFIG_X86_64 CONFIG_AARCH64 */
 #include "lib/assert.h"
 #include "lib/types.h"
 

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -25,6 +25,7 @@
 #ifndef __MOTR_LIB_VEC_H__
 #define __MOTR_LIB_VEC_H__
 
+#include "motr/config.h"  /* CONFIG_X86_64 CONFIG_AARCH64 */
 #include "lib/types.h"
 #include "lib/buf.h"
 #include "lib/varr.h"


### PR DESCRIPTION
Include config.h automatically where needed. This
will simplify life for Motr API users.

Closes #1212.

# Problem Statement
`motr/config.h` has to be included by Motr API user apps in addition to some motr headers - which is inconvenient.

# Design
Include `motr/config.h` automatically from public headers where required.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide