### PR TITLE
EOS-25789 : Add retry mechanism for DNS resolution in libfabric.

### DIFF
--- a/motr/motr-pub.api
+++ b/motr/motr-pub.api
@@ -226,8 +226,6 @@ m0_net_all_xprt_get
 m0_net_domain_fini
 m0_net_domain_init
 m0_net_end_point_put
-m0_net_ip_parse
-m0_net_ip_print
 m0_net_xprt_default_get
 m0_net_xprt_nr
 m0_node_uuid_init

--- a/net/ip.c
+++ b/net/ip.c
@@ -56,11 +56,11 @@ static uint8_t ip_autotm[1024] = {};
  */
 static int m0_net_ip_inet_parse(const char *name, struct m0_net_ip_addr *addr)
 {
+	uint32_t     portnum;
 	int          shift = 0;
 	int          f;
 	int          s;
 	int          rc;
-	uint16_t     portnum;
 	char         ip[M0_NET_IP_STRLEN_MAX] = {};
 	char         port[M0_NET_IP_PORTLEN_MAX] = {};
 	char        *at;
@@ -94,8 +94,9 @@ static int m0_net_ip_inet_parse(const char *name, struct m0_net_ip_addr *addr)
 		if (at == NULL || at[0] < '0' || at[0] > '9')
 			return M0_ERR(-EINVAL);
 		strcpy(port, at);
-		portnum = (uint16_t)atoi(port);
-		addr->na_port = portnum;
+		portnum = atoi(port);
+		M0_ASSERT(portnum < M0_NET_IP_PORT_MAX);
+		addr->na_port = (uint16_t)portnum;
 	}
 
 	rc = m0_net_hostname_to_ip((char *)ep_name, ip, &addr->na_format);
@@ -229,7 +230,7 @@ M0_INTERNAL int m0_net_hostname_to_ip(char *hostname, char *ip,
 		return M0_ERR(-EINVAL);
 
 	n = cp - hostname;
-	strncpy(name, hostname, n);
+	memcpy(name, hostname, n);
 	name[n] = '\0';
 
 	if (inet_pton(AF_INET, name, &ip_n[0]) == 1 ||

--- a/net/ip.c
+++ b/net/ip.c
@@ -249,7 +249,6 @@ M0_INTERNAL int m0_net_hostname_to_ip(char *hostname, char *ip,
 		for(i = 0; addr[i] != NULL; i++) {
 			/** Return the first one. */
 			strcpy(ip, inet_ntoa(*addr[i]));
-			n=strlen(ip);
 			M0_LOG(M0_DEBUG, "fqdn=%s ip=%s", (char*)name, ip);
 			return M0_RC(0);
 		}

--- a/net/ip.c
+++ b/net/ip.c
@@ -56,11 +56,11 @@ static uint8_t ip_autotm[1024] = {};
  */
 static int m0_net_ip_inet_parse(const char *name, struct m0_net_ip_addr *addr)
 {
-	uint32_t     portnum;
 	int          shift = 0;
 	int          f;
 	int          s;
 	int          rc;
+	uint16_t     portnum;
 	char         ip[M0_NET_IP_STRLEN_MAX] = {};
 	char         port[M0_NET_IP_PORTLEN_MAX] = {};
 	char        *at;
@@ -94,9 +94,8 @@ static int m0_net_ip_inet_parse(const char *name, struct m0_net_ip_addr *addr)
 		if (at == NULL || at[0] < '0' || at[0] > '9')
 			return M0_ERR(-EINVAL);
 		strcpy(port, at);
-		portnum = atoi(port);
-		M0_ASSERT(portnum < M0_NET_IP_PORT_MAX);
-		addr->na_port = (uint16_t)portnum;
+		portnum = (uint16_t)atoi(port);
+		addr->na_port = portnum;
 	}
 
 	rc = m0_net_hostname_to_ip((char *)ep_name, ip, &addr->na_format);
@@ -110,7 +109,7 @@ static int m0_net_ip_inet_parse(const char *name, struct m0_net_ip_addr *addr)
 	addr->na_addr.ia.nia_type = s;
 
 	/* Ignore the error due to gethostbyname() as it will be retried. */
-	return rc >=0 ? M0_RC(0) : M0_ERR(rc);
+	return rc >= 0 ? M0_RC(0) : M0_ERR(rc);
 }
 
 /**
@@ -231,6 +230,7 @@ M0_INTERNAL int m0_net_hostname_to_ip(char *hostname, char *ip,
 
 	n = cp - hostname;
 	strncpy(name, hostname, n);
+	name[n] = '\0';
 
 	if (inet_pton(AF_INET, name, &ip_n[0]) == 1 ||
 	    inet_pton(AF_INET6, name, &ip_n[0]) == 1) {

--- a/net/ip.h
+++ b/net/ip.h
@@ -26,6 +26,7 @@
 #define __MOTR_NET_IP_H__
 
 #define M0_NET_IP_STRLEN_MAX  100
+#define M0_NET_IP_PORTLEN_MAX 6
 #define M0_NET_IP_PORT_MAX    65536
 
 /** Represents format of network address */
@@ -87,12 +88,23 @@ struct m0_net_ip_addr {
  * This function decodes addresses based on address format type
  * such as lnet or inet address format.
  */
-int m0_net_ip_parse(const char *name, struct m0_net_ip_addr *addr);
+M0_INTERNAL int m0_net_ip_parse(const char *name, struct m0_net_ip_addr *addr);
 
 /**
  * This function returns printable ip address format.
  */
-int m0_net_ip_print(const struct m0_net_ip_addr *nia, char *buf, uint32_t len);
+M0_INTERNAL int m0_net_ip_print(const struct m0_net_ip_addr *nia, char *buf,
+				uint32_t len);
+
+/**
+ * This function convert the hostname/FQDN format to ip format.
+ * Here hostname can be FQDN or local machine hostname.
+ * Return value:  = 0 in case of succesful fqdn to ip resolution.
+ *                > 0 when gethostbyname fails (dns resolution failed).
+ *                < 0 error
+ */
+M0_INTERNAL int m0_net_hostname_to_ip(char *hostname, char *ip,
+				      enum m0_net_ip_format *fmt);
 
 #endif /* __MOTR_NET_IP_H__ */
 


### PR DESCRIPTION
Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- During testing in K8s env it was observed that, sometimes, the DNS resolution fails for some FQDNs when all the containers are not in ready state.

# Design
-  Added a retry mechanism for DNS resolution. The retry will be done during connection establishment.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
