### PR TITLE
EOS-25297 : fix compilation errors with gcc-8 for libfabric

### DIFF
--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -532,15 +532,14 @@ static int libfab_ep_addr_decode_native(const char *ep_name, char *node,
 		++cp;
 	}
 
-	if (node_size < (n+1) || port_size < (strlen(cp)+1))
+	if (n+1 > node_size || strlen(cp)+1 > port_size)
 		return M0_ERR(-EINVAL);
 
-	strncpy(node, name, n);
-	node[n] = '\0';
+	node[0] = '\0';
+	strncat(node, name, n);
 
-	n=strlen(cp);
-	strncpy(port, cp, n);
-	port[n] = '\0';
+	port[0] = '\0';
+	strncat(port, cp, port_size-1);
 
 	return M0_RC(0);
 }
@@ -727,19 +726,19 @@ static void libfab_straddr_gen(struct m0_fab__conn_data *cd, char *buf,
 {
 	libfab_ep_ntop(cd->fcd_netaddr, en);
 	if (cd->fcd_tmid == 0xFFFF)
-		sprintf(buf, "%s@%s:12345:%d:*",
+		snprintf(buf, len, "%s@%s:12345:%d:*",
 			cd->fcd_iface == FAB_LO ? "0" : en->fen_addr,
 			cd->fcd_iface == FAB_LO ? "lo" : 
 				((cd->fcd_iface == FAB_TCP) ? "tcp" : "o2ib"),
 			cd->fcd_portal);
 	else
-		sprintf(buf, "%s@%s:12345:%d:%d",
+		snprintf(buf, len, "%s@%s:12345:%d:%d",
 			cd->fcd_iface == FAB_LO ? "0" : en->fen_addr,
 			cd->fcd_iface == FAB_LO ? "lo" : 
 			((cd->fcd_iface == FAB_TCP) ? "tcp" : "o2ib"),
 			cd->fcd_portal, cd->fcd_tmid);
 
-	M0_ASSERT(len >= strlen(buf));
+	M0_ASSERT(len > strlen(buf));
 }
 
 /**
@@ -770,7 +769,7 @@ static uint32_t libfab_handle_connect_request_events(struct m0_fab__tm *tm)
 	if (rc >= (int)sizeof(struct fi_eq_cm_entry) && event == FI_CONNREQ) {
 		cm_entry = (struct fi_eq_cm_entry *)entry;
 		cd = (struct m0_fab__conn_data*)(cm_entry->data);
-		libfab_straddr_gen(cd, straddr, sizeof(straddr), &en);
+		libfab_straddr_gen(cd, straddr, ARRAY_SIZE(straddr), &en);
 		rc = libfab_fab_ep_find(tm, &en, straddr, &ep);
 		if (rc == 0) {
 			rc = libfab_conn_accept(ep, tm, cm_entry->info);

--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -742,7 +742,7 @@ static void libfab_straddr_gen(struct m0_fab__conn_data *cd, char *buf,
 			cd->fcd_portal, cd->fcd_tmid);
 
 	M0_ASSERT(rc > 0);
-	M0_ASSERT_INFO(rc >= len, "Net addr should not be truncated "
+	M0_ASSERT_INFO(rc < len, "Net addr should not be truncated "
 		       "(wanted %d, available %d)", rc, (int)len);
 }
 

--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -532,7 +532,7 @@ static int libfab_ep_addr_decode_native(const char *ep_name, char *node,
 		++cp;
 	}
 
-	if (n+1 > node_size || strlen(cp)+1 > port_size)
+	if (n + 1 > node_size || strlen(cp) + 1 > port_size)
 		return M0_ERR(-EINVAL);
 
 	node[0] = '\0';

--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -724,21 +724,26 @@ static void libfab_tm_buf_done(struct m0_fab__tm *ftm)
 static void libfab_straddr_gen(struct m0_fab__conn_data *cd, char *buf,
 			       uint8_t len, struct m0_fab__ep_name *en)
 {
+	int rc;
+
 	libfab_ep_ntop(cd->fcd_netaddr, en);
+
 	if (cd->fcd_tmid == 0xFFFF)
-		snprintf(buf, len, "%s@%s:12345:%d:*",
+		rc = snprintf(buf, len, "%s@%s:12345:%d:*",
 			cd->fcd_iface == FAB_LO ? "0" : en->fen_addr,
 			cd->fcd_iface == FAB_LO ? "lo" : 
 				((cd->fcd_iface == FAB_TCP) ? "tcp" : "o2ib"),
 			cd->fcd_portal);
 	else
-		snprintf(buf, len, "%s@%s:12345:%d:%d",
+		rc = snprintf(buf, len, "%s@%s:12345:%d:%d",
 			cd->fcd_iface == FAB_LO ? "0" : en->fen_addr,
 			cd->fcd_iface == FAB_LO ? "lo" : 
 			((cd->fcd_iface == FAB_TCP) ? "tcp" : "o2ib"),
 			cd->fcd_portal, cd->fcd_tmid);
 
-	M0_ASSERT(len > strlen(buf));
+	M0_ASSERT(rc > 0);
+	M0_ASSERT_INFO(rc >= len, "Net addr should not be truncated "
+		       "(wanted %d, available %d)", rc, (int)len);
 }
 
 /**

--- a/net/libfab/libfab_internal.h
+++ b/net/libfab/libfab_internal.h
@@ -48,7 +48,7 @@ extern struct m0_net_xprt m0_net_libfab_xprt;
 
 #define LIBFAB_ADDR_LEN_MAX	INET6_ADDRSTRLEN
 #define LIBFAB_PORT_LEN_MAX	6
-#define LIBFAB_ADDR_STRLEN_MAX  (LIBFAB_ADDR_LEN_MAX + LIBFAB_PORT_LEN_MAX + 1)
+#define LIBFAB_ADDR_STRLEN_MAX  (LIBFAB_ADDR_LEN_MAX + LIBFAB_PORT_LEN_MAX + 32)
 
 /**
  * Parameters required for libfabric configuration


### PR DESCRIPTION
Closes #1119.

# Problem Statement
Compilation with gcc-8 fails, see #1119 for details.

# Design
N/A

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
