### PR TITLE
ADDB: setup addb path buffer size to 512 bytes to support long pathname

### DIFF
--- a/motr/setup.c
+++ b/motr/setup.c
@@ -2262,7 +2262,7 @@ static int _args_parse(struct m0_motr *cctx, int argc, char **argv)
 			M0_STRINGARG('A', "ADDB storage domain location",
 				LAMBDA(void, (const char *s)
 				{
-                                        char tmp_buf[128];
+                                        char tmp_buf[512];
                                         sprintf(tmp_buf, "%s-%d", s, (int)m0_pid());
                                         rctx->rc_addb_stlocation = strdup(tmp_buf);
 				})),


### PR DESCRIPTION
# Problem Statement
- If a long pathname is used for addb path then m0d crashes.
 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

2021-11-08 14:57:40 cortx_setup [14]: ERROR [main] Traceback (most recent call last):
File "/usr/lib/python3.6/site-packages/cortx/setup/cortx_setup.py", line 127, in main
rc = command.process()
File "/usr/lib/python3.6/site-packages/cortx/setup/cortx_setup.py", line 117, in process
CortxProvisioner.cluster_bootstrap(self._args.cortx_conf, mock)
File "/usr/lib/python3.6/site-packages/cortx/provisioner/provisioner.py", line 202, in cluster_bootstrap
"%s phase for %s. %s", interface, components[comp_idx]['name'], err)
cortx.provisioner.error.CortxProvisionerError: error(1): Unable to execute init phase for hare. b'2021-11-08 14:57:39,431 [ERROR] Error while initializing cluster :key=Command [\'/usr/libexec/cortx-motr/motr-mkfs\', \'0x7200000000000001:0x15a\', \'--conf\'] exited with error code 42. Command output: ios seg size is set to LVM size:$MOTR_M0D_IOS_BESEG_SIZE\nMOTR_M0D_EP: inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-1799@3001\nMOTR_PROCESS_FID: 0x7200000000000001:0x15a\nMOTR_HA_EP: inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-1799@2001\nMOTR_M0D_DATA_DIR: /etc/cortx/motr\nmotr transport : libfab\n+ exec /usr/sbin/m0mkfs -e libfab:inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-1799@3001 -A linuxstob:/etc/cortx/share/var/log/cortx/motr/686ade725e1b4832b6c0aa5969b5c940/addb/m0d-0x7200000000000001:0x15a/addb-stobs -f \'<0x7200000000000001:0x15a>\' -T ad -S stobs -D db -m 524288 -q 16 -H inet:tcp:cortx-data-headless-svc-ssc-vm-g3-rhev4-1799@2001 -U -B /dev/sdc -z 26843545600 -F -u 686ade725e1b4832b6c0aa5969b5c940 -r 1073741824 -c /etc/cortx/motr/sysconfig/686ade725e1b4832b6c0aa5969b5c940/confd.xc\n*** buffer overflow detected ***: /usr/sbin/m0mkfs terminated\n======= Backtrace: =========\n/lib64/libc.so.6(__fortify_fail+0x37)[0x7f37c8400607]\n/lib64/libc.so.6(+0x116782)[0x7f37c83fe782]\n/lib64/libc.so.6(+0x115c8b)[0x7f37c83fdc8b]\n/lib64/libc.so.6(_IO_default_xsputn+0xe1)[0x7f37c8364fa1]\n/lib64/libc.so.6(_IO_vfprintf+0x28c5)[0x7f37c8332ec5]\n/lib64/libc.so.6(__vsprintf_chk+0x88)[0x7f37c83fdd18]\n/lib64/libc.so.6(__sprintf_chk+0x7d)[0x7f37c83fdc6d]\n/lib64/libmotr.so.2(+0x37eeb2)[0x7f37ca2f5eb2]\n/lib64/libmotr.so.2(m0_getopts+0x31e)[0x7f37ca2ea8ee]\n/lib64/libmotr.so.2(+0x3802fa)[0x7f37ca2f72fa]\n/lib64/libmotr.so.2(+0x382be3)[0x7f37ca2f9be3]\n/lib64/libmotr.so.2(+0x3b50ce)[0x7f37ca32c0ce]\n/lib64/libmotr.so.2(m0_module_init+0x1a)[0x7f37ca32c16a]\n/lib64/libmotr.so.2(m0_cs_setup_env+0x3b)[0x7f37ca2fc6cb]\n/usr/sbin/m0mkfs(main+0x1d7)[0x400d47]\n/lib64/libc.so.6(__libc_start_main+0xf5)
