### PR TITLE
EOS-25302 After delete, storage is not reclaimed completely.

### DIFF
--- a/ioservice/ut/bulkio_ut.c
+++ b/ioservice/ut/bulkio_ut.c
@@ -1775,6 +1775,7 @@ static void bulkio_init(void)
 	 */
 	m0_fi_enable("io_fop_di_prepare", "skip_di_for_ut");
 	m0_fi_enable("m0_file_init", "skip_di_for_ut");
+	m0_fi_enable("stob_ad_domain_create", "write_undo");
 
 	M0_ALLOC_PTR(bp);
 	M0_ASSERT(bp != NULL);
@@ -1806,6 +1807,7 @@ static void bulkio_fini(void)
 
 	m0_fi_disable("io_fop_di_prepare", "skip_di_for_ut");
 	m0_fi_disable("m0_file_init", "skip_di_for_ut");
+	m0_fi_disable("stob_ad_domain_create", "write_undo");
 }
 
 /*

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1174,6 +1174,16 @@ static void stob_ad_write_credit(const struct m0_stob_domain *dom,
 	 * of 'emap paste' (that is frags + 1) to verify this idea.
 	 */
 	m0_be_emap_credit(&adom->sad_adata, M0_BEO_PASTE, frags + 1, accum);
+
+	/*
+	 * Commenting out below part of code with #if 0, earlier it was based
+	 * on assumption that that adom->sad_overwrite will be always false,
+	 * Now we have set it to True by default to fix EOS-25302 hence
+	 * disabling it with "#if 0"
+	 * TODO: Probably sad_overwrite is introduce for COW(Copy on Write) and
+	 * for Object versioning in Motr, which is not implemented yet. Need to
+	 * revisit this part while implementing COW and object versioning.
+	 */
 #if 0
 	if (adom->sad_overwrite && ballroom->ab_ops->bo_free_credit != NULL) {
 		/* for each emap_paste() seg_free() could be called 3 times */

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1701,26 +1701,22 @@ static int stob_ad_write_map_ext(struct m0_stob_io *io,
 	m0_be_emap_paste(&it, &io->si_tx->tx_betx, &todo, ext->e_start,
 	 LAMBDA(void, (struct m0_be_emap_seg *seg) {
 			/* handle extent deletion. */
-			if (adom->sad_overwrite) {
-				M0_LOG(M0_DEBUG, "del: val=0x%llx",
-					(unsigned long long)seg->ee_val);
-				M0_ASSERT_INFO(seg->ee_val != ext->e_start,
-				"Delete of the same just allocated block");
-				rc = rc ?:
-				     stob_ad_seg_free(io->si_tx, adom, seg,
-						      &seg->ee_ext, seg->ee_val);
-			}
+			M0_LOG(M0_DEBUG, "del: val=0x%llx",
+			       (unsigned long long)seg->ee_val);
+			M0_ASSERT_INFO(seg->ee_val != ext->e_start,
+				       "Delete of the same just allocated block");
+			rc = rc ?:
+			     stob_ad_seg_free(io->si_tx, adom, seg,
+					      &seg->ee_ext, seg->ee_val);
 		 }),
 	 LAMBDA(void, (struct m0_be_emap_seg *seg, struct m0_ext *ext,
 		       uint64_t val) {
 			/* cut left */
 			M0_ASSERT(ext->e_start > seg->ee_ext.e_start);
-
 			seg->ee_val = val;
-			if (adom->sad_overwrite)
-				rc = rc ?:
-				     stob_ad_seg_free(io->si_tx, adom, seg,
-						      ext, val);
+			rc = rc ?:
+			     stob_ad_seg_free(io->si_tx, adom, seg,
+					      ext, val);
 		}),
 	 LAMBDA(void, (struct m0_be_emap_seg *seg, struct m0_ext *ext,
 		       uint64_t val) {
@@ -1735,8 +1731,7 @@ static int stob_ad_write_map_ext(struct m0_stob_io *io,
 				 * logical extent, because otherwise "cut left"
 				 * already freed it.
 				 */
-				if (adom->sad_overwrite &&
-				    ext->e_start == seg->ee_ext.e_start)
+				if (ext->e_start == seg->ee_ext.e_start)
 					rc = rc ?:
 					     stob_ad_seg_free(io->si_tx, adom,
 							      seg, ext, val);

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1180,14 +1180,14 @@ static void stob_ad_write_credit(const struct m0_stob_domain *dom,
 	 * on assumption that that adom->sad_overwrite will be always false,
 	 * Now we have set it to True by default to fix EOS-25302 hence
 	 * disabling it with "#if 0"
-	 * TODO: Probably sad_overwrite is introduce for COW(Copy on Write) and
+	 * TODO: Probably sad_overwrite is introduced for COW(Copy on Write) and
 	 * for Object versioning in Motr, which is not implemented yet. Need to
 	 * revisit this part while implementing COW and object versioning.
 	 * We do not know whether bo_free_credit should be commented out or not,
 	 * but this is done to maintain existing behavior as the code was
 	 * anyway redundant earlier.
 	 */
-#if
+#if 0
 	if (adom->sad_overwrite && ballroom->ab_ops->bo_free_credit != NULL) {
 		/* for each emap_paste() seg_free() could be called 3 times */
 		ballroom->ab_ops->bo_free_credit(ballroom, 3 * frags, accum);

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1183,8 +1183,11 @@ static void stob_ad_write_credit(const struct m0_stob_domain *dom,
 	 * TODO: Probably sad_overwrite is introduce for COW(Copy on Write) and
 	 * for Object versioning in Motr, which is not implemented yet. Need to
 	 * revisit this part while implementing COW and object versioning.
+	 * We do not know whether bo_free_credit should be commented out or not,
+	 * but this is done to maintain existing behavior as the code was
+	 * anyway redundant earlier.
 	 */
-#if 0
+#if
 	if (adom->sad_overwrite && ballroom->ab_ops->bo_free_credit != NULL) {
 		/* for each emap_paste() seg_free() could be called 3 times */
 		ballroom->ab_ops->bo_free_credit(ballroom, 3 * frags, accum);

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1720,7 +1720,7 @@ static int stob_ad_write_map_ext(struct m0_stob_io *io,
 			/* handle extent deletion. */
 			if (adom->sad_overwrite) {
 				M0_LOG(M0_DEBUG, "del: val=0x%llx",
-				       (unsigned long long)seg->ee_val);
+					(unsigned long long)seg->ee_val);
 				M0_ASSERT_INFO(seg->ee_val != ext->e_start,
 					       "Delete of the same just allocated block");
 				rc = rc ?:

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1722,7 +1722,7 @@ static int stob_ad_write_map_ext(struct m0_stob_io *io,
 				M0_LOG(M0_DEBUG, "del: val=0x%llx",
 					(unsigned long long)seg->ee_val);
 				M0_ASSERT_INFO(seg->ee_val != ext->e_start,
-					       "Delete of the same just allocated block");
+				"Delete of the same just allocated block");
 				rc = rc ?:
 				     stob_ad_seg_free(io->si_tx, adom, seg,
 						      &seg->ee_ext, seg->ee_val);
@@ -1732,6 +1732,7 @@ static int stob_ad_write_map_ext(struct m0_stob_io *io,
 		       uint64_t val) {
 			/* cut left */
 			M0_ASSERT(ext->e_start > seg->ee_ext.e_start);
+
 			seg->ee_val = val;
 			if (adom->sad_overwrite)
 				rc = rc ?:


### PR DESCRIPTION
Problem :
In some cases, after deleting the object, entire space used by object
is not reclaimed.

Root cause:
This issues is observed in some cases where we do not write a complete
parity group in one IO request. Following happens in 3+2 config (an example)
1.Write 1 M at offset 0 - space consumed is 3M (1M for data and 2 M for parity)
2.Write 2 M at offset 1048576 - space consumed is 4M (2M for data and 2 M for parity)
Total space consumed is 7M, after unlink space reclaimed is 5M. Leak of 2M.
This leak is because of parity units.

In step 2, a memory leak happens.
We do not deallocated the space consumed by parity units because of step 1 and
we reallocate space for the parity units again.
Because of this leak we are not able to reclaim space even after object delete.

Memory leak happens because in motr code, to release a balloc segment, a condition
check is done and this condition check is always false as of today.

Solution:
Removed the condition check which was preventing balloc segment to be released
and causing this leak.

Testing done:
verified the issues is not getting reproduced after changes.
ST's (mostly related to healthy IO path, dgmode IO and SNS repair).

Signed-off-by: Shipra Gupta <shipra.gupta@seagate.com>