### PR TITLE
Fix C++ compiler warnings for public headers

### DIFF
--- a/be/fmt.h
+++ b/be/fmt.h
@@ -206,8 +206,8 @@ struct m0_be_fmt_log_header {
 	m0_bcount_t flh_group_size;
 } M0_XCA_RECORD M0_XCA_DOMAIN(be);
 
-#define BFLH_F "(flh_serial=%"PRIu64" flh_discarded=%"PRIu64" " \
-		"flh_group_lsn=%"PRIu64" flh_group_size=%"PRIu64")"
+#define BFLH_F "(flh_serial=%" PRIu64 " flh_discarded=%" PRIu64 " " \
+		"flh_group_lsn=%" PRIu64 " flh_group_size=%" PRIu64 ")"
 #define BFLH_P(log_hdr) (log_hdr)->flh_serial, (log_hdr)->flh_discarded, \
 			(log_hdr)->flh_group_lsn, (log_hdr)->flh_group_size
 
@@ -265,8 +265,9 @@ struct m0_be_fmt_log_record_header {
 	struct m0_be_fmt_log_record_header_io_size lrh_io_size;
 } M0_XCA_RECORD M0_XCA_DOMAIN(be);
 
-#define BFLRH_F "(pos=%"PRIu64" size=%"PRIu64" discarded=%"PRIu64" " \
-		"prev_pos=%"PRIu64" prev_size=%"PRIu64" io_nr_max=%"PRIu64")"
+#define BFLRH_F "(pos=%" PRIu64 " size=%" PRIu64 " discarded=%" PRIu64 " " \
+		"prev_pos=%" PRIu64 " prev_size=%" PRIu64 \
+		" io_nr_max=%" PRIu64 ")"
 #define BFLRH_P(h) (h)->lrh_pos, (h)->lrh_size, (h)->lrh_discarded, \
 		   (h)->lrh_prev_pos, (h)->lrh_prev_size,           \
 		   (h)->lrh_io_nr_max

--- a/be/io.h
+++ b/be/io.h
@@ -79,7 +79,8 @@ struct m0_be_io_credit {
 	.bic_part_nr = (part_nr),                                            \
 }
 
-#define BE_IOCRED_F "(reg_nr=%"PRIu64" reg_size=%"PRIu64" part_nr=%"PRIu64")"
+#define BE_IOCRED_F "(reg_nr=%" PRIu64 " reg_size=%" PRIu64 \
+		    " part_nr=%" PRIu64 ")"
 #define BE_IOCRED_P(iocred) \
 	     (iocred)->bic_reg_nr, (iocred)->bic_reg_size, (iocred)->bic_part_nr
 

--- a/be/log.h
+++ b/be/log.h
@@ -316,7 +316,7 @@ struct m0_be_log {
 
 /* m0_be_log */
 #define BL_F "(lg_current=%" PRIu64 " lg_discarded=%" PRIu64 \
-             " lg_free=%" PRIu64 ")"
+	     " lg_free=%" PRIu64 ")"
 #define BL_P(log) (log)->lg_current, (log)->lg_discarded, (log)->lg_free
 
 /** This structure represents minimal unit for log operations. */

--- a/be/log.h
+++ b/be/log.h
@@ -315,7 +315,8 @@ struct m0_be_log {
 };
 
 /* m0_be_log */
-#define BL_F "(lg_current=%"PRIu64" lg_discarded=%"PRIu64" lg_free=%"PRIu64")"
+#define BL_F "(lg_current=%" PRIu64 " lg_discarded=%" PRIu64 \
+             " lg_free=%" PRIu64 ")"
 #define BL_P(log) (log)->lg_current, (log)->lg_discarded, (log)->lg_free
 
 /** This structure represents minimal unit for log operations. */
@@ -374,9 +375,9 @@ struct m0_be_log_record {
 };
 
 /* m0_be_log_record */
-#define BLR_F "(lgr_last_discarded=%"PRIu64" lgr_position=%"PRIu64" " \
-	       "lgr_size=%"PRIu64" " \
-	       "lgr_prev_pos=%"PRIu64" lgr_prev_size=%"PRIu64")"
+#define BLR_F "(lgr_last_discarded=%" PRIu64 " lgr_position=%" PRIu64 " " \
+	       "lgr_size=%" PRIu64 " " \
+	       "lgr_prev_pos=%" PRIu64 " lgr_prev_size=%" PRIu64 ")"
 #define BLR_P(record) (record)->lgr_last_discarded, (record)->lgr_position, \
 		      (record)->lgr_size, \
 		      (record)->lgr_prev_pos, (record)->lgr_prev_size

--- a/ha/link_fops.h
+++ b/ha/link_fops.h
@@ -72,8 +72,8 @@ struct m0_ha_link_params {
 	struct m0_ha_link_tags hlp_tags_remote;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
-#define HLTAGS_F "(confirmed=%"PRIu64" delivered=%"PRIu64" next=%"PRIu64" "   \
-		 "assign=%"PRIu64")"
+#define HLTAGS_F "(confirmed=%" PRIu64 " delivered=%" PRIu64 \
+		 " next=%" PRIu64 " assign=%" PRIu64 ")"
 #define HLTAGS_P(_tags) (_tags)->hlt_confirmed, (_tags)->hlt_delivered,       \
 			(_tags)->hlt_next, (_tags)->hlt_assign
 

--- a/lib/bob.h
+++ b/lib/bob.h
@@ -146,7 +146,7 @@ scope bool type ## _bob_check(const struct type *bob)
 	__amb = container_of(__ptr, type, field);			\
 									\
 	M0_ASSERT_INFO(m0_bob_check(bt, __amb),			\
-		"%s.%s [%p->%p (%s)] got: %"PRIx64" want: %"PRIx64	\
+		"%s.%s [%p->%p (%s)] got: %" PRIx64 " want: %" PRIx64	\
 		" check: %i.", (bt)->bt_name, #field, __ptr, __amb, #type, \
 		*((uint64_t *)(((void *)__amb) + (bt)->bt_magix_offset)), \
 		(bt)->bt_magix,					\

--- a/lib/ext.h
+++ b/lib/ext.h
@@ -82,7 +82,7 @@ M0_INTERNAL m0_bindex_t m0_ext_cap(const struct m0_ext *ext2, m0_bindex_t val);
 /** Tells if start of extent is less than end of extent. */
 M0_INTERNAL bool m0_ext_is_valid(const struct m0_ext *ext);
 
-#define EXT_F  "[%"PRIx64", %"PRIx64")"
+#define EXT_F  "[%" PRIx64 ", %" PRIx64 ")"
 #define EXT_P(x)  (x)->e_start, (x)->e_end
 
 /** @} end of ext group */

--- a/lib/time.h
+++ b/lib/time.h
@@ -41,7 +41,7 @@ enum {
 	M0_TIME_ONE_MSEC    = M0_TIME_ONE_SECOND / 1000,
 };
 
-#define TIME_F "[%"PRIu64":%09"PRIu64"]"
+#define TIME_F "[%" PRIu64 ":%09" PRIu64 "]"
 #define TIME_P(t) m0_time_seconds(t), m0_time_nanoseconds(t)
 
 /**

--- a/lib/types.h
+++ b/lib/types.h
@@ -39,13 +39,13 @@ struct m0_uint128 {
 
 #define M0_UINT128(hi, lo) (struct m0_uint128) { .u_hi = (hi), .u_lo = (lo) }
 
-#define U128X_F "%"PRIx64":%"PRIx64
-#define U128D_F "%"PRId64":%"PRId64
-#define U128I_F "%"PRIi64":%"PRIi64
+#define U128X_F "%" PRIx64 ":%" PRIx64
+#define U128D_F "%" PRId64 ":%" PRId64
+#define U128I_F "%" PRIi64 ":%" PRIi64
 #define U128_P(x) (x)->u_hi, (x)->u_lo
 #define U128_S(u) &(u)->u_hi, &(u)->u_lo
 
-#define U128X_F_SAFE "%s%"PRIx64":%"PRIx64
+#define U128X_F_SAFE "%s%" PRIx64 ":%" PRIx64
 #define U128_P_SAFE(x) \
 	((x) != NULL ? "" : "(null) "), \
 	((x) != NULL ? (x)->u_hi : 0), ((x) != NULL ? (x)->u_lo : 0)


### PR DESCRIPTION
# Problem Statement
When compiling a C++ app with Motr API by gcc version 8.3,
there is a lot of warnings for string literals and macors:

    /usr/include/motr/be/log.h:318:58: warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]
     #define BL_F "(lg_current=%"PRIu64" lg_discarded=%"PRIu64" lg_free=%"PRIu64")"
                                                              ^
Solution: add spaces between the literals and macros.

Closes #1216.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
