### PR TITLE
EOS-22462 dtm0/ut/drlink: send DTM0 messages from server to client

### DIFF
--- a/be/linux_kernel/stubs.c
+++ b/be/linux_kernel/stubs.c
@@ -34,6 +34,8 @@
 struct m0_be_btree;
 struct m0_be_btree_kv_ops;
 struct m0_be_btree_cursor;
+struct m0_be_queue;
+struct m0_buf;
 
 /* fake segment header. */
 static struct m0_be_seg_hdr khdr;
@@ -309,5 +311,20 @@ M0_INTERNAL void m0_be_ut_free(struct m0_be_ut_backend *ut_be,
 {
 	m0_be_free(NULL, NULL, NULL, ptr);
 }
+
+M0_INTERNAL void m0_be_queue_put(struct m0_be_queue  *bq,
+                                 struct m0_be_op     *op,
+                                 const struct m0_buf *data)
+{
+}
+
+M0_INTERNAL void m0_be_queue_lock(struct m0_be_queue *bq)
+{
+}
+
+M0_INTERNAL void m0_be_queue_unlock(struct m0_be_queue *bq)
+{
+}
+
 
 #undef M0_TRACE_SUBSYSTEM

--- a/dtm0/drlink.h
+++ b/dtm0/drlink.h
@@ -40,6 +40,7 @@ struct dtm0_req_fop;
 struct m0_dtm0_service;
 struct m0_fid;
 struct m0_fom;
+struct m0_be_op;
 
 M0_INTERNAL int  m0_dtm0_rpc_link_mod_init(void);
 M0_INTERNAL void m0_dtm0_rpc_link_mod_fini(void);
@@ -47,6 +48,7 @@ M0_INTERNAL void m0_dtm0_rpc_link_mod_fini(void);
 /**
  * Asynchronously send a DTM0 message to a remote DTM0 service.
  * @param svc local DTM0 service.
+ * @param op BE op to wait for completion. Could be NULL.
  * @param req DTM0 message to be sent.
  * @param tgt FID of the remote DTM0 service.
  * @param parent_fom FOM that caused this DTM0 message (used by ADDB).
@@ -59,6 +61,7 @@ M0_INTERNAL void m0_dtm0_rpc_link_mod_fini(void);
  *         if the remote service does not exist in the conf cache (-ENOENT).
  */
 M0_INTERNAL int m0_dtm0_req_post(struct m0_dtm0_service    *svc,
+                                 struct m0_be_op           *op,
 				 const struct dtm0_req_fop *req,
 				 const struct m0_fid       *tgt,
 				 const struct m0_fom       *parent_fom,

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -42,6 +42,7 @@ M0_INTERNAL int m0_dtm0_fop_init(void);
 M0_INTERNAL void m0_dtm0_fop_fini(void);
 
 enum m0_dtm0s_msg {
+	DTM_TEST,
 	DTM_EXECUTE,
 	DTM_EXECUTED,
 	DTM_PERSISTENT,

--- a/dtm0/linux_kernel/stubs.c
+++ b/dtm0/linux_kernel/stubs.c
@@ -43,12 +43,14 @@ M0_INTERNAL void m0_dtm0_rpc_link_mod_fini(void)
  *         if the remote service does not exist in the conf cache (-ENOENT).
  */
 M0_INTERNAL int m0_dtm0_req_post(struct m0_dtm0_service    *svc,
+                                 struct m0_be_op           *op,
 				 const struct dtm0_req_fop *req,
 				 const struct m0_fid       *tgt,
 				 const struct m0_fom       *parent_fom,
 				 bool                       wait_for_ack)
 {
 	(void) svc;
+	(void) op;
 	(void) req;
 	(void) tgt;
 	(void) parent_fom;

--- a/dtm0/service.h
+++ b/dtm0/service.h
@@ -30,6 +30,7 @@
 
 struct m0_be_dtm0_log;
 struct dtm0_req_fop;
+struct m0_be_queue;
 
 enum m0_dtm0_service_origin {
 	DTM0_UNKNOWN = 0,
@@ -47,6 +48,13 @@ struct m0_dtm0_service {
 	uint64_t                     dos_magix;
 	struct m0_dtm0_clk_src       dos_clk_src;
 	struct m0_be_dtm0_log       *dos_log;
+	/*
+	 * A queue for DTM_TEST message for drlink UTs.
+	 * The UTs are fully responsible for the queue init/fini/get.
+	 * DTM_TEST fom puts dtm0_req_fop::dtr_txr::dtd_id::dti_fid to the
+	 * queue.
+	 */
+	struct m0_be_queue          *dos_ut_queue;
 };
 
 extern struct m0_reqh_service_type dtm0_service_type;

--- a/dtm0/ut/Makefile.sub
+++ b/dtm0/ut/Makefile.sub
@@ -1,3 +1,6 @@
 ut_libmotr_ut_la_SOURCES += \
-                            dtm0/ut/main.c \
-                            dtm0/ut/clk_src_ut.c
+                            dtm0/ut/clk_src_ut.c \
+                            dtm0/ut/drlink.c \
+                            dtm0/ut/helper.c \
+                            dtm0/ut/helper.h \
+                            dtm0/ut/main.c

--- a/dtm0/ut/drlink.c
+++ b/dtm0/ut/drlink.c
@@ -1,0 +1,167 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+/**
+ * @addtogroup dtm0
+ *
+ * @{
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_UT
+#include "lib/trace.h"
+
+#include "dtm0/drlink.h"
+
+#include "ut/ut.h"              /* M0_UT_ASSERT */
+#include "fid/fid.h"            /* M0_FID_INIT */
+#include "be/queue.h"           /* m0_be_queue_init */
+
+#include "dtm0/service.h"       /* m0_dtm0_service */
+#include "dtm0/fop.h"           /* dtm0_req_fop */
+
+#include "dtm0/ut/helper.h"     /* m0_ut_dtm0_helper_init */
+
+
+enum {
+	DTM0_UT_DRLINK_SIMPLE_POST_NR = 0x100,
+};
+
+void m0_dtm0_ut_drlink_simple(void)
+{
+	struct m0_ut_dtm0_helper *udh;
+	struct m0_dtm0_service   *svc;
+	struct m0_fom             fom = {}; // just a fom for m0_dtm0_req_post()
+	struct m0_dtm0_tx_pa      pa = {};
+	struct dtm0_req_fop      *fop;
+	struct m0_be_op          *op;
+	struct m0_be_op           op_out = {};
+	struct m0_fid            *fid;
+	struct m0_fid             fid_out;
+	bool                      successful;
+	bool                      found;
+	int                       rc;
+	int                       i;
+	int                       j;
+
+	M0_ALLOC_PTR(udh);
+	M0_ASSERT(udh != NULL);
+
+	m0_ut_dtm0_helper_init(udh);
+	svc = udh->udh_client_dtm0_service;
+
+	M0_ALLOC_ARR(fid, DTM0_UT_DRLINK_SIMPLE_POST_NR);
+	M0_UT_ASSERT(fid != NULL);
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i) {
+		fid[i] = M0_FID_INIT(0, i+1);  /* TODO set fid type */
+	}
+	M0_ALLOC_ARR(fop, DTM0_UT_DRLINK_SIMPLE_POST_NR);
+	M0_UT_ASSERT(fop != NULL);
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i) {
+		fop[i] = (struct dtm0_req_fop){
+			.dtr_msg = DTM_TEST,
+			.dtr_txr = {
+				.dtd_id = {
+					.dti_fid = fid[i],
+				},
+				.dtd_ps = {
+					.dtp_nr = 1,
+					.dtp_pa = &pa,
+				},
+			},
+		};
+	}
+	M0_ALLOC_ARR(op, DTM0_UT_DRLINK_SIMPLE_POST_NR);
+	M0_UT_ASSERT(op != NULL);
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i)
+		m0_be_op_init(&op[i]);
+
+	M0_ALLOC_PTR(svc->dos_ut_queue);
+	M0_UT_ASSERT(svc->dos_ut_queue != 0);
+	rc = m0_be_queue_init(svc->dos_ut_queue,
+			      &(struct m0_be_queue_cfg){
+			.bqc_q_size_max = DTM0_UT_DRLINK_SIMPLE_POST_NR,
+			.bqc_producers_nr_max = DTM0_UT_DRLINK_SIMPLE_POST_NR,
+			.bqc_consumers_nr_max = 1,
+			.bqc_item_length = sizeof fid[0],
+                              });
+	M0_UT_ASSERT(rc == 0);
+
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i) {
+		rc = m0_dtm0_req_post(udh->udh_server_dtm0_service,
+				      &op[i], &fop[i],
+		                      &udh->udh_client_dtm0_fid, &fom, true);
+		M0_UT_ASSERT(rc == 0);
+	}
+	m0_be_op_init(&op_out);
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i) {
+		successful = false;
+		m0_be_queue_lock(svc->dos_ut_queue);
+		M0_BE_QUEUE_GET(svc->dos_ut_queue, &op_out, &fid_out,
+				&successful);
+		m0_be_queue_unlock(svc->dos_ut_queue);
+		m0_be_op_wait(&op_out);
+		M0_UT_ASSERT(successful);
+		m0_be_op_reset(&op_out);
+		found = false;
+		for (j = 0; j < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++j) {
+			if (m0_fid_eq(&fid_out, &fid[j])) {
+				found = true;
+				fid[j] = M0_FID0;
+				break;
+			}
+		}
+		M0_UT_ASSERT(found);
+	}
+	m0_be_op_fini(&op_out);
+	m0_be_queue_fini(svc->dos_ut_queue);
+	m0_free(svc->dos_ut_queue);
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i)
+		M0_UT_ASSERT(m0_fid_eq(&fid[i], &M0_FID0));
+	m0_free(fid);
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i) {
+		m0_be_op_wait(&op[i]);
+		m0_be_op_fini(&op[i]);
+	}
+	m0_free(op);
+	m0_free(fop);
+
+	m0_ut_dtm0_helper_fini(udh);
+	m0_free(udh);
+
+}
+
+
+#undef M0_TRACE_SUBSYSTEM
+
+/** @} end of dtm0 group */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/ut/helper.c
+++ b/dtm0/ut/helper.c
@@ -1,0 +1,140 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+/**
+ * @addtogroup dtm0
+ *
+ * @{
+ */
+
+#define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_DTM0
+#include "lib/trace.h"
+
+#include "dtm0/ut/helper.h"
+
+#include "ut/ut.h"              /* M0_UT_ASSERT */
+
+#include "lib/misc.h"           /* M0_IS0 */
+#include "net/net.h"            /* m0_net_all_xprt_get */
+#include "dtm0/service.h"       /* m0_dtm0_service */
+
+
+struct m0_reqh_service;
+
+enum {
+	MAX_RPCS_IN_FLIGHT = 10,
+};
+
+#define SERVER_ENDPOINT_ADDR   "0@lo:12345:34:1"
+#define SERVER_ENDPOINT        M0_NET_XPRT_PREFIX_DEFAULT":"SERVER_ENDPOINT_ADDR
+#define DTM0_UT_CONF_PROCESS   "<0x7200000000000001:5>"
+
+char *ut_dtm0_helper_argv[] = {
+	"m0d", "-T", "linux",
+	"-D", "dtm0_sdb", "-S", "dtm0_stob",
+	"-A", "linuxstob:dtm0_addb_stob",
+	"-e", SERVER_ENDPOINT,
+	"-H", SERVER_ENDPOINT_ADDR,
+	"-w", "10",
+	"-f", DTM0_UT_CONF_PROCESS,
+	"-c", M0_SRC_PATH("dtm0/conf.xc")
+};
+static const char *ut_dtm0_client_endpoint = "0@lo:12345:34:2";
+const char        *ut_dtm0_helper_log      = "dtm0_ut_server.log";
+
+
+M0_INTERNAL void m0_ut_dtm0_helper_init(struct m0_ut_dtm0_helper *udh)
+{
+	struct m0_reqh_service *svc;
+	int                     rc;
+
+	M0_PRE(M0_IS0(udh));
+
+	*udh = (struct m0_ut_dtm0_helper){
+		.udh_sctx = {
+			.rsx_xprts         = m0_net_all_xprt_get(),
+			.rsx_xprts_nr      = m0_net_xprt_nr(),
+			.rsx_argv          = ut_dtm0_helper_argv,
+			.rsx_argc          = ARRAY_SIZE(ut_dtm0_helper_argv),
+			.rsx_log_file_name = ut_dtm0_helper_log,
+		},
+		.udh_cctx = {
+			.rcx_net_dom            = &udh->udh_client_net_domain,
+			.rcx_local_addr         = ut_dtm0_client_endpoint,
+			.rcx_remote_addr        = SERVER_ENDPOINT_ADDR,
+			.rcx_max_rpcs_in_flight = MAX_RPCS_IN_FLIGHT,
+			.rcx_fid                = &g_process_fid,
+		},
+		.udh_server_reqh =
+			&udh->udh_sctx.rsx_motr_ctx.cc_reqh_ctx.rc_reqh,
+		.udh_client_reqh = &udh->udh_cctx.rcx_reqh,
+		.udh_server_dtm0_fid = M0_FID_INIT(0x7300000000000001, 0x1c),
+		.udh_client_dtm0_fid = M0_FID_INIT(0x7300000000000001, 0x1a),
+	};
+	rc = m0_rpc_server_start(&udh->udh_sctx);
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_net_domain_init(&udh->udh_client_net_domain,
+				m0_net_xprt_default_get());
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_rpc_client_start(&udh->udh_cctx);
+	M0_UT_ASSERT(rc == 0);
+	rc = m0_dtm_client_service_start(udh->udh_client_reqh,
+					 &udh->udh_client_dtm0_fid,
+					 &svc);
+	M0_UT_ASSERT(rc == 0);
+
+	udh->udh_client_dtm0_service = container_of(svc, struct m0_dtm0_service,
+						    dos_generic);
+
+	svc = m0_reqh_service_lookup(udh->udh_server_reqh,
+	                             &udh->udh_server_dtm0_fid);
+	/* TODO export the function which does bob_of() */
+	udh->udh_server_dtm0_service = container_of(svc, struct m0_dtm0_service,
+	                                            dos_generic);
+}
+
+M0_INTERNAL void m0_ut_dtm0_helper_fini(struct m0_ut_dtm0_helper *udh)
+{
+	int rc;
+
+	m0_dtm_client_service_stop(&udh->udh_client_dtm0_service->dos_generic);
+	rc = m0_rpc_client_stop(&udh->udh_cctx);
+	M0_UT_ASSERT(rc == 0);
+	m0_net_domain_fini(&udh->udh_client_net_domain);
+	m0_rpc_server_stop(&udh->udh_sctx);
+}
+
+#undef M0_TRACE_SUBSYSTEM
+
+/** @} end of dtm0 group */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/ut/helper.h
+++ b/dtm0/ut/helper.h
@@ -1,0 +1,77 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2013-2020 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+#pragma once
+
+#ifndef __MOTR_DTM0_UT_HELPER_H__
+#define __MOTR_DTM0_UT_HELPER_H__
+
+/**
+ * @defgroup dtm0
+ *
+ * @{
+ */
+
+#include "net/net.h"            /* m0_net_domain */
+#include "fid/fid.h"            /* m0_fid */
+#include "rpc/rpclib.h"         /* m0_rpc_server_ctx */
+
+
+struct m0_reqh;
+struct m0_dtm0_service;
+
+
+struct m0_ut_dtm0_helper {
+	struct m0_rpc_server_ctx  udh_sctx;
+	struct m0_rpc_client_ctx  udh_cctx;
+
+	struct m0_net_domain      udh_client_net_domain;
+	/**
+	 * The following fields are available read-only for the users of this
+	 * structure. They are populated in m0_ut_dtm0_helper_init().
+	 */
+	struct m0_reqh           *udh_server_reqh;
+	struct m0_reqh           *udh_client_reqh;
+	struct m0_fid             udh_server_dtm0_fid;
+	struct m0_fid             udh_client_dtm0_fid;
+	struct m0_dtm0_service   *udh_server_dtm0_service;
+	struct m0_dtm0_service   *udh_client_dtm0_service;
+};
+
+M0_INTERNAL void m0_ut_dtm0_helper_init(struct m0_ut_dtm0_helper *udh);
+M0_INTERNAL void m0_ut_dtm0_helper_fini(struct m0_ut_dtm0_helper *udh);
+
+
+/** @} end of dtm0 group */
+#endif /* __MOTR_DTM0_UT_HELPER_H__ */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -31,214 +31,10 @@
 #include "cas/cas.h"
 #include "cas/cas_xc.h"
 
-#define M0_FID(c_, k_)  { .f_container = c_, .f_key = k_ }
-#define SERVER_ENDPOINT_ADDR   "0@lo:12345:34:1"
-#define SERVER_ENDPOINT        M0_NET_XPRT_PREFIX_DEFAULT":"SERVER_ENDPOINT_ADDR
-#define DTM0_UT_CONF_PROCESS   "<0x7200000000000001:5>"
-#define DTM0_UT_LOG            "dtm0_ut_server.log"
 
-enum { MAX_RPCS_IN_FLIGHT = 10,
-       NUM_CAS_RECS = 10,
+enum {
+	NUM_CAS_RECS = 10,
 };
-
-struct m0_reqh  *dtm0_cli_srv_reqh;
-
-static struct m0_fid cli_srv_fid = M0_FID(0x7300000000000001, 0x1a);
-static struct m0_fid srv_dtm0_fid = M0_FID(0x7300000000000001, 0x1c);
-static const char *cl_ep_addr =  "0@lo:12345:34:2";
-static const char *srv_ep_addr =  SERVER_ENDPOINT_ADDR;
-static char *dtm0_ut_argv[] = { "m0d", "-T", "linux",
-			       "-D", "dtm0_sdb", "-S", "dtm0_stob",
-			       "-A", "linuxstob:dtm0_addb_stob",
-			       "-e", SERVER_ENDPOINT,
-			       "-H", SERVER_ENDPOINT_ADDR,
-			       "-w", "10",
-			       "-f", DTM0_UT_CONF_PROCESS,
-			       "-c", M0_SRC_PATH("dtm0/conf.xc")};
-
-struct cl_ctx {
-	struct m0_net_domain     cl_ndom;
-	struct m0_rpc_client_ctx cl_ctx;
-};
-
-static struct dtm0_rep_fop *reply(struct m0_rpc_item *reply)
-{
-	return m0_fop_data(m0_rpc_item_to_fop(reply));
-}
-
-static void dtm0_ut_send_fops(struct m0_rpc_session *cl_rpc_session)
-{
-	int                    rc;
-        struct m0_fop         *fop;
-	struct dtm0_rep_fop   *rep;
-	struct dtm0_req_fop   *req;
-
-	struct m0_dtm0_tx_desc txr = {};
-	struct m0_dtm0_tid     reply_data;
-
-	struct m0_dtm0_clk_src dcs;
-	struct m0_dtm0_ts      now;
-	struct m0_dtm0_service *dtm0 = m0_dtm0_service_find(dtm0_cli_srv_reqh);
-	struct m0_be_dtm0_log  *log = dtm0->dos_log;
-
-
-
-	m0_dtm0_clk_src_init(&dcs, M0_DTM0_CS_PHYS);
-	m0_dtm0_clk_src_now(&dcs, &now);
-
-	M0_PRE(cl_rpc_session != NULL);
-
-	rc = m0_dtm0_tx_desc_init(&txr, 1);
-	M0_UT_ASSERT(rc == 0);
-
-	txr.dtd_ps.dtp_pa[0].p_fid = srv_dtm0_fid;
-	/* txr.dtd_ps.dtp_pa[0].p_state = M0_DTPS_INIT; */
-	txr.dtd_id = (struct m0_dtm0_tid) {
-		.dti_ts = now,
-		.dti_fid = cli_srv_fid
-	};
-	fop = m0_fop_alloc_at(cl_rpc_session,
-			      &dtm0_req_fop_fopt);
-	req = m0_fop_data(fop);
-	req->dtr_msg = DTM_EXECUTE;
-	req->dtr_txr = txr;
-	/*
-	 * TODO: Use a blocking version of m0_dtm0_req_post instead of
-	 * m0_rpc_post_sync.
-	 */
-	M0_ASSERT(0);
-	rc = m0_rpc_post_sync(fop, cl_rpc_session, NULL,
-			      M0_TIME_IMMEDIATELY);
-	M0_UT_ASSERT(rc == 0);
-	rep = reply(fop->f_item.ri_reply);
-	reply_data = rep->dr_txr.dtd_id;
-
-	M0_ASSERT(m0_dtm0_ts__invariant(&reply_data.dti_ts));
-
-	M0_UT_ASSERT(m0_dtm0_tid_cmp(&dcs, &txr.dtd_id, &reply_data) ==
-		     M0_DTS_EQ);
-	m0_fop_put_lock(fop);
-
-	/* Test PERSISTENT message */
-	rc = m0_dtm0_tx_desc_init(&txr, 1);
-	M0_UT_ASSERT(rc == 0);
-	txr.dtd_ps.dtp_pa[0].p_fid = srv_dtm0_fid;
-	txr.dtd_ps.dtp_pa[0].p_state = M0_DTPS_INPROGRESS;
-	txr.dtd_id = (struct m0_dtm0_tid) {
-		.dti_ts = now,
-		.dti_fid = cli_srv_fid
-	};
-	fop = m0_fop_alloc_at(cl_rpc_session,
-			      &dtm0_req_fop_fopt);
-	req = m0_fop_data(fop);
-	req->dtr_msg = DTM_PERSISTENT;
-	req->dtr_txr = txr;
-
-	m0_mutex_lock(&log->dl_lock);
-	rc = m0_be_dtm0_log_update(log, NULL, &txr, &(struct m0_buf){});
-	m0_mutex_unlock(&log->dl_lock);
-	M0_UT_ASSERT(rc == 0);
-
-	/*
-	 * TODO: Use a blocking version of m0_dtm0_req_post instead of
-	 * m0_rpc_post_sync.
-	 */
-	M0_ASSERT(0);
-	rc = m0_rpc_post_sync(fop, cl_rpc_session, NULL, M0_TIME_IMMEDIATELY);
-	M0_UT_ASSERT(rc == 0);
-	rep = reply(fop->f_item.ri_reply);
-	reply_data = rep->dr_txr.dtd_id;
-
-	M0_ASSERT(m0_dtm0_ts__invariant(&reply_data.dti_ts));
-
-	M0_UT_ASSERT(m0_dtm0_tid_cmp(&dcs, &txr.dtd_id, &reply_data) ==
-		     M0_DTS_EQ);
-	m0_fop_put_lock(fop);
-}
-
-static void dtm0_ut_client_init(struct cl_ctx *cctx, const char *cl_ep_addr,
-				const char *srv_ep_addr,
-				struct m0_net_xprt *xprt)
-{
-	int                       rc;
-	struct m0_rpc_client_ctx *cl_ctx;
-
-	M0_PRE(cctx != NULL && cl_ep_addr != NULL &&
-	       srv_ep_addr != NULL && xprt != NULL);
-
-	rc = m0_net_domain_init(&cctx->cl_ndom, xprt);
-	M0_UT_ASSERT(rc == 0);
-
-	cl_ctx = &cctx->cl_ctx;
-
-	cl_ctx->rcx_net_dom            = &cctx->cl_ndom;
-	cl_ctx->rcx_local_addr         = cl_ep_addr;
-	cl_ctx->rcx_remote_addr        = srv_ep_addr;
-	cl_ctx->rcx_max_rpcs_in_flight = MAX_RPCS_IN_FLIGHT;
-	cl_ctx->rcx_fid                = &g_process_fid;
-
-	rc = m0_rpc_client_start(cl_ctx);
-	M0_UT_ASSERT(rc == 0);
-}
-
-static void dtm0_ut_client_fini(struct cl_ctx *cctx)
-{
-	int rc;
-
-	rc = m0_rpc_client_stop(&cctx->cl_ctx);
-	M0_UT_ASSERT(rc == 0);
-
-	m0_net_domain_fini(&cctx->cl_ndom);
-}
-
-
-/* TODO: This test is disabled until full-fledged DTM0 RPC link is ready. */
-void dtm0_ut_service(void)
-{
-	int rc;
-	struct cl_ctx            cctx = {};
-	struct m0_rpc_server_ctx sctx = {
-		.rsx_xprts         = m0_net_all_xprt_get(),
-		.rsx_xprts_nr      = m0_net_xprt_nr(),
-		.rsx_argv          = dtm0_ut_argv,
-		.rsx_argc          = ARRAY_SIZE(dtm0_ut_argv),
-		.rsx_log_file_name = DTM0_UT_LOG,
-	};
-	struct m0_reqh_service  *cli_srv;
-	struct m0_reqh_service  *srv_srv;
-	struct m0_reqh          *srv_reqh;
-
-	srv_reqh = &sctx.rsx_motr_ctx.cc_reqh_ctx.rc_reqh;
-
-	m0_fi_enable("m0_dtm0_in_ut", "ut");
-
-	rc = m0_rpc_server_start(&sctx);
-	M0_UT_ASSERT(rc == 0);
-
-	dtm0_ut_client_init(&cctx, cl_ep_addr, srv_ep_addr,
-			    m0_net_xprt_default_get());
-	rc = m0_dtm_client_service_start(&cctx.cl_ctx.rcx_reqh,
-					 &cli_srv_fid, &cli_srv);
-	M0_UT_ASSERT(rc == 0);
-	srv_srv = m0_reqh_service_lookup(srv_reqh, &srv_dtm0_fid);
-	rc = m0_dtm0_service_process_connect(srv_srv, &cli_srv_fid, cl_ep_addr,
-					     false);
-	M0_UT_ASSERT(rc == 0);
-
-	dtm0_cli_srv_reqh = &cctx.cl_ctx.rcx_reqh;
-
-	dtm0_ut_send_fops(&cctx.cl_ctx.rcx_session);
-
-	rc = m0_dtm0_service_process_disconnect(srv_srv, &cli_srv_fid);
-	M0_UT_ASSERT(rc == 0);
-	(void)srv_srv;
-
-	m0_dtm_client_service_stop(cli_srv);
-	dtm0_ut_client_fini(&cctx);
-	m0_rpc_server_stop(&sctx);
-	m0_fi_disable("m0_dtm0_in_ut", "ut");
-}
-
 
 struct record
 {
@@ -306,10 +102,13 @@ static void cas_xcode_test(void)
     m0_xcode_free_obj(&M0_XCODE_OBJ(m0_cas_op_xc, op_out));
 }
 
+extern void m0_dtm0_ut_drlink_simple(void);
+
 struct m0_ut_suite dtm0_ut = {
         .ts_name = "dtm0-ut",
         .ts_tests = {
-                { "xcode",   cas_xcode_test },
+                { "xcode",         &cas_xcode_test },
+                { "drlink-simple", &m0_dtm0_ut_drlink_simple },
 		{ NULL, NULL },
 	}
 };


### PR DESCRIPTION
The UT is called dtm0-ut:drlink-simple.

The patch also introduces m0_ut_dtm0_helper to simplify rpc server and
client startup/shutdown for DTM0 UTs.

Signed-off-by: Maksym Medvied <maksym.medvied@seagate.com>