### PR TITLE
EOS-25890: FDMI plugin failure test in ST

### DIFF
--- a/fdmi/plugins/fdmi_app
+++ b/fdmi/plugins/fdmi_app
@@ -109,7 +109,7 @@ def process_fdmi_record(kv_record):
     # Check de-dup records
     kv_i = kv_records.get(keystr)
     if kv_i is not None:
-        #print('dup: {}'.format(kv), file=sys.stdout, flush = True)
+        print('dup: {}'.format(kv), file=sys.stdout, flush = True)
         return
     else:
         print('new: {}'.format(kv), file=sys.stdout, flush = True)

--- a/fdmi/plugins/fdmi_app
+++ b/fdmi/plugins/fdmi_app
@@ -109,10 +109,10 @@ def process_fdmi_record(kv_record):
     # Check de-dup records
     kv_i = kv_records.get(keystr)
     if kv_i is not None:
-        #print('dup: {}'.format(kv), file=sys.stderr, flush = True)
+        #print('dup: {}'.format(kv), file=sys.stdout, flush = True)
         return
     else:
-        print('new: {}'.format(kv), file=sys.stderr, flush = True)
+        print('new: {}'.format(kv), file=sys.stdout, flush = True)
         kv_records[keystr] = kv
         keystr_LRU.append(keystr)
         return
@@ -121,7 +121,7 @@ def process_fdmi_record(kv_record):
 # Handle SIGNT and SIGTERM. Stop the underlying processes and exit.
 def signal_handler(sig, frame):
     print('CTRL + C pressed', file=sys.stderr)
-    print('Stopping all fdmi_sample_plugin processes...')
+    print('Stopping all fdmi_sample_plugin processes...', file=sys.stderr)
     for p in processes:
         p.send_signal(sig)
         p.wait()

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -98,13 +98,15 @@ do_some_kv_operations()
 			echo "When you have done that, Press Enter to go ..."
 			read
 		else
+			rc=1
 			stop_fdmi_plugin      && sleep 5                         &&
 			start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
-			start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" || {
+			start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" && rc=0
+			if [[ $rc -eq 1 ]] ; then
 				echo "Can not stop and start plug again".
-				rc=1
 				return $rc
-			}
+			fi
+			sleep 5
 		fi
 
 		echo "Let's put {key3: ***}"
@@ -118,8 +120,8 @@ do_some_kv_operations()
 		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 		echo "Now do more index put ..."
-		echo "Because the plug was restarted, these operations"
-		echo " will trigger failure handling"
+		echo "Because the plug was restarted, these operations "
+		echo "will trigger failure handling"
 		for ((j=0; j<20; j++)); do
 			echo "j=$j"
 			"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
@@ -156,7 +158,7 @@ do_some_kv_operations()
 		}
 		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
-		echo "Sleep 100 seconds, if any failure, this would be engough to recover."
+		echo "Sleep 100 seconds, if any failure, this would be enough to recover."
 		sleep 100
 
 	done

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -68,7 +68,7 @@ do_some_kv_operations()
 		}
 		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
-		echo "Let put {key1: ***}"
+		echo "Let's put {key1: ***}"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
 					index put    "$DIX_FID" "key1" "something1 anotherstring2 YETanotherstring3"      \
 					      get    "$DIX_FID" "key1"                     \
@@ -78,7 +78,7 @@ do_some_kv_operations()
 		}
 		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
-		echo "Let put {key2: ***}"
+		echo "Let's put {key2: ***}"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
 					index put    "$DIX_FID" "key2" "something1_anotherstring2*YETanotherstring3"      \
 					      get    "$DIX_FID" "key2"                     \
@@ -88,7 +88,17 @@ do_some_kv_operations()
 		}
 		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
-		echo "Let put {key3: ***}"
+		echo "Now, kill the two fdmi plug app and start them again..."
+		echo "This is to simulate the plugin failure and start"
+		stop_fdmi_plugin      && sleep 5                         &&
+		start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
+		start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" || {
+			echo "Can not stop and start plug again".
+			rc=1
+			return $rc
+		}
+
+		echo "Let's put {key3: ***}"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
 					index put    "$DIX_FID" "key3" "{Bucket-Name:SomeBucket, Object-Name:Someobject, x-amz-meta-replication:Pending}"      \
 					      get    "$DIX_FID" "key3"                     \
@@ -96,6 +106,16 @@ do_some_kv_operations()
 			rc=$?
 			echo "m0kv failed"
 		}
+		if $interactive ; then echo "Press Enter to go ..." && read; fi
+
+		echo "Now do more index put ..."
+		echo "Because the plug was restarted, these operations"
+		echo " will trigger failure handling"
+		for ((j=0; j<20; j++)); do
+			echo "j=$j"
+			"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+					index put    "$DIX_FID" "key2-$j" "something1_anotherstring2*YETanotherstring3-$j"
+		done
 		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
 		echo "Now, let's delete 'key2' from this index. The plugin must show the del op coming"
@@ -127,6 +147,9 @@ do_some_kv_operations()
 		}
 		if $interactive ; then echo "Press Enter to go ..." && read; fi
 
+		echo "Sleep 100 seconds, if any failure, this would be engough to recover."
+		sleep 100
+
 	done
 	return $rc
 }
@@ -139,18 +162,18 @@ start_fdmi_plugin()
 	local rc=0
 
 	# Using `fdmi_sample_plugin`, which has duplicated records.
-	# MOTR_PARAM="-l ${lnet_nid}:$fdmi_plugin_ep        \
+	# PLUG_PARAM="-l ${lnet_nid}:$fdmi_plugin_ep        \
 	#	    -h ${lnet_nid}:$HA_EP -p $PROF_OPT    \
 	#	    -f $M0T1FS_PROC_ID                    "
-	# PLUGIN_CMD="$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $MOTR_PARAM -g $fdmi_filter_fid -s"
+	# PLUGIN_CMD="$M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin $PLUG_PARAM -g $fdmi_filter_fid -s"
 
 	# Using `fdmi_app`, which can de-dup the duplicated records
-	MOTR_PARAM="-le ${lnet_nid}:$fdmi_plugin_ep        \
+	 APP_PARAM="-le ${lnet_nid}:$fdmi_plugin_ep        \
 		    -he ${lnet_nid}:$HA_EP -pf $PROF_OPT    \
 		    -sf $M0T1FS_PROC_ID                     \
 		    -fi $fdmi_filter_fid                    \
 		    --plugin-path $M0_SRC_DIR/fdmi/plugins/fdmi_sample_plugin"
-	PLUGIN_CMD="$M0_SRC_DIR/fdmi/plugins/fdmi_app $MOTR_PARAM"
+	PLUGIN_CMD="$M0_SRC_DIR/fdmi/plugins/fdmi_app $APP_PARAM"
 
 	if $interactive ; then
 		echo "Please use another terminal and run this command:"
@@ -159,7 +182,7 @@ start_fdmi_plugin()
 		read
 	else
 		echo "Please check fdmi plugin output from this file: $(pwd)/${fdmi_output_file}"
-		(${PLUGIN_CMD} 2>&1 |& tee "${fdmi_output_file}" ) &
+		(${PLUGIN_CMD} 2>&1 |& tee -a "${fdmi_output_file}" ) &
 		sleep 5
 	fi
 

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -91,23 +91,16 @@ do_some_kv_operations()
 		echo "Now, kill the two fdmi plug app and start them again..."
 		echo "This is to simulate the plugin failure and start"
 
-		if $interactive ; then
-			echo "Now please go to the plugin terminals and "
-			echo "Press CTRL+C to stop them, and then   "
-			echo "Please start them again with the same command"
-			echo "When you have done that, Press Enter to go ..."
-			read
-		else
-			rc=1
-			stop_fdmi_plugin      && sleep 5                         &&
-			start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
-			start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" && rc=0
-			if [[ $rc -eq 1 ]] ; then
-				echo "Can not stop and start plug again".
-				return $rc
-			fi
-			sleep 5
+		rc=1
+		stop_fdmi_plugin      && sleep 5                         &&
+		start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
+		start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" && rc=0
+		if [[ $rc -eq 1 ]] ; then
+			echo "Can not stop and start plug again".
+			return $rc
 		fi
+		sleep 5
+		rc=0
 
 		echo "Let's put {key3: ***}"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \

--- a/fdmi/plugins/fdmi_plugin_st.sh
+++ b/fdmi/plugins/fdmi_plugin_st.sh
@@ -90,13 +90,22 @@ do_some_kv_operations()
 
 		echo "Now, kill the two fdmi plug app and start them again..."
 		echo "This is to simulate the plugin failure and start"
-		stop_fdmi_plugin      && sleep 5                         &&
-		start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
-		start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" || {
-			echo "Can not stop and start plug again".
-			rc=1
-			return $rc
-		}
+
+		if $interactive ; then
+			echo "Now please go to the plugin terminals and "
+			echo "Press CTRL+C to stop them, and then   "
+			echo "Please start them again with the same command"
+			echo "When you have done that, Press Enter to go ..."
+			read
+		else
+			stop_fdmi_plugin      && sleep 5                         &&
+			start_fdmi_plugin "$FDMI_FILTER_FID"  "$FDMI_PLUGIN_EP"  &&
+			start_fdmi_plugin "$FDMI_FILTER_FID2" "$FDMI_PLUGIN_EP2" || {
+				echo "Can not stop and start plug again".
+				rc=1
+				return $rc
+			}
+		fi
 
 		echo "Let's put {key3: ***}"
 		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \


### PR DESCRIPTION
# Problem Statement
The existing FDMI plugin ST needs improvement for failure case testing.

# Design
-  For Feature, Post the link for design
Adding failure case testing in batch mode. (Previously only manually doing failure case test)
Doing more KV ops to show that client operations are stalled when FDMI plugin fails.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
