### PR TITLE
EOS-26198: re-enable st 49motr-rpc-cancel for libfabric

### DIFF
--- a/motr/st/utils/motr_rpc_cancel_test.sh
+++ b/motr/st/utils/motr_rpc_cancel_test.sh
@@ -43,7 +43,7 @@ stride=4
 
 motr_change_controller_state()
 {
-	local lnet_nid=`sudo lctl list_nids | head -1`
+	local lnet_nid=$(m0_local_nid_get)
 	local s_endpoint="$lnet_nid:12345:34:101"
 	local c_endpoint="$lnet_nid:$M0HAM_CLI_EP"
 	local dev_fid=$1

--- a/scripts/m0
+++ b/scripts/m0
@@ -83,7 +83,6 @@ LIBFAB_TESTS_SKIPLIST=(04initscripts
                 40motr-dgmode
                 43motr-sync-replication
                 45motr-rmw
-                49motr-rpc-cancel
                 51kem)
 
 # libisal does not need kernel based ST


### PR DESCRIPTION
Re-enable ST 49motr-rpc-cancel for libfabric as it is completely running in user-space.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- Problem statement

# Design
-  Re-enable ST 49motr-rpc-cancel for libfabric as it is completely running in user-space.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
