### PR TITLE
Revert "rpc: call ->rio_sent() unconditionally."

### DIFF
--- a/rpc/frmops.c
+++ b/rpc/frmops.c
@@ -502,7 +502,6 @@ static void item_sent(struct m0_rpc_item *item)
 		 */
 		M0_ASSERT(m0_rpc_item_is_request(item));
 		M0_ASSERT(item->ri_error == -ECANCELED);
-		m0_rpc_item_sent_invoke(item);
 		return;
 	}
 
@@ -517,7 +516,8 @@ static void item_sent(struct m0_rpc_item *item)
 
 	if (item->ri_nr_sent == 1) { /* not resent */
 		stats->rs_nr_sent_items_uniq++;
-		m0_rpc_item_sent_invoke(item);
+		if (item->ri_ops != NULL && item->ri_ops->rio_sent != NULL)
+			item->ri_ops->rio_sent(item);
 	} else if (item->ri_nr_sent == 2) {
 		/* item with ri_nr_sent >= 2 are counted as 1 in
 		   rs_nr_resent_items i.e. rs_nr_resent_items counts number

--- a/rpc/item.c
+++ b/rpc/item.c
@@ -800,7 +800,10 @@ M0_INTERNAL void m0_rpc_item_failed(struct m0_rpc_item *item, int32_t rc)
 	m0_rpc_item_change_state(item, M0_RPC_ITEM_FAILED);
 	m0_rpc_item_timer_stop(item);
 	/* XXX ->rio_sent() can be called multiple times (due to cancel). */
-	m0_rpc_item_sent_invoke(item);
+	if (m0_rpc_item_is_oneway(item) &&
+	    item->ri_ops != NULL && item->ri_ops->rio_sent != NULL)
+		item->ri_ops->rio_sent(item);
+
 	m0_rpc_session_item_failed(item);
 	/*
 	 * Reference release done here is for the reference taken
@@ -1761,12 +1764,6 @@ M0_INTERNAL void m0_rpc_item_replied_invoke(struct m0_rpc_item *req)
 		req->ri_ops->rio_replied(req);
 		m0_addb2_pop(M0_AVI_RPC_REPLIED);
 	}
-}
-
-M0_INTERNAL void m0_rpc_item_sent_invoke(struct m0_rpc_item *item)
-{
-	if (item->ri_ops != NULL && item->ri_ops->rio_sent != NULL)
-		item->ri_ops->rio_sent(item);
 }
 
 #undef M0_TRACE_SUBSYSTEM

--- a/rpc/item_internal.h
+++ b/rpc/item_internal.h
@@ -80,7 +80,6 @@ M0_INTERNAL void m0_rpc_item_send_reply(struct m0_rpc_item *req,
 					struct m0_rpc_item *reply);
 
 M0_INTERNAL void m0_rpc_item_replied_invoke(struct m0_rpc_item *item);
-M0_INTERNAL void m0_rpc_item_sent_invoke(struct m0_rpc_item *item);
 
 /** @} */
 #endif /* __MOTR_RPC_ITEM_INT_H__ */


### PR DESCRIPTION
Reverts Seagate/cortx-motr#980.