### PR TITLE
EOS-26541: Incorrect check of M0_ENF_META flag in oi_flags field of struct m0_op_idx

### DIFF
--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -581,7 +581,7 @@ static void dix_build(const struct m0_op_idx *oi,
 		m0_dix_ldesc_init(&out->dd_layout.u.dl_desc,
 				  &(struct m0_ext) { .e_start = 0,
 				  .e_end = IMASK_INF }, 1, HASH_FNC_CITY,
-				  (oi->oi_flags & M0_ENF_META) ?
+				  (idx->in_entity.en_flags & M0_ENF_META) ?
 				  &idx->in_attr.idx_pver :
 				  &dix_inst(oi)->di_index_pver);
 	}


### PR DESCRIPTION
# Problem Statement
Incorrect check of M0_ENF_META flag in oi_flags

# Design
Analysis:
Actually M0_ENF_META flag is available in entity_flags. It is validated
with oi_flags. Need to modify M0_ENF_META flag validation.

Fix:
Modified M0_ENF_META flag validation for index creation.

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
