### PR TITLE
EOS-25895 : stable/115: m0panic at fi_close after libfab_buf_dom_dereg

### DIFF
--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -2121,12 +2121,16 @@ static void libfab_pending_bufs_send(struct m0_fab__ep *ep)
  */
 static int libfab_target_notify(struct m0_fab__buf *buf)
 {
-	struct m0_fab__active_ep *aep = libfab_aep_get(buf->fb_txctx);
+	struct m0_fab__active_ep *aep;
 	struct m0_fab__buf       *fbp;
 	struct m0_fab__tm        *tm;
 	struct iovec              iv;
 	struct fi_msg             op_msg;
 	int                       ret = 0;
+
+	M0_PRE(buf != NULL && buf->fb_txctx != NULL);
+	aep = libfab_aep_get(buf->fb_txctx);
+	M0_ASSERT(aep != NULL);
 
 	if (buf->fb_nb->nb_qtype == M0_NET_QT_ACTIVE_BULK_RECV &&
 	    aep->aep_tx_state == FAB_CONNECTED) {
@@ -2749,8 +2753,11 @@ static int libfab_buf_dom_dereg(struct m0_fab__buf *fbp)
 {
 	m0_time_t tmout;
 	int       i;
-	int       ret    = 0;
-	uint32_t  seg_nr = fbp->fb_nb->nb_buffer.ov_vec.v_nr;
+	int       ret = 0;
+	uint32_t  seg_nr;
+
+	M0_PRE(fbp != NULL && fbp->fb_nb != NULL);
+	seg_nr = fbp->fb_nb->nb_buffer.ov_vec.v_nr;
 
 	for (i = 0; i < seg_nr; i++) {
 		if (fbp->fb_mr.bm_mr[i] != NULL) {

--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -2121,14 +2121,15 @@ static void libfab_pending_bufs_send(struct m0_fab__ep *ep)
  */
 static int libfab_target_notify(struct m0_fab__buf *buf)
 {
-	struct m0_fab__active_ep *aep;
+	struct m0_fab__active_ep *aep = libfab_aep_get(buf->fb_txctx);
 	struct m0_fab__buf       *fbp;
 	struct m0_fab__tm        *tm;
 	struct iovec              iv;
 	struct fi_msg             op_msg;
 	int                       ret = 0;
 
-	if (buf->fb_nb->nb_qtype == M0_NET_QT_ACTIVE_BULK_RECV) {
+	if (buf->fb_nb->nb_qtype == M0_NET_QT_ACTIVE_BULK_RECV &&
+	    aep->aep_tx_state == FAB_CONNECTED) {
 		M0_ALLOC_PTR(fbp);
 		if (fbp == NULL)
 			return M0_ERR(-ENOMEM);
@@ -2137,7 +2138,6 @@ static int libfab_target_notify(struct m0_fab__buf *buf)
 		fbp->fb_dummy[0] = FAB_DUMMY_DATA;
 		fbp->fb_dummy[1] = buf->fb_rbd->fbd_buftoken;
 		fbp->fb_txctx = buf->fb_txctx;
-		aep = libfab_aep_get(fbp->fb_txctx);
 		tm = libfab_buf_tm(buf);
 		fbp->fb_token = libfab_buf_token_get(tm, fbp);
 		aep->aep_bulk_cnt++;


### PR DESCRIPTION
In libfab_buf_dom_dereg(), call fi_close() only for the used segments of network buffer.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Motr confd service crashed due to invalid memory access of unused variable arising due to suspected bit-rot of in-memory data structure.

# Design
- This can be handled in the libfabric code in the following way.
In libfab_buf_dom_dereg(), call fi_close() only for the used segments of network buffer.
This will prevent the service from crashing, but the root cause of the issue could not analyzed from the core dump.
Also this will be an optimized way of deregistering the buffer segments and hence it avoids unnecessary access of unused variables.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
