### PR TITLE
EOS-25581 : main/551: m0d panic at m0_tlist_remove after m0_tlist_del

### DIFF
--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -1751,6 +1751,7 @@ static void libfab_buf_fini(struct m0_fab__buf *buf)
 	if (buf->fb_bulk_op != NULL && fab_bulk_tlink_is_in(buf->fb_bulk_op)) {
 		fab_bulk_tlist_del(buf->fb_bulk_op);
 		m0_free(buf->fb_bulk_op);
+		buf->fb_bulk_op = NULL;
 	}
 
 	if(buf->fb_txctx != NULL) {


### PR DESCRIPTION
Reset the buf->fb_bulk_op to NULL in libfab_buf_fini().

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Motr ioservice crashed during `libfab_buf_fini()`.

# Design
-  For a network buffer, `libfab_buf_fini()` is called before generation of buffer completion event and from the same event callback it is called again during buffer deregister. This leads to motr service crashing due to invalid contents in the `buf->fb_bulk_op` during the first call to `libfab_buf_fini()`. Hence explicitly setting this field to NULL after freeing the memory in the first call to `libfab_buf_fini()` to avoid accessing memory which is already freed.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
