### PR TITLE
EOS-26562: motr code fails to build if motr/config.h is not found.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -943,6 +943,15 @@ AC_SUBST([LIBFAB_LIBS])
 AM_CONDITIONAL([ENABLE_LIBFAB],
                [test "x$enable_libfab" = xyes || ! test -z "$with_libfab"])
 
+AC_MSG_CHECKING([for motr/config.h])
+MOTR_CONFIG="motr/config.h"
+AS_IF([! test -e "ABS_BUILDDIR/$MOTR_CONFIG"],
+    [
+      AC_MSG_NOTICE([$MOTR_CONFIG not found! Creating the symlink.])
+        (cd "$ABS_BUILDDIR/motr" && $LN_S "../config.h" "config.h")
+    ]
+)
+
 #
 # Checking Lustre --------------------------------------------------------- {{{1
 #


### PR DESCRIPTION
To solve this issue, if motr/config.h does not exist
then create motr/config.h as a symlink to ../config.h
during configure.

Signed-off-by: Mehul Joshi <mehul.joshi@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
