### PR TITLE
EOS-26104 : libfabric-devel is needed for 'make rpms' for motr

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -40,7 +40,9 @@ Build
     sudo modprobe lnet
     sudo lctl list_nids
 
-   Make sure that libfabric package is not installed::
+   Make sure that libfabric package is not installed.
+   Please refer the following document for un-installation of libfabric package.
+   https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/711230113/Libfabric+setup+and+using+libfabric+with+motr#Uninstalling-libfabric-package ::
 
     fi_info --version
     bash: fi_info: command not found

--- a/scripts/provisioning/roles/motr-build/tasks/main.yml
+++ b/scripts/provisioning/roles/motr-build/tasks/main.yml
@@ -323,8 +323,16 @@
       with_items:
         - sed -i 's/(4)/(8)/g' ./prov/tcp/src/tcpx.h
         - ./configure
-        - make -j4
-        - make install
+        - make rpm
+
+    - name: install local libfabric rpms
+      yum:
+        name:
+          - /root/rpmbuild/RPMS/x86_64/libfabric-1.11.2-1.el7.x86_64.rpm
+          - /root/rpmbuild/RPMS/x86_64/libfabric-devel-1.11.2-1.el7.x86_64.rpm
+        state: present
+      when: ansible_distribution_version is version('7.6.1810', '>')
+      tags: libfabric-custom-build
 
     - name: write libfab config file on vmware_desktop provider
       lineinfile:


### PR DESCRIPTION
# Problem Statement
- During installation of motr build dependencies, make and install local libfabric rpms instead of installing libfabric binaries.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
