### PR TITLE
go/mio: fix bogus ENOENT error on read

### DIFF
--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -345,9 +345,8 @@ func (mio *Mio) Create(id string, sz uint64, anyPool ...string) error {
     return mio.open(sz)
 }
 
-func roundupPower2(x int) (power int) {
-    for power = 1; power < x; power *= 2 {}
-    return power
+func roundup(x int, by int) int {
+    return ((x - 1) / by + 1) * by
 }
 
 const maxM0BufSz = 512 * 1024 * 1024
@@ -388,14 +387,14 @@ func (mio *Mio) getOptimalBlockSz(bufSz int) (bsz, gsz int) {
     // P * N / (N + K + S) - number of data units to span the pool-width
     maxBs := int(k * C.uint(usz) * pa.pa_P * pa.pa_N /
                                   (pa.pa_N + pa.pa_K + pa.pa_S))
-    maxBs = ((maxBs - 1) / gsz + 1) * gsz // multiple of group size
+    maxBs = roundup(maxBs, gsz) // multiple of group size
 
     if bufSz >= maxBs {
         return maxBs, gsz
     } else if bufSz <= gsz {
         return gsz, gsz
     } else {
-        return roundupPower2(bufSz), gsz
+        return roundup(bufSz, gsz), gsz
     }
 }
 


### PR DESCRIPTION
# Problem Statement

The problem is with getOptimalBlockSz(): sometimes, it may
return the size which is bigger than amount of parity groups
spanned by the object. For example, with 1+0+0 EC configuration,
unit size of 4M and object size of 9485447 bytes, it will
return 16MB bs - which is more than 3 parity groups spanned
by the object (4 * 3 == 12MB).

# Design

Solution: fix the logic of getOptimalBlockSz(), so that it
would never return the size bigger than the size of all parity
groups spanned by the object. (The size of a parity group
meant here is measured by the size of all data units in it.)

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
