### PR TITLE
EOS-26638: Align metadata size to nearest 4k size

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -721,6 +721,9 @@ def get_cvg_cnt_and_cvg_k8(self):
     check_type(cvg, list, "cvg")
     return cvg_cnt, cvg
 
+def align_val(val, size):
+    return (int(val/size) * size)
+
 def update_bseg_size(self):
     dev_count = 0
     lvm_min_size = None
@@ -732,6 +735,7 @@ def update_bseg_size(self):
         for i in range(md_len):
             lvm_min_size = calc_lvm_min_size(self, md_disks[i], lvm_min_size)
         if lvm_min_size:
+            align_val(lvm_min_size, 4096)
             self.logger.info(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}\n")
             cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {MOTR_SYS_CFG}'
             execute_command(self, cmd)


### PR DESCRIPTION
# Problem Statement
If Metadata disk size is not 4k aligned value, mini provisioner fails with the below motr panic.
Motr panic: (m0_is_aligned(g->sg_size, M0_BE_SEG_PAGE_SIZE)) at be_seg_hdr_create() be/seg.c:108

# Design
Align BESEG size ot the nearest 4K size,
for ex : if metadata device is 5000, it will be set to 4096.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
