### PR TITLE
EOS-26166: [DTM Enabler] Identify changes to support DIX use cases in single transaction

### DIFF
--- a/cas/client.c
+++ b/cas/client.c
@@ -1376,7 +1376,13 @@ M0_INTERNAL int m0_cas_index_delete(struct m0_cas_req      *req,
 	M0_PRE(req->ccr_sess != NULL);
 	M0_PRE(m0_cas_req_is_locked(req));
 	M0_PRE(m0_forall(i, cids_nr, m0_cas_id_invariant(&cids[i])));
-	M0_PRE((flags & ~(COF_CROW | COF_DEL_LOCK)) == 0);
+
+	if (flags & COF_CROW)
+		M0_LOG(M0_ALWAYS, "CROW FLAG is enabled for delete(FOP-2)");
+	if (flags & COF_DEL_LOCK)
+		M0_LOG(M0_ALWAYS, "DEL LOCK FLAG is enabled for delete(FOP-2)");
+
+	 M0_PRE((flags & ~(COF_CROW | COF_DEL_LOCK)) == 0);
 	(void)dtx;
 	rc = cas_index_req_prepare(req, cids, cids_nr, cids_nr, false, flags,
 				   &op);
@@ -1827,6 +1833,12 @@ M0_INTERNAL int m0_cas_del(struct m0_cas_req *req,
 	M0_PRE(m0_cas_req_is_locked(req));
 	M0_PRE(m0_cas_id_invariant(index));
 	M0_PRE(M0_IN(flags, (0, COF_DEL_LOCK, COF_SYNC_WAIT)));
+
+	if (flags & COF_CROW) {
+		M0_LOG(M0_ALWAYS, "26166: CROW Flag is enabled");
+	} else {
+		M0_LOG(M0_ALWAYS, "26166: CROW Flag is disabled");
+	}
 
 	rc = cas_req_prep(req, index, keys, NULL, keys->ov_vec.v_nr, flags,
 			  &op);

--- a/dix/req.c
+++ b/dix/req.c
@@ -804,9 +804,12 @@ static void dix_idxop_meta_update_ast_cb(struct m0_sm_group *grp,
 		 * catalogues shouldn't be created => no CAS create requests
 		 * should be sent.
 		 */
+		M0_LOG(M0_ALWAYS, "26166: dr_type: %d, crow: %d, cont: %d", req->dr_type, crow, cont);
 		cont = cont && !(req->dr_type == DIX_CREATE && crow);
-		if (cont)
+		if (cont) {
+			M0_LOG(M0_ALWAYS, "26166: Enter to trigger second FOP");
 			rc = dix_idxop_reqs_send(req);
+		}
 	}
 
 	m0_dix_meta_req_fini(meta_req);
@@ -971,6 +974,12 @@ static void dix_idxop(struct m0_dix_req *req)
 	/*
 	 * Put/delete ordinary indices layouts in 'layout' meta-index.
 	 */
+
+	if (req->dr_type == DIX_CREATE || req->dr_type == DIX_DELETE) {
+		M0_LOG(M0_ALWAYS, "26166: Enter in meta flag");
+		req->dr_is_meta = true;
+	}
+
 	if (!req->dr_is_meta &&
 	    M0_IN(req->dr_type, (DIX_CREATE, DIX_DELETE))) {
 		rc = dix_idxop_meta_update(req);
@@ -1004,6 +1013,11 @@ M0_INTERNAL int m0_dix_create(struct m0_dix_req   *req,
 	       indices[i].dd_layout.dl_type != DIX_LTYPE_UNKNOWN));
 	M0_PRE(ergo(req->dr_is_meta, dix_id_layouts_nr(req) == 0));
 	M0_PRE(M0_IN(flags, (0, COF_CROW)));
+
+	if (!(flags & COF_CROW)) {
+		M0_LOG(M0_ALWAYS, "26166: COF_CROW Flag is disabled");
+	}
+
 	req->dr_dtx = dtx;
 	/*
 	 * Save indices identifiers in two arrays. Indices identifiers in
@@ -1780,9 +1794,20 @@ static int dix_cas_rops_send(struct m0_dix_req *req)
 					req->dr_dtx, cas_rop->crp_flags);
 			break;
 		case DIX_NEXT:
+			{
+				struct m0_fid temp_dix_fid;	
+			if((req->dr_indices->dd_fid.f_container == m0_dix_layout_fid.f_container) &&
+			   (req->dr_indices->dd_fid.f_key == m0_dix_layout_fid.f_key))
+			{
+				memcpy((void *)&temp_dix_fid,cas_rop->crp_keys.ov_buf[0], sizeof(temp_dix_fid));
+				m0_dix_fid_convert_dix2cctg(&temp_dix_fid, cas_rop->crp_keys.ov_buf[0],
+					    sdev_idx);
+			}
 			rc = m0_cas_next(creq, &cctg_id, &cas_rop->crp_keys,
 					 req->dr_recs_nr,
 					 cas_rop->crp_flags | COF_SLANT);
+			M0_LOG(M0_ALWAYS,"26166: client key = "FID_F,FID_P(&temp_dix_fid));
+			}
 			break;
 		default:
 			M0_IMPOSSIBLE("Unknown req type %u", req->dr_type);
@@ -2440,7 +2465,7 @@ M0_INTERNAL void m0_dix_next_rep(const struct m0_dix_req  *req,
 	const struct m0_dix_next_resultset  *rs = &req->dr_rs;
 	struct m0_dix_next_results          *res;
 	struct m0_cas_next_reply           **reps;
-
+	struct m0_fid temp_cat_fid;
 	M0_ASSERT(rs != NULL);
 	M0_ASSERT(key_idx < rs->nrs_res_nr);
 	res  = &rs->nrs_res[key_idx];
@@ -2449,6 +2474,13 @@ M0_INTERNAL void m0_dix_next_rep(const struct m0_dix_req  *req,
 	M0_ASSERT(reps[val_idx]->cnp_rc == 0);
 	rep->dnr_key = reps[val_idx]->cnp_key;
 	rep->dnr_val = reps[val_idx]->cnp_val;
+
+	if((req->dr_indices->dd_fid.f_container == m0_dix_layout_fid.f_container) &&
+	   (req->dr_indices->dd_fid.f_key == m0_dix_layout_fid.f_key))
+	{
+		memcpy((void *)&temp_cat_fid, rep->dnr_key.b_addr, sizeof(temp_cat_fid));
+		m0_dix_fid_convert_cctg2dix(&temp_cat_fid, rep->dnr_key.b_addr);
+	}
 }
 
 M0_INTERNAL uint32_t m0_dix_next_rep_nr(const struct m0_dix_req *req,

--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -567,7 +567,7 @@ static void dix_build(const struct m0_op_idx *oi,
 					  HASH_FNC_CITY,
 					  &idx->in_attr.idx_pver);
 		}
-	} else if (M0_IN(opcode, (M0_EO_CREATE))) {
+	} else if (M0_IN(opcode, (M0_EO_CREATE, M0_EO_DELETE, M0_IC_LOOKUP))) {
 		/*
 		 * Use default layout for all indices:
 		 * - city hash function;
@@ -951,6 +951,7 @@ static bool dixreq_clink_cb(struct m0_clink *cl)
 		switch (op->op_code) {
 		case M0_EO_CREATE:
 		case M0_EO_DELETE:
+		case M0_IC_LOOKUP:
 			M0_ASSERT(m0_dix_req_nr(dreq) == 1);
 			rc = m0_dix_item_rc(dreq, 0);
 			break;
@@ -1006,7 +1007,7 @@ static void dix_index_create_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	M0_ENTRY();
 	dix_build(oi, &dix);
 	m0_clink_add(&dreq->dr_sm.sm_chan, &dix_req->idr_clink);
-	rc = m0_dix_create(dreq, &dix, 1, NULL, COF_CROW);
+	rc = m0_dix_create(dreq, &dix, 1, NULL, 0);
 	if (rc != 0)
 		dix_req_immed_failure(dix_req, M0_ERR(rc));
 	m0_dix_fini(&dix);
@@ -1032,7 +1033,7 @@ static void dix_index_delete_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	M0_ENTRY();
 	dix_build(oi, &dix);
 	m0_clink_add(&dreq->dr_sm.sm_chan, &dix_req->idr_clink);
-	rc = m0_dix_delete(dreq, &dix, 1, NULL, COF_CROW);
+	rc = m0_dix_delete(dreq, &dix, 1, NULL, 0);
 	if (rc != 0)
 		dix_req_immed_failure(dix_req, M0_ERR(rc));
 	M0_LEAVE();
@@ -1042,12 +1043,14 @@ static void dix_index_lookup_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 {
 	struct dix_req          *dix_req = ast->sa_datum;
 	struct m0_op_idx        *oi = dix_req->idr_oi;
-	struct m0_dix_meta_req  *mreq = &dix_req->idr_mreq;
+	struct m0_dix_req       *dreq = &dix_req->idr_dreq;
+	struct m0_dix            dix = {};
 	int                      rc;
 
 	M0_ENTRY();
-	m0_clink_add_lock(&mreq->dmr_chan, &dix_req->idr_clink);
-	rc = m0_dix_layout_get(mreq, OI_IFID(oi), 1);
+	dix_build(oi, &dix);
+	m0_clink_add(&dreq->dr_sm.sm_chan, &dix_req->idr_clink);
+	rc = m0_dix_cctgs_lookup(dreq, &dix, 1);
 	if (rc != 0)
 		dix_req_immed_failure(dix_req, M0_ERR(rc));
 	M0_LEAVE();
@@ -1086,7 +1089,7 @@ static void dix_put_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	struct m0_op_idx        *oi = dix_req->idr_oi;
 	struct m0_dix            dix;
 	struct m0_dix_req       *dreq = &dix_req->idr_dreq;
-	uint32_t                 flags = COF_CROW;
+	uint32_t                 flags = 0;
 	int                      rc;
 
 	M0_ENTRY();
@@ -1267,7 +1270,7 @@ static int dix_index_lookup(struct m0_op_idx *oi)
 	int             rc;
 
 	M0_ASSERT(dix_iname_args_are_valid(oi));
-	rc = dix_mreq_create(oi, &req);
+	rc = dix_req_create(oi, &req);
 	if (rc != 0)
 		return M0_ERR(rc);
 	dix_req_exec(req, idx_is_distributed(oi) ?


### PR DESCRIPTION
# Problem Statement
EOS-26166: DTM Enabler -[Spike] Identify changes to support DIX use cases in single transaction

# Fixes for PoC
Disabled COF_CROW flag from client side.
Disabled layout put transaction for "index create" and "index delete".
Modified m0kv tool to pass pool version and layout type for index operations.
All m0kv Operations was verified. It is working as expected.
It is verified with S3bench and it is working as expected.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [X] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
