### PR TITLE
EOS-26618 dtm0: skip execution of REDO UT if DTM0 is disabled

### DIFF
--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -1144,6 +1144,9 @@ static void st_dtm0_r(void)
 	uint64_t  key = 111;
 	uint64_t  val = 222;
 
+	if (!ENABLE_DTM0)
+		return;
+
 	idx_setup();
 	exec_one_by_one(1, M0_IC_PUT);
 	dtm0_ut_send_redo(&duc.duc_ifid, &key, &val);


### PR DESCRIPTION
The DTM0 service is required for REDO UT. So this UT should not
be executed if DTM0 is disabled.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>
