### PR TITLE
EOS-26774: re-enable 23spiel-dix-repair* for libfabric

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -368,6 +368,24 @@ Tests:
     polltime : 30
     timeout  : 1800
 
+  - id       : 23spiel-dix-repair
+    script   : 'm0 run-st 23spiel-dix-repair'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    sandbox  : /var/motr/root/sandbox.st-23spiel-dix-repair
+    groupname: 05motr-single-node
+    polltime : 30
+    timeout  : 1800
+
+  - id       : 23spiel-dix-repair-quiesce
+    script   : 'm0 run-st 23spiel-dix-repair-quiesce'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    sandbox  : /var/motr/root/sandbox.st-23spiel-dix-repair-quiesce
+    groupname: 05motr-single-node
+    polltime : 30
+    timeout  : 1800
+
   - id       : 24motr-dix-repair-lookup-insert
     script   : 'm0 run-st 24motr-dix-repair-lookup-insert'
     dir      : src/scripts

--- a/scripts/m0
+++ b/scripts/m0
@@ -71,8 +71,6 @@ LIBFAB_TESTS_SKIPLIST=(04initscripts
                 21fsync-single-node
                 22sns-repair-ios-fail
                 23sns-abort-quiesce
-                23spiel-dix-repair
-                23spiel-dix-repair-quiesce
                 26motr-user-kernel-tests
                 28sys-kvs
                 28sys-kvs-kernel


### PR DESCRIPTION
# Problem Statement
- 23spiel-dix-repair* STs were disabled for libfabric. 

# Design
-  Re-enabled below STs as those are executed successfully even for libfabric
> 23spiel-dix-repair
23spiel-dix-repair-quiesce

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
