### PR TITLE
EOS-24982: motr crash observed in rconfc_herd_cctx_fini

### DIFF
--- a/conf/rconfc.c
+++ b/conf/rconfc.c
@@ -2552,7 +2552,12 @@ static void rconfc_herd_cctxs_fini(struct m0_rconfc *rconfc)
 	struct rconfc_link *lnk;
 
 	m0_tl_for (rcnf_herd, &rconfc->rc_herd, lnk) {
-		if (lnk->rl_state == CONFC_DEAD)
+		/*
+		 * When lnk->fl_fom_queued is true then it means 
+		 * that the fom fini is in progress.
+		 */
+		if (lnk->rl_state == CONFC_DEAD || 
+		    (lnk->rl_fom_queued  && lnk->rl_state == CONFC_IDLE ))
 			/*
 			 * Even with version elected some links may remain dead
 			 * in the herd and require no finalisation. Dead link is


### PR DESCRIPTION
Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
HA invoked rconfc_herd_link_on_death_cb, we see version
election has been called before the fini which caused
a crash, this patch fixes it.

# Design
We are avoiding finalization if the link has rl_fom_queued & the state is CONFC_IDLE

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
