### PR TITLE
bug fixes for reading objects after cluster reboot

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -5414,7 +5414,7 @@ static void vkvv_calc_size_for_capture(struct slot *slot, int count,
 			    dir_entry[idx].key_offset;
 		*p_vsize  = dir_entry[count].val_offset -
 			    dir_entry[idx].val_offset;
-		*p_dsize = (sizeof(struct dir_rec)) * (count - idx + 1);
+		*p_dsize = (sizeof(struct dir_rec)) * (count + 1);
 	} else {
 		*p_dsize = 0;
 		*p_vsize = vkvv_get_vspace() * (count - idx);
@@ -5438,7 +5438,6 @@ static void vkvv_capture(struct slot *slot, struct m0_be_tx *tx)
 {
 	struct vkvv_head *h         = vkvv_data(slot->s_node);
 	struct m0_be_seg *seg       = slot->s_node->n_tree->t_seg;
-	struct dir_rec   *dir_entry = vkvv_get_dir_addr(slot->s_node);
 	m0_bcount_t       hsize     = sizeof(*h) - sizeof(h->vkvv_opaque);
 
 	void *key_addr;
@@ -5454,10 +5453,11 @@ static void vkvv_capture(struct slot *slot, struct m0_be_tx *tx)
 	if (slot->s_idx < h->vkvv_used) {
 		key_addr = vkvv_key(slot->s_node, slot->s_idx);
 		val_addr = vkvv_val(slot->s_node, h->vkvv_used);
+		dir_addr = vkvv_get_dir_addr(slot->s_node);
+
 		if (bnode_level(slot->s_node) != 0)
 			val_addr -= INT_OFFSET;
 
-		dir_addr = dir_entry + slot->s_idx;
 		vkvv_calc_size_for_capture(slot, h->vkvv_used, p_ksize, p_vsize,
 					   p_dsize);
 		M0_BTREE_TX_CAPTURE(tx, seg, key_addr, ksize);
@@ -6105,6 +6105,11 @@ static int64_t btree_put_root_split_handle(struct m0_btree_op *bop,
 	/* Increase height by one */
 	tree->t_height++;
 	bop->bo_arbor->t_height = tree->t_height;
+	if (tree->t_height > MAX_TREE_HEIGHT) {
+		M0_LOG(M0_ERROR,
+		       "Tree height increased beyond MAX_TREE_HEIGHT");
+		M0_ASSERT(0);
+	}
 	/* Capture this change in transaction */
 
 	/* TBD : This check needs to be removed when debugging is done. */

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -511,7 +511,7 @@ static void ctg_meta_insert_credit(struct m0_btree_type   *bt,
 				   struct m0_be_tx_credit *accum)
 {
 	struct m0_cas_ctg *ctg;
-	m0_btree_put_credit2(bt, M0_CTG_ROOT_NODE_SHIFT, nr,
+	m0_btree_put_credit2(bt, M0_CTG_ROOT_NODE_SIZE, nr,
 			     M0_CAS_CTG_KV_HDR_SIZE + sizeof(struct m0_fid),
 			     M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg), accum);
 	/*
@@ -527,7 +527,7 @@ static void ctg_meta_delete_credit(struct m0_btree_type   *bt,
 {
 	struct m0_cas_ctg *ctg;
 
-	m0_btree_del_credit2(bt, M0_CTG_ROOT_NODE_SHIFT, nr,
+	m0_btree_del_credit2(bt, M0_CTG_ROOT_NODE_SIZE, nr,
 			     M0_CAS_CTG_KV_HDR_SIZE + sizeof(struct m0_fid),
 			     M0_CAS_CTG_KV_HDR_SIZE + sizeof(ctg), accum);
 	M0_BE_FREE_CREDIT_PTR(ctg, seg, accum);


### PR DESCRIPTION
Signed-off-by: Radha Gulhane <radha.gulhane@seagate.com>

# Problem Statement
- Bug fixes for reading objects after cluster reboot

# Design
-  Fixing node capturing: capturing the entire directory for variable key variable value node format

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
