### PR TITLE
EOS-26205 dix/dtm0: DIX support of transient failures w.r.t. DTX

### DIFF
--- a/dix/req.c
+++ b/dix/req.c
@@ -2193,7 +2193,7 @@ static int dix_cas_rops_alloc(struct m0_dix_req *req)
 	struct m0_dix_cas_rop      *cas_rop;
 	struct m0_dix_pg_unit      *unit;
 	bool                        del_lock;
-	uint32_t                  **skipped_sdevs;
+	uint32_t                  **skipped_sdevs = NULL;
 	uint32_t                    skipped_sdevs_num = 0;
 	uint32_t                    skipped_sdevs_max =
 		rop->dg_pver->pv_attr.pa_P;

--- a/dix/req.c
+++ b/dix/req.c
@@ -1735,6 +1735,7 @@ static int dix_cas_rops_send(struct m0_dix_req *req)
 	struct m0_dix_cas_rop      *cas_rop;
 	struct m0_cas_req          *creq;
 	uint32_t                    sdev_idx;
+	uint32_t                    pa_idx;
 	struct m0_cas_id            cctg_id;
 	struct m0_reqh_service_ctx *cas_svc;
 	struct m0_dix_layout       *layout = &req->dr_indices[0].dd_layout;
@@ -1814,6 +1815,15 @@ static int dix_cas_rops_send(struct m0_dix_req *req)
 		rc = m0_dtx0_close(req->dr_dtx);
 		if (rc != 0)
 			return M0_ERR(rc);
+		/*
+		 * It is safe to set EXECUTED dtx state for those
+		 * participants that experience transient failure,
+		 * it allows to trigger EXECUTED-ALL logic.
+		 */
+		for (pa_idx = cas_rop_tlist_length(&rop->dg_cas_reqs);
+		     pa_idx < req->dr_dtx->tx_dtx->dd_txd.dtd_ps.dtp_nr;
+		     pa_idx++)
+			m0_dtx0_executed(req->dr_dtx, pa_idx);
 	}
 
 	return M0_RC(0);
@@ -2161,7 +2171,8 @@ static bool dix_pg_unit_skip(struct m0_dix_req     *req,
 			     struct m0_dix_pg_unit *unit)
 {
 	if (dix_req_state(req) != DIXREQ_DEL_PHASE2)
-		return unit->dpu_failed || unit->dpu_is_spare;
+		return unit->dpu_failed || unit->dpu_is_spare ||
+			unit->dpu_pd_state == M0_PNDS_OFFLINE;
 	else
 		return !unit->dpu_del_phase2;
 }
@@ -2175,15 +2186,27 @@ static int dix_cas_rops_alloc(struct m0_dix_req *req)
 	struct m0_dix_rec_op       *rec_op;
 	uint32_t                    i;
 	uint32_t                    j;
+	uint32_t                    pa_idx;
+	uint32_t                    pa_nr;
 	uint32_t                    max_failures;
 	struct m0_dix_cas_rop     **map = rop->dg_target_rop;
 	struct m0_dix_cas_rop      *cas_rop;
 	struct m0_dix_pg_unit      *unit;
 	bool                        del_lock;
+	uint32_t                  **skipped_sdevs;
+	uint32_t                    skipped_sdevs_num = 0;
+	uint32_t                    skipped_sdevs_max =
+		rop->dg_pver->pv_attr.pa_P;
 	int                         rc = 0;
 
 	M0_ENTRY("req %p %u", req, rop->dg_rec_ops_nr);
 	M0_ASSERT(rop->dg_rec_ops_nr > 0);
+
+	if (dtx != NULL) {
+		M0_ALLOC_ARR(skipped_sdevs, skipped_sdevs_max);
+		if (skipped_sdevs == NULL)
+			return M0_ERR(-ENOENT);
+	}
 
 	max_failures = dix_rop_max_failures(rop);
 	for (i = 0; i < rop->dg_rec_ops_nr; i++) {
@@ -2202,8 +2225,16 @@ static int dix_cas_rops_alloc(struct m0_dix_req *req)
 		}
 		for (j = 0; j < rec_op->dgp_units_nr; j++) {
 			unit = &rec_op->dgp_units[j];
-			if (dix_pg_unit_skip(req, unit))
+			if (dix_pg_unit_skip(req, unit)) {
+				if (dtx != NULL &&
+				    unit->dpu_pd_state == M0_PNDS_OFFLINE &&
+				    skipped_sdevs[unit->dpu_tgt] == NULL) {
+					skipped_sdevs[unit->dpu_tgt] =
+						&unit->dpu_sdev_idx;
+					skipped_sdevs_num++;
+				}
 				continue;
+			}
 			if (map[unit->dpu_tgt] == NULL) {
 				rc = dix_cas_rop_alloc(req, unit->dpu_sdev_idx,
 						       &cas_rop);
@@ -2218,21 +2249,25 @@ static int dix_cas_rops_alloc(struct m0_dix_req *req)
 	}
 
 	/* It is possible that all data units are not available. */
-	if (cas_rop_tlist_is_empty(&rop->dg_cas_reqs))
+	if (cas_rop_tlist_is_empty(&rop->dg_cas_reqs)) {
+		m0_free(skipped_sdevs);
 		return M0_ERR(-EIO);
+	}
 
 	if (dtx != NULL) {
 		M0_ASSERT(!req->dr_is_meta);
 		M0_ASSERT(M0_IN(req->dr_type, (DIX_PUT, DIX_DEL)));
-		rc = m0_dtx0_open(dtx, cas_rop_tlist_length(&rop->dg_cas_reqs));
+		pa_nr = cas_rop_tlist_length(&rop->dg_cas_reqs) +
+			skipped_sdevs_num;
+		rc = m0_dtx0_open(dtx, pa_nr);
 		if (rc != 0)
 			goto end;
 	}
 
-	i = 0;
+	pa_idx = 0;
 	m0_tl_for(cas_rop, &rop->dg_cas_reqs, cas_rop) {
 		if (dtx != NULL) {
-			cas_rop->crp_pa_idx = i++;
+			cas_rop->crp_pa_idx = pa_idx++;
 			cas_svc = pc->pc_dev2svc[cas_rop->crp_sdev_idx].pds_ctx;
 			M0_ASSERT(cas_svc->sc_type == M0_CST_CAS);
 			rc = m0_dtx0_fid_assign(dtx, cas_rop->crp_pa_idx,
@@ -2258,11 +2293,21 @@ static int dix_cas_rops_alloc(struct m0_dix_req *req)
 		cas_rop->crp_cur_key = 0;
 	} m0_tl_endfor;
 
+	for (i = 0; i < skipped_sdevs_max && dtx != NULL && rc == 0; i++) {
+		if (skipped_sdevs[i] != NULL) {
+			cas_svc = pc->pc_dev2svc[*skipped_sdevs[i]].pds_ctx;
+			M0_ASSERT(cas_svc->sc_type == M0_CST_CAS);
+			M0_ASSERT(pa_idx < pa_nr);
+			rc = m0_dtx0_fid_assign(dtx, pa_idx,
+						&cas_svc->sc_fid);
+		}
+	}
 end:
 	if (rc != 0) {
 		dix_cas_rops_fini(&rop->dg_cas_reqs);
 		return M0_ERR(rc);
 	}
+	m0_free(skipped_sdevs);
 	return M0_RC(0);
 }
 


### PR DESCRIPTION
The following changes are introduced:
 - skip sending of CAS requests to OFFLINE devices (as TRANSIENT
   notification is mapped to OFFLINE devices state);
 - add services that correspond to OFFLINE devices into
   participants list;
 - move transient participants into EXECUTED state right after
   CAS requests is sent.

Moving of transient participants into EXECUTED state after CAS
requests are sent allows to trigger EXECUTED-ALL logic without
significant changes in current participants maintenance by DTX.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>
