### PR TITLE
lib: fix m0_uint128_sscanf() for large values

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -51,6 +51,11 @@ M0_INTERNAL int m0_uint128_cmp(const struct m0_uint128 *u0,
 M0_INTERNAL int m0_uint128_sscanf(const char *s, struct m0_uint128 *u128)
 {
 	int rc = sscanf(s, U128I_F, U128_S(u128));
+
+	if (rc < 2 || u128->u_hi == LLONG_MAX || u128->u_lo == LLONG_MAX)
+		/* fallback to hex format */
+		rc = sscanf(s, U128X_F, U128_S(u128));
+
 	return rc == 2 ? 0 : -EINVAL;
 }
 

--- a/lib/types.h
+++ b/lib/types.h
@@ -66,6 +66,11 @@ M0_INTERNAL void m0_uint128_add(struct m0_uint128 *res,
 /** res = a * b; */
 M0_INTERNAL void m0_uint128_mul64(struct m0_uint128 *res, uint64_t a,
 				  uint64_t b);
+
+/**
+ * Scans uint128 in num:num format, where num can be in hex, octal
+ * or decimal format (depending on prefix).
+ */
 M0_INTERNAL int m0_uint128_sscanf(const char *s, struct m0_uint128 *u128);
 
 /** count of bytes (in extent, IO operation, etc.) */


### PR DESCRIPTION
# Problem Statement

Currently, if any of the u64 values is bigger than LLONG_MAX, say, `0x8f9381cfacb7576a` - m0_uint128_sscanf() returns just LLONG_MAX for it (`0x7fffffffffffffff`), which is, obviously, wrong.

# Design
Solution: fix m0_uint128_sscanf() in such a way that if any of the u64 values are resulted in LLONG_MAX - it will try to scan the numbers in unsigned hex format.

Also, make 0x prefix for hex format optional. If 0x prefix is not specified, decimal format is tried. If it fails to
parse the values, hex format is tried then. This way we try our best to parse the numbers in various formats.

Relates to https://github.com/Seagate/cortx-motr/pull/486.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
