### PR TITLE
[EOS-25904] support 'data_node' or 'storage_node' as node type

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -405,7 +405,7 @@ def update_to_file(self, index, url, machine_id, md_disks):
 def update_motr_hare_keys(self, nodes):
     # key = machine_id value = node_info
     for machine_id, node_info in nodes.items():
-        if node_info['type'] == 'storage_node':
+        if (node_info['type'] == 'storage_node' or node_info['type'] == 'data_node'):
             md_disks_lists = get_md_disks_lists(self, node_info)
             update_to_file(self, self._index_motr_hare, self._url_motr_hare, machine_id, md_disks_lists)
 
@@ -413,14 +413,14 @@ def motr_config_k8(self):
     if not verify_libfabric(self):
         raise MotrError(errno.EINVAL, "libfabric is not up.")
 
-    # Update motr-hare keys only for storage node
-    if self.node['type'] == 'storage_node':
+    # Update motr-hare keys for storage node and data node
+    if (self.node['type'] == 'storage_node' or self.node['type'] == 'data_node'):
         update_motr_hare_keys(self, self.nodes)
 
     execute_command(self, MOTR_CONFIG_SCRIPT, verbose = True)
 
-    # Update be_seg size only for storage node
-    if self.node['type'] == 'storage_node':
+    # Update be_seg size for storage node and data node
+    if (self.node['type'] == 'storage_node' or self.node['type'] == 'data_node'):
         update_bseg_size(self)
 
     # Modify motr config file

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -78,7 +78,7 @@ class Cmd:
             self.cluster = get_value(self, 'cluster', dict)
             self.nodes = get_value(self, 'node', dict)
             self.node = get_server_node(self, True)
-            if self.node['type'] == 'storage_node':
+            if (self.node['type'] == 'storage_node' or self.node['type'] == 'data_node'):
                 self.storage = get_storage(self)
             Conf.load(self._index_motr_hare, self._url_motr_hare)
     @property


### PR DESCRIPTION
# Problem Statement
- add 'data_node' and 'storage_node' as valid node types for F99C integration.

# Design
-  Changes for separate s3 pod

# Coding
-  Coding conventions are followed and code is consistent

# Testing 
-  Test Cases cover Happy Path, Non-Happy Path and Scalability
-  Testing was performed with RPM

# Review Checklist 
- https://jts.seagate.com/browse/EOS-25904

Signed-off-by: Jugal Patil <jugal.patil@seagate.com>
