### PR TITLE
EOS-27025: Memory leak during Degraded Read operation

### DIFF
--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -415,6 +415,9 @@ void target_ioreq_fini(struct target_ioreq *ti)
 		m0_free( (void *)ti->ti_cksum_seg_b_nob );
 	}
 
+	if ( opcode == M0_OC_READ )
+		m0_indexvec_free(&ti->ti_goff_ivec);
+
 	m0_free(ti);
 	M0_LEAVE();
 }

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -413,8 +413,7 @@ void target_ioreq_fini(struct target_ioreq *ti)
 	if ( opcode == M0_OC_WRITE ) {
 		m0_buf_free( &ti->ti_attrbuf );
 		m0_free( (void *)ti->ti_cksum_seg_b_nob );
-	}
-	else if ( opcode == M0_OC_READ )
+	} else if ( opcode == M0_OC_READ )
 		m0_indexvec_free(&ti->ti_goff_ivec);
 
 	m0_free(ti);

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -414,8 +414,7 @@ void target_ioreq_fini(struct target_ioreq *ti)
 		m0_buf_free( &ti->ti_attrbuf );
 		m0_free( (void *)ti->ti_cksum_seg_b_nob );
 	}
-
-	if ( opcode == M0_OC_READ )
+	else if ( opcode == M0_OC_READ )
 		m0_indexvec_free(&ti->ti_goff_ivec);
 
 	m0_free(ti);


### PR DESCRIPTION
In degraded read ti_goff_ivec not cleared after operations

Signed-off-by: Vinoth.V <vinoth.v@seagate.com>

# Problem Statement
Memory leak shall happen during degraded read