### PR TITLE
vsize changes for internal fixed format node

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -2679,18 +2679,19 @@ static void *ff_val(const struct nd *node, int idx)
 		   (0 <= idx && idx <= h->ff_used)));
 
 	node_end_addr = node_start_addr + h->ff_nsize;
-	value_offset  = h->ff_vsize * (idx + 1);
+	value_offset  = ff_valsize(node) * (idx + 1);
 
 	return node_end_addr - value_offset;
 }
 
 static bool ff_rec_is_valid(const struct slot *slot)
 {
-	struct ff_head *h = ff_data(slot->s_node);
+	struct ff_head *h     = ff_data(slot->s_node);
+	int             vsize = m0_vec_count(&slot->s_rec.r_val.ov_vec);
 	bool            val_is_valid;
-	val_is_valid = h->ff_level > 0 ?
-		       m0_vec_count(&slot->s_rec.r_val.ov_vec) <= h->ff_vsize :
-		       m0_vec_count(&slot->s_rec.r_val.ov_vec) == h->ff_vsize;
+
+	val_is_valid = h->ff_level > 0 ? vsize == INTERNAL_NODE_VALUE_SIZE :
+		       vsize == h->ff_vsize;
 
 	return
 	   _0C(m0_vec_count(&slot->s_rec.r_key.k_data.ov_vec) == h->ff_ksize) &&
@@ -2836,7 +2837,7 @@ static int ff_space(const struct nd *node)
 {
 	struct ff_head *h = ff_data(node);
 	return h->ff_nsize - sizeof *h -
-		(h->ff_ksize + h->ff_vsize) * h->ff_used;
+		(h->ff_ksize + ff_valsize(node)) * h->ff_used;
 }
 
 static int ff_level(const struct nd *node)
@@ -2864,7 +2865,12 @@ static int ff_keysize(const struct nd *node)
 
 static int ff_valsize(const struct nd *node)
 {
-	return ff_data(node)->ff_vsize;
+	struct ff_head *h = ff_data(node);
+
+	if (h->ff_level == 0)
+		return ff_data(node)->ff_vsize;
+	else
+		return INTERNAL_NODE_VALUE_SIZE;
 }
 
 static bool ff_isunderflow(const struct nd *node, bool predict)
@@ -2878,7 +2884,7 @@ static bool ff_isunderflow(const struct nd *node, bool predict)
 static bool ff_isoverflow(const struct nd *node, const struct m0_btree_rec *rec)
 {
 	struct ff_head *h = ff_data(node);
-	return (ff_space(node) < h->ff_ksize + h->ff_vsize) ? true : false;
+	return (ff_space(node) < h->ff_ksize + ff_valsize(node)) ? true : false;
 }
 
 static void ff_fid(const struct nd *node, struct m0_fid *fid)
@@ -2897,7 +2903,7 @@ static void ff_rec(struct slot *slot)
 		    slot->s_idx <= h->ff_used));
 
 	slot->s_rec.r_val.ov_vec.v_nr = 1;
-	slot->s_rec.r_val.ov_vec.v_count[0] = h->ff_vsize;
+	slot->s_rec.r_val.ov_vec.v_count[0] = ff_valsize(slot->s_node);
 	slot->s_rec.r_val.ov_buf[0] = ff_val(slot->s_node, slot->s_idx);
 	ff_node_key(slot);
 	M0_POST(ff_rec_is_valid(slot));
@@ -2930,7 +2936,7 @@ static bool ff_isfit(struct slot *slot)
 	struct ff_head *h = ff_data(slot->s_node);
 
 	M0_PRE(ff_rec_is_valid(slot));
-	return h->ff_ksize + h->ff_vsize <= ff_space(slot->s_node);
+	return h->ff_ksize + ff_valsize(slot->s_node) <= ff_space(slot->s_node);
 }
 
 static void ff_done(struct slot *slot, bool modified)
@@ -2946,6 +2952,7 @@ static void ff_make(struct slot *slot)
 	struct ff_head *h  = ff_data(slot->s_node);
 	void           *key_addr;
 	void           *val_addr;
+	int             vsize;
 	int             total_key_size;
 	int             total_val_size;
 
@@ -2958,11 +2965,12 @@ static void ff_make(struct slot *slot)
 	key_addr       = ff_key(slot->s_node, slot->s_idx);
 	val_addr       = ff_val(slot->s_node, h->ff_used - 1);
 
+	vsize          = ff_valsize(slot->s_node);
 	total_key_size = h->ff_ksize * (h->ff_used - slot->s_idx);
-	total_val_size = h->ff_vsize * (h->ff_used - slot->s_idx);
+	total_val_size = vsize * (h->ff_used - slot->s_idx);
 
 	m0_memmove(key_addr + h->ff_ksize, key_addr, total_key_size);
-	m0_memmove(val_addr - h->ff_vsize, val_addr, total_val_size);
+	m0_memmove(val_addr - vsize, val_addr, total_val_size);
 
 	h->ff_used++;
 }
@@ -2994,6 +3002,7 @@ static void ff_del(const struct nd *node, int idx)
 	struct ff_head *h     = ff_data(node);
 	void           *key_addr;
 	void           *val_addr;
+	int             vsize;
 	int             total_key_size;
 	int             total_val_size;
 
@@ -3007,11 +3016,12 @@ static void ff_del(const struct nd *node, int idx)
 	key_addr       = ff_key(node, idx);
 	val_addr       = ff_val(node, h->ff_used - 1);
 
+	vsize          = ff_valsize(node);
 	total_key_size = h->ff_ksize * (h->ff_used - idx - 1);
-	total_val_size = h->ff_vsize * (h->ff_used - idx - 1);
+	total_val_size = vsize * (h->ff_used - idx - 1);
 
 	m0_memmove(key_addr, key_addr + h->ff_ksize, total_key_size);
-	m0_memmove(val_addr + h->ff_vsize, val_addr, total_val_size);
+	m0_memmove(val_addr + vsize, val_addr, total_val_size);
 
 	h->ff_used--;
 }
@@ -3143,9 +3153,11 @@ static void ff_capture(struct slot *slot, struct m0_be_tx *tx)
 		void *start_key        = ff_key(slot->s_node, slot->s_idx);
 		void *last_val         = ff_val(slot->s_node, h->ff_used - 1);
 		int   rec_modify_count = h->ff_used - slot->s_idx;
-		int   krsize           = h->ff_ksize * rec_modify_count;
-		int   vrsize           = h->ff_vsize * rec_modify_count;
+		int   krsize;
+		int   vrsize;
 
+		krsize   = h->ff_ksize * rec_modify_count;
+		vrsize   = ff_valsize(slot->s_node) * rec_modify_count;
 
 		M0_BTREE_TX_CAPTURE(tx, seg, start_key, krsize);
 		M0_BTREE_TX_CAPTURE(tx, seg, last_val, vrsize);

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -2557,7 +2557,7 @@ static int  ff_space(const struct nd *node);
 static int  ff_level(const struct nd *node);
 static int  ff_shift(const struct nd *node);
 static int  ff_nsize(const struct nd *node);
-static int  ff_valsize(const struct nd *node);
+static inline int  ff_valsize(const struct nd *node);
 static int  ff_keysize(const struct nd *node);
 static bool ff_isunderflow(const struct nd *node, bool predict);
 static bool ff_isoverflow(const struct nd *node,
@@ -2863,7 +2863,7 @@ static int ff_keysize(const struct nd *node)
 	return ff_data(node)->ff_ksize;
 }
 
-static int ff_valsize(const struct nd *node)
+static inline int ff_valsize(const struct nd *node)
 {
 	struct ff_head *h = ff_data(node);
 


### PR DESCRIPTION
Earlier, internal nodes for fixed format were refering to value
size provided by user. Therefore, making changes to use 8 bytes
as value size for internal nodes.

Signed-off-by: Radha Gulhane <radha.gulhane@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
