### PR TITLE
EOS-26951: m0reportbug doesn't collect binary along with core file un…

### DIFF
--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -645,6 +645,12 @@ backtraces_cores() {
             cp $core $outdir/$IN_DIR/
         fi
     done
+    if [ -d $outdir ] && ! rmdir $outdir 2>/dev/null; then
+        find "$outdir" -type f \( -name core\*.xz -o -name core\*.gz \) | while read dir; do
+            ## Core dumps were collected. We need to collect binaries.
+            COLLECT_BINARIES_P=1
+        done
+    fi
 }
 
 binaries() {


### PR DESCRIPTION
…less --binaries option is specified.

Added check for core file is present in m0reportbug-cores.

Signed-off-by: Papan Kumar Singh <papan.kumarsingh@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
