### PR TITLE
[EOS_27101] UUID parsing failing for klibm0-ut

### DIFF
--- a/ut/m0kut
+++ b/ut/m0kut
@@ -33,7 +33,7 @@ readonly top_srcdir=$(echo $(dirname $self) |
                       sed -r -e 's#/?(utils|ut)/?$##' -e 's#^/usr/s?bin##')
 
 # KUT expects particular predefined UUID
-readonly node_uuid="12345678-90ab-cdef-fedc-ba0987654321"
+readonly node_uuid="1234567890abcdeffedcba0987654321"
 
 # variables
 verbose=false


### PR DESCRIPTION
Parsing of uuid was failing for uuid of length 36 updated m0_uuid_parse to parse uuid of length 36 and 32.
Signed-off-by: Jugal Patil <jugal.patil@seagate.com>

# Problem Statement
- UUID parsing failing for klibm0-ut

# Design
-  update lib/uuid.c/m0_uuid_parse to parse uuid of length 36 and 32.

# Coding
-  Coding conventions are followed and code is consistent

# Testing 
- kernel ut is now passing details in JIRA EOS-27101

# Review Checklist 
- https://jts.seagate.com/browse/EOS-27101 
