### PR TITLE
EOS 24233: Disable checksum verification for degraded read and read verify

### DIFF
--- a/motr/client_internal.h
+++ b/motr/client_internal.h
@@ -964,7 +964,9 @@ M0_INTERNAL void m0__obj_attr_set(struct m0_obj *obj,
 				  uint64_t       lid);
 M0_INTERNAL bool
 m0__obj_pool_version_is_valid(const struct m0_obj *obj);
+M0_INTERNAL bool m0__obj_is_parity_verify_mode(struct m0_client *instance);
 M0_INTERNAL bool m0__obj_is_di_enabled(struct m0_op_io *ioo);
+M0_INTERNAL bool m0__obj_is_cksum_validation_allowed(struct m0_op_io *ioo);
 M0_INTERNAL int m0__obj_io_build(struct m0_io_args *args,
 				 struct m0_op     **op);
 M0_INTERNAL void m0__obj_op_done(struct m0_op *op);

--- a/motr/io.c
+++ b/motr/io.c
@@ -640,9 +640,26 @@ static void obj_io_args_check(struct m0_obj      *obj,
 	M0_ASSERT(mask == 0);
 }
 
+M0_INTERNAL bool m0__obj_is_parity_verify_mode(struct m0_client *instance)
+{
+        return instance->m0c_config->mc_is_read_verify;
+}
+
 M0_INTERNAL bool m0__obj_is_di_enabled(struct m0_op_io *ioo)
 {
 	return ioo->ioo_obj->ob_entity.en_flags & M0_ENF_DI;
+}
+
+M0_INTERNAL bool m0__obj_is_cksum_validation_allowed(struct m0_op_io *ioo)
+{
+	/*
+	 * Checksum validation is not allowed for degraded read and
+	 * for read verify mode in parity.
+	 */
+	return m0__obj_is_di_enabled(ioo) &&
+	       !ioo->ioo_dgmode_io_sent &&
+	       !m0__obj_is_parity_verify_mode(
+			       m0__op_instance(m0__ioo_to_op(ioo)));
 }
 
 M0_INTERNAL int m0__obj_io_build(struct m0_io_args *args,

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -1315,7 +1315,8 @@ static int ioreq_application_data_copy(struct m0_op_io *ioo,
 		 * skip checksum verification during degraded I/O
 		 */
 		if (ioreq_sm_state(ioo) != IRS_DEGRADED_READING &&
-		    m0__obj_is_di_enabled(ioo) &&
+		    m0__obj_is_di_enabled(ioo) && !ioo->ioo_dgmode_io_sent &&
+		    !is_parity_verify_mode(m0__op_instance(&ioo->ioo_oo.oo_oc.oc_op)) &&
 		    !verify_checksum(ioo)) {
 			return M0_RC(-EIO);
 		}

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -827,11 +827,6 @@ static int ioreq_iomaps_parity_groups_cal(struct m0_op_io *ioo)
 	return M0_RC(0);
 }
 
-static bool is_parity_verify_mode(struct m0_client *instance)
-{
-	return instance->m0c_config->mc_is_read_verify;
-}
-
 static void set_paritybuf_type(struct m0_op_io *ioo)
 {
 
@@ -839,7 +834,7 @@ static void set_paritybuf_type(struct m0_op_io *ioo)
 	struct m0_op             *op = &ioo->ioo_oo.oo_oc.oc_op;
 	struct m0_client         *cinst = m0__op_instance(op);
 
-	if ((m0__is_read_op(op) && is_parity_verify_mode(cinst)) ||
+	if ((m0__is_read_op(op) && m0__obj_is_parity_verify_mode(cinst)) ||
 	    (m0__is_update_op(op) && !m0_pdclust_is_replicated(play)))
 		ioo->ioo_pbuf_type = M0_PBUF_DIR;
 	else if (m0__is_update_op(op) && m0_pdclust_is_replicated(play))
@@ -1315,8 +1310,7 @@ static int ioreq_application_data_copy(struct m0_op_io *ioo,
 		 * skip checksum verification during degraded I/O
 		 */
 		if (ioreq_sm_state(ioo) != IRS_DEGRADED_READING &&
-		    m0__obj_is_di_enabled(ioo) && !ioo->ioo_dgmode_io_sent &&
-		    !is_parity_verify_mode(m0__op_instance(m0__ioo_to_op(ioo))) &&
+		    m0__obj_is_cksum_validation_allowed(ioo) &&
 		    !verify_checksum(ioo)) {
 			return M0_RC(-EIO);
 		}

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -1316,7 +1316,7 @@ static int ioreq_application_data_copy(struct m0_op_io *ioo,
 		 */
 		if (ioreq_sm_state(ioo) != IRS_DEGRADED_READING &&
 		    m0__obj_is_di_enabled(ioo) && !ioo->ioo_dgmode_io_sent &&
-		    !is_parity_verify_mode(m0__op_instance(&ioo->ioo_oo.oo_oc.oc_op)) &&
+		    !is_parity_verify_mode(m0__op_instance(m0__ioo_to_op(ioo))) &&
 		    !verify_checksum(ioo)) {
 			return M0_RC(-EIO);
 		}

--- a/motr/io_req_fop.c
+++ b/motr/io_req_fop.c
@@ -305,9 +305,13 @@ static void io_bottom_half(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	gen_rep = m0_fop_data(m0_rpc_item_to_fop(reply_item));
 	rw_reply = io_rw_rep_get(reply_fop);
 
-	/* Copy attributes to client if reply received from read operation */
-	if (m0_is_read_rep(reply_fop) && op->op_code ==
-	    M0_OC_READ && m0__obj_is_di_enabled(ioo)) {
+	/*
+	 * Copy attributes to client if reply received from read operation
+	 * Skipping attribute_copy() for degraded read and for read verify mode.
+	 */
+	if (m0_is_read_rep(reply_fop) && op->op_code == M0_OC_READ &&
+	    m0__obj_is_di_enabled(ioo) && !ioo->ioo_dgmode_io_sent &&
+	    !instance->m0c_config->mc_is_read_verify) {
 		m0_indexvec_wire2mem(&rwfop->crw_ivec,
 					rwfop->crw_ivec.ci_nr, 0,
 					&rep_attr_ivec);

--- a/motr/io_req_fop.c
+++ b/motr/io_req_fop.c
@@ -307,11 +307,10 @@ static void io_bottom_half(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 
 	/*
 	 * Copy attributes to client if reply received from read operation
-	 * Skipping attribute_copy() for degraded read and for read verify mode.
+	 * Skipping attribute_copy() if cksum validation is not allowed.
 	 */
 	if (m0_is_read_rep(reply_fop) && op->op_code == M0_OC_READ &&
-	    m0__obj_is_di_enabled(ioo) && !ioo->ioo_dgmode_io_sent &&
-	    !instance->m0c_config->mc_is_read_verify) {
+	    m0__obj_is_cksum_validation_allowed(ioo)) {
 		m0_indexvec_wire2mem(&rwfop->crw_ivec,
 					rwfop->crw_ivec.ci_nr, 0,
 					&rep_attr_ivec);


### PR DESCRIPTION
# Problem Statement
- Checksum verification is failing in degraded I/O path and in read verify mode, because we don't send checksums for parity, so 
the checksums are not recreated for the missing data unit in degraded I/O path, so checksum verify function fails and returns IO ERORR (EIO)

# Design
 Disable checksum verification check for degraded I/O and if read verify is enabled. 
 
# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


-----
[View rendered .github/pull_request_template.md](https://github.com/yatin-mahajan/cortx-motr-1/blob/EOS-24233/.github/pull_request_template.md)
[View rendered bindings/go/README.md](https://github.com/yatin-mahajan/cortx-motr-1/blob/EOS-24233/bindings/go/README.md)