### PR TITLE
EOS-27125:  Errors in UT io-nw-xfer-ut and m0singlenode script

### DIFF
--- a/motr/ut/io_nw_xfer.c
+++ b/motr/ut/io_nw_xfer.c
@@ -386,6 +386,9 @@ static void ut_test_target_ioreq_fini(void)
 	M0_ALLOC_PTR(ti->ti_pageattrs);
 	rc = m0_indexvec_alloc(&ti->ti_ivec, 1);
 	M0_UT_ASSERT(rc == 0);
+	rc = m0_indexvec_alloc(&ti->ti_goff_ivec,1);
+	M0_UT_ASSERT(rc == 0);
+
 	target_ioreq_fini(ti);
 	ut_dummy_ioo_delete(ioo, dummy_instance);
 }

--- a/utils/m0singlenode
+++ b/utils/m0singlenode
@@ -32,8 +32,8 @@ readonly base_dir=$(dirname $self)
 M0_SRC_DIR=`readlink -f $0`
 M0_SRC_DIR=${M0_SRC_DIR%/*/*}
 
-. $M0_SRC_DIR/utils/functions # m0_default_xprt
-XPRT=$(m0_default_xprt)
+source /usr/libexec/cortx-motr/motr-service.functions
+XPRT=$(m0_get_motr_transport)
 
 # variables
 verbose=false

--- a/utils/m0singlenode
+++ b/utils/m0singlenode
@@ -32,8 +32,8 @@ readonly base_dir=$(dirname $self)
 M0_SRC_DIR=`readlink -f $0`
 M0_SRC_DIR=${M0_SRC_DIR%/*/*}
 
-source /usr/libexec/cortx-motr/motr-service.functions
-XPRT=$(m0_get_motr_transport)
+. $M0_SRC_DIR/utils/functions # m0_default_xprt
+XPRT=$(m0_default_xprt)
 
 # variables
 verbose=false


### PR DESCRIPTION
	- Allocate ti_goff_ivec in UT testcase before free call
        - m0singlenode update default xprt fetch function

Signed-off-by: Vinoth.V <vinoth.v@seagate.com>