### PR TITLE
EOS-25942 : Update ST-52motr-singlenode-sanity files to use the transport specific address format.

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/sanity/motr_sanity.sh
+++ b/scripts/install/opt/seagate/cortx/motr/sanity/motr_sanity.sh
@@ -37,7 +37,12 @@ user_config=/etc/sysconfig/motr
 currdir=$(pwd)
 timestamp=$(date +%d_%b_%Y_%H_%M)
 SANITY_SANDBOX_DIR="/var/motr/sanity_$timestamp"
-base_port=301
+XPRT=$(m0_default_xprt)
+if [ "$XPRT" = "lnet" ]; then
+	base_port=301
+else
+	base_port=3301
+fi
 IP=""
 port=""
 local_endpoint=""
@@ -146,7 +151,11 @@ node_sanity_check()
 		echo "Error: $conf is missing, it should already be created by m0setup"
 		return 1
 	fi
-	string=`grep $IP $conf | cut -d'"' -f 2 | cut -d ':' -f 1`
+	if [ "$XPRT" = "lnet" ]; then
+		string=$(grep "$IP" "$conf" | cut -d '"' -f 2 | cut -d ':' -f 1)
+	else
+		string=$(grep "$IP" "$conf" | cut -d '"' -f 2 | cut -d '@' -f 1)
+	fi
 	set -- $string
 	ip=`echo $1`
 	if [ "$ip" != "$IP" ]
@@ -181,10 +190,15 @@ generate_endpoints()
 	fi
 
 	unused_port_get "$base_port"
-	local_endpoint="${IP}:12345:44:$port"
-	echo "Local endpoint: $local_endpoint"
+	if [ "$XPRT" = "lnet" ]; then
+		local_endpoint="${IP}:12345:44:$port"
+		ha_endpoint="${IP}:12345:45:1"
+	else
+		local_endpoint="${IP}@$port"
+		ha_endpoint="${IP}@2001"
+	fi
 
-	ha_endpoint="${IP}:12345:45:1"
+	echo "Local endpoint: $local_endpoint"
 	echo "HA endpoint: $ha_endpoint"
 
 	profile_fid='<0x7000000000000001:0>'
@@ -337,7 +351,7 @@ m0spiel_test()
         	libmotr_path=$MOTR_DEVEL_WORKDIR_PATH/motr/.libs/libmotr.so
 	[[ ! -s $libmotr_path ]] && libmotr_path=$libmotr_sys_path
 	format_profile_fid=$(echo $profile_fid | sed 's/.*<\(.*\)>/\1/' | sed 's/:/,/')
-	/usr/bin/m0_filesystem_stats -s $ha_endpoint -p $format_profile_fid -c ${ha_endpoint}000 -l $libmotr_path
+	/usr/bin/m0_filesystem_stats -s "$ha_endpoint" -p "$format_profile_fid" -c "${ha_endpoint}0" -l "$libmotr_path"
 	rc=$?
 	if [ $rc -ne 0 ] ; then
 		error_handling "Failed to run m0_filesystem_stats " $rc

--- a/scripts/install/opt/seagate/cortx/motr/sanity/motr_sanity.sh
+++ b/scripts/install/opt/seagate/cortx/motr/sanity/motr_sanity.sh
@@ -344,14 +344,20 @@ kv_test()
 
 m0spiel_test()
 {
+	local spiel_client_ep
 	local rc
+	if [ "$XPRT" = "lnet" ]; then
+		spiel_client_ep="${IP}:12345:45:1000"
+	else
+		spiel_client_ep="${IP}@20010"
+	fi
 	echo "m0_filesystem_stats"
 	libmotr_sys_path="/usr/lib64/libmotr.so"
 	[[ -n "$MOTR_DEVEL_WORKDIR_PATH" ]] && \
         	libmotr_path=$MOTR_DEVEL_WORKDIR_PATH/motr/.libs/libmotr.so
 	[[ ! -s $libmotr_path ]] && libmotr_path=$libmotr_sys_path
 	format_profile_fid=$(echo $profile_fid | sed 's/.*<\(.*\)>/\1/' | sed 's/:/,/')
-	/usr/bin/m0_filesystem_stats -s "$ha_endpoint" -p "$format_profile_fid" -c "${ha_endpoint}0" -l "$libmotr_path"
+	/usr/bin/m0_filesystem_stats -s "$ha_endpoint" -p "$format_profile_fid" -c "$spiel_client_ep" -l "$libmotr_path"
 	rc=$?
 	if [ $rc -ne 0 ] ; then
 		error_handling "Failed to run m0_filesystem_stats " $rc

--- a/scripts/install/usr/libexec/cortx-motr/motr-service.functions
+++ b/scripts/install/usr/libexec/cortx-motr/motr-service.functions
@@ -267,7 +267,7 @@ m0_get_lnet_nid()
                 local iface=`cat /etc/libfab.conf | grep '\S' | grep --invert-match "^ *#" | cut -d "(" -f2 | cut -d ")" -f1`
                 local proto=`cat /etc/libfab.conf | grep '\S' | grep --invert-match "^ *#" | cut -d "=" -f2 | cut -d "(" -f1`
                 local ip_addr=`ip addr show $iface |grep inet| head -1 | awk '{print $2}'|cut -d '/' -f1`
-                lnid=$ip_addr@$proto
+                lnid=inet:$proto:$ip_addr
             fi
             [[ -z "$lnid" ]] && \
                 m0_exit 'Failed to auto-detect Lnet NID, please check that' \
@@ -365,6 +365,7 @@ m0_get_ep_of()
 {
     local service=$1
     local node=$2
+    local xprt=$(m0_get_motr_transport)
 
     # services managed by Halong get their endpoints from the per-service config
     # file
@@ -378,40 +379,78 @@ m0_get_ep_of()
     local found=false
     local lnid=$(m0_get_lnet_nid $node)
     local lpid=12345
-    local confd_tid=1
-    local mds_tid=201
-    local rms_tid=301
-    local ha_tid=1
-    local ios_tid=401
-    local cas_tid=501
-    local fdmi_tid=601
+	if [ "$XPRT" = "lnet" ]; then
+        local confd_tid=1
+        local mds_tid=201
+        local rms_tid=301
+        local ha_tid=1
+        local ios_tid=401
+        local cas_tid=501
+        local fdmi_tid=601
+    else
+        local confd_tid=3001
+        local mds_tid=3201
+        local rms_tid=3301
+        local ha_tid=2001
+        local ios_tid=3401
+        local cas_tid=3501
+        local fdmi_tid=3601
+    fi
     local portal=$(_portal_id $1)
     local ep
     local s
 
-    for s in $(m0_get_services $node); do
-        case $s in
-            confd*) ep=${MOTR_CONFD_EP:-$lnid:$lpid:$portal:$((confd_tid++))}
-                ;;
-            mds*) ep=${MOTR_MDS_EP:-$lnid:$lpid:$portal:$((mds_tid++))}
-                ;;
-            ios*) ep=$lnid:$lpid:$portal:$((ios_tid++))
-                ;;
-            cas*) ep=$lnid:$lpid:$portal:$((cas_tid++))
-                ;;
-            rms*) ep=$lnid:$lpid:$portal:$((rms_tid++))
-                ;;
-            fdmi*) ep=$lnid:$lpid:$portal:$((fdmi_tid++))
-                ;;
-            ha*)  ep=${MOTR_HA_EP:-$lnid:$lpid:$portal:$((ha_tid++))}
-                ;;
-        esac
+	if [ "$XPRT" = "lnet" ]; then
+        # Use lnet address format
+        for s in $(m0_get_services $node); do
+            case $s in
+                confd*) ep=${MOTR_CONFD_EP:-$lnid:$lpid:$portal:$((confd_tid++))}
+                    ;;
+                mds*) ep=${MOTR_MDS_EP:-$lnid:$lpid:$portal:$((mds_tid++))}
+                    ;;
+                ios*) ep=$lnid:$lpid:$portal:$((ios_tid++))
+                    ;;
+                cas*) ep=$lnid:$lpid:$portal:$((cas_tid++))
+                    ;;
+                rms*) ep=$lnid:$lpid:$portal:$((rms_tid++))
+                    ;;
+                fdmi*) ep=$lnid:$lpid:$portal:$((fdmi_tid++))
+                    ;;
+                ha*)  ep=${MOTR_HA_EP:-$lnid:$lpid:$portal:$((ha_tid++))}
+                    ;;
+            esac
 
-        if [[ $s == $service ]] ; then
-            found=true
-            break
-        fi
-    done
+            if [[ $s == $service ]] ; then
+                found=true
+                break
+            fi
+        done
+	else
+        # Use libfab inet address format
+        for s in $(m0_get_services $node); do
+            case $s in
+                confd*) ep=${MOTR_CONFD_EP:-$lnid@$((confd_tid++))}
+                    ;;
+                mds*) ep=${MOTR_MDS_EP:-$lnid@$((mds_tid++))}
+                    ;;
+                ios*) ep=$lnid@$((ios_tid++))
+                    ;;
+                cas*) ep=$lnid@$((cas_tid++))
+                    ;;
+                rms*) ep=$lnid@$((rms_tid++))
+                    ;;
+                fdmi*) ep=$lnid@$((fdmi_tid++))
+                    ;;
+                ha*)  ep=${MOTR_HA_EP:-$lnid@$((ha_tid++))}
+                    ;;
+            esac
+
+            if [[ $s == $service ]] ; then
+                found=true
+                break
+            fi
+        done
+    fi
 
     if ! $found ; then
         m0_echo_err "cannot find endpoint of '$service' on the" \


### PR DESCRIPTION
Update ST-52motr-singlenode-sanity files to use the transport specific address format.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  Use the below format when using lnet as the transport.
`<ip>@<tcp/o2ib>:12345:<portal id>:<tmid>`

-  Use the below format when using libfabric as the transport.
`<inet>:<tcp>:<fqdn/ip>@<port>`

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
