### PR TITLE
EOS-27115: Enable partition stob based on different configuration

### DIFF
--- a/be/domain.h
+++ b/be/domain.h
@@ -83,10 +83,10 @@ struct m0_be_part_stob_cfg {
 	char        *bpc_seg0_cfg;
 	char        *bpc_seg1_cfg;
 	char        *bpc_log_cfg;
-	m0_bcount_t  bpc_seg_size;
-	m0_bcount_t  bpc_data_size;
+	m0_bcount_t  bpc_seg0_size_in_chunks;
 	m0_bcount_t  bpc_seg_size_in_chunks;
 	m0_bcount_t  bpc_log_size_in_chunks;
+	m0_bcount_t  bpc_data_size_in_chunks;
 	m0_bcount_t  bpc_dom_key;
 	m0_bcount_t  bpc_chunk_size_in_bits;
 	m0_bcount_t  bpc_total_chunk_count;

--- a/motr/conf.c
+++ b/motr/conf.c
@@ -250,7 +250,8 @@ static bool is_device(const struct m0_conf_obj *obj)
 }
 
 M0_INTERNAL int cs_conf_get_parition_dev(struct cs_stobs *stob,
-					 struct m0_conf_sdev **sdev_ptr)
+					 struct m0_conf_sdev **sdev_ptr,
+					 uint32_t *dev_count)
 {
 	int                     rc;
 	struct m0_motr         *cctx;
@@ -265,6 +266,8 @@ M0_INTERNAL int cs_conf_get_parition_dev(struct cs_stobs *stob,
 	uint32_t                dev_nr;
 	struct m0_fid          *proc_fid;
         struct m0_conf_sdev    *sdev;
+
+	*dev_count = 0;
 
 
 	M0_ENTRY();
@@ -317,15 +320,17 @@ M0_INTERNAL int cs_conf_get_parition_dev(struct cs_stobs *stob,
 			M0_CONF_DIRNEXT) {
 			sdev = M0_CONF_CAST(m0_conf_diter_result(&it),
 					    m0_conf_sdev);
+			*dev_count +=1;
+
 			M0_LOG(M0_ALWAYS,
 			       "sdev " FID_F " device index: %d "
 			       "sdev.sd_filename: %s, "
-			       "sdev.sd_size: %" PRIu64,
+			       "sdev.sd_size: %" PRIu64
+			       "dev count: %d ",
 			       FID_P(&sdev->sd_obj.co_id), sdev->sd_dev_idx,
-			       sdev->sd_filename, sdev->sd_size);
+			       sdev->sd_filename, sdev->sd_size,*(dev_count));
 				*sdev_ptr = sdev;
 			rc = 0;
-			break;
 		}
 		m0_conf_diter_fini(&it);
 		m0_confc_close(svc_obj);

--- a/motr/setup_internal.h
+++ b/motr/setup_internal.h
@@ -60,7 +60,8 @@ M0_INTERNAL int cs_conf_device_reopen(struct m0_poolmach *pm,
 
 M0_INTERNAL int cs_conf_services_init(struct m0_motr *cctx);
 
-M0_INTERNAL int cs_conf_get_parition_dev (struct cs_stobs *stob, struct m0_conf_sdev **sdev);
+M0_INTERNAL int cs_conf_get_parition_dev (struct cs_stobs *stob, struct m0_conf_sdev **sdev,
+					  uint32_t *dev_count);
 /** @} endgroup m0d */
 #endif /* __MOTR_SETUP_INTERNAL_H__ */
 


### PR DESCRIPTION
# Problem Statement
Enable partition stob based on different configuration 

# Design
1. Single Data specified(confd) No meta specified per cvg or same meta n data disc specified:
Part Stob:  
  - seg0 - Max (1MB , chunk size)
  - seg1 - 10% of total
  - log  - Max(128M, chunk size)  //TODO:
  - data - remaining

2. Single Data specified(confd) : Meta  specified (cmdline)
Part Stob:  
  - seg0 - Max (1MB , chunk size)
  - seg1 - remaining
  - log  - Max(128M, chunk size)  //TODO:

3. Single Data specified(confd) : Meta specified (cmdline): Log specified (cmdline)
 -  partition stob not needed
 
4. Multiple Data specified (confd) : meta specified
  - seg0 - Max (1MB , chunk size)
  - seg1 - remaining
  - log  - Max(128M, chunk size)  //TODO:

5. Multiple Data specified (confd) : No meta specified 

no parition stob  

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
