### PR TITLE
EOS-26965: Update ST files to use the transport specific address format.

### DIFF
--- a/ha/ham-st
+++ b/ha/ham-st
@@ -25,7 +25,12 @@
 ### ------------------------------------------------------------------
 
 set ctrl_c \x03
-set endpoint 0@lo:12345:43:100
+
+set cwd [file dirname $argv0]
+set awkCmd {{print $3}}
+set endpoint [exec cat "$cwd/../ut/ep.h" | grep M0_UT_SERVER_EP_ADDR | awk $awkCmd]
+#Trim start and ending '"' from string
+set endpoint [exec echo $endpoint | tail -c +2 | head -c -2]
 
 proc die {msg {rc 1}} {
     send_error "**ERROR** $msg\n"

--- a/ha/ham.c
+++ b/ha/ham.c
@@ -57,9 +57,10 @@
 #include <libgen.h>           /* basename */
 #include <getopt.h>           /* getopt_long */
 #include <unistd.h>           /* isatty */
+#include "ut/ep.h"
 
-#define HAM_SERVER_EP_DEFAULT   "0@lo:12345:43:100"
-#define HAM_CLIENT_EP_DEFAULT   "0@lo:12345:43:101"
+#define HAM_SERVER_EP_DEFAULT   M0_UT_SERVER_EP_ADDR
+#define HAM_CLIENT_EP_DEFAULT   M0_UT_CLIENT_EP_ADDR
 #define HAM_SERVER_WAIT_DEFAULT 0
 
 enum ham_mode { HM_CONNECT, HM_LISTEN, HM_SELF_CHECK };

--- a/utils/functions
+++ b/utils/functions
@@ -83,22 +83,29 @@ m0_modules_remove() {
 }
 
 lnet_up() {
+    XPRT=$(m0_default_xprt)
+    local NID=$(m0_local_nid_get)
+
     if [ "$XPRT" = "lnet" ]; then
         modprobe lnet
         lctl network up >/dev/null
+        ## LNet endpoint address format (see net/lnet/lnet.h):
+        ##     NID:PID:Portal:TMID
+        ##
+        ## The PID value of 12345 is used by Lustre in the kernel and is
+        ## the only value currently supported.
+        export M0T1FS_ENDPOINT="$NID:12345:34:1"
+        export M0D1_ENDPOINT="$NID:12345:34:1001"
+        export M0D2_ENDPOINT="$NID:12345:34:1002"
+        export M0D3_ENDPOINT="$NID:12345:34:1003"
+        export SPIEL_ENDPOINT="$NID:12345:34:2001"
+    else
+        export M0T1FS_ENDPOINT="$NID@3000"
+        export M0D1_ENDPOINT="$NID@4001"
+        export M0D2_ENDPOINT="$NID@4002"
+        export M0D3_ENDPOINT="$NID@4003"
+        export SPIEL_ENDPOINT="$NID@5001"
     fi
-    local LNET_NID=$(m0_local_nid_get)
-
-    ## LNet endpoint address format (see net/lnet/lnet.h):
-    ##     NID:PID:Portal:TMID
-    ##
-    ## The PID value of 12345 is used by Lustre in the kernel and is
-    ## the only value currently supported.
-    export M0T1FS_ENDPOINT="$LNET_NID:12345:34:1"
-    export M0D1_ENDPOINT="$LNET_NID:12345:34:1001"
-    export M0D2_ENDPOINT="$LNET_NID:12345:34:1002"
-    export M0D3_ENDPOINT="$LNET_NID:12345:34:1003"
-    export SPIEL_ENDPOINT="$LNET_NID:12345:34:2001"
 }
 
 ## Adding function to identify the default available transport layer

--- a/utils/spiel/m0spiel
+++ b/utils/spiel/m0spiel
@@ -44,17 +44,24 @@ def get_ip_address(ifname):
         struct.pack('256s', ifname[:15].encode('utf-8'))
     )[20:24])
 
-def address_get():
+# Returns the default transport
+def get_xprt():
     i = 0
     for arg in sys.argv:
         i = i+1
         if format(str(arg)) == "-l":
             break
-
+    if i == 0:
+        return ''
     path = format(str(sys.argv[i]))
     path = path.rstrip(path.rsplit('/')[-1]) + "../../scripts/st.d/net_xpt"
     f = open(path, "r")
     xprt = f.read()
+    f.close()
+    return xprt
+
+def address_get():
+    xprt = get_xprt()
 
     if "libfab" in xprt :
         conf = open("/etc/libfab.conf", "r")
@@ -62,7 +69,8 @@ def address_get():
         iface_type = (xprt[xprt.find("=")+1:xprt.find("(")])
         iface = (xprt[xprt.find("(")+1:xprt.find(")")])
         ip_addr = get_ip_address(iface)
-        return ip_addr+"@"+iface_type
+        # Currently using ipv4 address (inet)
+        return "inet:"+iface_type+":"+ip_addr
     else:
         try:
             p = Popen(['lctl', 'list_nids'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -76,8 +84,12 @@ def address_get():
 
 default_libmotr_path = '../../motr/.libs/libmotr.so'
 addr = address_get()
-default_ha_ep = addr + ':12345:34:1001'
-default_client_ep = addr + ':12345:34:200'
+if "libfab" in get_xprt():
+    default_ha_ep = addr + '@4001'
+    default_client_ep = addr + '@4002'
+else:
+    default_ha_ep = addr + ':12345:34:1001'
+    default_client_ep = addr + ':12345:34:200'
 
 
 # Helper function to check the type of the function parameter. This is useful


### PR DESCRIPTION
Changes:
Updated following ST files to use transport specific address format
02rpcping
06conf
06ham
07m0d-fatal
07mount
07mount-multiple
08spiel
08spiel-multiple-confd
24stob-domain-recreate-on-corruption

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
