### PR TITLE
EOS-27288: CAS request should succeed even one put request is success

### DIFF
--- a/dix/req.c
+++ b/dix/req.c
@@ -1625,13 +1625,32 @@ static void dix_rop_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	struct m0_dix_rop_ctx *rop_del_phase2 = NULL;
 	bool                   del_phase2 = false;
 	struct m0_dix_cas_rop *cas_rop;
+	uint32_t                req_cnt = 0;
+	bool			cas_success = false;
 
 	(void)grp;
 	if (req->dr_type == DIX_NEXT)
 		m0_dix_next_result_prepare(req);
 	else
-		m0_tl_for(cas_rop, &rop->dg_cas_reqs, cas_rop) {
-			dix_cas_rop_rc_update(cas_rop, 0);
+		/*
+		 * Check return status of N cas request, if any one CAS
+		 * Request is success, we return success to client. For failed
+		 * request skipping to send rc_update() but if it is last request
+		 * and we do not found any success request reply so far then
+		 * do update rc_update() for last failed CAS request also.
+		 */
+		m0_tl_for (cas_rop, &rop->dg_cas_reqs, cas_rop) {
+			req_cnt++;
+			if (cas_rop->crp_creq.ccr_sm.sm_rc == 0)
+				cas_success = true;
+			if (cas_success) {
+				if (cas_rop->crp_creq.ccr_sm.sm_rc == 0)
+					dix_cas_rop_rc_update(cas_rop, 0);
+			} else {
+				if (req_cnt == rop->dg_cas_reqs_nr &&
+				    !cas_success)
+					dix_cas_rop_rc_update(cas_rop, 0);
+			}
 			m0_cas_req_fini(&cas_rop->crp_creq);
 		} m0_tl_endfor;
 

--- a/dix/req.c
+++ b/dix/req.c
@@ -1625,8 +1625,9 @@ static void dix_rop_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	struct m0_dix_rop_ctx *rop_del_phase2 = NULL;
 	bool                   del_phase2 = false;
 	struct m0_dix_cas_rop *cas_rop;
-	uint32_t                req_cnt = 0;
-	bool			cas_success = false;
+	uint32_t	       req_cnt = 0;
+	int		       rc = 0;
+	bool		       cas_success = false;
 
 	(void)grp;
 	if (req->dr_type == DIX_NEXT)
@@ -1634,23 +1635,22 @@ static void dix_rop_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	else
 		/*
 		 * Check return status of N cas request, if any one CAS
-		 * Request is success, we return success to client. For failed
+		 * request is success, we return success to client. For failed
 		 * request skipping to send rc_update() but if it is last request
 		 * and we do not found any success request reply so far then
 		 * do update rc_update() for last failed CAS request also.
 		 */
 		m0_tl_for (cas_rop, &rop->dg_cas_reqs, cas_rop) {
 			req_cnt++;
-			if (cas_rop->crp_creq.ccr_sm.sm_rc == 0)
+			rc = cas_rop->crp_creq.ccr_sm.sm_rc;
+			if (!cas_success && rc == 0)
 				cas_success = true;
-			if (cas_success) {
-				if (cas_rop->crp_creq.ccr_sm.sm_rc == 0)
-					dix_cas_rop_rc_update(cas_rop, 0);
-			} else {
-				if (req_cnt == rop->dg_cas_reqs_nr &&
-				    !cas_success)
-					dix_cas_rop_rc_update(cas_rop, 0);
-			}
+
+			if (cas_success && rc == 0)
+				dix_cas_rop_rc_update(cas_rop, 0);
+			else if (!cas_success && req_cnt == rop->dg_cas_reqs_nr)
+				dix_cas_rop_rc_update(cas_rop, 0);
+
 			m0_cas_req_fini(&cas_rop->crp_creq);
 		} m0_tl_endfor;
 

--- a/dix/req.c
+++ b/dix/req.c
@@ -1626,7 +1626,7 @@ static void dix_rop_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	bool                   del_phase2 = false;
 	struct m0_dix_cas_rop *cas_rop;
 	uint32_t	       req_cnt = 0;
-	int		       rc = 0;
+	int		       rc;
 	bool		       cas_success = false;
 
 	(void)grp;

--- a/dix/req.c
+++ b/dix/req.c
@@ -1625,34 +1625,27 @@ static void dix_rop_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	struct m0_dix_rop_ctx *rop_del_phase2 = NULL;
 	bool                   del_phase2 = false;
 	struct m0_dix_cas_rop *cas_rop;
-	uint32_t	       req_cnt = 0;
-	int		       rc;
-	bool		       cas_success = false;
 
 	(void)grp;
 	if (req->dr_type == DIX_NEXT)
 		m0_dix_next_result_prepare(req);
-	else
+	else {
 		/*
-		 * Check return status of N cas request, if any one CAS
-		 * request is success, we return success to client. For failed
-		 * request skipping to send rc_update() but if it is last request
-		 * and we do not found any success request reply so far then
-		 * do update rc_update() for last failed CAS request also.
+		 * Return success if there is atleast one successful CAS
+		 * request
 		 */
+		if (m0_tl_forall(cas_rop, cas_rop,
+				 &rop->dg_cas_reqs,
+				 cas_rop->crp_creq.ccr_sm.sm_rc != 0))
+			    dix_cas_rop_rc_update(cas_rop_tlist_tail(
+						  &rop->dg_cas_reqs), 0);
+
 		m0_tl_for (cas_rop, &rop->dg_cas_reqs, cas_rop) {
-			req_cnt++;
-			rc = cas_rop->crp_creq.ccr_sm.sm_rc;
-			if (!cas_success && rc == 0)
-				cas_success = true;
-
-			if (cas_success && rc == 0)
+			if (cas_rop->crp_creq.ccr_sm.sm_rc == 0)
 				dix_cas_rop_rc_update(cas_rop, 0);
-			else if (!cas_success && req_cnt == rop->dg_cas_reqs_nr)
-				dix_cas_rop_rc_update(cas_rop, 0);
-
 			m0_cas_req_fini(&cas_rop->crp_creq);
 		} m0_tl_endfor;
+	}
 
 	if (req->dr_type == DIX_DEL &&
 	    dix_req_state(req) == DIXREQ_INPROGRESS)

--- a/dix/req.c
+++ b/dix/req.c
@@ -1631,8 +1631,8 @@ static void dix_rop_completed(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 		m0_dix_next_result_prepare(req);
 	else {
 		/*
-		 * Return success if there is atleast one successful CAS
-		 * request
+		 * Consider DIX request to be successful if there is at least
+		 * one successful CAS request.
 		 */
 		if (m0_tl_forall(cas_rop, cas_rop,
 				 &rop->dg_cas_reqs,


### PR DESCRIPTION

# Problem Statement
 In case of degraded cluster getting failure for some of the put request which goes
 to failed node and because of that whole index put failed even though we other put
 requests are successful. Which actually fails bucket creation and multipart upload in
 degraded mode.

# Design
  Returns success from motr client for dix put request even we got success from single
  request out of N request and report failure only if all the put requests are failed.
   
 UT is not added in this PR, Separate Jira [EOS-27333](https://jts.seagate.com/browse/EOS-27333) is created to add UT.
 
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
