### PR TITLE
scripts: fix vanilla OS provisioning issues

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -8,12 +8,7 @@ Prerequisites
 *************
 The prerequisite that is necessary to install the Motr component is mentioned below.
 
-- CentOS 7 on x86_64 or ARM64 (AArch64) platform.
-
-- **Ansible** is needed::
-
-    sudo yum install epel-release # Install EPEL yum repo
-    sudo yum install ansible
+- CentOS 7.9/8.3+ or Rocky Linux 8.4+ on x86_64 or ARM64 (AArch64) platform.
 
 Get the Sources
 ===============

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -107,11 +107,18 @@ parse_cli_options $@
 (( UID == 0 )) ||
     die 'Error: Please, run this script with "root" privileges'
 
+case $(distro_type) in
+    redhat) yum -y install python3-pip ;;
+    debian) apt install python3-pip ;;
+esac
 pip3 install ipaddress
 
 if ! which ansible &>/dev/null ; then
     case $(distro_type) in
-        redhat) yum -y install ansible ;;
+        redhat) yum -y install epel-release
+                yum -y install epel-release # Update it
+                yum -y install ansible
+                ;;
         debian) apt install ansible ;;
     esac
 fi

--- a/scripts/provisioning/roles/base-os/tasks/main.yml
+++ b/scripts/provisioning/roles/base-os/tasks/main.yml
@@ -35,7 +35,7 @@
             path: /etc/redhat-release
           register: redhat_release_file
         - set_fact:
-            redhat_full_release: '{{ redhat_release_file.content | b64decode | regex_search("\d+(\.\d+(\.\d+)*)*") }}'
+            redhat_full_release: '{{ redhat_release_file.content | b64decode | regex_search("\d+(\.\d+(\.\d+)?)?") }}'
     - name: get closest release repo
       # find first vault release that is less or equal to the current redhat release version
       shell: |
@@ -95,6 +95,11 @@
     gpgcheck: no
   when: ansible_os_family == 'RedHat'
   tags: debuginfo
+
+- name: enable PowerTools repo
+  command: yum config-manager --set-enabled powertools
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
+  ignore_errors: yes # maybe it's called differently in yum.repo.d
 
 - name: configure 'ZFS' repository
   package:

--- a/scripts/provisioning/roles/base-os/vars/RedHat.yml
+++ b/scripts/provisioning/roles/base-os/vars/RedHat.yml
@@ -20,6 +20,7 @@
 ---
 basic_tools_pkgs:
   - ansible  # for local mode, helpful on Windouz hosts
+  - yum-utils
   - dstat
   - emacs
   - htop

--- a/scripts/provisioning/roles/lustre-client/tasks/main.yml
+++ b/scripts/provisioning/roles/lustre-client/tasks/main.yml
@@ -32,7 +32,7 @@
         path: /etc/redhat-release
       register: redhat_release_file
     - set_fact:
-       redhat_release: '{{ redhat_release_file.content | b64decode | regex_search("\d+(\.\d+)*") }}'
+       redhat_release: '{{ redhat_release_file.content | b64decode | regex_search("\d+(\.\d+)?") }}'
        redhat_release_major: '{{ redhat_release_file.content | b64decode | regex_search("\d+") }}'
   tags: lustre
 
@@ -55,8 +55,11 @@
     - { version: 2.10.8, enabled: '{{ (redhat_release is version("7.6", "=")) | ternary("yes", "no") }}' }
     - { version: 2.12.4, enabled: '{{ (redhat_release is version("7.7", "=")) | ternary("yes", "no") }}' }
     - { version: 2.12.5, enabled: '{{ (redhat_release is version("7.8", "=")) | ternary("yes", "no") }}' }
-    - { version: 2.12.6, enabled: '{{ (redhat_release is version("7.9", "=")) | ternary("yes", "no") }}' }
-    - { version: 2.12.8, enabled: '{{ (redhat_release is version("8", ">=")) | ternary("yes", "no") }}' }
+    - { version: 2.12.6, enabled: '{{ (redhat_release is version("7.9", "="))
+                                   or (redhat_release is version("8.3", "=")) | ternary("yes", "no") }}' }
+    - { version: 2.12.7, enabled: '{{ (redhat_release is version("8.4", "=")) | ternary("yes", "no") }}' }
+    - { version: 2.12.8, enabled: '{{ (redhat_release is version("8.5", ">="))
+                                   or (redhat_release is version("8", "=")) | ternary("yes", "no") }}' } # Stream
   when: ansible_os_family == 'RedHat'
   tags:
     - lustre

--- a/scripts/provisioning/roles/motr-build/tasks/main.yml
+++ b/scripts/provisioning/roles/motr-build/tasks/main.yml
@@ -31,14 +31,14 @@
     state: present
     name:  '{{ motr_build_deps_pkgs }}'
 
-- name: install Motr build-time CentOS 7 specific dependencies
-  when: redhat_release_major == 7
+- name: install Motr build-time el7 specific dependencies
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
   package:
     state: present
     name:  '{{ motr_build_deps_el7_pkgs }}'
 
-- name: install Motr build-time CentOS 8 specific dependencies
-  when: redhat_release_major == 8
+- name: install Motr build-time el8 specific dependencies
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
   package:
     state: present
     name:  '{{ motr_build_deps_el8_pkgs }}'
@@ -117,15 +117,15 @@
   tags:
     - isa-l
 
-- name: install Motr build-time python3 dependencies
-  when: redhat_release_major == 7
+- name: install Motr build-time python3 el7 dependencies
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
   package:
     state: present
     name:  '{{ motr_build_deps_python3_el7_pkgs }}'
   tags: motr-build-python3
 
-- name: install Motr build-time python3 dependencies
-  when: redhat_release_major == 8
+- name: install Motr build-time python3 el8 dependencies
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
   package:
     state: present
     name:  '{{ motr_build_deps_python3_el8_pkgs }}'
@@ -246,6 +246,11 @@
         line: 'Release: 99%{?dist}'
 
     - name: install Lustre rpm build dependencies
+      command: yum-builddep -y ~/rpmbuild/SPECS/lustre.spec
+      register: builddep_result
+      changed_when: '"No uninstalled build requires" not in builddep_result.stdout'
+
+    - name: install Lustre rpm build dependencies again just in case
       command: yum-builddep -y ~/rpmbuild/SPECS/lustre.spec
       register: builddep_result
       changed_when: '"No uninstalled build requires" not in builddep_result.stdout'

--- a/scripts/provisioning/roles/motr-build/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-build/vars/RedHat.yml
@@ -67,9 +67,8 @@ motr_build_deps_python3_el7_pkgs:
 
 motr_build_deps_python3_el8_pkgs:
   - python3
-  - python3-devel
+  - python36-devel
   - python3-numpy   # performance tools addb2 analisys
-  - python3-plumbum # performance tools addb2 analisys
   - python3-ply
   - python3-PyYAML  # required only for tests (m0hagen)
   - python3-tqdm    # performance tools addb2 analisys

--- a/scripts/provisioning/roles/motr-runtime/tasks/main.yml
+++ b/scripts/provisioning/roles/motr-runtime/tasks/main.yml
@@ -34,7 +34,7 @@
   package:
     state: present
     name:  '{{ motr_runtime_deps_el7_pkgs }}'
-  when: redhat_release_major == 7
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
 
 - name: get current kernel version
   command:  uname -r


### PR DESCRIPTION
# Problem Statement
On vanilla CentOS provisioning, there are a number of different issues.

# Design
- install pip3 at install-build-deps
- enable el8 PowerTools repo
- drop python3-plumbum from el8_pkgs
- install yum-utils
- ignore failure on enabling powertools
- install lustre build deps 2 times
- extend supported lustre versions

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
