### PR TITLE
Disabled DTM for partition stob

### DIFF
--- a/be/domain.c
+++ b/be/domain.c
@@ -716,7 +716,7 @@ static int be_domain_level_enter(struct m0_module *module)
 	unsigned                 i;
 
 	level_name = levels_be_domain[level].ml_name;
-	M0_ENTRY("dom=%p level=%d level_name=%s", dom, level, level_name);
+	M0_LOG(M0_ALWAYS, "dom=%p level=%d level_name=%s", dom, level, level_name);
 	switch (level) {
 	case M0_BE_DOMAIN_LEVEL_INIT:
 		zt_tlist_init(&dom->bd_0types);
@@ -783,17 +783,21 @@ static int be_domain_level_enter(struct m0_module *module)
 		 * The part stob domain is never destroyed in case of failure, even
 		 * in mkfs mode: it helps with the debugging.
 		 */
-		return M0_RC(m0_stob_domain_create(cfg->bc_part_cfg.bpc_location,
+		rc = m0_stob_domain_create(cfg->bc_part_cfg.bpc_location,
 						   cfg->bc_part_cfg.bpc_init_cfg,
 						   cfg->bc_part_cfg.bpc_dom_key,
 						   cfg->bc_part_cfg.bpc_create_cfg,
-						   &dom->bd_part_stob_domain));
+						   &dom->bd_part_stob_domain);
+		M0_LOG(M0_ALWAYS, "rinkudebug: m0_stob_domain_create rc = %d", rc);
+		return M0_RC(rc);
 	case M0_BE_DOMAIN_LEVEL_NORMAL_PART_STOB_DOMAIN_INIT:
 		if (cfg->bc_mkfs_mode || !cfg->bc_part_cfg.bpc_part_mode_set)
 			return M0_RC(0);
-		return M0_RC(m0_stob_domain_init(cfg->bc_part_cfg.bpc_location,
+		rc = m0_stob_domain_init(cfg->bc_part_cfg.bpc_location,
 						 cfg->bc_part_cfg.bpc_init_cfg,
-						 &dom->bd_part_stob_domain));
+						 &dom->bd_part_stob_domain);
+		M0_LOG(M0_ALWAYS, "rinkudebug: m0_stob_domain_init rc = %d", rc);
+		return M0_RC(rc);
 	case M0_BE_DOMAIN_LEVEL_LOG_CONFIGURE:
 		cfg->bc_log.lc_got_space_cb = m0_be_engine_got_log_space_cb;
 		cfg->bc_log.lc_full_cb      = m0_be_engine_full_log_cb;

--- a/be/log_store.c
+++ b/be/log_store.c
@@ -321,6 +321,7 @@ static int be_log_store_level_enter(struct m0_module *module)
 					    stob_cfg);
 			if(stob_cfg!= NULL)
 				m0_free(stob_cfg);
+			M0_LOG(M0_ALWAYS, "rinkudebug: m0_stob_create rc = %d", rc);
 			return rc;
 		}
 		return m0_stob_state_get(ls->ls_stob) == CSS_EXISTS ?

--- a/be/partition_table.c
+++ b/be/partition_table.c
@@ -248,7 +248,7 @@ M0_INTERNAL int m0_be_ptable_get_part_info(struct m0_be_ptable_part_tbl_info
 			&rd_partition_table.pt_device_path_name[0];
 		primary_part_info->pti_part_alloc_info =
 			&rd_partition_table.pt_part_alloc_info[0];
-		M0_LOG(M0_DEBUG, "dev size(in chunks)=%"PRIu64
+		M0_LOG(M0_ALWAYS, "dev size(in chunks)=%"PRIu64
 		       "chunk size(in bits)=%"PRIu64,
 		       primary_part_info->pti_dev_size_in_chunks,
 		       primary_part_info->pti_chunk_size_in_bits);

--- a/cas/service.c
+++ b/cas/service.c
@@ -1178,6 +1178,7 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	struct m0_cas_ctg  *meta    = m0_ctg_meta();
 	struct m0_cas_ctg  *ctidx   = m0_ctg_ctidx();
 	struct m0_cas_rec  *rec     = NULL;
+	/** To disable DTM we had given false to the below variable */
 	bool                is_dtm0_used =
 		!m0_dtm0_tx_desc_is_none(&op->cg_txd);
 	bool                is_index_drop;

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -46,7 +46,7 @@
 %define _use_internal_dependency_generator 0
 
 # configure options
-%define  configure_release_opts --enable-release --with-trace-kbuf-size=256 --with-trace-ubuf-size=16
+%define  configure_release_opts --enable-release --with-trace-kbuf-size=512 --with-trace-ubuf-size=256
 %define  configure_ut_opts      --enable-dev-mode --disable-altogether-mode
 
 %if %{with cassandra}

--- a/motr/init.c
+++ b/motr/init.c
@@ -241,6 +241,7 @@ struct init_fini_call subsystem[] = {
 #ifndef __KERNEL__
 	{ &m0_fdmi_init,         &m0_fdmi_fini,         "fdmi" },
 	{ &m0_fol_fdmi_src_init, &m0_fol_fdmi_src_fini, "fol_fdmi_source" },
+	/* The below line was commented to disable DTM */
 	{ &m0_dtm0_stype_init,   &m0_dtm0_stype_fini,   "dtm0"},
 #endif
 };

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -1485,7 +1485,8 @@ static char *cs_storage_partdom_location_gen(const char          *stob_path,
 
 	M0_ALLOC_ARR(location,
 		     strlen(stob_path) + ARRAY_SIZE(prefix) + 128);
-	if (location != NULL)
+	M0_ASSERT(location != NULL);
+	/*if (location != NULL)*/
 		sprintf(location, "%s:%s:%p", prefix, stob_path, dom);
 	return location;
 }
@@ -1532,7 +1533,7 @@ static void cs_part_domain_setup(struct m0_reqh_context *rctx)
             (dev_count < 1) ||
 	    (sdev->sd_size == 0))
 			return;
-	enum { len = 128 };
+	enum { len = 256 };
 
 
 	if ((rctx->rc_be_seg_path == NULL ||

--- a/stob/domain.c
+++ b/stob/domain.c
@@ -148,7 +148,7 @@ static int stob_domain_init_create(const char *location,
 
 	M0_ENTRY();
 
-	M0_LOG(M0_INFO, "location=%s str_cfg_init=%s dom_key=%"PRIu64" "
+	M0_LOG(M0_ALWAYS, "location=%s str_cfg_init=%s dom_key=%"PRIu64" "
 		 "str_cfg_create=%s init=%d",
 		 location, str_cfg_init, dom_key, str_cfg_create, !!init);
 

--- a/stob/partition.c
+++ b/stob/partition.c
@@ -140,6 +140,7 @@ static int stob_part_domain_cfg_init_parse(const char *str_cfg_init,
 	if (rc != 3)
 		return M0_RC(-EINVAL);
 
+	M0_LOG(M0_ALWAYS, "rinkudebug %s part_be_domain=%p devname=%s size=%"PRIu64, str_cfg_init, part_cfg->part_be_domain, devname, size);
 	cfg = &part_cfg->part_config;
 	cfg->pc_dev_path_name = devname;
 	cfg->pc_dev_size_in_bytes = size;
@@ -182,6 +183,8 @@ static int stob_part_domain_destroy(struct m0_stob_type *type,
 	colon++;
 
 	sscanf(colon,"%lx",&dom_val);
+	M0_LOG(M0_ALWAYS, "rinkudebug colon=%s dom_val=%lx",colon,dom_val);
+ 
 	dom = (struct m0_be_domain *)dom_val;
 
 	ldom = m0_stob_linux_domain_container(dom->bd_stob_domain);
@@ -234,6 +237,7 @@ static int stob_part_domain_cfg_create_parse(const char *str_cfg_create,
 		    devname, &size);
 	if ( rc != 3 )
 		return M0_RC(-EINVAL);
+
 
         part_init_cfg = &part_cfg->part_be_domain->bd_cfg.bc_part_cfg;
 	cfg = &part_cfg->part_config;
@@ -787,21 +791,21 @@ static m0_bcount_t stob_part_dev_offset_get(struct m0_stob_part *partstob,
 		             stob_part_block_shift(&partstob->part_stob);
 	chunk_off_mask = (1 << chunk_size_in_bits) - 1;
 	offset_within_chunk = user_offset & chunk_off_mask;
-	M0_LOG(M0_DEBUG, "relative offset in given chunk: %" PRIu64,
-	       offset_within_chunk);
+	M0_LOG(M0_ALWAYS, "rinkudebug : stob_part_dev_offset_get partstob->part_id %d relative offset in given chunk: %" PRIu64, 
+		(int) partstob->part_id, offset_within_chunk);
 	user_chunk_index =
 		(user_offset >> chunk_size_in_bits);
-	M0_LOG(M0_DEBUG, "table_index :%" PRIu64,
+	M0_LOG(M0_ALWAYS, "table_index :%" PRIu64,
 	       user_chunk_index);
 
 	device_chunk_index = partstob->part_table[user_chunk_index];
 
-	M0_LOG(M0_DEBUG, "device_chunk_index: %" PRIu64,
+	M0_LOG(M0_ALWAYS, "device_chunk_index: %" PRIu64,
 	       device_chunk_index);
 	device_byte_offset =
 		( device_chunk_index << chunk_size_in_bits ) +
 		offset_within_chunk;
-	M0_LOG(M0_DEBUG, "device offset in bytes: %" PRIu64,
+	M0_LOG(M0_ALWAYS, "device offset in bytes: %" PRIu64,
 	       device_byte_offset);
 
 	return(device_byte_offset);


### PR DESCRIPTION
# Problem Statement
Diabling dtm for partition stob.

# Design
While testing partition stob in k8s env we see some failures due to dtm hence disabling it. 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
