### PR TITLE
EOS-27531: Remove K8 flag from motr mini provisioner

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -288,11 +288,6 @@ def validate_motr_rpm(self):
     kernel_ver = op.replace('\n', '')
     check_type(kernel_ver, str, "kernel version")
 
-    if not self.k8:
-        kernel_module = f"/lib/modules/{kernel_ver}/kernel/fs/motr/m0tr.ko"
-        self.logger.info(f"Checking for {kernel_module}\n")
-        validate_file(kernel_module)
-
     self.logger.info(f"Checking for {MOTR_SYS_CFG}\n")
     validate_file(MOTR_SYS_CFG)
 
@@ -473,23 +468,9 @@ def motr_config(self):
 
 def configure_net(self):
     """Wrapper function to detect lnet/libfabric transport."""
-    if self.k8 == 'K8':
-        transport_type = "libfabric"
-        configure_libfabric_k8(self)
-        return
-    try:
-        transport_type = self.server_node['network']['data']['transport_type']
-    except:
-        raise MotrError(errno.EINVAL, "transport_type not found")
-
-    check_type(transport_type, str, "transport_type")
-
-    if transport_type == "lnet":
-        configure_lnet(self)
-    elif transport_type == "libfabric":
-        configure_libfabric(self)
-    else:
-        raise MotrError(errno.EINVAL, "Unknown data transport type\n")
+    transport_type = "libfabric"
+    configure_libfabric_k8(self)
+    return
 
 def configure_lnet(self):
     '''
@@ -723,10 +704,7 @@ def create_lvm(self, index, metadata_dev):
     return True
 
 def calc_lvm_min_size(self, lv_path, lvm_min_size):
-    if self.k8 == 'K8':
-        cmd = f"lsblk --noheadings --bytes {lv_path} | " "awk '{print $4}'"
-    else:
-        cmd = f"lvs {lv_path} -o LV_SIZE --noheadings --units b --nosuffix"
+    cmd = f"lsblk --noheadings --bytes {lv_path} | " "awk '{print $4}'"
     res = execute_command(self, cmd)
     lv_size = res[0].rstrip("\n")
     lv_size = int(lv_size)
@@ -798,45 +776,18 @@ def align_val(val, size):
 def update_bseg_size(self):
     dev_count = 0
     lvm_min_size = None
-    # For k8
-    if self.k8 == 'K8':
-        md_disks_list = get_md_disks_lists(self, self.node)
-        md_disks = get_mdisks_from_list(self, md_disks_list)
-        md_len = len(md_disks)
-        for i in range(md_len):
-            lvm_min_size = calc_lvm_min_size(self, md_disks[i], lvm_min_size)
-        if lvm_min_size:
-            align_val(lvm_min_size, 4096)
-            self.logger.info(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}\n")
-            cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {MOTR_SYS_CFG}'
-            execute_command(self, cmd)
-        return
 
-    # For non k8
-    cvg_cnt, cvg = get_cvg_cnt_and_cvg(self)
-    for i in range(int(cvg_cnt)):
-        cvg_item = cvg[i]
-        try:
-            metadata_devices = cvg_item["metadata_devices"]
-        except:
-            raise MotrError(errno.EINVAL, "metadata devices not found\n")
-        check_type(metadata_devices, list, "metadata_devices")
-        self.logger.info(f"\nlvm metadata_devices: {metadata_devices}\n\n")
-        for device in metadata_devices:
-            cmd = f"pvs --noheadings {device}"
-            vgname = (execute_command(self, cmd)[0]).split(sep=None)[1]
-            cmd = "lvdisplay | grep \"LV Path\" | grep {} | grep -v swap".format(vgname)
-            lv_list = (execute_command(self, cmd)[0]).replace("LV Path", '').split('\n')[0:-1]
-            len_lv_list = len(lv_list)
-            for i in range(len_lv_list):
-                # lv_list[i] contains initial spaces. So removing these spaces.
-                lv_list[i] = lv_list[i].strip()
-                lv_path = lv_list[i]
-                lvm_min_size = calc_lvm_min_size(self, lv_path, lvm_min_size)
+    md_disks_list = get_md_disks_lists(self, self.node)
+    md_disks = get_mdisks_from_list(self, md_disks_list)
+    md_len = len(md_disks)
+    for i in range(md_len):
+        lvm_min_size = calc_lvm_min_size(self, md_disks[i], lvm_min_size)
     if lvm_min_size:
+        align_val(lvm_min_size, 4096)
         self.logger.info(f"setting MOTR_M0D_IOS_BESEG_SIZE to {lvm_min_size}\n")
         cmd = f'sed -i "/MOTR_M0D_IOS_BESEG_SIZE/s/.*/MOTR_M0D_IOS_BESEG_SIZE={lvm_min_size}/" {MOTR_SYS_CFG}'
         execute_command(self, cmd)
+    return
 
 def config_lvm(self):
     dev_count = 0
@@ -1021,8 +972,6 @@ def lvm_exist(self):
     return True
 
 def cluster_up(self):
-    if self.k8 == "K8":
-        return False
     cmd = '/usr/bin/hctl status'
     self.logger.info(f"Executing cmd : '{cmd}'\n")
     ret = execute_command_without_exception(self, cmd)

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -47,44 +47,33 @@ class Cmd:
         self._debug = args.debug
         configure_machine_id(self, None)
 
-        if self._index:
-            self.k8 = Conf.get(self._index, 'cortx>common>environment_type')
-            self.k8 = Conf.get(self._index, 'cortx>common>setup_type')
-        if self.k8 != "K8":
-            self.logfile = LOGFILE
-            self.logger = config_logger(self)
-            self._motr_hare_conf = MOTR_HARE_CONF_PATH
-            self._url_motr_hare = f"json://{self._motr_hare_conf}"
-            Conf.load(self._index_motr_hare, self._url_motr_hare)
-            self.server_node = get_server_node(self, False)
-        else:
-            # Configure log files and logger
-            self.local_path = get_value(self, 'cortx>common>storage>local', str)
-            self.log_path = get_value(self, 'cortx>common>storage>log', str)
-            self.local_path_motr = f"{self.local_path}/motr/{self.machine_id}"
-            self._motr_hare_conf = f"{self.local_path_motr}/motr_hare_keys.json"
-            self._url_motr_hare = f"json://{self._motr_hare_conf}"
-            self.log_path_motr = f"{self.log_path}/motr/{self.machine_id}"
+	# Configure log files and logger
+	self.local_path = get_value(self, 'cortx>common>storage>local', str)
+	self.log_path = get_value(self, 'cortx>common>storage>log', str)
+	self.local_path_motr = f"{self.local_path}/motr/{self.machine_id}"
+	self._motr_hare_conf = f"{self.local_path_motr}/motr_hare_keys.json"
+	self._url_motr_hare = f"json://{self._motr_hare_conf}"
+	self.log_path_motr = f"{self.log_path}/motr/{self.machine_id}"
 
-            # Get setup size: VM=small, HW=large
-            self.setup_size = get_value(self, 'cortx>common>setup_size', str)
+	# Get setup size: VM=small, HW=large
+	self.setup_size = get_value(self, 'cortx>common>setup_size', str)
 
-            # Check if local and log path exists, return if not exists
-            validate_files([self.local_path, self.log_path])
+	# Check if local and log path exists, return if not exists
+	validate_files([self.local_path, self.log_path])
 
-            create_dirs(self, [self.local_path_motr, self.log_path_motr])
-            self.logfile =  f"{self.log_path_motr}/mini_provisioner"
-            self.logger = config_logger(self)
+	create_dirs(self, [self.local_path_motr, self.log_path_motr])
+	self.logfile =  f"{self.log_path_motr}/mini_provisioner"
+	self.logger = config_logger(self)
 
-            # Fetch important data from Confstore
-            self.cortx = get_value(self, 'cortx', dict)
-            self.cluster = get_value(self, 'cluster', dict)
-            self.nodes = get_value(self, 'node', dict)
-            self.node = get_server_node(self, True)
-            self.storage_nodes = get_data_nodes(self)
-            if self.machine_id in self.storage_nodes:
-                self.storage = get_storage(self)
-            Conf.load(self._index_motr_hare, self._url_motr_hare)
+	# Fetch important data from Confstore
+	self.cortx = get_value(self, 'cortx', dict)
+	self.cluster = get_value(self, 'cluster', dict)
+	self.nodes = get_value(self, 'node', dict)
+	self.node = get_server_node(self, True)
+	self.storage_nodes = get_data_nodes(self)
+	if self.machine_id in self.storage_nodes:
+		self.storage = get_storage(self)
+	Conf.load(self._index_motr_hare, self._url_motr_hare)
     @property
     def args(self) -> str:
         return self._args
@@ -140,11 +129,8 @@ class PrepareCmd(Cmd):
     def process(self):
         self.logger.info(f"Processing {self.name} {self.url} {self._args}\n")
 
-        # If hare is installed and cluster is up then exit otherwise go ahead
-        if pkg_installed(self, "cortx-hare"):
-            if cluster_up(self):
-                self.logger.warning("Cluster is already up...Exiting.\n")
-                return
+        # No need to check if cluster is up in any deployment phases in K8s env
+        # Configure network transport
         configure_net(self)
         self.logger.info("SUCCESS\n")
 
@@ -159,23 +145,9 @@ class PostInstallCmd(Cmd):
         self.logger.info(f"Processing {self.name} {self.url} {self._args}\n")
         validate_motr_rpm(self)
 
-        # Check if lvms are already created.
-        # If not, create it. Otherwise, skip.
-        # If cluster is not up, go ahead. Otherwise, exit.
-        if pkg_installed(self, "cortx-hare"):
-            if cluster_up(self):
-                self.logger.info("Cluster is already up...Exiting.\n")
-                return
-        if self.k8 == 'K8':
-            # Nothing required for post_install stage in k8
-            self.logger.info("SUCCESS\n")
-            return 0
-        else:
-            if lvm_exist(self):
-                config_lvm(self)
-            else:
-                self.logger.error("There are LVM configurations present on the system. "
-                                  "Skipping LVM creation.\n")
+ 	    # Nothing required for post_install stage in k8
+	    self.logger.info("SUCCESS\n")
+	    return 0
 
 class ConfigCmd(Cmd):
     """Config Setup Cmd"""
@@ -186,14 +158,9 @@ class ConfigCmd(Cmd):
 
     def process(self):
         self.logger.info(f"Processing {self.name} {self.url} {self._args}\n")
-        if self.k8 == 'K8':
-            motr_config_k8(self)
-            return
-
-        # Update keys from other nodes
-        if self.server_node["name"] == "srvnode-1":
-            update_motr_hare_keys_for_all_nodes(self)
+        motr_config_k8(self)
         self.logger.info("SUCCESS\n")
+        return
 
 class InitCmd(Cmd):
     """Init Setup Cmd"""
@@ -266,10 +233,7 @@ class CleanupCmd(Cmd):
         patterns = ["addb", "*trace", "m0d"]
         remove_logs(self, patterns)
         if (len(self._args) == 1) and (self._args[0] == "pre-factory"):
-            if not self.k8:
-                lvm_clean(self)
-            else:
-                part_clean(self)
+            self.logger.info("Currently NOOP in pre-factory cleanup\n")
         pass
 
 class UpgradeCmd(Cmd):


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
Remove K8 flag from motr mini provisioner and only have calls specific to k8s environment implementation and not LR.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
