### PR TITLE
reqh: md device service type is not M0_CST_IOS

### DIFF
--- a/reqh/reqh.c
+++ b/reqh/reqh.c
@@ -213,7 +213,10 @@ m0_reqh_mdpool_service_index_to_session(const struct m0_reqh *reqh,
 		pd_sdev_idx;
 	ctx = md_pv->pv_pc->pc_dev2svc[idx].pds_ctx;
 	M0_ASSERT(ctx != NULL);
-	M0_ASSERT(ctx->sc_type == M0_CST_IOS);
+        /* XXX Should the service type associated to a metadata device in
+         * a given m0d be more generic, e.g. M0_CST_BE?
+         */
+	M0_ASSERT(ctx->sc_type == M0_CST_CAS);
 	session = &ctx->sc_rlink.rlk_sess;
 
 	M0_LOG(M0_DEBUG, "device index %d id %d -> ctx=%p session=%p", idx,


### PR DESCRIPTION
While generating confguration, Hare assigns metadata device to CAS
service type, M0_CST_CAS. But m0_reqh_mdpool_service_index_to_session()
expects it to be M0_CST_IOS and asserts the same.

Solution:
Expect metadata device service type to be M0_CST_CAS instead
of M0_CST_IOS.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
