### PR TITLE
EOS-27562: Motr Support Bundle generated by the script

### DIFF
--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -129,15 +129,14 @@ main() {
     done >>$REPORT
 
     # Collects compressed core generated in /var/crash and /var/log/crash
-    if [ $COLLECT_COREDUMPS_P -eq 1 ]
-    then
-         MACHINE_ID=$(cat /etc/machine-id)
-         if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
-            M0TR_M0D_CORE_DIR=$(source /etc/cortx/motr/sysconfig/$MACHINE_ID/motr ; echo $MOTR_M0D_DATA_DIR)
-         else
-            M0TR_M0D_CORE_DIR=$(source /etc/sysconfig/motr ; echo $MOTR_M0D_DATA_DIR)
-         fi
-
+    MACHINE_ID=$(cat /etc/machine-id)
+    if [ -d /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
+        MOTR_SYSCONFIG="/etc/cortx/motr/sysconfig/$MACHINE_ID/motr"
+    else
+        MOTR_SYSCONFIG="/etc/sysconfig/motr"
+    fi
+    if [ $COLLECT_COREDUMPS_P -eq 1 ]; then
+        M0TR_M0D_CORE_DIR=$(source $MOTR_SYSCONFIG ; echo $MOTR_M0D_DATA_DIR)
         CORE_DIRS+=("$M0TR_M0D_CORE_DIR")
     fi 
     for IN_DIR in  ${CORE_DIRS[@]}; do
@@ -197,12 +196,7 @@ main() {
     fi
 
     # Collects traces of m0d process(confd, ios) only
-    MACHINE_ID=$(cat /etc/machine-id)
-    if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
-        M0TR_M0D_TRACE_DIR=$(source /etc/cortx/motr/sysconfig/$MACHINE_ID/motr ; echo $MOTR_M0D_TRACE_DIR)
-    else
-        M0TR_M0D_TRACE_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
-    fi
+    M0TR_M0D_TRACE_DIR=$(source $MOTR_SYSCONFIG; echo $MOTR_M0D_TRACE_DIR)
     M0D_TRACE_DIR="${M0TR_M0D_TRACE_DIR%\'}"
     M0D_TRACE_DIR="${M0D_TRACE_DIR#\'}"
 
@@ -219,11 +213,7 @@ main() {
     fi
 
     # Collects addb record files for process(confd, ios and s3server)
-    if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
-        ADDB_RECORD_DIR=$(source /etc/cortx/motr/sysconfig/$MACHINE_ID/motr ; echo $MOTR_M0D_ADDB_STOB_DIR)
-    else
-        ADDB_RECORD_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
-    fi
+    ADDB_RECORD_DIR=$(source $MOTR_SYSCONFIG; echo $MOTR_M0D_ADDB_STOB_DIR)
     ADDB_DIR="${ADDB_RECORD_DIR%\'}"
     ADDB_DIR="${ADDB_DIR#\'}"
 

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -131,7 +131,13 @@ main() {
     # Collects compressed core generated in /var/crash and /var/log/crash
     if [ $COLLECT_COREDUMPS_P -eq 1 ]
     then
-        M0TR_M0D_CORE_DIR=$(source /etc/sysconfig/motr ; echo $MOTR_M0D_DATA_DIR)
+         MACHINE_ID=$(cat /etc/machine-id)
+         if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
+            M0TR_M0D_CORE_DIR=$(source /etc/cortx/motr/sysconfig/$MACHINE_ID/motr ; echo $MOTR_M0D_DATA_DIR)
+         else
+            M0TR_M0D_CORE_DIR=$(source /etc/sysconfig/motr ; echo $MOTR_M0D_DATA_DIR)
+         fi
+
         CORE_DIRS+=("$M0TR_M0D_CORE_DIR")
     fi 
     for IN_DIR in  ${CORE_DIRS[@]}; do
@@ -191,7 +197,12 @@ main() {
     fi
 
     # Collects traces of m0d process(confd, ios) only
-    M0TR_M0D_TRACE_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
+    MACHINE_ID=$(cat /etc/machine-id)
+    if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
+        M0TR_M0D_TRACE_DIR=$(cat /etc/cortx/motr/sysconfig/$MACHINE_ID/motr | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
+    else
+        M0TR_M0D_TRACE_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
+    fi
     M0D_TRACE_DIR="${M0TR_M0D_TRACE_DIR%\'}"
     M0D_TRACE_DIR="${M0D_TRACE_DIR#\'}"
 
@@ -208,7 +219,11 @@ main() {
     fi
 
     # Collects addb record files for process(confd, ios and s3server)
-    ADDB_RECORD_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
+    if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
+        ADDB_RECORD_DIR=$(cat /etc/cortx/motr/sysconfig/$MACHINE_ID/motr | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
+    else
+        ADDB_RECORD_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
+    fi
     ADDB_DIR="${ADDB_RECORD_DIR%\'}"
     ADDB_DIR="${ADDB_DIR#\'}"
 

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -199,7 +199,7 @@ main() {
     # Collects traces of m0d process(confd, ios) only
     MACHINE_ID=$(cat /etc/machine-id)
     if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
-        M0TR_M0D_TRACE_DIR=$(cat /etc/cortx/motr/sysconfig/$MACHINE_ID/motr | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
+        M0TR_M0D_TRACE_DIR=$(source /etc/cortx/motr/sysconfig/$MACHINE_ID/motr ; echo $MOTR_M0D_TRACE_DIR)
     else
         M0TR_M0D_TRACE_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_TRACE_DIR" | cut -d '=' -f2)
     fi
@@ -220,7 +220,7 @@ main() {
 
     # Collects addb record files for process(confd, ios and s3server)
     if [ -d  /etc/cortx/motr/sysconfig/$MACHINE_ID ]; then
-        ADDB_RECORD_DIR=$(cat /etc/cortx/motr/sysconfig/$MACHINE_ID/motr | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
+        ADDB_RECORD_DIR=$(source /etc/cortx/motr/sysconfig/$MACHINE_ID/motr ; echo $MOTR_M0D_ADDB_STOB_DIR)
     else
         ADDB_RECORD_DIR=$(cat /etc/sysconfig/motr  | grep "^MOTR_M0D_ADDB_STOB_DIR" | cut -d '=' -f2)
     fi


### PR DESCRIPTION
./deploy-scripts/k8_cortx_cloud/logs-cortx-cloud.sh does not
contains m0reportbug-traces.tar.gz.

*problem: Motr Support Bundle generated from container other than cortx-motr-io-001
and cortx-motr-io-002 does not contains m0reportbug-traces.tar.gz.

*Solution: Get M0TR_M0D_TRACE_DIR value from /etc/cortx/motr/sysconfig//motr instead of
 /etc/sysconfig/motr.

Signed-off-by: Papan Kumar Singh <papan.kumarsingh@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
