### PR TITLE
install-build-deps: drop obsolete check for python3

### DIFF
--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -136,11 +136,6 @@ zfs
 END_TAGS
 )
 
-# python3 packages available starting from CentOS/RedHat 7.7
-if (( $(grep -Po '(?<=release 7\.).' /etc/redhat-release) < 7 )) ; then
-    skip_tags+=,motr-build-python3
-fi
-
 if ! $install_epel ; then
     skip_tags+=,epel
 fi

--- a/scripts/provisioning/roles/motr-build/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-build/vars/RedHat.yml
@@ -55,6 +55,7 @@ motr_build_deps_el7_pkgs:
   - gccxml
 
 motr_build_deps_el8_pkgs:
+  - python2-devel
   - castxml
 
 motr_build_deps_python3_el7_pkgs:


### PR DESCRIPTION
# Problem Statement

The check for python3 on CentOS version less than 7.7
is obsolete by now, and it gives errors.

# Design
Just drop the check. It's not needed anymore.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
