### PR TITLE
install-build-deps: fix no-ansible option

### DIFF
--- a/scripts/build-prep-1node-cortx-mgw.sh
+++ b/scripts/build-prep-1node-cortx-mgw.sh
@@ -36,7 +36,7 @@ cd $CORTX_WDIR
 
 yum install wget -y
 wget https://raw.githubusercontent.com/Seagate/cortx-motr/main/scripts/build-prep-1node.sh
-echo 'sh +x ~/build-prep-1node.sh "$1" "$2"'
+sh +x ./build-prep-1node.sh "$1" "$2"
 rm build-prep-1node.sh
 
 

--- a/scripts/build-prep-1node.sh
+++ b/scripts/build-prep-1node.sh
@@ -41,14 +41,10 @@ which git || sudo yum install -y git
 }
 
 echo 'Install Motr deps...'
+[[ -f scripts/$(basename "$0") ]] || cd motr
 if [[ $pkg == "yes" ]]; then
-    [[ -f scripts/$(basename "$0") ]] || cd motr
     sudo scripts/install-build-deps --no-ansible
 else
-    sudo yum install -y epel-release # Install EPEL yum repo
-    sudo yum install -y epel-release # Update to the latest version
-    sudo yum install -y ansible
-    [[ -f scripts/$(basename "$0") ]] || cd motr
     sudo scripts/install-build-deps
 fi
 

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -116,13 +116,6 @@ case $(distro_type) in
 esac
 pip3 install ipaddress
 
-if ! which ansible &>/dev/null ; then
-    case $(distro_type) in
-        redhat) yum -y install ansible ;;
-        debian) apt install ansible ;;
-    esac
-fi
-
 skip_tags=$(paste --serial --delimiters=, <<END_TAGS
 c75-workarounds
 c76-workarounds
@@ -176,6 +169,13 @@ if ! $use_ansible ; then
 	;;
    esac
    exit 0
+elif ! which ansible &>/dev/null ; then
+    case $(distro_type) in
+        redhat) yum -y install epel-release
+                yum -y install epel-release # Update it
+                yum -y install ansible ;;
+        debian) apt install ansible ;;
+    esac
 fi
 
 $TOP_SRCDIR/scripts/setup-node localhost \


### PR DESCRIPTION
# Problem Statement
With `--no-ansible` option it would still install
ansible. And when it installs it (even without the option)
it would not make sure epel repo is installed and updated.
This is a regression introduced at commit 86d2c997f.

# Design
Fix it by introducing the old ansible logic back.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
