### PR TITLE
scripts/install-build-deps: support only user mode for --no-ansible

### DIFF
--- a/scripts/build-prep-1node-cortx-mgw.sh
+++ b/scripts/build-prep-1node-cortx-mgw.sh
@@ -9,7 +9,7 @@
 #
 #   -dev  development mode, don't build and install rpms
 #   -mgs  keep ceph mgs which provides dashboard
-#   -pkg  install known packages without adding repo
+#   -pkg  quickly install required packages without building them
 #         (If this option is not specified motr/scripts/install-build-deps
 #          is called which adds required repo and also build and installs
 #          lustre, libfabric and isa packages and installs kernel packages too.)

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -141,14 +141,17 @@ rpm-build
 packages_debian=(
 )
 
+SEAGATE_GITHUB_CORTX_DEPS_REPO=https://github.com/Seagate/cortx/releases/download/build-dependencies/
 if ! $use_ansible ; then
   case $(distro_type) in
       redhat)
-        yum install -y https://github.com/Seagate/cortx/releases/download/build-dependencies/isa-l-2.30.0-1.el7.x86_64.rpm
-        yum install -y https://github.com/Seagate/cortx/releases/download/build-dependencies/libfabric-1.11.2-1.el7.x86_64.rpm
-        yum install -y https://github.com/Seagate/cortx/releases/download/build-dependencies/libfabric-devel-1.11.2-1.el7.x86_64.rpm
+        yum install -y $SEAGATE_GITHUB_CORTX_DEPS_REPO/isa-l-2.30.0-1.el7.x86_64.rpm
+        yum install -y $SEAGATE_GITHUB_CORTX_DEPS_REPO/libfabric-1.11.2-1.el7.x86_64.rpm
+        yum install -y $SEAGATE_GITHUB_CORTX_DEPS_REPO/libfabric-devel-1.11.2-1.el7.x86_64.rpm
         echo "For user mode only motr lustre client and kernel rpms are not needed"
         cp cortx-motr.spec.in cortx-motr.spec
+        sed -i "/BuildRequires:  kernel*/d" cortx-motr.spec
+        sed -i "/BuildRequires:  %{lustre_devel}/d" cortx-motr.spec
         sed -i 's/@BUILD_DEPEND_LIBFAB@//g' cortx-motr.spec
         sed -i 's/@.*@/111/g' cortx-motr.spec
         yum-builddep cortx-motr.spec


### PR DESCRIPTION
When "scripts/install-build-deps --no-ansible" is used which calls
'yum-build-deps cortx-motr.spec', which may fail to find
lustre devel packages. This causes exit of the other build-prep*.sh
scripts.
To fix this issue install only user mode packages with --no-ansible.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
