### PR TITLE
scripts: install the packages without manual intervention

### DIFF
--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -154,14 +154,12 @@ if ! $use_ansible ; then
         sed -i "/BuildRequires:  %{lustre_devel}/d" cortx-motr.spec
         sed -i 's/@BUILD_DEPEND_LIBFAB@//g' cortx-motr.spec
         sed -i 's/@.*@/111/g' cortx-motr.spec
-        yum-builddep cortx-motr.spec
+        yum-builddep cortx-motr.spec -y
         rm cortx-motr.spec
 
         for i in ${packages_redhat[@]}
         do
-          if [[ `rpm -qa | grep $i` == "" ]]; then
             sudo yum install $i -y
-          fi
 	done
 	;;
       debian)


### PR DESCRIPTION
fix rpm-build package installation, as due to presence of rpm-build-libs
it was getting skipped.
Also use "yum-build-deps -y", so that no manual intervention is needed.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
