### PR TITLE
EOS-27394: Fix partition stob crash

### DIFF
--- a/be/log_store.c
+++ b/be/log_store.c
@@ -307,7 +307,7 @@ static int be_log_store_level_enter(struct m0_module *module)
 				char    *direct_io_cfg="directio:true";
 				stob_cfg =
 					m0_alloc(strlen(ls->ls_cfg.lsc_stob_create_cfg) +
-						    ARRAY_SIZE(direct_io_cfg) + 2 );
+						    strlen(direct_io_cfg) + 2 );
 				if (stob_cfg!= NULL)
 					sprintf(stob_cfg, "%s:%s",
 						ls->ls_cfg.lsc_stob_create_cfg,

--- a/ioservice/storage_dev.c
+++ b/ioservice/storage_dev.c
@@ -95,7 +95,7 @@ storage_dev_get_part_stob(struct m0_be_domain *domain,
 	if (i == M0_BE_MAX_PARTITION_USERS)
 		return -ENOENT;
 	stob_cfg = m0_alloc(strlen(dev_pathname) +
-			    ARRAY_SIZE(direct_io_cfg) + 4);
+			    strlen(direct_io_cfg) + 4);
 	if (stob_cfg!= NULL)
 		sprintf(stob_cfg, "%s:%s", dev_pathname, direct_io_cfg);
 	else

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -1484,13 +1484,13 @@ static char *cs_storage_partdom_location_gen(const char          *stob_path,
 	const char *prefix = m0_stob_part_type.st_fidt.ft_name;
 
 	M0_ALLOC_ARR(location,
-		     strlen(stob_path) + ARRAY_SIZE(prefix) + 128);
+		     strlen(stob_path) + strlen(prefix) + 128);
 	if (location != NULL)
 		sprintf(location, "%s:%s:%p", prefix, stob_path, dom);
 	return location;
 }
 
-#define PART_STOB_MAX_CHUNK_SIZE_IN_BITS  64
+#define PART_STOB_MAX_CHUNK_SIZE_IN_BITS  30
 static int align_chunk_size(m0_bcount_t proposed_chunk_size)
 {
 	int chunksize_in_bits;
@@ -1503,7 +1503,7 @@ static int align_chunk_size(m0_bcount_t proposed_chunk_size)
 		else
 			break;
 	}
-	M0_ASSERT(i < PART_STOB_MAX_CHUNK_SIZE_IN_BITS);chunksize_in_bits = i;
+	chunksize_in_bits = i;
 	return (chunksize_in_bits);
 }
 
@@ -1583,10 +1583,12 @@ static void cs_part_domain_setup(struct m0_reqh_context *rctx)
 		part_cfg->bpc_part_mode_seg1 = true;
 		rctx->rc_be_seg_path = sdev->sd_filename;
 
-		rctx->rc_be_seg_size = meta_size;
 		part_cfg->bpc_seg_size_in_chunks =
-			rctx->rc_be_seg_size >> part_cfg->bpc_chunk_size_in_bits;
+			meta_size  >> part_cfg->bpc_chunk_size_in_bits;
+		rctx->rc_be_seg_size = part_cfg->bpc_seg_size_in_chunks << part_cfg->bpc_chunk_size_in_bits;
 		used_chunks += part_cfg->bpc_seg_size_in_chunks;
+
+		M0_LOG(M0_ALWAYS, "rc_be_seg_size : %"PRIu64,rctx->rc_be_seg_size);
 
 		/** Log configuration*/
 		part_cfg->bpc_part_mode_log = true;

--- a/stob/partition.c
+++ b/stob/partition.c
@@ -783,10 +783,12 @@ static m0_bcount_t stob_part_dev_offset_get(struct m0_stob_part *partstob,
 
 	M0_ENTRY();
 	M0_PRE(partstob != NULL);
+	M0_LOG(M0_ALWAYS, "partstob id : %d  user_offset :%"PRIu64,(int)partstob->part_id, user_offset); 
 	chunk_size_in_bits = partstob->part_chunk_size_in_bits -
 		             stob_part_block_shift(&partstob->part_stob);
 	chunk_off_mask = (1 << chunk_size_in_bits) - 1;
 	offset_within_chunk = user_offset & chunk_off_mask;
+	M0_LOG(M0_ALWAYS, "chunk_off_mask : %"PRIu64,chunk_off_mask); 
 	M0_LOG(M0_DEBUG, "relative offset in given chunk: %" PRIu64,
 	       offset_within_chunk);
 	user_chunk_index =


### PR DESCRIPTION
Co-authored-by: Vidyadhar Pinglikar <vidyadhar.pinglikar@seagate.com>
Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
Partition STOB feature branch not working on HW set-up with partition size above 50GB

# Design
Instead of using ARRAY_SIZE macro we are using strlen now.  
Also we fix some calculations.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
