### PR TITLE
EOS-27532 m0ctl: removed support for m0ctl kernel module

### DIFF
--- a/Kbuild.in
+++ b/Kbuild.in
@@ -38,7 +38,6 @@ else
 # provided by INSTALL_MOD_DIR Kbuild variable and "motr" is taken from module's
 # build directory
 obj-m := m0tr.o
-obj-m += m0ctl.o
 
 # these modules are built unless '--disable-unit-tests' option of ./configure
 # script is used
@@ -160,11 +159,7 @@ include $(src)/be/ut/Kbuild.sub
 include $(src)/ha/ut/Kbuild.sub
 
 #
-# m0ctl.ko -------------------------------------------- {{{1
 #
-
-m0ctl-y   = $(m0ctl_objects)
-m0ctl_objects :=
 
 include $(src)/utils/Kbuild.sub
 

--- a/doc/fault-injection.md
+++ b/doc/fault-injection.md
@@ -66,8 +66,11 @@ beginning and end of the test block, which uses fault injection. For example:
     }
 
 
-m0ctl.ko driver
+m0ctl.ko driver [Unsupported]
 ---------------
+
+m0ctl.ko module support is removed, as it uses debugfs,
+which is available only for GPL-licensed modules.
 
 m0ctl driver provides a debugfs interface to control m0tr in runtime. All
 control files are placed under "motr/" directory in the root of debugfs file

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -30,7 +30,6 @@ MOTR_TEST_LOGFILE=$SANDBOX_DIR/motr_`date +"%Y-%m-%d_%T"`.log
 MOTR_M0T1FS_MOUNT_DIR=/tmp/test_m0t1fs_`date +"%d-%m-%Y_%T"`
 
 MOTR_MODULE=m0tr
-MOTR_CTL_MODULE=m0ctl #debugfs interface to control m0tr at runtime
 
 # kernel space tracing parameters
 MOTR_MODULE_TRACE_MASK='!all'
@@ -188,38 +187,6 @@ load_kernel_module()
         	              $motr_module_path/$motr_module.ko"
         	        return 1
         	fi
-	fi
-}
-
-load_motr_ctl_module()
-{
-	echo "Mount debugfs and insert $MOTR_CTL_MODULE.ko so as to use fault injection"
-	mount -t debugfs none /sys/kernel/debug
-	mount | grep debugfs
-	if [ $? -ne 0 ]
-	then
-		echo "Failed to mount debugfs"
-		return 1
-	fi
-
-	echo "insmod $motr_module_path/$MOTR_CTL_MODULE.ko"
-	insmod $motr_module_path/$MOTR_CTL_MODULE.ko
-	lsmod | grep $MOTR_CTL_MODULE
-	if [ $? -ne 0 ]
-	then
-		echo "Failed to insert module" \
-		     " $motr_module_path/$MOTR_CTL_MODULE.ko"
-		return 1
-	fi
-}
-
-unload_motr_ctl_module()
-{
-	echo "rmmod $motr_module_path/$MOTR_CTL_MODULE.ko"
-	rmmod $motr_module_path/$MOTR_CTL_MODULE.ko
-	if [ $? -ne 0 ]; then
-		echo "Failed: $MOTR_CTL_MODULE.ko could not be unloaded"
-		return 1
 	fi
 }
 

--- a/m0t1fs/linux_kernel/st/m0t1fs_rlock_revoke.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_rlock_revoke.sh
@@ -60,8 +60,6 @@ revoke_pre()
 	prog_file_pattern="$st_dir/m0t1fs_io_file_pattern"
 	local source_abcd="$revoke_sandbox/revoke_abcd"
 
-	load_motr_ctl_module || return 1
-
 	rm -rf $revoke_sandbox
 	mkdir -p $revoke_sandbox
 	echo "Creating data file $source_abcd"
@@ -92,8 +90,6 @@ revoke_post()
 		# Note: trace may be read as follows
 		#$M0_SRC_DIR/utils/trace/m0trace -w0 -s m0t1fs,rpc -I /var/log/motr/m0tr_ko.img -i /var/log/motr/m0trace.bin -o $MOTR_TEST_LOGFILE.trace
 	fi
-
-	unload_motr_ctl_module || return 1
 }
 
 revoke_read_lock()

--- a/m0t1fs/linux_kernel/st/m0t1fs_test.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_test.sh
@@ -38,18 +38,9 @@ m0t1fs_test()
 		return 1
 	fi
 
-	# Load m0ctl module in order to collect kernel logs with m0reportbug
-	load_motr_ctl_module
-	if [ $? -ne 0 ]
-	then
-		motr_service stop
-		return 1
-	fi
-
 	m0t1fs_system_tests
 	rc=$?
 
-	unload_motr_ctl_module
 	# motr_service stop --collect-addb
 	motr_service stop
 	if [ $? -ne 0 ]

--- a/scripts/install/usr/libexec/cortx-motr/motr-service.functions
+++ b/scripts/install/usr/libexec/cortx-motr/motr-service.functions
@@ -104,7 +104,6 @@ _trap_munge()
 # path to binaries inside working directory
 declare -rA _path_inside_workdir=(
     [m0tr.ko]='m0tr.ko'
-    [m0ctl.ko]='m0ctl.ko'
     [m0d]='motr/m0d'
     [m0mkfs]='utils/mkfs/m0mkfs'
     [m0traced]='utils/trace/m0traced'
@@ -191,26 +190,15 @@ m0_load_modules()
             m0_exit "Failed to load m0tr module"
         }
         _trap_munge "rmmod $(m0_path_to m0tr.ko)" ERR
-
-        insmod $(m0_path_to m0ctl.ko) || {
-            # FIXME: looks wrong, should be able to use `rmmod m0tr`
-            rmmod $(m0_path_to m0tr.ko)
-            m0_exit "Failed to load m0ctl module"
-        }
-        _trap_munge "rmmod $(m0_path_to m0ctl.ko)" ERR
     else
         set -x
         modprobe m0tr $m0tr_params
-        set +x
-        modprobe m0ctl
     fi
 }
 
 # Unload Motr modules.
 m0_unload_modules()
 {
-    lsmod | grep -q m0ctl && ( rmmod m0ctl || m0_exit "Failed to unload m0ctl module" )
-
     if [ -n "$MOTR_DEVEL_WORKDIR_PATH" ] ; then
         rmmod m0tr || m0_exit "Failed to unload m0tr module"
     else

--- a/utils/functions
+++ b/utils/functions
@@ -71,14 +71,9 @@ m0_modules_insert() {
     || {
         die 'Inserting m0tr.ko failed'
     }
-    insmod $M0_SRC_DIR/m0ctl.ko || {
-        rmmod m0tr
-        die 'inserting m0ctl failed'
-    }
 }
 
 m0_modules_remove() {
-    rmmod m0ctl || true
     rmmod m0tr || true
 }
 


### PR DESCRIPTION
As m0ctl uses debugfs, which supports only GPL licensed modules,
use of m0ctl for kernel tests is removed and build of m0ctl
kernel module too is removed.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>

# Problem Statement
- Problem statement
 
 Fix for motr build failure in RL 8.x in kernel mode, https://github.com/Seagate/cortx-motr/issues/1384

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


-----
[View rendered doc/fault-injection.md](https://github.com/Seagate/cortx-motr/blob/remove-m0ctl-module/doc/fault-injection.md)