### PR TITLE
spec: drop "any" suffix for user mode only motr rpm name

### DIFF
--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -25,10 +25,10 @@
 
 %if %{with usermode}
 %define with_lustre %( echo "--with-lustre=no" )
-%define kernel_ver %( echo "any" )
+%define kernel_ver %( echo "" )
 %else
 %define with_lustre %( test -n "$lustre_src" && echo "--with-lustre=$lustre_src" )
-%define kernel_ver %( echo %{raw_kernel_ver} | tr - _ | sed -e 's/\.debug$//' -e 's/\.%{_arch}$//' -e 's/\.%{?dist:-el7}$//' -e 's/\.el7$//'  )
+%define kernel_ver _%( echo %{raw_kernel_ver} | tr - _ | sed -e 's/\.debug$//' -e 's/\.%{_arch}$//' -e 's/\.%{?dist:-el7}$//' -e 's/\.el7$//'  )
 %endif
 
 %define kernel_ver_requires %( echo %{raw_kernel_ver} | sed -e 's/\.debug$//' -e 's/\.%{_arch}$//' )
@@ -65,7 +65,7 @@
 
 Name:           @PACKAGE@
 Version:        @PACKAGE_VERSION@
-Release:        %{build_num}_@GIT_REV_ID_RPM@_%{kernel_ver}%{?dist}
+Release:        %{build_num}_@GIT_REV_ID_RPM@%{kernel_ver}%{?dist}
 Summary:        CORTX Motr
 Group:          System Environment/Base
 License:        Seagate
@@ -127,7 +127,9 @@ BuildRequires:  systemd-devel
 %if %{rhel} < 8
 BuildRequires:  python-devel
 %else
+# @todo Deprecate python2
 BuildRequires:  python2-devel
+BuildRequires:  python3-devel
 %endif
 @BUILD_DEPEND_LIBFAB@
 BuildRequires:  libedit-devel

--- a/scripts/build-prep-1node-cortx-mgw.sh
+++ b/scripts/build-prep-1node-cortx-mgw.sh
@@ -71,13 +71,13 @@ echo "========================================="
 
 echo
 echo 'update singlenode.yaml with devices in "path: /dev/loop0" format'
-echo 'Do not use "/dev/$available_device" in cluster yaml'
+echo "Do not use "/dev/$available_device" in cluster yaml"
 echo 'Also do not use the devices with filesystem on them'
 echo 'Now you are ready to start the singlenode Motr cluster!'
-echo 'To start, run: hctl bootstrap --mkfs singlenode.yaml'
+echo "To start, run: hctl bootstrap --mkfs  $CORTX_WDIR/singlenode.yaml"
 echo 'check:     hctl status'
 echo 'To connect to Motr cluster, add the following configuration'
-echo 'parameters from `hctl status` to build/ceph.conf:'
+echo "parameters from `hctl status` to $CORTX_WDIR/cortx-rgw/build/ceph.conf:'
 echo '[client]'
 echo '      ...'
 echo '      rgw backend store = motr'
@@ -88,10 +88,11 @@ echo '[client.rgw.8000]'
 echo '      ...'
 echo '      motr my endpoint  = inet:tcp:10.0.0.1@5001'
 echo '      motr my fid       = 0x7200000000000001:0x29'
-echo 'Then run:  MDS=0 RGW=1 ../src/vstart.sh -d $mgs'
+echo "Current directory: $PWD"
+echo "Then run:  MDS=0 RGW=1 ../src/vstart.sh -d $mgs"
 echo 'check:     hctl status'
 echo 'm0client should be in a started state'
 echo 'To stop the cluster run: ../src/stop.sh'
 echo 'Then:  hctl shutdown'
 echo 'If local directory is used then after reboot of the node,'
-echo 'run: mount "/dev/$available_device" $CORTX_WDIR'
+echo "run: mount "/dev/$available_device" $CORTX_WDIR"

--- a/scripts/build-prep-1node-cortx-mgw.sh
+++ b/scripts/build-prep-1node-cortx-mgw.sh
@@ -77,7 +77,7 @@ echo 'Now you are ready to start the singlenode Motr cluster!'
 echo "To start, run: hctl bootstrap --mkfs  $CORTX_WDIR/singlenode.yaml"
 echo 'check:     hctl status'
 echo 'To connect to Motr cluster, add the following configuration'
-echo "parameters from `hctl status` to $CORTX_WDIR/cortx-rgw/build/ceph.conf:'
+echo "parameters from 'hctl status' to $CORTX_WDIR/cortx-rgw/build/ceph.conf:"
 echo '[client]'
 echo '      ...'
 echo '      rgw backend store = motr'
@@ -94,5 +94,5 @@ echo 'check:     hctl status'
 echo 'm0client should be in a started state'
 echo 'To stop the cluster run: ../src/stop.sh'
 echo 'Then:  hctl shutdown'
-echo 'If local directory is used then after reboot of the node,'
+echo 'If local directory is not used then after reboot of the node,'
 echo "run: mount "/dev/$available_device" $CORTX_WDIR"

--- a/scripts/build-prep-1node-cortx-mgw.sh
+++ b/scripts/build-prep-1node-cortx-mgw.sh
@@ -71,7 +71,7 @@ echo "========================================="
 
 echo
 echo 'update singlenode.yaml with devices in "path: /dev/loop0" format'
-echo "Do not use "/dev/$available_device" in cluster yaml"
+echo "Do not use /dev/$available_device in cluster yaml"
 echo 'Also do not use the devices with filesystem on them'
 echo 'Now you are ready to start the singlenode Motr cluster!'
 echo "To start, run: hctl bootstrap --mkfs  $CORTX_WDIR/singlenode.yaml"
@@ -95,4 +95,4 @@ echo 'm0client should be in a started state'
 echo 'To stop the cluster run: ../src/stop.sh'
 echo 'Then:  hctl shutdown'
 echo 'If local directory is not used then after reboot of the node,'
-echo "run: mount "/dev/$available_device" $CORTX_WDIR"
+echo "run: mount /dev/$available_device $CORTX_WDIR"

--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -145,7 +145,9 @@ SEAGATE_GITHUB_CORTX_DEPS_REPO=https://github.com/Seagate/cortx/releases/downloa
 if ! $use_ansible ; then
   case $(distro_type) in
       redhat)
-        yum install -y $SEAGATE_GITHUB_CORTX_DEPS_REPO/isa-l-2.30.0-1.el7.x86_64.rpm
+        yum-config-manager --enable powertools
+	# @todo use el8 rpms
+	yum install -y $SEAGATE_GITHUB_CORTX_DEPS_REPO/isa-l-2.30.0-1.el7.x86_64.rpm
         yum install -y $SEAGATE_GITHUB_CORTX_DEPS_REPO/libfabric-1.11.2-1.el7.x86_64.rpm
         yum install -y $SEAGATE_GITHUB_CORTX_DEPS_REPO/libfabric-devel-1.11.2-1.el7.x86_64.rpm
         echo "For user mode only motr lustre client and kernel rpms are not needed"


### PR DESCRIPTION
Currently "any" suffix in usermode only rpm name represents that
it can work with any kernel version. Use of "any" suffix is not a
standard practice for rpm name, without it too same can be represented,
so removing it.

Also enabled powertools repo for quick package installation option.
Added python3-devel as dependency in cortx-motr.spec.
Fixed echo statement in build prepare scripts for MGW deployment.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
