### PR TITLE
EOS-28457 : GITHUB ISSUE-Kernel module compilation fails with --enable-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1057,6 +1057,9 @@ AS_IF([test x$enable_debug = xyes],
        M0_CPPFLAGS="-DDEBUG $M0_CPPFLAGS"
        M0_KCPPFLAGS="-DDEBUG $M0_KCPPFLAGS"
        M0_CFLAGS="-g -O0 $M0_CFLAGS"
+       # For kernel modules compilation, keep the optimization level to -O2 to
+       # fix issue on CentOS 8 and Rocky Linux 8.
+       # Refer https://gcc.gnu.org/bugzilla//show_bug.cgi?id=84187#c3
        M0_KCFLAGS="-g -O2 $M0_KCFLAGS"
        AC_DEFINE([ENABLE_DEBUG])
       ],[

--- a/configure.ac
+++ b/configure.ac
@@ -1057,7 +1057,7 @@ AS_IF([test x$enable_debug = xyes],
        M0_CPPFLAGS="-DDEBUG $M0_CPPFLAGS"
        M0_KCPPFLAGS="-DDEBUG $M0_KCPPFLAGS"
        M0_CFLAGS="-g -O0 $M0_CFLAGS"
-       M0_KCFLAGS="-g -O0 $M0_KCFLAGS"
+       M0_KCFLAGS="-g -O2 $M0_KCFLAGS"
        AC_DEFINE([ENABLE_DEBUG])
       ],[
        M0_CFLAGS="-g -O2 $M0_CFLAGS"


### PR DESCRIPTION
Fix compilation issue for kernel module when '--enable-debug' is set to true.
[Refer this](https://gcc.gnu.org/bugzilla//show_bug.cgi?id=84187#c3)

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
