### PR TITLE
Update Quick-Start-Guide.rst

### DIFF
--- a/doc/Quick-Start-Guide.rst
+++ b/doc/Quick-Start-Guide.rst
@@ -55,7 +55,8 @@ Build
      consider using libfabric, and use ``--with-user-mode-only`` configure
      option during the build (see below).
    - Make sure libfabric package is not installed for LNet-transport builds.
-     If it is installed, uninstall it manually.
+     If it is installed, uninstall it manually using ``sudo yum remove libfabric`` 
+     or ``sudo apt purge libfabric``, depending on your Linux distribution.
 
    In libfabric case, download and install the packages from:
 


### PR DESCRIPTION
Add command on how to uninstall Libfabric.
Running ``sudo ./scripts/install-build-deps`` may install Libfabric for users. Thus we need to tell the users how to uninstall it.

The modification is based on discussion #1395 

Signed-off-by: Meng Wang <mengwanguc@gmail.com>