### PR TITLE
EOS-28430 btree: btree-ut hangs when code compiled without --enable-debug flag

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -9781,27 +9781,27 @@ struct btree_ut_thread_info {
  *  for the same btree nodes to work on thus exercising possible race
  *  conditions.
  */
-volatile static int64_t thread_run;
+static volatile int64_t thread_run;
 
 
 static struct m0_atomic64 threads_quiesced;
 static struct m0_atomic64 threads_running;
 
 #define  UT_START_THREADS()                                                   \
-	thread_run = true
+	thread_run = 1
 
 #define  UT_STOP_THREADS()                                                    \
-	thread_run = false
+	thread_run = 0
 
 #define UT_THREAD_WAIT()                                                      \
 	do {                                                                  \
-		while (!thread_run)                                           \
+		while (thread_run == 0)                                       \
 			;                                                     \
 	} while (0)
 
 #define UT_THREAD_QUIESCE_IF_REQUESTED()                                      \
 	do {                                                                  \
-		if (!thread_run) {                                            \
+		if (thread_run == 0) {                                        \
 			m0_atomic64_inc(&threads_quiesced);                   \
 			UT_THREAD_WAIT();                                     \
 			m0_atomic64_dec(&threads_quiesced);                   \
@@ -9813,8 +9813,7 @@ static struct m0_atomic64 threads_running;
 		bool try_again;                                               \
 		do {                                                          \
 			try_again = false;                                    \
-			if (m0_atomic64_cas((int64_t *)&thread_run, true,     \
-					    false)) {                         \
+			if (m0_atomic64_cas((int64_t *)&thread_run, 1, 0)) {  \
 				while (m0_atomic64_get(&threads_quiesced) <   \
 				      m0_atomic64_get(&threads_running) - 1)  \
 					;                                     \

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -9781,7 +9781,7 @@ struct btree_ut_thread_info {
  *  for the same btree nodes to work on thus exercising possible race
  *  conditions.
  */
-static int64_t thread_run;
+volatile static int64_t thread_run;
 
 
 static struct m0_atomic64 threads_quiesced;
@@ -9795,7 +9795,7 @@ static struct m0_atomic64 threads_running;
 
 #define UT_THREAD_WAIT()                                                      \
 	do {                                                                  \
-		while (!thread_run)                                            \
+		while (!thread_run)                                           \
 			;                                                     \
 	} while (0)
 
@@ -9813,8 +9813,9 @@ static struct m0_atomic64 threads_running;
 		bool try_again;                                               \
 		do {                                                          \
 			try_again = false;                                    \
-			if (m0_atomic64_cas(&thread_run, true, false)) {      \
-				while (m0_atomic64_get(&threads_quiesced) <    \
+			if (m0_atomic64_cas((int64_t *)&thread_run, true,     \
+					    false)) {                         \
+				while (m0_atomic64_get(&threads_quiesced) <   \
 				      m0_atomic64_get(&threads_running) - 1)  \
 					;                                     \
 			} else {                                              \

--- a/lib/user_space/user_x86_64_atomic.h
+++ b/lib/user_space/user_x86_64_atomic.h
@@ -38,7 +38,7 @@
  */
 
 struct m0_atomic64 {
-	long a_value;
+	volatile long a_value;
 };
 
 static inline void m0_atomic64_set(struct m0_atomic64 *a, int64_t num)


### PR DESCRIPTION
Solution:
Make variable "thread_run" volatile.
Make variable struct m0_atomic64::long a_value volatile.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- "btree-ut" hang when code is compiled without "--enable-debug" flag

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
