### PR TITLE
be: fix doc cosmetics for m0_be_emap_paste()

### DIFF
--- a/be/extmap.c
+++ b/be/extmap.c
@@ -482,19 +482,19 @@ M0_INTERNAL void m0_be_emap_split(struct m0_be_emap_cursor *it,
  * extent. It is assumed that cursor is correctly placed so ext is part of
  * cursor-segment (it->ec_seg).
  *
- * 1. Finds the overlap of current-segment with extent (ext)
+ * 1. Finds the overlap of current-segment with the new extent (ext)
  * 2. Based on the overlap, atmost 3 sub-segment can get created
  *    (term left/right w.r.t area of current segment left after removing clip area)
  *    a. Left   sub-seg : Overlap of start of cur-seg  with ext
- *        		      |  cur-seg  |
+ *                        |  cur-seg  |
  *                             | clip - ext |
  *                        |Left| => [curr-seg:Start - clip:Start]
  *    b. Middle sub-seg : If ext part (to be pasted) fully overlaps with curr-seg (clip)
- *        			      |         cur-seg              |
+ *                        |         cur-seg              |
  *                               | clip - ext |
  *                        | Left |   Middle   |  Right   |
  *    c. Right  sub-seg : Overalp of end of cur-seg with ext
- *        			      |  cur-seg  |
+ *                        |  cur-seg  |
  *                | clip - ext |
  *                             |Right | => [clip:End - curr-seg:End]
  * 3. EMAP operation for these three segments are performed (not all may be needed)

--- a/scripts/install/etc/sysconfig/motr
+++ b/scripts/install/etc/sysconfig/motr
@@ -76,7 +76,7 @@ MOTR_M0D_MAX_RPC_MSG_SIZE=524288
 #MOTR_M0D_IOS_BUFFER_POOL_SIZE=32
 
 # SNS Repair/Rebalance buffer pool configuration.
-# Same as MOTR_M0D_IOS_BUFFER_POOL_SIZE, but for SNS I/O.
+# Same as MOTR_M0D_IOS_BUFFER_POOL_SIZE, but for SNS I/O.
 #MOTR_M0D_SNS_BUFFER_POOL_SIZE=64
 
 # Backend log size (in bytes) for all m0d's. Default is 512 MiB.


### PR DESCRIPTION
# Problem Statement
The documentations for `m0_be_emap_paste()` have some diagrams which have tabs and are broken in different editors.

# Design
Use spaces instead of tabs.

The tiny fix in the comment at `scripts/install/etc/sysconfig/motr` appeared to fix https://jts.seagate.com/browse/EOS-28468 issue with mini-provisioner also.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
