### PR TITLE
EOS-27820: Memory limit functionality crashing with lower watermarks.

### DIFF
--- a/balloc/balloc.h
+++ b/balloc/balloc.h
@@ -216,11 +216,11 @@ enum {
 #define __AAL(x) __attribute__((aligned(x)))
 
 /** Root node alignment for balloc extend and group descriptor trees. */
-#define BALLOC_ROOT_NODE_ALIGN  1024
+#define BALLOC_ROOT_NODE_ALIGN  4096
 
 enum {
 	/** Root node size for balloc extend and group descriptor trees. */
-	BALLOC_ROOT_NODE_SIZE = 1024,
+	BALLOC_ROOT_NODE_SIZE = 4096,
 };
 
 /**


### PR DESCRIPTION
Bug Fixes for memory limit support
Objective: Bug Fixes for memory limit support

Description: With the following values of LRU list watermarks,
low=6MB, target=9MB, high=12MB
We hit the lru_list_purge() functionality but soon we get a crash related to balloc.

Setup: 1 Node K8s
ssc-vm-g4-rhev4-0170.colo.seagate.com

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
