### PR TITLE
EOS-27537 : Services for the pod which is restarted are going in offline state.

### DIFF
--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -2218,6 +2218,7 @@ static int libfab_dns_resolve_retry(struct m0_fab__ep *ep)
 			inet_pton(en->nia_n.nip_fmt_pvt.ia.nia_family ==
 				  M0_NET_IP_AF_INET ? AF_INET : AF_INET6,
 				  ip, &en->nia_n.nip_ip_n.sn[0]);
+			libfab_ep_pton(en, &ep->fep_name_n);
 			M0_LOG(M0_DEBUG, "ip=%s port=%d fqdn=%s", (char *)ip,
 			       (int)en->nia_n.nip_port, (char *)fqdn);
 		} else


### PR DESCRIPTION
Use updated ip of restarted service in libfab_conn_init() instead of stale value.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- After pod restart, when the connection is being re-established, the dst is getting updated/calculated wrongly in libfab_conn_init().
Generally after pod restart IP's are changed and libfab_conn_init is still referring to older IP even though the dns resolution correctly returned the new ip.

# Fix
-  Use updated ip of restarted service in libfab_conn_init() instead of stale value.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
