### PR TITLE
[WIP]EOS-26852: Support new FID communication in entry point reply

### DIFF
--- a/ha/entrypoint_fops.h
+++ b/ha/entrypoint_fops.h
@@ -151,6 +151,7 @@ struct m0_ha_entrypoint_req {
 
 struct m0_ha_entrypoint_rep {
 	uint32_t                        hae_quorum;
+	struct m0_fid                   hae_process_fid;
 	struct m0_fid_arr               hae_confd_fids;
 	const char                    **hae_confd_eps;
 	struct m0_fid                   hae_active_rm_fid;


### PR DESCRIPTION
* It should be possible to communicate new process FID in entrypoint
  reply hence added hae_process_fid to struct m0_ha_entrypoint_rep
  structure so hare can send new FID in reply.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
