### PR TITLE
EOS-27572: Motr CI: failure seen in dix-client-ut while running local failures test

### DIFF
--- a/dix/ut/client_ut.c
+++ b/dix/ut/client_ut.c
@@ -2531,15 +2531,16 @@ static void local_failures(void)
 	rc = dix_common_idx_op(&index, 1, REQ_CREATE);
 	M0_UT_ASSERT(rc == 0);
 	/*
-	 * Only two CAS requests can be sent successfully, but N + K = 3, so
-	 * no record will be successfully put to all component catalogues.
+ 	 * Consider DIX request to be successful if there is at least
+ 	 * one successful CAS request. Here two cas requests can be 
+ 	 * sent successfully. 
 	 */
 	m0_fi_enable_off_n_on_m("cas_req_replied_cb", "send-failure", 2, 3);
 	rc = dix_ut_put(&index, &keys, &vals, 0, &rep);
 	m0_fi_disable("cas_req_replied_cb", "send-failure");
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(rep.dra_nr == COUNT);
-	M0_UT_ASSERT(m0_forall(i, COUNT, rep.dra_rep[i].dre_rc != 0));
+	M0_UT_ASSERT(m0_forall(i, COUNT, rep.dra_rep[i].dre_rc == 0));
 	dix_rep_free(&rep);
 	dix_kv_destroy(&keys, &vals);
 	dix_index_fini(&index);


### PR DESCRIPTION
# Problem Statement
Motr CI: failure seen in dix-client-ut while running local_failures test

# Design
Analysis:
As per new change (PR# 1363), Consider DIX request to be successful if there is at least
one successful CAS request. Before DIX request to be failed if there is at least
one failed CAS request.

Fix:
Two cas requests can be sent successfully, So local-failures UT will get reply code
as 0.

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
