### PR TITLE
EOS-27717: Don't post FDMI records if no FDMI filters defined.

### DIFF
--- a/fdmi/fol_fdmi_src.c
+++ b/fdmi/fol_fdmi_src.c
@@ -668,6 +668,11 @@ M0_INTERNAL void m0_fol_fdmi_post_record(struct m0_fom *fom)
 		M0_LOG(M0_ERROR, "src dock fom is not running");
 		return;
 	}
+	if (!src_dock->fsdc_filters_defined) {
+		/* No filters defined. Let's not post the records. */
+		return;
+	}
+
 
 	/**
 	 * There is no "unpost record" method, so we have to prepare

--- a/fdmi/source_dock_internal.h
+++ b/fdmi/source_dock_internal.h
@@ -101,6 +101,9 @@ struct m0_fdmi_src_dock {
 	/** FDMI source dock started flag */
 	bool                  fsdc_started;
 
+	/** FDMI source dock has any filter defined? */
+	bool                  fsdc_filters_defined;
+
 	/**
 	   List of registered FDMI source instances.
 	   Links using m0_fdmi_src_ctx.fsc_linkage

--- a/fdmi/ut/fol_ut.c
+++ b/fdmi/ut/fol_ut.c
@@ -187,6 +187,7 @@ static void fdmi_fol_test_ops(enum ffs_ut_test_op test_op)
 	dock = m0_fdmi_src_dock_get();
 	M0_UT_ASSERT(dock != NULL);
 	dock->fsdc_started = true;
+	dock->fsdc_filters_defined = true;
 	src_ctx = m0_fdmi__src_ctx_get(M0_FDMI_REC_TYPE_FOL);
 	M0_UT_ASSERT(src_ctx != NULL);
 	src_reg = &src_ctx->fsc_src;


### PR DESCRIPTION
Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
FDMI records are posted regardless any FDMI filters are defined.

# Design
When starting FDMI service, check if any FDMI filter is defined.
If no FDMI filters are defined in configuration, we will skip posting FDMI records.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
