### PR TITLE
go: update module name to cortx-motr/bindings/go

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -14,6 +14,12 @@ provided there is enough buffer size to accomodate several of such blocks in one
 Read()/Write() request. (For example, see the source code of `mcp` utility and its `-bsz`
 option.)
 
+To use `go/mio` in your app 1) install motr-devel pkg and 2):
+
+```Go
+import github.com/Seagate/cortx-motr/bindings/go/mio
+```
+
 ## mcp
 
 `mcp` (Motr cp) utility is a client application example written in pure Go which uses

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,3 +1,3 @@
-module motr
+module cortx-motr/bindings/go
 
 go 1.15

--- a/bindings/go/mcp/mcp.go
+++ b/bindings/go/mcp/mcp.go
@@ -28,7 +28,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "motr/mio"
+    "cortx-motr/bindings/go/mio"
 )
 
 func usage() {

--- a/bindings/go/mkv/mkv.go
+++ b/bindings/go/mkv/mkv.go
@@ -27,7 +27,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "motr/mio"
+    "cortx-motr/bindings/go/mio"
 )
 
 func usage() {


### PR DESCRIPTION
# Problem Statement
Currently, it's not possible to use motr go bindings outside of motr sources.

# Design
Update module name to `cortx-motr/bindings/go`. This allows to use:

    import github.com/Seagate/cortx-motr/bindings/go/mio

in external go apps.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
