### PR TITLE
configure: fix --enable-debug for kernel module

### DIFF
--- a/addb2/sys.c
+++ b/addb2/sys.c
@@ -330,7 +330,7 @@ int m0_addb2_sys_net_start_with(struct m0_addb2_sys *sys, struct m0_tl *head)
 {
 	struct m0_reqh_service_ctx *service;
 	struct m0_rpc_conn         *conn;
-	int                         result;
+	int                         result = 0;
 
 	if (sys->sy_net == NULL) {
 		result = m0_addb2_sys_net_start(sys);
@@ -350,6 +350,7 @@ int m0_addb2_sys_net_start_with(struct m0_addb2_sys *sys, struct m0_tl *head)
 			}
 		}
 	} m0_tl_endfor;
+
 	return result;
 }
 

--- a/cas/client.c
+++ b/cas/client.c
@@ -807,7 +807,7 @@ static int nreq_asmbl_prep(struct m0_cas_req *req, struct m0_cas_op *op)
 	struct m0_cas_op  *orig = m0_fop_data(req->ccr_fop);
 	struct m0_cas_rec *rec;
 	uint64_t           i;
-	int                rc;
+	int                rc = 0;
 
 	M0_PRE(op->cg_rec.cr_nr == orig->cg_rec.cr_nr);
 	op->cg_id = orig->cg_id;
@@ -831,6 +831,7 @@ err:
 		op->cg_rec.cr_nr = i + 1;
 		creq_recv_fini(&op->cg_rec, fid_is_meta(&op->cg_id.ci_fid));
 	}
+
 	return M0_RC(rc);
 }
 

--- a/conf/cache.c
+++ b/conf/cache.c
@@ -210,7 +210,7 @@ static int conf_cache_encode(const struct m0_conf_cache *cache,
 			     struct m0_confx *dest, bool debug)
 {
 	struct m0_conf_obj *obj;
-	int                 rc;
+	int                 rc = 0;
 	size_t              nr;
 	char               *data;
 
@@ -249,6 +249,7 @@ static int conf_cache_encode(const struct m0_conf_cache *cache,
 		m0_free(data);
 		dest->cx__objs = NULL;
 	}
+
 	return M0_RC(rc);
 }
 

--- a/conf/helpers.c
+++ b/conf/helpers.c
@@ -610,7 +610,7 @@ M0_INTERNAL int m0_conf_confc_ha_update_async(struct m0_confc *confc,
 	struct m0_conf_cache *cache = &confc->cc_cache;
 	struct m0_conf_obj   *obj;
 	int32_t               total;
-	int                   rc;
+	int                   rc = 0;
 	int                   i = 0;
 
 	total = m0_tl_reduce(m0_conf_cache, obj, &cache->ca_registry, 0,

--- a/configure.ac
+++ b/configure.ac
@@ -1057,10 +1057,9 @@ AS_IF([test x$enable_debug = xyes],
        M0_CPPFLAGS="-DDEBUG $M0_CPPFLAGS"
        M0_KCPPFLAGS="-DDEBUG $M0_KCPPFLAGS"
        M0_CFLAGS="-g -O0 $M0_CFLAGS"
-       # For kernel modules compilation, keep the optimization level to -O2 to
-       # fix issue on CentOS 8 and Rocky Linux 8.
-       # Refer https://gcc.gnu.org/bugzilla//show_bug.cgi?id=84187#c3
-       M0_KCFLAGS="-g -O2 $M0_KCFLAGS"
+       # Kernel code cannot be compiled without any optimisation at all,
+       # but -Og can be used, see https://lwn.net/Articles/756616/.
+       M0_KCFLAGS="-g -Og $M0_KCFLAGS"
        AC_DEFINE([ENABLE_DEBUG])
       ],[
        M0_CFLAGS="-g -O2 $M0_CFLAGS"

--- a/ha/link.c
+++ b/ha/link.c
@@ -1264,20 +1264,20 @@ static int ha_link_outgoing_fop_replied(struct m0_ha_link *hl)
 
 	M0_PRE(m0_mutex_is_locked(&hl->hln_lock));
 
-	if (hl->hln_rpc_rc == 0) {
+	rc = hl->hln_rpc_rc;
+	if (rc == 0) {
 		req_item = m0_fop_to_rpc_item(&hl->hln_outgoing_fop);
 		rep_fop  = m0_fop_data(m0_rpc_item_to_fop(req_item->ri_reply));
 		rc = rep_fop->lmr_rc;
 		M0_LOG(M0_DEBUG, "lmr_rc=%"PRIi32, rep_fop->lmr_rc);
-	} else {
-		rc = hl->hln_rpc_rc;
+		if (rc == 0)
+			ha_link_tags_update(hl, rep_fop->lmr_out_next,
+					    rep_fop->lmr_in_delivered);
 	}
-	if (rc == 0) {
-		ha_link_tags_update(hl, rep_fop->lmr_out_next,
-		                    rep_fop->lmr_in_delivered);
-	} else {
+
+	if (rc != 0)
 		m0_ha_lq_try_unnext(&hl->hln_q_out);
-	}
+
 	if (ha_link_backoff_check(hl, rc, &nr, &old_rc, &old_nr)) {
 		m0_ha_lq_tags_get(&hl->hln_q_out, &tags);
 		M0_LOG(M0_WARN, "rc=%d nr=%"PRIu64" hl=%p ep=%s "
@@ -1289,6 +1289,7 @@ static int ha_link_outgoing_fop_replied(struct m0_ha_link *hl)
 			       hl->hln_conn_cfg.hlcc_rpc_endpoint);
 		}
 	}
+
 	return M0_RC(rc);
 }
 

--- a/layout/linear_enum.c
+++ b/layout/linear_enum.c
@@ -145,17 +145,20 @@ M0_INTERNAL int m0_linear_enum_build(struct m0_layout_domain *dom,
 
 	M0_PRE(out != NULL);
 	M0_ENTRY("domain %p", dom);
+
 	rc = linear_allocate(dom, &e);
 	if (rc == 0) {
 		lin_enum = bob_of(e, struct m0_layout_linear_enum,
 			          lle_base, &linear_bob);
 		rc = linear_populate(lin_enum, attr);
-		if (rc == 0)
+		if (rc == 0) {
+			linear_invariant(lin_enum);
 			*out = lin_enum;
-		else
+		} else {
 			linear_delete(e);
+		}
 	}
-	M0_POST(ergo(rc == 0, linear_invariant(lin_enum)));
+
 	M0_LEAVE("domain %p, rc %d", dom, rc);
 	return M0_RC(rc);
 }

--- a/layout/linear_enum.c
+++ b/layout/linear_enum.c
@@ -152,7 +152,7 @@ M0_INTERNAL int m0_linear_enum_build(struct m0_layout_domain *dom,
 			          lle_base, &linear_bob);
 		rc = linear_populate(lin_enum, attr);
 		if (rc == 0) {
-			linear_invariant(lin_enum);
+			M0_POST(linear_invariant(lin_enum));
 			*out = lin_enum;
 		} else {
 			linear_delete(e);

--- a/lib/locality.c
+++ b/lib/locality.c
@@ -336,7 +336,7 @@ static int loc_nr(void)
 
 static int chore_add_all(struct m0_locality_chore *chore)
 {
-	int result;
+	int result = 0;
 
 	M0_PRE(chore->lc_active == 0);
 
@@ -351,6 +351,7 @@ static int chore_add_all(struct m0_locality_chore *chore)
 			break;
 		}
 	} LOC_ENDFOR;
+
 	M0_POST((result == 0) == (chore->lc_active == loc_nr()));
 	M0_POST(M0_IN(chore->lc_active, (0, loc_nr())));
 	return result;

--- a/motr/st/layout.c
+++ b/motr/st/layout.c
@@ -438,7 +438,7 @@ static int layout_composite_add_layers(struct m0_client_layout *layout,
 {
 	int                  i;
 	int                  j;
-	int                  rc;
+	int                  rc = 0;
 	struct m0_uint128    id;
 	struct m0_obj        obj;
 

--- a/rm/rm_fops.c
+++ b/rm/rm_fops.c
@@ -401,7 +401,7 @@ static void rm_borrow_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 {
 	struct rm_out               *outreq = M0_AMB(outreq, ast, ou_ast);
 	const struct m0_rpc_item    *item = &outreq->ou_fop.f_item;
-	struct m0_rm_fop_borrow_rep *borrow_reply;
+	struct m0_rm_fop_borrow_rep *borrow_reply = NULL;
 	struct m0_rm_owner          *owner;
 	struct m0_rm_loan           *loan = NULL;
 	struct m0_rm_credit         *credit;


### PR DESCRIPTION
# Problem Statement
In commit 46047958a `-O0` gcc option was changed to `-O2` for debug mode build of the kernel module to fix some compilation issues, but it will generate the code which would be hard to debug, defeating the purpose of the debug mode build.

# Design
Use special `-Og` option, which allows building kernel code and yet generates debug-friendly code.

Read more about `-Og` at https://lwn.net/Articles/756616/.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
