### PR TITLE
E0S-28545 : Replace cursor calls with get and iter routines

### DIFF
--- a/be/extmap.c
+++ b/be/extmap.c
@@ -1249,7 +1249,7 @@ static void be_emap_close(struct m0_be_emap_cursor *it)
 	m0_btree_cursor_fini(&it->ec_cursor);
 }
 
-static int emap_it_cb(struct m0_btree_cb *cb, struct m0_btree_rec *rec)
+static int emap_it_get_cb(struct m0_btree_cb *cb, struct m0_btree_rec *rec)
 {
 	int                       rc;
 	struct m0_be_emap_cursor *it = cb->c_datum;
@@ -1301,7 +1301,7 @@ static int emap_it_get(struct m0_be_emap_cursor *it)
 		.k_data =  M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 	};
 	struct m0_btree_cb  cb    = {
-		.c_act   = emap_it_cb,
+		.c_act   = emap_it_get_cb,
 		.c_datum = it,
 	};
 
@@ -1340,7 +1340,7 @@ static int be_emap_next(struct m0_be_emap_cursor *it)
 		.k_data =  M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 	};
 	struct m0_btree_cb  cb    = {
-		.c_act   = emap_it_cb,
+		.c_act   = emap_it_get_cb,
 		.c_datum = it,
 	};
 
@@ -1363,7 +1363,7 @@ be_emap_prev(struct m0_be_emap_cursor *it)
 		.k_data =  M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 	};
 	struct m0_btree_cb  cb    = {
-		.c_act   = emap_it_cb,
+		.c_act   = emap_it_get_cb,
 		.c_datum = it,
 	};
 

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7461,7 +7461,8 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 			}
 		}
 
-		rc = bop->bo_cb.c_act(&bop->bo_cb, &s.s_rec);
+		if (bop->bo_cb.c_act != NULL)
+			rc = bop->bo_cb.c_act(&bop->bo_cb, &s.s_rec);
 
 		lock_op_unlock(tree);
 		if (rc != 0)
@@ -8681,7 +8682,10 @@ M0_INTERNAL void m0_btree_get(struct m0_btree *arbor,
 	bop->bo_arbor     = arbor;
 	bop->bo_rec.r_key = *key;
 	bop->bo_flags     = flags;
-	bop->bo_cb        = *cb;
+	if (cb == NULL)
+		M0_SET0(&bop->bo_cb);
+	else
+		bop->bo_cb = *cb;
 	bop->bo_tx        = NULL;
 	bop->bo_seg       = NULL;
 	bop->bo_i         = NULL;

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1433,8 +1433,8 @@ M0_INTERNAL void m0_cob_iterator_fini(struct m0_cob_iterator *it)
 	m0_free(it->ci_key);
 }
 
-static int cob_iterator_callback(struct m0_btree_cb *cb,
-				 struct m0_btree_rec *rec)
+static int cob_iterator_get_callback(struct m0_btree_cb *cb,
+				     struct m0_btree_rec *rec)
 {
 	struct m0_cob_iterator *it = cb->c_datum;
 	struct m0_cob_nskey    *nskey;
@@ -1459,7 +1459,7 @@ M0_INTERNAL int m0_cob_iterator_get(struct m0_cob_iterator *it)
 		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 	};
 	struct m0_btree_cb   iterator_cb = {
-		.c_act   = cob_iterator_callback,
+		.c_act   = cob_iterator_get_callback,
 		.c_datum = it,
 	};
 
@@ -1485,7 +1485,7 @@ M0_INTERNAL int m0_cob_iterator_next(struct m0_cob_iterator *it)
 		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 	};
 	struct m0_btree_cb   iterator_cb = {
-		.c_act   = cob_iterator_callback,
+		.c_act   = cob_iterator_get_callback,
 		.c_datum = it,
 	};
 
@@ -1526,8 +1526,8 @@ M0_INTERNAL int m0_cob_ea_iterator_init(struct m0_cob *cob,
 	return M0_RC(rc);
 }
 
-static int cob_ea_iterator_callback(struct m0_btree_cb *cb,
-				    struct m0_btree_rec *rec)
+static int cob_ea_iterator_get_callback(struct m0_btree_cb *cb,
+				        struct m0_btree_rec *rec)
 {
 	struct m0_cob_ea_iterator *it = cb->c_datum;
 	struct m0_cob_eakey       *eakey;
@@ -1552,7 +1552,7 @@ M0_INTERNAL int m0_cob_ea_iterator_get(struct m0_cob_ea_iterator *it)
 		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 	};
 	struct m0_btree_cb   ea_iterator_cb = {
-		.c_act   = cob_ea_iterator_callback,
+		.c_act   = cob_ea_iterator_get_callback,
 		.c_datum = it,
 	};
 
@@ -1574,7 +1574,7 @@ M0_INTERNAL int m0_cob_ea_iterator_next(struct m0_cob_ea_iterator *it)
 		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
 	};
 	struct m0_btree_cb   ea_iterator_cb = {
-		.c_act   = cob_ea_iterator_callback,
+		.c_act   = cob_ea_iterator_get_callback,
 		.c_datum = it,
 	};
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1445,8 +1445,21 @@ static int cob_iterator_get_callback(struct m0_btree_cb *cb,
 	 * Check if we are stil inside the object bounds. Assert and key copy
 	 * can be done only in this case.
 	 */
-	if (!m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob)))
-		return -ENOENT;
+	if (!m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob))) {
+		#ifdef DEBUG
+			M0_LOG(M0_DEBUG, "fid values are different.\
+			       required fid="FID_F" found fid="FID_F,
+			       FID_P(&nskey->cnk_pfid),
+			       FID_P(m0_cob_fid(it->ci_cob)));
+			M0_ASSERT(0);
+		#else
+			M0_LOG(M0_DEBUG, "fid values are different.\
+			       required fid="FID_F" found fid="FID_F,
+			       FID_P(&nskey->cnk_pfid),
+			       FID_P(m0_cob_fid(it->ci_cob)));
+			return -ENOENT;
+		#endif
+	}
 
 	M0_ASSERT(m0_cob_nskey_size(nskey) <= m0_cob_max_nskey_size());
 	memcpy(it->ci_key, nskey, m0_cob_nskey_size(nskey));
@@ -1540,11 +1553,25 @@ static int cob_ea_iterator_get_callback(struct m0_btree_cb *cb,
 
 	eakey = (struct m0_cob_eakey *)rec->r_key.k_data.ov_buf[0];
 
-	if (!m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob)))
-		return -ENOENT;
+	if (!m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob))) {
+		#ifdef DEBUG
+			M0_LOG(M0_DEBUG, "fid values are different.\
+			       required fid="FID_F" found fid="FID_F,
+			       FID_P(&eakey->cek_fid),
+			       FID_P(m0_cob_fid(it->ci_cob)));
+			M0_ASSERT(0);
+		#else
+			M0_LOG(M0_DEBUG, "fid values are different.\
+			       required fid="FID_F" found fid="FID_F,
+			       FID_P(&eakey->cek_fid),
+			       FID_P(m0_cob_fid(it->ci_cob)));
+			return -ENOENT;
+		#endif
+	}
 
 	M0_ASSERT(m0_cob_eakey_size(eakey) <= m0_cob_max_eakey_size());
 	memcpy(it->ci_key, eakey, m0_cob_eakey_size(eakey));
+
 	return 0;
 }
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -409,7 +409,7 @@ int m0_cob_domain_init(struct m0_cob_domain *dom, struct m0_be_seg *seg)
 	M0_ASSERT(dom->cd_object_index);
 	keycmp.rko_keycmp = oi_cmp;
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
-				      m0_btree_open(dom->cd_oi_node,
+				      m0_btree_open(&dom->cd_oi_node,
 						    sizeof dom->cd_oi_node,
 						    dom->cd_object_index, seg,
 						    &b_op, &keycmp));
@@ -962,8 +962,8 @@ static int cob_table_insert(struct m0_btree *tree, struct m0_be_tx *tx,
 						     &kv_op, tx));
 }
 
-static int cob_table_lookup_callback(struct m0_btree_cb  *cb,
-				 struct m0_btree_rec *rec)
+static int cob_table_lookup_callback(struct m0_btree_cb *cb,
+				     struct m0_btree_rec *rec)
 {
 	struct m0_btree_rec     *datum = cb->c_datum;
 
@@ -1171,6 +1171,35 @@ static int cob_ns_lookup(struct m0_cob *cob)
 	return rc;
 }
 
+static int cob_oi_lookup_callback(struct m0_btree_cb  *cb,
+				  struct m0_btree_rec *rec)
+{
+	int                  rc;
+	struct m0_cob       *cob    = cb->c_datum;
+	struct m0_cob_oikey  oldkey = cob->co_oikey;
+	struct m0_cob_oikey *oikey;
+	struct m0_cob_nskey *nskey;
+
+	oikey = (struct m0_cob_oikey *)rec->r_key.k_data.ov_buf[0];
+	nskey = (struct m0_cob_nskey *)rec->r_val.ov_buf[0];
+
+	/*
+	 * Found position should have same fid.
+	 */
+	if (!m0_fid_eq(&oldkey.cok_fid, &oikey->cok_fid)) {
+		M0_LOG(M0_DEBUG, "old fid="FID_F" fid="FID_F,
+		       FID_P(&oldkey.cok_fid), FID_P(&oikey->cok_fid));
+		rc = -ENOENT;
+		return rc;
+	}
+
+	rc = m0_cob_nskey_make(&cob->co_nskey, &nskey->cnk_pfid,
+			       m0_bitstring_buf_get(&nskey->cnk_name),
+			       m0_bitstring_len_get(&nskey->cnk_name));
+	cob->co_flags |= (M0_CA_NSKEY | M0_CA_NSKEY_FREE);
+	return rc;
+}
+
 /**
    Search for a record in the object index table.
    Most likely we want stat data for a given fid, so let's do that as well.
@@ -1179,18 +1208,18 @@ static int cob_ns_lookup(struct m0_cob *cob)
  */
 static int cob_oi_lookup(struct m0_cob *cob)
 {
-	struct m0_btree_cursor  cursor;
-	m0_bcount_t             ksize  = sizeof cob->co_oikey;
-	void                   *k_ptr  = &cob->co_oikey;
-	struct m0_btree_key     start = {
-				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
-				};
-	struct m0_buf           key;
-	struct m0_buf           val;
-	struct m0_cob_oikey     oldkey;
-	struct m0_cob_oikey    *oikey;
-	struct m0_cob_nskey    *nskey;
-	int                     rc;
+	int                  rc;
+	struct m0_btree     *tree         = cob->co_dom->cd_object_index;
+	void                *k_ptr        = &cob->co_oikey;
+	m0_bcount_t          ksize        = sizeof cob->co_oikey;
+	struct m0_btree_op   kv_op        = {};
+	struct m0_btree_key  key          = {
+		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+	};
+	struct m0_btree_cb   oi_lookup_cb = {
+		.c_act   = cob_oi_lookup_callback,
+		.c_datum = cob,
+	};
 
 	if (cob->co_flags & M0_CA_NSKEY)
 		return 0;
@@ -1200,50 +1229,10 @@ static int cob_oi_lookup(struct m0_cob *cob)
 		cob->co_flags &= ~M0_CA_NSKEY_FREE;
 	}
 
-	oldkey = cob->co_oikey;
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+				      m0_btree_get(tree, &key, &oi_lookup_cb,
+						   BOF_SLANT, &kv_op));
 
-	/*
-	 * Find the name from the object index table. Note the key buffer
-	 * is out of scope outside of this function, but the record is good
-	 * until m0_db_pair_fini.
-	 */
-
-	/*
-	 * We use cursor here because in some situations we need
-	 * to find most suitable position instead of exact location.
-	 */
-	m0_btree_cursor_init(&cursor, cob->co_dom->cd_object_index);
-	rc = m0_btree_cursor_get(&cursor, &start, true);
-	if (rc != 0) {
-		M0_LOG(M0_DEBUG, "btree_cursor_get_sync() failed with %d", rc);
-		goto out;
-	}
-
-	m0_btree_cursor_kv_get(&cursor, &key, &val);
-	nskey = (struct m0_cob_nskey *)val.b_addr;
-	oikey = (struct m0_cob_oikey *)key.b_addr;
-
-	M0_LOG(M0_DEBUG, "found: fid="FID_F" lno=%d pfid="FID_F" name='%s'",
-	       FID_P(&oikey->cok_fid), (int)oikey->cok_linkno,
-	       FID_P(&nskey->cnk_pfid), (char*)nskey->cnk_name.b_data);
-
-	/*
-	 * Found position should have same fid.
-	 */
-	if (!m0_fid_eq(&oldkey.cok_fid, &oikey->cok_fid)) {
-		M0_LOG(M0_DEBUG, "old fid="FID_F" fid="FID_F,
-				FID_P(&oldkey.cok_fid),
-				FID_P(&oikey->cok_fid));
-		rc = -ENOENT;
-		goto out;
-	}
-
-	rc = m0_cob_nskey_make(&cob->co_nskey, &nskey->cnk_pfid,
-			       m0_bitstring_buf_get(&nskey->cnk_name),
-			       m0_bitstring_len_get(&nskey->cnk_name));
-	cob->co_flags |= (M0_CA_NSKEY | M0_CA_NSKEY_FREE);
-out:
-	m0_btree_cursor_fini(&cursor);
 	return M0_RC(rc);
 }
 
@@ -1444,62 +1433,69 @@ M0_INTERNAL void m0_cob_iterator_fini(struct m0_cob_iterator *it)
 	m0_free(it->ci_key);
 }
 
+static int cob_iterator_callback(struct m0_btree_cb *cb,
+				 struct m0_btree_rec *rec)
+{
+	struct m0_cob_iterator *it = cb->c_datum;
+	struct m0_cob_nskey    *nskey;
+
+	nskey = (struct m0_cob_nskey *)rec->r_key.k_data.ov_buf[0];
+
+	M0_ASSERT(m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob)));
+	M0_ASSERT(m0_cob_nskey_size(nskey) <= m0_cob_max_nskey_size());
+
+	memcpy(it->ci_key, nskey, m0_cob_nskey_size(nskey));
+	return 0;
+}
+
 M0_INTERNAL int m0_cob_iterator_get(struct m0_cob_iterator *it)
 {
-        struct m0_cob_nskey *nskey;
-	m0_bcount_t          ksize  = m0_cob_nskey_size(it->ci_key);
-	void                *k_ptr  = it->ci_key;
-	struct m0_btree_key  find_key = {
-				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
-				};
-	struct m0_buf        key;
 	int                  rc;
+	struct m0_btree_op   kv_op       = {};
+	struct m0_btree     *tree        = it->ci_cursor.bc_arbor;
+	void                *k_ptr       = it->ci_key;
+	m0_bcount_t          ksize       = m0_cob_nskey_size(it->ci_key);
+	struct m0_btree_key  find_key    = {
+		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+	};
+	struct m0_btree_cb   iterator_cb = {
+		.c_act   = cob_iterator_callback,
+		.c_datum = it,
+	};
 
 	M0_COB_NSKEY_LOG(ENTRY, "[%lx:%lx]/%.*s", it->ci_key);
-	rc = m0_btree_cursor_get(&it->ci_cursor, &find_key, true);
-	if (rc == 0) {
-		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
-		nskey = (struct m0_cob_nskey *)key.b_addr;
 
-                /**
-                   Check if we are stil inside the object bounds. Assert and
-                   key copy can be done only in this case.
-                 */
-		if (!m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob)))
-			rc = -ENOENT;
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+				      m0_btree_get(tree, &find_key,
+						   &iterator_cb, BOF_SLANT,
+						   &kv_op));
 
-                if (rc == 0) {
-                        M0_ASSERT(m0_cob_nskey_size(nskey) <= m0_cob_max_nskey_size());
-		        memcpy(it->ci_key, nskey, m0_cob_nskey_size(nskey));
-                }
-	}
 	M0_COB_NSKEY_LOG(LEAVE, "[%lx:%lx]/%.*s rc: %d", it->ci_key, rc);
 	return M0_RC(rc);
 }
 
 M0_INTERNAL int m0_cob_iterator_next(struct m0_cob_iterator *it)
 {
-        struct m0_cob_nskey *nskey;
-	struct m0_buf key;
-	int rc;
+	int                  rc;
+	struct m0_btree_op   kv_op       = {};
+	struct m0_btree     *tree        = it->ci_cursor.bc_arbor;
+	void                *k_ptr       = it->ci_key;
+	m0_bcount_t          ksize       = m0_cob_nskey_size(it->ci_key);
+	struct m0_btree_key  find_key    = {
+		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+	};
+	struct m0_btree_cb   iterator_cb = {
+		.c_act   = cob_iterator_callback,
+		.c_datum = it,
+	};
 
 	M0_COB_NSKEY_LOG(ENTRY, "[%lx:%lx]/%.*s", it->ci_key);
-	rc = m0_btree_cursor_next(&it->ci_cursor);
-	if (rc == 0) {
-		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
-		nskey = (struct m0_cob_nskey *)key.b_addr;
 
-                /**
-                   Check if we are stil inside the object bounds. Assert and
-                   key copy can be done only in this case.
-                 */
-		if (!m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob)))
-			rc = -ENOENT;
-                if (rc == 0) {
-                        M0_ASSERT(m0_cob_nskey_size(nskey) <= m0_cob_max_nskey_size());
-		        memcpy(it->ci_key, nskey, m0_cob_nskey_size(nskey));
-                }
-	}
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+				      m0_btree_iter(tree, &find_key,
+						    &iterator_cb, BOF_NEXT,
+						    &kv_op));
+
 	M0_COB_NSKEY_LOG(LEAVE, "[%lx:%lx]/%.*s rc: %d", it->ci_key, rc);
 	return M0_RC(rc);
 }
@@ -1530,62 +1526,62 @@ M0_INTERNAL int m0_cob_ea_iterator_init(struct m0_cob *cob,
 	return M0_RC(rc);
 }
 
+static int cob_ea_iterator_callback(struct m0_btree_cb *cb,
+				    struct m0_btree_rec *rec)
+{
+	struct m0_cob_ea_iterator *it = cb->c_datum;
+	struct m0_cob_eakey       *eakey;
+
+	eakey = (struct m0_cob_eakey *)rec->r_key.k_data.ov_buf[0];
+
+	M0_ASSERT(m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob)));
+	M0_ASSERT(m0_cob_eakey_size(eakey) <= m0_cob_max_eakey_size());
+
+	memcpy(it->ci_key, eakey, m0_cob_eakey_size(eakey));
+	return 0;
+}
+
 M0_INTERNAL int m0_cob_ea_iterator_get(struct m0_cob_ea_iterator *it)
 {
 	int                  rc;
-	m0_bcount_t          ksize  = m0_cob_eakey_size(it->ci_key);
-	void                *k_ptr  = it->ci_key;
-	struct m0_btree_key  find_key = {
-				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
-				};
-	struct m0_buf        key;
-        struct m0_cob_eakey *eakey;
+	struct m0_btree_op   kv_op          = {};
+	struct m0_btree     *tree           = it->ci_cursor.bc_arbor;
+	m0_bcount_t          ksize          = m0_cob_eakey_size(it->ci_key);
+	void                *k_ptr          = it->ci_key;
+	struct m0_btree_key  find_key       = {
+		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+	};
+	struct m0_btree_cb   ea_iterator_cb = {
+		.c_act   = cob_ea_iterator_callback,
+		.c_datum = it,
+	};
 
-	rc = m0_btree_cursor_get(&it->ci_cursor, &find_key, true);
-	if (rc == 0) {
-		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
-                eakey = (struct m0_cob_eakey *)key.b_addr;
-
-                /**
-                   Check if we are stil inside the object bounds. Assert and
-                   key copy can be done only in this case.
-                 */
-                if (!m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob)))
-                         rc = -ENOENT;
-
-                if (rc == 0) {
-                        M0_ASSERT(m0_cob_eakey_size(eakey) <=
-				  m0_cob_max_eakey_size());
-		        memcpy(it->ci_key, eakey, m0_cob_eakey_size(eakey));
-                }
-	}
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+				      m0_btree_get(tree, &find_key,
+						   &ea_iterator_cb, BOF_SLANT,
+						   &kv_op));
 	return M0_RC(rc);
 }
 
 M0_INTERNAL int m0_cob_ea_iterator_next(struct m0_cob_ea_iterator *it)
 {
-	int rc;
-	struct m0_buf key;
-        struct m0_cob_eakey *eakey;
+	int                  rc;
+	struct m0_btree_op   kv_op          = {};
+	struct m0_btree     *tree           = it->ci_cursor.bc_arbor;
+	m0_bcount_t          ksize          = m0_cob_eakey_size(it->ci_key);
+	void                *k_ptr          = it->ci_key;
+	struct m0_btree_key  find_key       = {
+		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+	};
+	struct m0_btree_cb   ea_iterator_cb = {
+		.c_act   = cob_ea_iterator_callback,
+		.c_datum = it,
+	};
 
-	rc = m0_btree_cursor_next(&it->ci_cursor);
-	if (rc == 0) {
-		m0_btree_cursor_kv_get(&it->ci_cursor, &key, NULL);
-                eakey = (struct m0_cob_eakey *)key.b_addr;
-
-                /**
-                   Check if we are stil inside the object bounds. Assert and
-                   key copy can be done only in this case.
-                 */
-                if (!m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob)))
-                         rc = -ENOENT;
-
-                if (rc == 0) {
-                        M0_ASSERT(m0_cob_eakey_size(eakey) <= m0_cob_max_eakey_size());
-		        memcpy(it->ci_key, eakey, m0_cob_eakey_size(eakey));
-                }
-	}
-
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+				      m0_btree_iter(tree, &find_key,
+						    &ea_iterator_cb, BOF_NEXT,
+						    &kv_op));
 	return M0_RC(rc);
 }
 
@@ -1603,21 +1599,31 @@ static bool m0_cob_is_valid(struct m0_cob *cob)
 	return m0_fid_is_set(m0_cob_fid(cob));
 }
 
+static int cob_alloc_omgid_callback(struct m0_btree_cb *cb,
+				    struct m0_btree_rec *rec)
+{
+	struct m0_cob_omgkey *omgkey = cb->c_datum;
+
+	*omgkey = *(struct m0_cob_omgkey*)rec->r_key.k_data.ov_buf[0];
+
+	return 0;
+}
+
 M0_INTERNAL int m0_cob_alloc_omgid(struct m0_cob_domain *dom, uint64_t *omgid)
 {
-	struct m0_btree_cursor cursor;
-	struct m0_cob_omgkey   omgkey = {};
-	m0_bcount_t            ksize  = sizeof omgkey;
-	void                  *k_ptr  = &omgkey;
-	struct m0_btree_key    find_key = {
-				  .k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
-				};
-	struct m0_buf          kbuf;
-	int                    rc;
+	int                   rc;
+	struct m0_btree      *tree        = dom->cd_fileattr_omg;
+	struct m0_cob_omgkey  omgkey      = {};
+	struct m0_cob_omgkey  prev_omgkey = {};
+	m0_bcount_t           ksize       = sizeof omgkey;
+	void                 *k_ptr       = &omgkey;
+	struct m0_btree_op    kv_op       = {};
+	struct m0_btree_cb    omgid_cb    = {};
+	struct m0_btree_key   find_key    = {
+		.k_data = M0_BUFVEC_INIT_BUF(&k_ptr, &ksize),
+	};
 
 	M0_ENTRY();
-
-	m0_btree_cursor_init(&cursor, dom->cd_fileattr_omg);
 
 	/*
 	 * Look for ~0ULL terminator record and do a step back to find last
@@ -1625,31 +1631,39 @@ M0_INTERNAL int m0_cob_alloc_omgid(struct m0_cob_domain *dom, uint64_t *omgid)
 	 * init time (mkfs or else).
 	 */
 	omgkey.cok_omgid = ~0ULL;
-	rc = m0_btree_cursor_get(&cursor, &find_key, true);
+
+	rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+				      m0_btree_get(tree, &find_key, NULL,
+						   BOF_SLANT, &kv_op));
 
 	/*
 	 * In case of error, most probably due to no terminator record found,
 	 * one needs to run mkfs.
 	 */
 	if (rc == 0) {
-                rc = m0_btree_cursor_prev(&cursor);
 		if (omgid != NULL) {
+			omgid_cb.c_act   = cob_alloc_omgid_callback;
+			omgid_cb.c_datum = &prev_omgkey;
+
+			rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+						      m0_btree_iter(tree,
+								    &find_key,
+								    &omgid_cb,
+								    BOF_PREV,
+								    &kv_op));
 			if (rc == 0) {
 				/* We found last allocated omgid.
 				 * Bump it by one. */
-				m0_btree_cursor_kv_get(&cursor, &kbuf, NULL);
-				omgkey = *(struct m0_cob_omgkey*)kbuf.b_addr;
-				*omgid = ++omgkey.cok_omgid;
+				*omgid = ++prev_omgkey.cok_omgid;
 			} else {
 				/* No last allocated found, this alloc call is
 				 * the first one. */
 				*omgid = 0;
+				rc = 0;
 			}
 		}
-		rc = 0;
 	}
 
-	m0_btree_cursor_fini(&cursor);
 	return M0_RC(rc);
 }
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1447,18 +1447,12 @@ static int cob_iterator_get_callback(struct m0_btree_cb *cb,
 	 */
 	if (!m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob))) {
 		#ifdef DEBUG
-			M0_LOG(M0_DEBUG, "fid values are different.\
-			       required fid="FID_F" found fid="FID_F,
-			       FID_P(&nskey->cnk_pfid),
-			       FID_P(m0_cob_fid(it->ci_cob)));
-			M0_ASSERT(0);
-		#else
-			M0_LOG(M0_DEBUG, "fid values are different.\
-			       required fid="FID_F" found fid="FID_F,
-			       FID_P(&nskey->cnk_pfid),
-			       FID_P(m0_cob_fid(it->ci_cob)));
-			return -ENOENT;
+		M0_LOG(M0_ERROR, "fid values are different. \
+		      fid found="FID_F" fid required="FID_F,
+		      FID_P(&nskey->cnk_pfid), FID_P(m0_cob_fid(it->ci_cob)));
+		M0_ASSERT(0);
 		#endif
+		return -ENOENT;
 	}
 
 	M0_ASSERT(m0_cob_nskey_size(nskey) <= m0_cob_max_nskey_size());
@@ -1555,18 +1549,12 @@ static int cob_ea_iterator_get_callback(struct m0_btree_cb *cb,
 
 	if (!m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob))) {
 		#ifdef DEBUG
-			M0_LOG(M0_DEBUG, "fid values are different.\
-			       required fid="FID_F" found fid="FID_F,
-			       FID_P(&eakey->cek_fid),
-			       FID_P(m0_cob_fid(it->ci_cob)));
-			M0_ASSERT(0);
-		#else
-			M0_LOG(M0_DEBUG, "fid values are different.\
-			       required fid="FID_F" found fid="FID_F,
-			       FID_P(&eakey->cek_fid),
-			       FID_P(m0_cob_fid(it->ci_cob)));
-			return -ENOENT;
+		M0_LOG(M0_ERROR, "fid values are different. \
+		      fid found="FID_F" fid required="FID_F,
+		      FID_P(&eakey->cek_fid), FID_P(m0_cob_fid(it->ci_cob)));
+		M0_ASSERT(0);
 		#endif
+		return -ENOENT;
 	}
 
 	M0_ASSERT(m0_cob_eakey_size(eakey) <= m0_cob_max_eakey_size());

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1441,10 +1441,16 @@ static int cob_iterator_get_callback(struct m0_btree_cb *cb,
 
 	nskey = (struct m0_cob_nskey *)rec->r_key.k_data.ov_buf[0];
 
-	M0_ASSERT(m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob)));
-	M0_ASSERT(m0_cob_nskey_size(nskey) <= m0_cob_max_nskey_size());
+	/**
+	 * Check if we are stil inside the object bounds. Assert and key copy
+	 * can be done only in this case.
+	 */
+	if (!m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob)))
+		return -ENOENT;
 
+	M0_ASSERT(m0_cob_nskey_size(nskey) <= m0_cob_max_nskey_size());
 	memcpy(it->ci_key, nskey, m0_cob_nskey_size(nskey));
+
 	return 0;
 }
 
@@ -1534,9 +1540,10 @@ static int cob_ea_iterator_get_callback(struct m0_btree_cb *cb,
 
 	eakey = (struct m0_cob_eakey *)rec->r_key.k_data.ov_buf[0];
 
-	M0_ASSERT(m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob)));
-	M0_ASSERT(m0_cob_eakey_size(eakey) <= m0_cob_max_eakey_size());
+	if (!m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob)))
+		return -ENOENT;
 
+	M0_ASSERT(m0_cob_eakey_size(eakey) <= m0_cob_max_eakey_size());
 	memcpy(it->ci_key, eakey, m0_cob_eakey_size(eakey));
 	return 0;
 }

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1446,12 +1446,14 @@ static int cob_iterator_get_callback(struct m0_btree_cb *cb,
 	 * can be done only in this case.
 	 */
 	if (!m0_fid_eq(&nskey->cnk_pfid, m0_cob_fid(it->ci_cob))) {
-		#ifdef DEBUG
 		M0_LOG(M0_ERROR, "fid values are different. \
 		      fid found="FID_F" fid required="FID_F,
 		      FID_P(&nskey->cnk_pfid), FID_P(m0_cob_fid(it->ci_cob)));
+
+		#ifdef DEBUG
 		M0_ASSERT(0);
 		#endif
+
 		return -ENOENT;
 	}
 
@@ -1548,12 +1550,14 @@ static int cob_ea_iterator_get_callback(struct m0_btree_cb *cb,
 	eakey = (struct m0_cob_eakey *)rec->r_key.k_data.ov_buf[0];
 
 	if (!m0_fid_eq(&eakey->cek_fid, m0_cob_fid(it->ci_cob))) {
-		#ifdef DEBUG
 		M0_LOG(M0_ERROR, "fid values are different. \
 		      fid found="FID_F" fid required="FID_F,
 		      FID_P(&eakey->cek_fid), FID_P(m0_cob_fid(it->ci_cob)));
+
+		#ifdef DEBUG
 		M0_ASSERT(0);
 		#endif
+
 		return -ENOENT;
 	}
 


### PR DESCRIPTION
Signed-off-by: Radha Gulhane <radha.gulhane@seagate.com>

# Problem Statement
- Cursor returns addresses of key and value. In the old btree , as keys and values are present outside the node, these addresses returned by the cursor will not change but in the new btree as keys and values are present inside the node, addresses key and value can change if there is any update operation on the node. This issue was found during the m0unlink testing. Therefore, while using the cursor in the new btree, It is required to copy the required key and value in a callback which will be done by m0_btree_get and m0_btree_iter functions.
- 
# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
