### PR TITLE
EOS-28602: Validate the UT for M0_OIF_SKIP_LAYOUT when enabled forcefully

### DIFF
--- a/cas/client.c
+++ b/cas/client.c
@@ -1376,7 +1376,7 @@ M0_INTERNAL int m0_cas_index_delete(struct m0_cas_req      *req,
 	M0_PRE(req->ccr_sess != NULL);
 	M0_PRE(m0_cas_req_is_locked(req));
 	M0_PRE(m0_forall(i, cids_nr, m0_cas_id_invariant(&cids[i])));
-	M0_PRE((flags & ~(COF_CROW | COF_DEL_LOCK)) == 0);
+	M0_PRE((flags & ~(COF_CROW | COF_DEL_LOCK | COF_SKIP_LAYOUT)) == 0);
 	(void)dtx;
 	rc = cas_index_req_prepare(req, cids, cids_nr, cids_nr, false, flags,
 				   &op);
@@ -1657,9 +1657,13 @@ M0_INTERNAL int m0_cas_put(struct m0_cas_req      *req,
 	M0_PRE(m0_cas_req_is_locked(req));
 	/* Create and overwrite flags can't be specified together. */
 	M0_PRE(!(flags & COF_CREATE) || !(flags & COF_OVERWRITE));
-	/* Only create, overwrite, crow and sync_wait flags are allowed. */
+	/* 
+ 	 * Only create, overwrite, crow, sync_wait, and skip_layout flags 
+ 	 * are allowed.
+ 	 */
 	M0_PRE((flags &
-		~(COF_CREATE | COF_OVERWRITE | COF_CROW | COF_SYNC_WAIT)) == 0);
+		~(COF_CREATE | COF_OVERWRITE | COF_CROW | COF_SYNC_WAIT | 
+		COF_SKIP_LAYOUT)) == 0);
 	M0_PRE(m0_cas_id_invariant(index));
 
 	rc = cas_req_prep(req, index, keys, values, keys->ov_vec.v_nr, flags,

--- a/dix/req.c
+++ b/dix/req.c
@@ -612,7 +612,6 @@ static int dix_idxop_pver_analyse(struct m0_dix_idxop_req *idxop_req,
 	M0_ENTRY();
 
 	M0_PRE(M0_IN(type, (DIX_CREATE, DIX_DELETE, DIX_CCTGS_LOOKUP)));
-	M0_PRE(ergo(type == DIX_CREATE, (dreq->dr_flags & COF_CROW) == 0));
 
 	*creqs_nr = 0;
 	for (i = 0; i < pm->pm_state->pst_nr_devices; i++) {

--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -1266,7 +1266,7 @@ static void dix_set_idx_flags(struct m0_op_idx *oi)
 	if (ENABLE_DTM0)
 		oi->oi_flags |= M0_OIF_SKIP_LAYOUT;
 
-	if(!(oi->oi_flags & M0_OIF_SKIP_LAYOUT))
+	if (!(oi->oi_flags & M0_OIF_SKIP_LAYOUT))
 		oi->oi_flags |= M0_OIF_CROW;
 }
 

--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -1262,10 +1262,11 @@ M0_INTERNAL int m0__idx_cancel(struct m0_op_idx *oi)
 }
 
 static void dix_set_idx_flags(struct m0_op_idx *oi)
-{
+{ 
 	if (ENABLE_DTM0)
 		oi->oi_flags |= M0_OIF_SKIP_LAYOUT;
-	else
+
+	if(!(oi->oi_flags & M0_OIF_SKIP_LAYOUT))
 		oi->oi_flags |= M0_OIF_CROW;
 }
 

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -419,9 +419,15 @@ static void ut_dix_namei_ops_dist(void)
 	ut_dix_namei_ops(true, 0);
 }
 
-static void ut_dix_namei_ops_dist_oi_flags(void)
+static void ut_dix_namei_ops_dist_oi_flags_skip_layout(void)
 {
 	uint32_t flags = M0_OIF_SKIP_LAYOUT;
+	ut_dix_namei_ops(true, flags);
+}
+
+static void ut_dix_namei_ops_dist_oi_flags_skip_layout_enable_crow(void)
+{
+	uint32_t flags = M0_OIF_SKIP_LAYOUT | M0_OIF_CROW;
 	ut_dix_namei_ops(true, flags);
 }
 
@@ -769,9 +775,15 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	idx_dix_ut_fini();
 }
 
-static void ut_dix_record_ops_dist_oi_flags(void)
+static void ut_dix_record_ops_dist_oi_flags_skip_layout(void)
 {
 	uint32_t flags = M0_OIF_SKIP_LAYOUT;
+	ut_dix_record_ops(true, flags);
+}
+
+static void ut_dix_record_ops_dist_oi_flags_skip_layout_enable_crow(void)
+{
+	uint32_t flags = M0_OIF_SKIP_LAYOUT | M0_OIF_CROW;
 	ut_dix_record_ops(true, flags);
 }
 
@@ -800,9 +812,17 @@ struct m0_ut_suite ut_suite_idx_dix = {
 		  "Vikram" },
 		{ "namei-ops-cancel-non-dist", ut_dix_namei_ops_cancel_non_dist,
 		  "Vikram" },
-		{ "namei-ops-dist-oi-flags", ut_dix_namei_ops_dist_oi_flags,
+		{ "namei-ops-dist-oi-flags-skip-layout",
+		  ut_dix_namei_ops_dist_oi_flags_skip_layout,
 		  "Venky" },
-		{ "record-ops-dist-oi-flags", ut_dix_record_ops_dist_oi_flags,
+		{ "record-ops-dist-oi-flags-skip-layout",
+		  ut_dix_record_ops_dist_oi_flags_skip_layout,
+		  "Venky" },
+		{ "namei-ops-dist-oi-flags-skip-layout-enable-crow",
+		  ut_dix_namei_ops_dist_oi_flags_skip_layout_enable_crow,
+		  "Venky" },
+		{ "record-ops-dist-oi-flags-skip-layout-enable-crow",
+		  ut_dix_record_ops_dist_oi_flags_skip_layout_enable_crow,
 		  "Venky" },
 		{ NULL, NULL }
 	}

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -321,7 +321,7 @@ static void ut_dix_namei_ops(bool dist, uint32_t flags)
 	/* Create the index. */
 	m0_idx_init(&idx, &realm.co_realm, (struct m0_uint128 *)&ifid);
 
-	if(flags & M0_OIF_SKIP_LAYOUT)
+	if (flags & M0_OIF_SKIP_LAYOUT)
 		idx.in_entity.en_flags |= M0_ENF_META;
 	rc = m0_entity_create(NULL, &idx.in_entity, &op);
 	M0_UT_ASSERT(rc == 0);
@@ -336,7 +336,7 @@ static void ut_dix_namei_ops(bool dist, uint32_t flags)
 
 	/* Create an index with the same fid once more => -EEXIST. */
 	m0_idx_init(&idup, &realm.co_realm, (struct m0_uint128 *)&ifid);
-	if(flags & M0_OIF_SKIP_LAYOUT)
+	if (flags & M0_OIF_SKIP_LAYOUT)
 		idx.in_entity.en_flags |= M0_ENF_META;
 	rc = m0_entity_create(NULL, &idup.in_entity, &op);
 	M0_UT_ASSERT(rc == 0);

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -371,7 +371,7 @@ static void ut_dix_namei_ops(bool dist, uint32_t flags)
 	m0_op_launch(&op, 1);
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
 	M0_UT_ASSERT(rc == 0);
-	if(flags & M0_OIF_SKIP_LAYOUT) {
+	if (flags & M0_OIF_SKIP_LAYOUT) {
 		M0_UT_ASSERT(rcs[0] == -ENOENT);
 		M0_UT_ASSERT(!m0_fid_eq(keys.ov_buf[0], &ifid));
 	} else {
@@ -419,13 +419,13 @@ static void ut_dix_namei_ops_dist(void)
 	ut_dix_namei_ops(true, 0);
 }
 
-static void ut_dix_namei_ops_dist_oi_flags_skip_layout(void)
+static void ut_dix_namei_ops_dist_skip_layout(void)
 {
 	uint32_t flags = M0_OIF_SKIP_LAYOUT;
 	ut_dix_namei_ops(true, flags);
 }
 
-static void ut_dix_namei_ops_dist_oi_flags_skip_layout_enable_crow(void)
+static void ut_dix_namei_ops_dist_skip_layout_enable_crow(void)
 {
 	uint32_t flags = M0_OIF_SKIP_LAYOUT | M0_OIF_CROW;
 	ut_dix_namei_ops(true, flags);
@@ -468,7 +468,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	general_ifid_fill(&ifid, dist);
 	m0_container_init(&realm, NULL, &M0_UBER_REALM, ut_m0c);
 	m0_idx_init(&idx, &realm.co_realm, (struct m0_uint128 *)&ifid);
-	if(flags & M0_OIF_SKIP_LAYOUT)
+	if (flags & M0_OIF_SKIP_LAYOUT)
 		idx.in_entity.en_flags |= M0_ENF_META;
 
 	/* Create index. */
@@ -775,13 +775,13 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	idx_dix_ut_fini();
 }
 
-static void ut_dix_record_ops_dist_oi_flags_skip_layout(void)
+static void ut_dix_record_ops_dist_skip_layout(void)
 {
 	uint32_t flags = M0_OIF_SKIP_LAYOUT;
 	ut_dix_record_ops(true, flags);
 }
 
-static void ut_dix_record_ops_dist_oi_flags_skip_layout_enable_crow(void)
+static void ut_dix_record_ops_dist_skip_layout_enable_crow(void)
 {
 	uint32_t flags = M0_OIF_SKIP_LAYOUT | M0_OIF_CROW;
 	ut_dix_record_ops(true, flags);
@@ -812,17 +812,17 @@ struct m0_ut_suite ut_suite_idx_dix = {
 		  "Vikram" },
 		{ "namei-ops-cancel-non-dist", ut_dix_namei_ops_cancel_non_dist,
 		  "Vikram" },
-		{ "namei-ops-dist-oi-flags-skip-layout",
-		  ut_dix_namei_ops_dist_oi_flags_skip_layout,
+		{ "namei-ops-dist-skip-layout",
+		  ut_dix_namei_ops_dist_skip_layout,
 		  "Venky" },
-		{ "record-ops-dist-oi-flags-skip-layout",
-		  ut_dix_record_ops_dist_oi_flags_skip_layout,
+		{ "record-ops-dist-skip-layout",
+		  ut_dix_record_ops_dist_skip_layout,
 		  "Venky" },
-		{ "namei-ops-dist-oi-flags-skip-layout-enable-crow",
-		  ut_dix_namei_ops_dist_oi_flags_skip_layout_enable_crow,
+		{ "namei-ops-dist-skip-layout-enable-crow",
+		  ut_dix_namei_ops_dist_skip_layout_enable_crow,
 		  "Venky" },
-		{ "record-ops-dist-oi-flags-skip-layout-enable-crow",
-		  ut_dix_record_ops_dist_oi_flags_skip_layout_enable_crow,
+		{ "record-ops-dist-skip-layout-enable-crow",
+		  ut_dix_record_ops_dist_skip_layout_enable_crow,
 		  "Venky" },
 		{ NULL, NULL }
 	}


### PR DESCRIPTION
# Problem Statement
Validate the UT for M0_OIF_SKIP_LAYOUT when enabled forcefully

# Design
Added two UT's to validate for M0_OIF_SKIP_LAYOUT.
 1. ut_dix_namei_ops_dist_oi_flags - Index operations
 2. ut_dix_record_ops_dist_oi_flags - Record operations

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [X] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
