### PR TITLE
EOS-28836: dix-client-ut:server-is-down with panic

### DIFF
--- a/dix/ut/client_ut.c
+++ b/dix/ut/client_ut.c
@@ -3153,8 +3153,9 @@ static void server_is_down(void)
 
 	ut_service_init();
 	dix_index_init(&index, 1);
-	m0_fi_enable_once("cas_sdev_state", "sdev_fail");
+	m0_fi_enable("cas_sdev_state", "sdev_fail");
 	rc = dix_common_idx_op(&index, 1, REQ_CREATE);
+	m0_fi_disable("cas_sdev_state", "sdev_fail");
 	M0_UT_ASSERT(rc == -EBADFD);
 	dix_index_fini(&index);
 	ut_service_fini();


### PR DESCRIPTION
Problem:
 This UT introduces failure in one of the cas request and expect failure in generic response, But now as part of
 f2ba0d107310b2a795e6c3818b7fb4fa454eb10a (for degraded write) we return generic response as success
 even though one of N CAS request is successful. This is causing panic in UT as expected failure is not received.

Solution:
 Change this UT as per new behavior, Introduce failure in all the CAS put requests  and expect failure in response.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>

# Problem Statement
 This UT introduces failure in one of the cas request and expect failure in generic response, But now as part of
 f2ba0d107310b2a795e6c3818b7fb4fa454eb10a (for degraded write) we return generic response as success
 even though one of N CAS request is successful. This is causing panic in UT as expected failure is not received.

# Design
  Change this UT as per new behavior, Introduce failure in all the CAS put requests  and expect failure in response.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Ran this UT locally on dev setup 
 
# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
