### PR TITLE
reset src_dock->fsdc_filters_defined manually in the end of UT

### DIFF
--- a/fdmi/ut/fol_ut.c
+++ b/fdmi/ut/fol_ut.c
@@ -355,6 +355,7 @@ static void fdmi_fol_test_ops(enum ffs_ut_test_op test_op)
 	m0_be_ut_backend_fini(&ut_be);
 
 	dock->fsdc_started = false;
+	dock->fsdc_filters_defined = false;
 
 	M0_LEAVE();
 }


### PR DESCRIPTION
At the end of this UT, we need to manually reset src_dock->fsdc_filters_defined.
Otherwise in the following UT, ASSERT failure happens.

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
