### PR TITLE
EOS-27044: Integrate bytecount btree operations in write and delete path

### DIFF
--- a/ioservice/cob_foms.c
+++ b/ioservice/cob_foms.c
@@ -32,6 +32,8 @@
 #include "motr/setup.h"            /* m0_cs_ctx_get */
 #include "stob/domain.h"           /* m0_stob_domain_find_by_stob_id */
 
+#define M0_BYTECOUNT_USER_ID 8881212
+
 struct m0_poolmach;
 
 /* Forward Declarations. */
@@ -74,6 +76,8 @@ static void cob_stob_create_credit(struct m0_fom *fom);
 static int cob_stob_delete_credit(struct m0_fom *fom);
 static struct m0_cob_domain *cdom_get(const struct m0_fom *fom);
 static int cob_ops_stob_find(struct m0_fom_cob_op *co);
+static int cob_bytecount_decrement(struct m0_cob *cob, struct m0_cob_bckey *key,
+				   uint64_t bytecount, struct m0_be_tx *tx);
 
 enum {
 	CC_COB_VERSION_INIT	= 0,
@@ -530,6 +534,7 @@ static int cob_stob_delete_credit(struct m0_fom *fom)
 	fop_type = cob_op->fco_fop_type;
 	if (cob_is_md(cob_op)) {
 		cob_op_credit(fom, M0_COB_OP_DELETE, tx_cred);
+		cob_op_credit(fom, M0_COB_OP_BYTECOUNT_UPDATE, tx_cred);
 		if (cob_op->fco_recreate)
 			cob_op_credit(fom, M0_COB_OP_CREATE, tx_cred);
 		cob_op->fco_is_done = true;
@@ -1118,7 +1123,9 @@ static int cd_cob_delete(struct m0_fom            *fom,
 			 const struct m0_cob_attr *attr)
 {
 	int                   rc;
+	uint64_t              cob_size = attr->ca_size;
 	struct m0_cob        *cob;
+	struct m0_cob_bckey   key;
 
 	M0_PRE(fom != NULL);
 	M0_PRE(cd != NULL);
@@ -1138,6 +1145,10 @@ static int cd_cob_delete(struct m0_fom            *fom,
 	rc = m0_cob_delete(cob, m0_fom_tx(fom));
 	if (rc == 0)
 		M0_LOG(M0_DEBUG, "Cob deleted successfully.");
+
+	key.cbk_pfid = cd->fco_pver->pv_id; 
+	key.cbk_user_id = M0_BYTECOUNT_USER_ID;
+	rc = cob_bytecount_decrement(cob, &key, cob_size, m0_fom_tx(fom));
 
 	return M0_RC(rc);
 }
@@ -1223,6 +1234,22 @@ static int ce_stob_edit(struct m0_fom *fom, struct m0_fom_cob_op *cd,
 		rc = m0_storage_dev_stob_destroy(devs, stob, &fom->fo_tx);
 
 	return M0_RC(rc);
+}
+
+static int cob_bytecount_decrement(struct m0_cob *cob, struct m0_cob_bckey *key,
+				   uint64_t bytecount, struct m0_be_tx *tx)
+{
+	int rc;
+	struct m0_cob_bcrec rec = {};
+
+	rc = m0_cob_bc_lookup(cob, key, &rec);
+	if (rc == 0) {
+		rec.cbr_bytecount -= bytecount;
+		m0_cob_bc_update(cob, key, &rec, tx);
+	} else
+		M0_ERR(rc);
+
+	return rc;
 }
 
 #undef M0_TRACE_SUBSYSTEM

--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1901,7 +1901,6 @@ static int io_finish(struct m0_fom *fom)
 {
 	struct m0_io_fom_cob_rw *fom_obj;
 	struct m0_stob_io_desc  *stio_desc;
-	struct m0_cob           *cob;
 	int                      rc  = 0;
 	m0_bcount_t              nob = 0;
 
@@ -1943,19 +1942,6 @@ static int io_finish(struct m0_fom *fom)
 			       fom_obj->fcrw_count, stio->si_count);
 		}
 		stobio_tlist_add(&fom_obj->fcrw_done_list, stio_desc);
-	}
-
-	if (rc == 0 && m0_is_write_fop(fom->fo_fop)) {
-		rc = fom_cob_locate(fom);
-		if (rc == 0) {
-			cob = fom_obj->fcrw_cob;
-			fom_obj->fcrw_cob_size =
-				max64u(fom_obj->fcrw_cob_size,
-				       fom_obj->fcrw_cob->co_nsrec.cnr_size);
-			rc = m0_cob_size_update(cob,
-				fom_obj->fcrw_cob_size, m0_fom_tx(fom));
-			m0_cob_put(cob);
-		}
 	}
 
 	M0_LOG(M0_DEBUG, "got    fom: %"PRIi64", req_count: %"PRIi64", "
@@ -2282,6 +2268,8 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 				m0_cob_tx_credit(fom_cdom(fom),
 						 M0_COB_OP_CREATE, accum);
 				m0_cob_tx_credit(fom_cdom(fom),
+						 M0_COB_OP_UPDATE, accum);
+				m0_cob_tx_credit(fom_cdom(fom),
 						 M0_COB_OP_DELETE, accum);
 				m0_cob_tx_credit(fom_cdom(fom),
 						 M0_COB_OP_BYTECOUNT_SET, accum);
@@ -2337,6 +2325,7 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 	if (m0_fom_phase(fom) == M0_FOPH_SUCCESS &&
 	    m0_is_write_fop(fom->fo_fop)) {
 		int                 bc_rc;
+		uint64_t            old_cob_size;
 		struct m0_cob_bckey key;
 
 		key.cbk_pfid = pver;
@@ -2344,8 +2333,18 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 		bc_rc = fom_cob_locate(fom);
 		if (bc_rc == 0) {
 			cob = fom_obj->fcrw_cob;
+			old_cob_size = cob->co_nsrec.cnr_size;
 			cob_bytecount_increment(cob, &key, byte_count,
 						m0_fom_tx(fom));
+			/**
+			 * XXX: Overlapping cob extentds are not accounted for
+			 * during cob overwrite. IF a cob is overwritten,
+			 * it will make cob size inaccurate.
+			 */
+			bc_rc = m0_cob_size_update(cob, old_cob_size + byte_count,
+						   m0_fom_tx(fom));
+			if (bc_rc != 0)
+				M0_ERR_INFO(bc_rc, "Failed to update cob_size");
 		}
 	}
 

--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1900,12 +1900,8 @@ static int io_finish(struct m0_fom *fom)
 {
 	struct m0_io_fom_cob_rw *fom_obj;
 	struct m0_stob_io_desc  *stio_desc;
-	struct m0_cob           *cob;
 	int                      rc  = 0;
 	m0_bcount_t              nob = 0;
-	m0_bcount_t              byte_count;
-	struct m0_fid            pver;
-	struct m0_fop_cob_rw    *rwfop;
 
 	M0_PRE(fom != NULL);
 	M0_PRE(m0_is_io_fop(fom->fo_fop));
@@ -1915,10 +1911,6 @@ static int io_finish(struct m0_fom *fom)
 
 	if (M0_FI_ENABLED("fake_error"))
 		rc = -EINVAL;
-
-	rwfop = io_rw_get(fom->fo_fop);
-	byte_count = m0_io_count(&rwfop->crw_ivec);
-	pver = rwfop->crw_pver;
 
 	fom_obj = container_of(fom, struct m0_io_fom_cob_rw, fcrw_gen);
 	M0_ASSERT(m0_io_fom_cob_rw_invariant(fom_obj));
@@ -1941,32 +1933,14 @@ static int io_finish(struct m0_fom *fom)
 			if (m0_is_write_fop(fom->fo_fop)) {
 				fom_obj->fcrw_cob_size =
 					max64u(fom_obj->fcrw_cob_size,
-					       m0_io_size(stio, 0));
+					       m0_io_size(stio,
+							  fom_obj->fcrw_bshift));
 			}
 			nob += stio->si_count;
 			M0_LOG(M0_DEBUG, "rw_count %"PRIi64", si_count %"PRIi64,
 			       fom_obj->fcrw_count, stio->si_count);
 		}
 		stobio_tlist_add(&fom_obj->fcrw_done_list, stio_desc);
-	}
-
-	if (rc == 0 && m0_is_write_fop(fom->fo_fop)) {
-		struct m0_cob_bckey key;
-
-		key.cbk_pfid = pver;
-		key.cbk_user_id = M0_BYTECOUNT_USER_ID;
-		rc = fom_cob_locate(fom);
-		if (rc == 0) {
-			cob = fom_obj->fcrw_cob;
-			cob_bytecount_increment(cob, &key, byte_count,
-						m0_fom_tx(fom));
-			fom_obj->fcrw_cob_size =
-				max64u(fom_obj->fcrw_cob_size,
-				       fom_obj->fcrw_cob->co_nsrec.cnr_size);
-			rc = m0_cob_size_update(cob,
-				fom_obj->fcrw_cob_size, m0_fom_tx(fom));
-			m0_cob_put(cob);
-		}
 	}
 
 	M0_LOG(M0_DEBUG, "got    fom: %"PRIi64", req_count: %"PRIi64", "
@@ -2246,6 +2220,9 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 {
 	int                                       rc;
 	int                                       phase = m0_fom_phase(fom);
+	m0_bcount_t                               byte_count;
+	struct m0_fid                             pver;
+	struct m0_cob                            *cob;
 	struct m0_io_fom_cob_rw                  *fom_obj;
 	struct m0_io_fom_cob_rw_state_transition  st;
 	struct m0_fop_cob_rw                     *rwfop;
@@ -2258,6 +2235,8 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 	M0_ASSERT(m0_io_fom_cob_rw_invariant(fom_obj));
 
 	rwfop = io_rw_get(fom->fo_fop);
+	byte_count = m0_io_count(&rwfop->crw_ivec);
+	pver = rwfop->crw_pver;
 
 	M0_ENTRY("fom %p, fop %p, item %p[%u] %s" FID_F, fom, fom->fo_fop,
 		 m0_fop_to_rpc_item(fom->fo_fop), m0_fop_opcode(fom->fo_fop),
@@ -2342,6 +2321,31 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 
 	M0_ASSERT(m0_io_fom_cob_rw_invariant(fom_obj));
 
+	if (m0_fom_phase(fom) == M0_FOPH_SUCCESS &&
+	    m0_is_write_fop(fom->fo_fop)) {
+		int                 bc_rc;
+		uint64_t            old_cob_size;
+		struct m0_cob_bckey key;
+
+		key.cbk_pfid = pver;
+		key.cbk_user_id = M0_BYTECOUNT_USER_ID;
+		bc_rc = fom_cob_locate(fom);
+		if (bc_rc == 0) {
+			cob = fom_obj->fcrw_cob;
+			old_cob_size = cob->co_nsrec.cnr_size;
+			cob_bytecount_increment(cob, &key, byte_count,
+						m0_fom_tx(fom));
+			/**
+			 * XXX: Overlapping cob extentds are not accounted for
+			 * during cob overwrite. IF a cob is overwritten,
+			 * it will make cob size inaccurate.
+			 */
+			bc_rc = m0_cob_size_update(cob, old_cob_size + byte_count,
+						   m0_fom_tx(fom));
+			if (bc_rc != 0)
+				M0_ERR_INFO(bc_rc, "Failed to update cob_size");
+		}
+	}
 	/* Set operation status in reply fop if FOM ends.*/
 	if (m0_fom_phase(fom) == M0_FOPH_SUCCESS ||
 	    m0_fom_phase(fom) == M0_FOPH_FAILURE) {

--- a/ioservice/io_service.h
+++ b/ioservice/io_service.h
@@ -66,6 +66,12 @@ M0_INTERNAL int m0_ios_register(void);
 M0_INTERNAL void m0_ios_unregister(void);
 
 /**
+ * Temporary hard coded user id to be used for
+ * bytecount btree key
+ */
+#define M0_BYTECOUNT_USER_ID 8881212
+
+/**
  * Data structure represents list of buffer pool per network domain.
  */
 struct m0_rios_buffer_pool {


### PR DESCRIPTION
Integrated bytecount btree calls in cob_write and cob_delete path.
Cob size is now updated in m0_cob::co_nsrec::cnr_size after each write.
Decrement of byetcount now works with cob updation.
Overlapping cob extents are not accounted for during cob overwrite.
If a cob is overwritten, it will make cob size inaccurate.

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
