### PR TITLE
CORTX-27738: Monitor script to restart crashed m0ds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1077,6 +1077,7 @@ dist_pkglibexec_SCRIPTS  = scripts/install/usr/libexec/cortx-motr/motr-service.f
                            scripts/install/usr/libexec/cortx-motr/motr-dixinit \
                            scripts/install/usr/libexec/cortx-motr/motr-trace \
                            scripts/install/usr/libexec/cortx-motr/motr-start \
+                           scripts/install/usr/libexec/cortx-motr/motr-monitor \
                            scripts/install/usr/libexec/cortx-motr/motr-free-space-monitor
 
 ################################################################################

--- a/scripts/install/usr/libexec/cortx-motr/motr-monitor
+++ b/scripts/install/usr/libexec/cortx-motr/motr-monitor
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -x 
+
+PID=
+
+if [[ $# < 1 ]]; then
+        echo "usage - sh $0 <service-fid>"
+        echo "to get fid details"
+	echo "execute below command from cortx-hax container shell"
+	echo "/opt/seagate/cortx/hare/bin/hctl status"
+        exit 1
+fi
+
+_handle_sigterm() {
+   echo "Caught SIGTERM"
+   if [[ -z $PID ]]; then
+      echo "No m0d process to kill"
+   else
+      echo "killing the process $PID"
+      kill -KILL $PID 2> /dev/null
+   fi
+}
+
+check_for_fids() {
+	fid=$1
+	var=$(ps -aux | grep "m0d" | grep $fid)
+	if [[ $? -eq 0 ]]; then
+		echo "$fid already running"
+		exit 1
+	fi
+}
+
+#trap _handle_sigterm SIGTERM SIGKILL
+
+#check_for_fids $1
+/usr/libexec/cortx-motr/motr-server "m0d-$1" &
+PID=$!
+
+while true; do
+	wait $PID
+	echo "why i am not here"
+	echo "m0d-$1 service exited with exit code=$?"
+	ps aux | grep $1 | grep "/usr/bin/m0d" | grep -q -v grep
+	if [ $? -ne 0 ]; then
+		echo "restarting $1"
+		/usr/libexec/cortx-motr/motr-server "m0d-$1" &
+		PID=$!
+	fi
+done


### PR DESCRIPTION
	- Individual m0ds are monitored and restarted if killed

Signed-off-by: Vinoth.V <vinoth.v@seagate.com>

# Problem Statement
- Motr restart script for monitoring m0d's

# Design
-  Aids in Monitoring m0d's without support of systemd
- Currently added as part of main but not invoked