### PR TITLE
EOS-28387: Added a bytecount btree operation to dump all key-values

### DIFF
--- a/cob/cob.h
+++ b/cob/cob.h
@@ -903,6 +903,33 @@ M0_INTERNAL int m0_cob_bc_iterator_next(struct m0_cob_bc_iterator *it);
 M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
 
 /**
+ * Returns all the entries in the bytecount btree in the form of
+ * Key and record buffers. Tis function uses bytecount iterator internally
+ * to traverse the btree.
+ *
+ * Key buffer contains all the keys in a contigious sequence of memory
+ * pointed by out_keys::b_addr. An individual key can be accessed by
+ * traversing the memory in chunks of sizeof(struct m0_cob_bckey).
+ *
+ * Similar logic applies to record buffer.
+ *
+ * @pre   out_keys == NULL
+ * @pre   iut_recs == NULL
+ *
+ * @param cdom      cob domain where the bytecount btree resides.
+ * @param out_keys  out parameter buffer which gets populated by keys.
+ * @param out_recs  out parameter buffer which gets populated by records.
+ * @param out_count out parameter with number of entries in the btree.
+ *
+ * @retval 0        Success.
+ * @retval -errno   Other error.
+ */ 
+M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
+				       struct m0_buf        *out_keys,
+				       struct m0_buf        *out_recs,
+				       uint32_t             *out_count);
+
+/**
  * Finish cob bc iterator.
  */
 M0_INTERNAL void m0_cob_bc_iterator_fini(struct m0_cob_bc_iterator *it);

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -904,7 +904,7 @@ M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
 
 /**
  * Returns all the entries in the bytecount btree in the form of
- * Key and record buffers. Tis function uses bytecount iterator internally
+ * Key and record buffers. This function uses bytecount iterator internally
  * to traverse the btree.
  *
  * Key buffer contains all the keys in a contigious sequence of memory
@@ -914,7 +914,7 @@ M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
  * Similar logic applies to record buffer.
  *
  * @pre   out_keys == NULL
- * @pre   iut_recs == NULL
+ * @pre   out_recs == NULL
  *
  * @param cdom      cob domain where the bytecount btree resides.
  * @param out_keys  out parameter buffer which gets populated by keys.


### PR DESCRIPTION
Added an operation m0_cob_bc_entries_dump() to traverse the bytecount
btree and dump all keys and records in a key buffer and a record buffer
as out parameters.
This operation also returns the count of key-value pairs in the btree.
Added UT to test this feature.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
