### PR TITLE
EOS-28388: fetch data from bytecount btree

### DIFF
--- a/cob/cob.c
+++ b/cob/cob.c
@@ -69,12 +69,6 @@ enum {
 	M0_COB_EA_MAX   = 4096
 };
 
-struct bc_entry {
-	struct m0_buf       be_key;
-	struct m0_buf       be_rec;
-	struct m0_list_link be_link;
-};
-
 static int cob0_init(struct m0_be_domain *dom, const char *suffix,
 		     const struct m0_buf *data)
 {
@@ -500,21 +494,23 @@ M0_INTERNAL void m0_cob_bc_iterator_fini(struct m0_cob_bc_iterator *it)
 }
 
 M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
-				       struct m0_buf        *out_keys,
-				       struct m0_buf        *out_recs,
+				       struct m0_buf       **out_keys,
+				       struct m0_buf       **out_recs,
 				       uint32_t             *out_count)
 {
 	struct m0_cob_bc_iterator it;
-	struct m0_list            entry_list;
-	struct m0_list_link      *list_pos;
-	int                       rc;
+	struct m0_buf             key_buf;
+	struct m0_buf             rec_buf;
 	void                     *key_cursor;
 	void                     *rec_cursor;
+	int                       rc;
 
-	M0_PRE(out_keys == NULL);
-	M0_PRE(out_recs == NULL);
+	M0_ENTRY();
 
-	if (cdom->cd_bytecount.bb_root != NULL)
+	M0_PRE(*out_keys == NULL);
+	M0_PRE(*out_recs == NULL);
+
+	if (cdom->cd_bytecount.bb_root == NULL)
 		return M0_ERR(-ENOENT);
 
 	*out_count = 0;
@@ -522,44 +518,35 @@ M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
 	rc = m0_be_btree_cursor_first_sync(&it.ci_cursor);
 
 	while (rc != -ENOENT) {
-		struct bc_entry *entry;
-
-		M0_ALLOC_PTR(entry);
-		m0_list_init(&entry_list);
-		m0_list_link_init(&entry->be_link);
-		m0_be_btree_cursor_kv_get(&it.ci_cursor, &entry->be_key,
-					  &entry->be_rec);
-		m0_list_add_tail(&entry_list, &entry->be_link);
-		rc = m0_be_btree_cursor_next_sync(&it.ci_cursor);		
+		rc = m0_be_btree_cursor_next_sync(&it.ci_cursor);
 		++(*out_count);
 	}
 
-	M0_ASSERT(m0_list_length(&entry_list) == *out_count);
+	M0_LOG(M0_DEBUG, "Found %"PRIu32" entries in btree", *out_count);
 
-	m0_buf_alloc(out_keys, sizeof(struct m0_cob_bckey) * (*out_count));
-	m0_buf_alloc(out_recs, sizeof(struct m0_cob_bcrec) * (*out_count));
-	key_cursor = out_keys->b_addr;
-	rec_cursor = out_recs->b_addr;
+	M0_ALLOC_PTR(*out_keys);
+	M0_ALLOC_PTR(*out_recs);
 
-	m0_list_for_each(&entry_list, list_pos) {
-		struct bc_entry *entry;
+	m0_buf_alloc(*out_keys, sizeof(struct m0_cob_bckey) * (*out_count));
+	m0_buf_alloc(*out_recs, sizeof(struct m0_cob_bcrec) * (*out_count));
+	key_cursor = (*out_keys)->b_addr;
+	rec_cursor = (*out_recs)->b_addr;
 
-		entry = m0_list_entry(list_pos, struct bc_entry, be_link);
+	rc = m0_be_btree_cursor_first_sync(&it.ci_cursor);
 
-		M0_ASSERT(entry->be_key.b_nob == sizeof(struct m0_cob_bckey));
-		M0_ASSERT(entry->be_rec.b_nob == sizeof(struct m0_cob_bcrec));
+	/**
+	 * TODO: Iterate over the btree only once, store the key-vals in a list
+	 * while iterating over the btree the 1st time.
+	 */
+	while (rc != -ENOENT) {
+		m0_be_btree_cursor_kv_get(&it.ci_cursor, &key_buf, &rec_buf);
 
-		memcpy(key_cursor, entry->be_key.b_addr, entry->be_key.b_nob);
-		memcpy(rec_cursor, entry->be_rec.b_addr, entry->be_rec.b_nob);
-
+		memcpy(key_cursor, key_buf.b_addr, key_buf.b_nob);
+		memcpy(rec_cursor, rec_buf.b_addr, rec_buf.b_nob);
 		key_cursor += sizeof(struct m0_cob_bckey);
 		rec_cursor += sizeof(struct m0_cob_bcrec);
 
-		m0_buf_free(&entry->be_key);
-		m0_buf_free(&entry->be_rec);
-
-		m0_list_del(&entry->be_link);
-		m0_free(entry);
+		rc = m0_be_btree_cursor_next_sync(&it.ci_cursor);
 	}
 
 	m0_be_btree_cursor_fini(&it.ci_cursor);

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -903,6 +903,33 @@ M0_INTERNAL int m0_cob_bc_iterator_next(struct m0_cob_bc_iterator *it);
 M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
 
 /**
+ * Returns all the entries in the bytecount btree in the form of
+ * Key and record buffers. Tis function uses bytecount iterator internally
+ * to traverse the btree.
+ *
+ * Key buffer contains all the keys in a contigious sequence of memory
+ * pointed by out_keys::b_addr. An individual key can be accessed by
+ * traversing the memory in chunks of sizeof(struct m0_cob_bckey).
+ *
+ * Similar logic applies to record buffer.
+ *
+ * @pre   out_keys == NULL
+ * @pre   iut_recs == NULL
+ *
+ * @param cdom      cob domain where the bytecount btree resides.
+ * @param out_keys  out parameter buffer which gets populated by keys.
+ * @param out_recs  out parameter buffer which gets populated by records.
+ * @param out_count out parameter with number of entries in the btree.
+ *
+ * @retval 0        Success.
+ * @retval -errno   Other error.
+ */ 
+M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
+				       struct m0_buf        *out_keys,
+				       struct m0_buf        *out_recs,
+				       uint32_t             *out_count);
+
+/**
  * Finish cob bc iterator.
  */
 M0_INTERNAL void m0_cob_bc_iterator_fini(struct m0_cob_bc_iterator *it);

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -925,8 +925,8 @@ M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
  * @retval -errno   Other error.
  */ 
 M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
-				       struct m0_buf        *out_keys,
-				       struct m0_buf        *out_recs,
+				       struct m0_buf       **out_keys,
+				       struct m0_buf       **out_recs,
 				       uint32_t             *out_count);
 
 /**

--- a/cob/ut/bytecount.c
+++ b/cob/ut/bytecount.c
@@ -155,7 +155,7 @@ void test_entries_dump(void)
 	void               *kcurr;
 	void               *rcurr;
 
-	rc = m0_cob_bc_entries_dump(cob->co_dom, keys, recs, &count);
+	rc = m0_cob_bc_entries_dump(cob->co_dom, &keys, &recs, &count);
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(count == KEY_VAL_NR);
 
@@ -274,6 +274,7 @@ struct m0_ut_suite bytecount_ut = {
 		{ "cob-dom-create",   test_cob_dom_create },
 		{ "cob-dom-init",     test_init },
 		{ "bc-tree-insert",   test_insert },
+		{ "bc-entries-dump",  test_entries_dump },
 		{ "bc-tree-iterator", test_iterator },
 		{ "bc-tree-lookup",   test_lookup },
 		{ "bc-tree-update",   test_update },

--- a/spiel/cmd.c
+++ b/spiel/cmd.c
@@ -2065,8 +2065,8 @@ static void spiel_process_counter_replied_ast(struct m0_sm_group *grp,
 
 	memcpy(proc->sci_data.pd_key.b_addr, rep->sspr_bckey.b_addr,
 		rep->sspr_bckey.b_nob);
-	memcpy(proc->sci_data.pd_key.b_addr, rep->sspr_bckey.b_addr,
-		rep->sspr_bckey.b_nob);
+	memcpy(proc->sci_data.pd_rec.b_addr, rep->sspr_bcrec.b_addr,
+		rep->sspr_bcrec.b_nob);
 	proc->sci_data.pd_kv_count = rep->sspr_kv_count;
 
 leave:

--- a/spiel/ut/spiel_ci_ut.c
+++ b/spiel/ut/spiel_ci_ut.c
@@ -528,6 +528,7 @@ void test_spiel_bc_stats(void)
 	spiel_ci_ut_init();
 
 	M0_SET0(&count_stats);
+	m0_fi_enable_once("ss_bytecount_stats_ingest", "dummy_bytecount_data");
 	rc = m0_spiel_proc_counters_fetch(&spiel, &proc_fid, &count_stats);
 
 	M0_UT_ASSERT(m0_fid_eq(&count_stats.pc_proc_fid, &proc_fid));

--- a/sss/process_foms.c
+++ b/sss/process_foms.c
@@ -403,10 +403,11 @@ static int ss_bytecount_stats_ingest(struct m0_cob_domain *cdom,
 		return 0;
 	}
 
-	rc = m0_cob_bc_entries_dump(cdom, key_buf, rec_buf, &rep->sspr_kv_count); 
-
-	m0_buf_init(&rep->sspr_bckey, key_buf->b_addr, key_buf->b_nob);
-	m0_buf_init(&rep->sspr_bcrec, rec_buf->b_addr, rec_buf->b_nob);
+	rc = m0_cob_bc_entries_dump(cdom, &key_buf, &rec_buf, &rep->sspr_kv_count);
+	if (rc == 0) {
+		m0_buf_init(&rep->sspr_bckey, key_buf->b_addr, key_buf->b_nob);
+		m0_buf_init(&rep->sspr_bcrec, rec_buf->b_addr, rec_buf->b_nob);
+	}
 
 	return rc;
 }

--- a/sss/process_fops.h
+++ b/sss/process_fops.h
@@ -127,6 +127,10 @@ struct m0_ss_process_rep {
 	 * Buffer which holds records from bytecount btree
 	 */
 	struct m0_buf sspr_bcrec;
+	/**
+	 * Number of key values in key and record buffers
+	 */
+	uint32_t      sspr_kv_count;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 struct m0_ss_process_svc_item {


### PR DESCRIPTION
sss foms now make m0_cob_bc_entries_dump() calls to populate
reply fop key record buffers with bytecount data from bytecount btree.

Changed implementation of spiel API m0_spiel_proc_counters_fetch() to
accept data from btree instead of hardcoded data.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
