### PR TITLE
Fix compilation with --enable-debug on CentOS 7.9

### DIFF
--- a/conf/cache.c
+++ b/conf/cache.c
@@ -209,7 +209,7 @@ conf_encode(struct m0_confx *enc, const struct m0_conf_obj *obj, bool debug)
 static int conf_cache_encode(const struct m0_conf_cache *cache,
 			     struct m0_confx *dest, bool debug)
 {
-	struct m0_conf_obj *obj;
+	struct m0_conf_obj *obj = NULL;
 	int                 rc = 0;
 	size_t              nr;
 	char               *data;


### PR DESCRIPTION
# Problem Statement

The compilation of kernel module on CentOS 7.9 with gcc-4.8 fails with --enable-debug configure option:

    conf/cache.c:226:31: error: ‘obj’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
            FID_P(&obj->co_id), obj->co_status);
                                 ^
    cc1: all warnings being treated as errors

The problem started appearing lately after we changed `-O0` flag to `-Og` for kernel modules compilation in the debug mode at commit 1fc7b4ba5.

# Design
Solution: initialise obj pointer at conf_cache_encode().


# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
