### PR TITLE
CORTX-27365 : btree-ut:lru_test is failing

### DIFF
--- a/balloc/ut/balloc.c
+++ b/balloc/ut/balloc.c
@@ -299,10 +299,22 @@ void test_reserve_extent()
 	m0_be_ut_backend_fini(&ut_be);
 }
 
+static int test_balloc_ut_suite_init(void)
+{
+	m0_btree_glob_init();
+	return 0;
+}
+
+static int test_balloc_ut_suite_fini(void)
+{
+	m0_btree_glob_fini();
+	return 0;
+}
+
 struct m0_ut_suite balloc_ut = {
         .ts_name  = "balloc-ut",
-	.ts_init = NULL,
-	.ts_fini = NULL,
+	.ts_init = test_balloc_ut_suite_init,
+	.ts_fini = test_balloc_ut_suite_fini,
         .ts_tests = {
 		{ "balloc", test_balloc},
 		{ "reserve blocks for extmap", test_reserve_extent},

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -1821,7 +1821,6 @@ M0_INTERNAL void m0_btree_glob_init(void)
 	m0_rwlock_init(&list_lock);
 }
 
-
 M0_INTERNAL void m0_btree_glob_fini(void)
 {
 	struct nd* node;

--- a/btree/btree.h
+++ b/btree/btree.h
@@ -696,6 +696,8 @@ M0_INTERNAL void m0_btree_del_credit2(const struct m0_btree_type *type,
 
 M0_INTERNAL int     m0_btree_mod_init(void);
 M0_INTERNAL void    m0_btree_mod_fini(void);
+M0_INTERNAL void    m0_btree_glob_init(void);
+M0_INTERNAL void    m0_btree_glob_fini(void);
 M0_INTERNAL int64_t m0_btree_lrulist_purge(int64_t size);
 M0_INTERNAL int64_t m0_btree_lrulist_purge_check(enum m0_btree_purge_user user,
 						 int64_t size);


### PR DESCRIPTION
Fix global variable init issue for btree-ut.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
-  When running multiple unit tests, the global variables of btree code contained some stale data from the balloc-ut which was run previously. This was causing the lru_test to crash.

# Design
-  Added global variable init and fini functions which are called from module inti/fini and ut init/fini functions.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
