### PR TITLE
EOS-27728: Increase max fol record size (FOL_REC_MAXSIZE) to 512K

### DIFF
--- a/fol/fol.h
+++ b/fol/fol.h
@@ -122,7 +122,7 @@ enum {
 	/* FOL_REC_MAXSIZE = 1024 * 1024 */
 
 	/* EN: Previous size is too big to fit into one RPC message */
-	FOL_REC_MAXSIZE = 1024 * 256
+	FOL_REC_MAXSIZE = 1024 * 512
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
- Due to bulk operations, fol record size may increase beyond 256k

# Design
-  Increase max fol record size to 512k


# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
