### PR TITLE
CORTX-28516 : Libfabric - Compatibility for v1.12

### DIFF
--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -646,7 +646,7 @@ static void libfab_txep_event_check(struct m0_fab__ep *txep,
 	 * -111 (ECONNREFUSED) if the remote service has not yet started. Thus
 	 * the connection request does not receive any reply and the endpoint
 	 * keeps waiting in the FAB_CONNECTING state. To avoid this, the state
-	 * of the endpoint is reset after a timeout of 1s to FAB_DISCONNECTED.
+	 * of the endpoint is reset after a timeout of 5s to FAB_DISCONNECTED.
 	 * Thus, when the next buffer is posted to the endpoint, it will again
 	 * try to establish connection by sending out a new connection request.
 	 */

--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -640,6 +640,26 @@ static void libfab_txep_event_check(struct m0_fab__ep *txep,
 		libfab_pending_bufs_send(txep);
 		txep->fep_connlink = FAB_CONNLINK_PENDING_SEND_DONE;
 	}
+
+	/*
+	 * For version >= 1.12, the libfabric library does not return the error
+	 * -111 (ECONNREFUSED) if the remote service has not yet started. Thus
+	 * the connection request does not receive any reply and the endpoint
+	 * keeps waiting in the FAB_CONNECTING state. To avoid this, the state
+	 * of the endpoint is reset after a timeout of 1s to FAB_DISCONNECTED.
+	 * Thus, when the next buffer is posted to the endpoint, it will again
+	 * try to establish connection by sending out a new connection request.
+	 */
+	if (aep->aep_tx_state == FAB_CONNECTING &&
+	    m0_time_is_in_past(aep->aep_connecting_tmout)) {
+		M0_LOG(M0_DEBUG,"Reset Conn from %s to %s",
+		       (char*)tm->ftm_pep->fep_name.nia_p,
+		       (char*)txep->fep_name.nia_p);
+		libfab_txep_init(aep, tm, txep);
+		m0_tl_teardown(fab_sndbuf, &txep->fep_sndbuf, fbp) {
+			libfab_buf_done(fbp, -ECONNREFUSED, false);
+		}
+	}
 }
 
 /**
@@ -2260,9 +2280,11 @@ static int libfab_conn_init(struct m0_fab__ep *ep, struct m0_fab__tm *ma,
 		M0_ASSERT(ret == 0 && sizeof(cd) < cm_max_size);
 
 		ret = fi_connect(aep->aep_txep, &dst, &cd, sizeof(cd));
-		if (ret == 0)
+		if (ret == 0) {
 			aep->aep_tx_state = FAB_CONNECTING;
-		else
+			aep->aep_connecting_tmout = m0_time_from_now(
+						       FAB_CONNECTING_TMOUT, 0);
+		} else
 			M0_LOG(M0_DEBUG, "Conn req failed ret=%d dst=%"PRIx64,
 			       ret, dst);
 	}

--- a/net/libfab/libfab_internal.h
+++ b/net/libfab/libfab_internal.h
@@ -106,7 +106,7 @@ enum m0_fab__libfab_params {
 	/** Min time interval between buffer timeout check (sec) */
 	FAB_BUF_TMOUT_CHK_INTERVAL     = 1,
 	/** Timeout interval for getting a reply to the CONNREQ (sec) */
-	FAB_CONNECTING_TMOUT           = 1,
+	FAB_CONNECTING_TMOUT           = 5,
 	/** The step for increasing array size of fids in a tm */
 	FAB_TM_FID_MALLOC_STEP         = 1024
 };

--- a/net/libfab/libfab_internal.h
+++ b/net/libfab/libfab_internal.h
@@ -105,6 +105,8 @@ enum m0_fab__libfab_params {
 	FAB_NUM_BUCKETS_PER_QTYPE      = 128,
 	/** Min time interval between buffer timeout check (sec) */
 	FAB_BUF_TMOUT_CHK_INTERVAL     = 1,
+	/** Timeout interval for getting a reply to the CONNREQ (sec) */
+	FAB_CONNECTING_TMOUT           = 1,
 	/** The step for increasing array size of fids in a tm */
 	FAB_TM_FID_MALLOC_STEP         = 1024
 };
@@ -324,18 +326,24 @@ struct m0_fab__active_ep {
 
 	/** Receive endpoint resources */
 	struct m0_fab__rx_res     aep_rx_res;
-	
+
 	/** connection status of Transmit ep */
 	enum m0_fab__conn_status  aep_tx_state;
-	
+
 	/** connection status of Receive ep */
 	enum m0_fab__conn_status  aep_rx_state;
-	
+
 	/** count of active bulk ops for the transmit endpoint */
 	volatile uint32_t         aep_bulk_cnt;
 
 	/** flag to indicate that the tx queue of the endpoint is full */
 	bool                      aep_txq_full;
+
+	/**
+	 * Timeout after which the endpoint connecting state would be reset if
+	 * no reply is received for the connection request.
+	 */
+	m0_time_t                 aep_connecting_tmout;
 };
 
 /**


### PR DESCRIPTION
Add support for libfabric v1.12

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- When running with libfabric v1.12.0, mkfs was getting stuck during cluster bootstrap.

# Design
-  For version >= 1.12, the libfabric library does not return the error -111 (ECONNREFUSED) if the remote service has not yet started. Thus the connection request does not receive any reply and the endpoint keeps waiting in the FAB_CONNECTING state. To avoid this, the state of the endpoint is reset after a timeout of 5s to FAB_DISCONNECTED. Thus, when the next buffer is posted to the endpoint, it will again try to establish connection by sending out a new connection request.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
