### PR TITLE
EOS-27770: Motr mini provisioner log rotate

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -987,15 +987,13 @@ motr_libexec_SCRIPTS = \
     scripts/install$(motrdir)/libexec/motr_data_recovery.sh \
     scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
     scripts/install$(motrdir)/libexec/motr_cfg.sh \
-    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh \
-    scripts/install$(motrdir)/libexec/motr_mini_prov_logrotate.sh
+    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
 EXTRA_DIST += $(motr_libexec_SCRIPTS)
 
 motr_crondir = $(sysconfdir)/cron.hourly
 motr_cron_SCRIPTS = \
     scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
-    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh \
-    scripts/install$(motrdir)/libexec/motr_mini_prov_logrotate.sh
+    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
 EXTRA_DIST += $(motr_cron_SCRIPTS)
 
 motr_confdir = $(motrdir)/conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -987,13 +987,15 @@ motr_libexec_SCRIPTS = \
     scripts/install$(motrdir)/libexec/motr_data_recovery.sh \
     scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
     scripts/install$(motrdir)/libexec/motr_cfg.sh \
-    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
+    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh \
+    scripts/install$(motrdir)/libexec/motr_mini_prov_logrotate.sh
 EXTRA_DIST += $(motr_libexec_SCRIPTS)
 
 motr_crondir = $(sysconfdir)/cron.hourly
 motr_cron_SCRIPTS = \
     scripts/install$(motrdir)/libexec/m0trace_logrotate.sh \
-    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh
+    scripts/install$(motrdir)/libexec/m0addb_logrotate.sh \
+    scripts/install$(motrdir)/libexec/motr_mini_prov_logrotate.sh
 EXTRA_DIST += $(motr_cron_SCRIPTS)
 
 motr_confdir = $(motrdir)/conf

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -426,18 +426,17 @@ def update_motr_hare_keys(self, nodes):
         md_disks_lists = get_md_disks_lists(self, node_info)
         update_to_file(self, self._index_motr_hare, self._url_motr_hare, machine_id, md_disks_lists)
 
-'''
-Write below content to /etc/logrotate.conf file so that mini_mini_provisioner
-log file will be rotated hourly and retained recent max 2 files. Max size of log file is 100M.
+# Write below content to /etc/cortx/motr/mini_prov_logrotate.conf file so that mini_mini_provisioner
+# log file will be rotated hourly and retained recent max 4 files. Max size of log file is 10M.
 
-Content:
-/etc/cortx/log/motr/<machine-id>/mini_provisioner {
-    hourly
-    size 10M
-    rotate 4
-    delaycompress
-}
-'''
+# Content:
+# /etc/cortx/log/motr/<machine-id>/mini_provisioner {
+#    hourly
+#    size 10M
+#    rotate 4
+#    delaycompress
+#    copytruncate
+# }
 def add_entry_to_logrotate_conf_file(self):
     MOTR_M0D_DATA_DIR = f"{self.local_path}/motr"
     validate_files([MOTR_M0D_DATA_DIR])
@@ -1456,7 +1455,7 @@ def start_service(self, service, idx):
     cmd = f"cp {MOTR_MINI_PROV_LOGROTATE_SCRIPT} {CROND_DIR}"
     execute_command(self, cmd)
     # Start crond service
-    cmd = f"/usr/sbin/crond start"
+    cmd = "/usr/sbin/crond start"
     execute_command(self, cmd, timeout_secs=120)
 
     # Copy confd_path to /etc/sysconfig
@@ -1477,7 +1476,7 @@ def start_service(self, service, idx):
     cmd = "/opt/seagate/cortx/motr/libexec/m0trace_logrotate.sh &"
     execute_command(self, cmd)
     cmd = "/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh &"
-    execute_command(self, cmd) 
+    execute_command(self, cmd)
     #Start motr services
     cmd = f"{MOTR_SERVER_SCRIPT_PATH} m0d-{fid}"
     execute_command_console(self, cmd)

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -444,7 +444,7 @@ def add_entry_to_logrotate_conf_file(self):
     mini_prov_conf_file = f"{MOTR_M0D_DATA_DIR}/mini_prov_logrotate.conf"
 
     indent=' '*4
-    lines=["{a} {b}\n".format(a=log_file, b='{'),
+    lines=["{a} {b}\n".format(a=self.logfile, b='{'),
            f"{indent}hourly\n",
            f"{indent}size 10M\n",
            f"{indent}rotate 4\n",
@@ -1473,7 +1473,11 @@ def start_service(self, service, idx):
     fid = fetch_fid(self, service, idx)
     if fid == -1:
         return -1
-
+    #Run log rotate in background to avoid delay in startup
+    cmd = "/opt/seagate/cortx/motr/libexec/m0trace_logrotate.sh &"
+    execute_command(self, cmd)
+    cmd = "/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh &"
+    execute_command(self, cmd) 
     #Start motr services
     cmd = f"{MOTR_SERVER_SCRIPT_PATH} m0d-{fid}"
     execute_command_console(self, cmd)

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -1467,11 +1467,6 @@ def start_service(self, service, idx):
     fid = fetch_fid(self, service, idx)
     if fid == -1:
         return -1
-    #Run log rotate in background to avoid delay in startup
-    cmd = "/opt/seagate/cortx/motr/libexec/m0trace_logrotate.sh &"
-    execute_command(self, cmd)
-    cmd = "/opt/seagate/cortx/motr/libexec/m0addb_logrotate.sh &"
-    execute_command(self, cmd)
 
     #Start motr services
     cmd = f"{MOTR_SERVER_SCRIPT_PATH} m0d-{fid}"

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -34,6 +34,8 @@ MOTR_SERVER_SCRIPT_PATH = "/usr/libexec/cortx-motr/motr-start"
 MOTR_MKFS_SCRIPT_PATH = "/usr/libexec/cortx-motr/motr-mkfs"
 MOTR_FSM_SCRIPT_PATH = "/usr/libexec/cortx-motr/motr-free-space-monitor"
 MOTR_CONFIG_SCRIPT = "/opt/seagate/cortx/motr/libexec/motr_cfg.sh"
+MOTR_MINI_PROV_LOGROTATE_SCRIPT = "/opt/seagate/cortx/motr/libexec/motr_mini_prov_logrotate.sh"
+CROND_DIR = "/etc/cron.hourly"
 LNET_CONF_FILE = "/etc/modprobe.d/lnet.conf"
 LIBFAB_CONF_FILE = "/etc/libfab.conf"
 SYS_CLASS_NET_DIR = "/sys/class/net/"
@@ -447,6 +449,7 @@ def add_entry_to_logrotate_conf_file(self):
            f"{indent}size 10M\n",
            f"{indent}rotate 4\n",
            f"{indent}delaycompress\n",
+           f"{indent}copytruncate\n",
            "{a}\n".format(a='}')]
     with open(f"{mini_prov_conf_file}", 'w+') as fp:
         for line in lines:
@@ -1449,9 +1452,12 @@ def start_service(self, service, idx):
         execute_command_verbose(self, cmd, set_timeout=False)
         return
 
+    # Copy mini prov logrotate script
+    cmd = f"cp {MOTR_MINI_PROV_LOGROTATE_SCRIPT} {CROND_DIR}"
+    execute_command(self, cmd)
     # Start crond service
     cmd = f"/usr/sbin/crond start"
-    execute_command_verbose(self, cmd, set_timeout=False)
+    execute_command(self, cmd, timeout_secs=120)
 
     # Copy confd_path to /etc/sysconfig
     # confd_path = MOTR_M0D_CONF_DIR/confd.xc

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -52,8 +52,6 @@ BE_LOG_SZ = 4*1024*1024*1024 #4G
 BE_SEG0_SZ = 128 * 1024 *1024 #128M
 MACHINE_ID_FILE = "/etc/machine-id"
 TEMP_FID_FILE = "/opt/seagate/cortx/motr/conf/service_fid.yaml"
-LOGROTATE_CONF_DIR = "/etc/logrotate.d"
-LOGROTATE_MOTR_CONF_FILE = "/etc/logrotate.d/motr"
 CMD_RETRY_COUNT = 5
 
 class MotrError(Exception):
@@ -433,21 +431,24 @@ log file will be rotated hourly and retained recent max 2 files. Max size of log
 Content:
 /etc/cortx/log/motr/<machine-id>/mini_provisioner {
     hourly
-    size 100M
-    rotate 2
+    size 10M
+    rotate 4
     delaycompress
 }
 '''
 def add_entry_to_logrotate_conf_file(self):
+    MOTR_M0D_DATA_DIR = f"{self.local_path}/motr"
+    validate_files([MOTR_M0D_DATA_DIR])
+    mini_prov_conf_file = f"{MOTR_M0D_DATA_DIR}/mini_prov_logrotate.conf"
+
     indent=' '*4
     lines=["{a} {b}\n".format(a=log_file, b='{'),
            f"{indent}hourly\n",
-           f"{indent}size 100M\n",
-           f"{indent}rotate 2\n",
+           f"{indent}size 10M\n",
+           f"{indent}rotate 4\n",
            f"{indent}delaycompress\n",
            "{a}\n".format(a='}')]
-    validate_files(LOGROTATE_CONF_DIR) 
-    with open(f"{LOGROTATE_MOTR_CONF_FILE}", 'w+') as fp:
+    with open(f"{mini_prov_conf_file}", 'w+') as fp:
         for line in lines:
             fp.write(line)
 

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_mini_prov_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_mini_prov_logrotate.sh
@@ -17,11 +17,10 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
-/usr/sbin/logrotate /etc/cortx/motr/mini_prov_logrotate.conf
-EXITVALUE=$?
-
-if [ $EXITVALUE == 0 ]; then
-    echo "Atul on 23 in motr_mini_prov_logrotate.sh....." >> /etc/cortx/atul
+LOGROTATE_CONF_FILE=/etc/cortx/motr/mini_prov_logrotate.conf
+if [[ -f "$LOGROTATE_CONF_FILE" ]]; then
+    /usr/sbin/logrotate $LOGROTATE_CONF_FILE
+    EXITVALUE=$?
 fi
 
 if [ $EXITVALUE != 0 ]; then

--- a/scripts/install/opt/seagate/cortx/motr/libexec/motr_mini_prov_logrotate.sh
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/motr_mini_prov_logrotate.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+/usr/sbin/logrotate /etc/cortx/motr/mini_prov_logrotate.conf
+EXITVALUE=$?
+
+if [ $EXITVALUE == 0 ]; then
+    echo "Atul on 23 in motr_mini_prov_logrotate.sh....." >> /etc/cortx/atul
+fi
+
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit $EXITVALUE

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -371,7 +371,7 @@ misc_files() {
     fi
 
     if [ -f ${MOTR_MINI_PROV_LOG_DIR} ]; then
-        cp ${MOTR_MINI_PROV_LOG_DIR} $outdir/
+        cp ${MOTR_MINI_PROV_LOG_DIR}* $outdir/
     fi
 
 


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
Restrict max size and max copies of motr mini provisioner log file with log rotation. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
