### PR TITLE
CORTX-23743: Add logging for DIX repair tests

### DIFF
--- a/dix/cm/st/dix_repair_st.sh
+++ b/dix/cm/st/dix_repair_st.sh
@@ -630,8 +630,8 @@ main() {
 	start
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	execute_tests 2>&1 | tee -a $MOTR_TEST_LOGFILE
-	rc=${PIPESTATUS[0]}
+	execute_tests 2>&1 | tee -a "$MOTR_TEST_LOGFILE"
+	rc="${PIPESTATUS[0]}"
 	[ $rc != 0 ] && "echo test cases failed"
 	stop
 	if [ $rc -eq 0 ]; then

--- a/dix/cm/st/dix_repair_st.sh
+++ b/dix/cm/st/dix_repair_st.sh
@@ -23,6 +23,7 @@ M0_SRC_DIR="$(readlink -f "${BASH_SOURCE[0]}")"
 M0_SRC_DIR="${M0_SRC_DIR%/*/*/*/*}"
 [ `id -u` -eq 0 ] || die 'Must be run by superuser'
 
+. "$M0_SRC_DIR"/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
 . "$M0_SRC_DIR"/spiel/st/m0t1fs_spiel_dix_common_inc.sh #dix spiel
 . "$M0_SRC_DIR"/motr/st/utils/motr_local_conf.sh
 . "$M0_SRC_DIR"/m0t1fs/linux_kernel/st/m0t1fs_dix_common_inc.sh
@@ -194,7 +195,7 @@ lookup() {
 	local lookup="lookup @${fids_file}"
 	local create="create @${fids_file}"
 	echo "Check existing indices after repair and rebalance"
-	${MOTRTOOL} ${create}
+	run "${MOTRTOOL} ${create}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -203,7 +204,7 @@ lookup() {
 	dix_repair_rebalance_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${lookup} >${out_file}
+	run "${MOTRTOOL} ${lookup} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
@@ -222,7 +223,7 @@ insert() {
 	local put="put \"${fid}\" @${keys_file} @${vals_file}"
 	local get="get \"${fid}\" @${keys_file}"
 	echo "Check existing records after repair and rebalance"
-	${MOTRTOOL} ${create} ${put}
+	run "${MOTRTOOL} ${create} ${put}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -231,13 +232,13 @@ insert() {
 	dix_repair_rebalance_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${lookup} >${out_file}
+	run "${MOTRTOOL} ${lookup} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
 	grep -v "found rc 0" ${rc_file}  | tee ${erc_file}
 	[ -s "${erc_file}" ] && return 1
-	${MOTRTOOL} ${get} >${out_file}
+	run "${MOTRTOOL} ${get} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -265,7 +266,7 @@ get_during() {
 	local get="get \"${fid}\" @${keys_file}"
 
 	echo "Execute GET record operations between repair and rebalance"
-	${MOTRTOOL} ${create} ${put}
+	run "${MOTRTOOL} ${create} ${put}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -276,13 +277,13 @@ get_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Check results.
-	${MOTRTOOL} ${lookup} >${out_file}
+	run "${MOTRTOOL} ${lookup} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
 	grep -v "found rc 0" ${rc_file}  | tee ${erc_file}
 	[ -s "${erc_file}" ] && return 1
-	${MOTRTOOL} ${get} >${out_file}
+	run "${MOTRTOOL} ${get} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -301,13 +302,13 @@ get_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Check results.
-	${MOTRTOOL} ${lookup} >${out_file}
+	run "${MOTRTOOL} ${lookup} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
 	grep -v "found rc 0" ${rc_file}  | tee ${erc_file}
 	[ -s "${erc_file}" ] && return 1
-	${MOTRTOOL} ${get} >${out_file}
+	run "${MOTRTOOL} ${get} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -334,7 +335,7 @@ drop_during() {
 	local drop="drop @${fids_file}"
 
 	echo "Execute drop index operations between repair and rebalance"
-	${MOTRTOOL} ${create} ${put}
+	run "${MOTRTOOL} ${create} ${put}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -345,7 +346,7 @@ drop_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Drop index
-	${MOTRTOOL} ${drop} >${out_file}
+	run "${MOTRTOOL} ${drop} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -356,7 +357,7 @@ drop_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Check results.
-	${MOTRTOOL} ${lookup} >${out_file}
+	run "${MOTRTOOL} ${lookup} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"    ${out_file} | tee ${rc_file}
@@ -376,7 +377,7 @@ put_during() {
 	local get="get \"${fid}\" @${keys_file}"
 
 	echo "Put record into empty index between repair and rebalance"
-	${MOTRTOOL} ${create}
+	run "${MOTRTOOL} ${create}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -387,7 +388,7 @@ put_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Put several records
-	${MOTRTOOL} ${put} >${out_file}
+	run "${MOTRTOOL} ${put} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -398,7 +399,7 @@ put_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Try to get all records.
-	${MOTRTOOL} ${get} >${out_file}
+	run "${MOTRTOOL} ${get} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -424,7 +425,7 @@ del_repair() {
 	local put="put \"${fid}\" @${keys_file} @${vals_file}"
 	local get="get \"${fid}\" @${keys_file}"
 	echo "Del records from index in case repair is in active state"
-	${MOTRTOOL} ${create} ${put}
+	run "${MOTRTOOL} ${create} ${put}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -433,7 +434,7 @@ del_repair() {
 	dix_repair_start
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${del} >${out_file}
+	run "${MOTRTOOL} ${del} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -442,7 +443,7 @@ del_repair() {
 	dix_rep_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${get} >${out_file}
+	run "${MOTRTOOL} ${get} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:" ${out_file}  | tee ${rc_file}
@@ -461,7 +462,7 @@ del_rebalance() {
 	local get="get \"${fid}\" @${keys_file}"
 
 	echo "Del records from index in case repair is in active state"
-	${MOTRTOOL} ${create} ${put}
+	run "${MOTRTOOL} ${create} ${put}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -471,7 +472,7 @@ del_rebalance() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	dix_rebalance_start
-	${MOTRTOOL} ${del} >${out_file}
+	run "${MOTRTOOL} ${del} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -480,7 +481,7 @@ del_rebalance() {
 	dix_reb_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${get} >${out_file}
+	run "${MOTRTOOL} ${get} >${out_file}"
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -493,7 +494,7 @@ del_rebalance() {
 
 clear_kvs() {
 	local drop="drop @${fids_file}"
-	${MOTRTOOL} ${drop}
+	run "${MOTRTOOL} ${drop}"
 }
 
 st_init() {
@@ -501,7 +502,7 @@ st_init() {
 	local gen="genf ${num} ${fids_file} genv ${num} ${size} ${vals_file}"
 
 	# generate source files for KEYS, VALS, FIDS
-	${MOTRTOOL} ${gen}
+	run "${MOTRTOOL} ${gen}"
 	[ $? != 0 ] && return 1
 
 	# We use this file because it contains human-readable values.
@@ -629,8 +630,8 @@ main() {
 	start
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	execute_tests
-	rc=$?
+	execute_tests 2>&1 | tee -a $MOTR_TEST_LOGFILE
+	rc=${PIPESTATUS[0]}
 	[ $rc != 0 ] && "echo test cases failed"
 	stop
 	if [ $rc -eq 0 ]; then

--- a/dix/cm/st/dix_repair_st.sh
+++ b/dix/cm/st/dix_repair_st.sh
@@ -23,7 +23,6 @@ M0_SRC_DIR="$(readlink -f "${BASH_SOURCE[0]}")"
 M0_SRC_DIR="${M0_SRC_DIR%/*/*/*/*}"
 [ `id -u` -eq 0 ] || die 'Must be run by superuser'
 
-. "$M0_SRC_DIR"/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
 . "$M0_SRC_DIR"/spiel/st/m0t1fs_spiel_dix_common_inc.sh #dix spiel
 . "$M0_SRC_DIR"/motr/st/utils/motr_local_conf.sh
 . "$M0_SRC_DIR"/m0t1fs/linux_kernel/st/m0t1fs_dix_common_inc.sh
@@ -195,7 +194,7 @@ lookup() {
 	local lookup="lookup @${fids_file}"
 	local create="create @${fids_file}"
 	echo "Check existing indices after repair and rebalance"
-	run "${MOTRTOOL} ${create}"
+	${MOTRTOOL} ${create}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -204,7 +203,7 @@ lookup() {
 	dix_repair_rebalance_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	run "${MOTRTOOL} ${lookup} >${out_file}"
+	${MOTRTOOL} ${lookup} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
@@ -223,7 +222,7 @@ insert() {
 	local put="put \"${fid}\" @${keys_file} @${vals_file}"
 	local get="get \"${fid}\" @${keys_file}"
 	echo "Check existing records after repair and rebalance"
-	run "${MOTRTOOL} ${create} ${put}"
+	${MOTRTOOL} ${create} ${put}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -232,13 +231,13 @@ insert() {
 	dix_repair_rebalance_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	run "${MOTRTOOL} ${lookup} >${out_file}"
+	${MOTRTOOL} ${lookup} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
 	grep -v "found rc 0" ${rc_file}  | tee ${erc_file}
 	[ -s "${erc_file}" ] && return 1
-	run "${MOTRTOOL} ${get} >${out_file}"
+	${MOTRTOOL} ${get} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -266,7 +265,7 @@ get_during() {
 	local get="get \"${fid}\" @${keys_file}"
 
 	echo "Execute GET record operations between repair and rebalance"
-	run "${MOTRTOOL} ${create} ${put}"
+	${MOTRTOOL} ${create} ${put}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -277,13 +276,13 @@ get_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Check results.
-	run "${MOTRTOOL} ${lookup} >${out_file}"
+	${MOTRTOOL} ${lookup} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
 	grep -v "found rc 0" ${rc_file}  | tee ${erc_file}
 	[ -s "${erc_file}" ] && return 1
-	run "${MOTRTOOL} ${get} >${out_file}"
+	${MOTRTOOL} ${get} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -302,13 +301,13 @@ get_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Check results.
-	run "${MOTRTOOL} ${lookup} >${out_file}"
+	${MOTRTOOL} ${lookup} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"   ${out_file} | tee ${rc_file}
 	grep -v "found rc 0" ${rc_file}  | tee ${erc_file}
 	[ -s "${erc_file}" ] && return 1
-	run "${MOTRTOOL} ${get} >${out_file}"
+	${MOTRTOOL} ${get} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -335,7 +334,7 @@ drop_during() {
 	local drop="drop @${fids_file}"
 
 	echo "Execute drop index operations between repair and rebalance"
-	run "${MOTRTOOL} ${create} ${put}"
+	${MOTRTOOL} ${create} ${put}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -346,7 +345,7 @@ drop_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Drop index
-	run "${MOTRTOOL} ${drop} >${out_file}"
+	${MOTRTOOL} ${drop} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -357,7 +356,7 @@ drop_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Check results.
-	run "${MOTRTOOL} ${lookup} >${out_file}"
+	${MOTRTOOL} ${lookup} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "found rc"    ${out_file} | tee ${rc_file}
@@ -377,7 +376,7 @@ put_during() {
 	local get="get \"${fid}\" @${keys_file}"
 
 	echo "Put record into empty index between repair and rebalance"
-	run "${MOTRTOOL} ${create}"
+	${MOTRTOOL} ${create}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -388,7 +387,7 @@ put_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Put several records
-	run "${MOTRTOOL} ${put} >${out_file}"
+	${MOTRTOOL} ${put} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -399,7 +398,7 @@ put_during() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	# Try to get all records.
-	run "${MOTRTOOL} ${get} >${out_file}"
+	${MOTRTOOL} ${get} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} | tee ${res_out_file}
@@ -425,7 +424,7 @@ del_repair() {
 	local put="put \"${fid}\" @${keys_file} @${vals_file}"
 	local get="get \"${fid}\" @${keys_file}"
 	echo "Del records from index in case repair is in active state"
-	run "${MOTRTOOL} ${create} ${put}"
+	${MOTRTOOL} ${create} ${put}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -434,7 +433,7 @@ del_repair() {
 	dix_repair_start
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	run "${MOTRTOOL} ${del} >${out_file}"
+	${MOTRTOOL} ${del} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -443,7 +442,7 @@ del_repair() {
 	dix_rep_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	run "${MOTRTOOL} ${get} >${out_file}"
+	${MOTRTOOL} ${get} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:" ${out_file}  | tee ${rc_file}
@@ -462,7 +461,7 @@ del_rebalance() {
 	local get="get \"${fid}\" @${keys_file}"
 
 	echo "Del records from index in case repair is in active state"
-	run "${MOTRTOOL} ${create} ${put}"
+	${MOTRTOOL} ${create} ${put}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	device_fail
@@ -472,7 +471,7 @@ del_rebalance() {
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	dix_rebalance_start
-	run "${MOTRTOOL} ${del} >${out_file}"
+	${MOTRTOOL} ${del} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -481,7 +480,7 @@ del_rebalance() {
 	dix_reb_wait
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	run "${MOTRTOOL} ${get} >${out_file}"
+	${MOTRTOOL} ${get} >${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep    "operation rc:"   ${out_file} | tee ${rc_file}
@@ -494,7 +493,7 @@ del_rebalance() {
 
 clear_kvs() {
 	local drop="drop @${fids_file}"
-	run "${MOTRTOOL} ${drop}"
+	${MOTRTOOL} ${drop}
 }
 
 st_init() {
@@ -502,7 +501,7 @@ st_init() {
 	local gen="genf ${num} ${fids_file} genv ${num} ${size} ${vals_file}"
 
 	# generate source files for KEYS, VALS, FIDS
-	run "${MOTRTOOL} ${gen}"
+	${MOTRTOOL} ${gen}
 	[ $? != 0 ] && return 1
 
 	# We use this file because it contains human-readable values.

--- a/dix/cm/st/m0t1fs_dix_repair.sh
+++ b/dix/cm/st/m0t1fs_dix_repair.sh
@@ -125,8 +125,8 @@ main()
 		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
 	done
 
-	dix_repair_test
-	if [ $? -ne 0 ]; then
+	dix_repair_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
+	if [ ${PIPESTATUS[0]} -ne 0 ]; then
 		echo "Failed: DIX repair failed.."
 		rc=1
 	fi

--- a/dix/cm/st/m0t1fs_dix_repair.sh
+++ b/dix/cm/st/m0t1fs_dix_repair.sh
@@ -125,8 +125,8 @@ main()
 		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
 	done
 
-	dix_repair_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
-	if [ ${PIPESTATUS[0]} -ne 0 ]; then
+	dix_repair_test 2>&1 | tee -a "$MOTR_TEST_LOGFILE"
+	if [ "${PIPESTATUS[0]}" -ne 0 ]; then
 		echo "Failed: DIX repair failed.."
 		rc=1
 	fi

--- a/dix/cm/st/m0t1fs_dix_repair_quiesce.sh
+++ b/dix/cm/st/m0t1fs_dix_repair_quiesce.sh
@@ -121,8 +121,8 @@ main()
 		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
 	done
 
-	dix_repair_quiesce_test
-	if [ $? -ne 0 ]; then
+	dix_repair_quiesce_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
+	if [ ${PIPESTATUS[0]} -ne 0 ]; then
 		echo "Failed: DIX repair quiesce failed.."
 		rc=1
 	fi

--- a/dix/cm/st/m0t1fs_dix_repair_quiesce.sh
+++ b/dix/cm/st/m0t1fs_dix_repair_quiesce.sh
@@ -121,8 +121,8 @@ main()
 		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
 	done
 
-	dix_repair_quiesce_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
-	if [ ${PIPESTATUS[0]} -ne 0 ]; then
+	dix_repair_quiesce_test 2>&1 | tee -a "$MOTR_TEST_LOGFILE"
+	if [ "${PIPESTATUS[0]}" -ne 0 ]; then
 		echo "Failed: DIX repair quiesce failed.."
 		rc=1
 	fi

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -866,7 +866,6 @@ function run()
 {
 	echo "# $*"
 	eval $*
-	return $?
 }
 
 ha_events_post()

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -866,6 +866,7 @@ function run()
 {
 	echo "# $*"
 	eval $*
+	return $?
 }
 
 ha_events_post()

--- a/m0t1fs/linux_kernel/st/m0t1fs_dix_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_dix_common_inc.sh
@@ -20,6 +20,8 @@
 M0_SRC_DIR="$(readlink -f "${BASH_SOURCE[0]}")"
 M0_SRC_DIR="${M0_SRC_DIR%/*/*/*/*}"
 
+. "$M0_SRC_DIR"/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+
 CM_OP_REPAIR=1
 CM_OP_REBALANCE=2
 CM_OP_REPAIR_QUIESCE=3
@@ -36,8 +38,7 @@ dix_repair()
 	local rc=0
 
 	repair_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REPAIR -t 1 -C ${lnet_nid}:${DIX_CLI_EP} $ios_eps"
-	echo "$repair_trigger"
-	eval "$repair_trigger"
+	run "$repair_trigger"
 	rc=$?
 	if [ $rc != 0 ]; then
 		echo "DIX Repair failed. rc=$rc"
@@ -51,8 +52,7 @@ dix_rebalance()
 	local rc=0
 
         rebalance_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REBALANCE -t 1 -C ${lnet_nid}:${DIX_CLI_EP} $ios_eps"
-        echo "$rebalance_trigger"
-	eval "$rebalance_trigger"
+	run "$rebalance_trigger"
 	rc=$?
         if [ $rc != 0 ] ; then
                 echo "DIX Re-balance failed. rc=$rc"
@@ -66,8 +66,7 @@ dix_repair_quiesce()
 	local rc=0
 
 	repair_quiesce_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REPAIR_QUIESCE -t 1 -C ${lnet_nid}:${DIX_QUIESCE_CLI_EP} $ios_eps"
-	echo "$repair_quiesce_trigger"
-	eval "$repair_quiesce_trigger"
+	run "$repair_quiesce_trigger"
 	rc=$?
 	if [ $rc != 0 ]; then
 		echo "DIX Repair quiesce failed. rc=$rc"
@@ -81,8 +80,7 @@ dix_rebalance_quiesce()
 	local rc=0
 
 	rebalance_quiesce_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REBALANCE_QUIESCE -t 1 -C ${lnet_nid}:${DIX_QUIESCE_CLI_EP} $ios_eps"
-	echo "$rebalance_quiesce_trigger"
-	eval "$rebalance_quiesce_trigger"
+	run "$rebalance_quiesce_trigger"
 	rc=$?
 	if [ $rc != 0 ] ; then
 		echo "DIX Re-balance quiesce failed. rc=$rc"
@@ -96,8 +94,7 @@ dix_repair_resume()
 	local rc=0
 
 	repair_resume_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REPAIR_RESUME -t 1 -C ${lnet_nid}:${DIX_CLI_EP} $ios_eps"
-	echo "$repair_resume_trigger"
-	eval "$repair_resume_trigger"
+	run "$repair_resume_trigger"
 	rc=$?
 	if [ $rc != 0 ]; then
 		echo "DIX Repair resume failed. rc=$rc"
@@ -111,8 +108,7 @@ dix_rebalance_resume()
 	local rc=0
 
 	rebalance_resume_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REBALANCE_RESUME -t 1 -C ${lnet_nid}:${DIX_CLI_EP} $ios_eps"
-	echo "$rebalance_resume_trigger"
-	eval "$rebalance_resume_trigger"
+	run "$rebalance_resume_trigger"
 	rc=$?
 	if [ $rc != 0 ]; then
 		echo "DIX Rebalance resume failed. rc=$rc"
@@ -126,8 +122,7 @@ dix_rebalance_abort()
 	local rc=0
 
 	rebalance_abort_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REBALANCE_ABORT -t 1 -C ${lnet_nid}:${DIX_QUIESCE_CLI_EP} $ios_eps"
-	echo "$rebalance_abort_trigger"
-	eval "$rebalance_abort_trigger"
+	run "$rebalance_abort_trigger"
 	rc=$?
 	if [ $rc != 0 ] ; then
 		echo "DIX Re-balance abort failed. rc=$rc"
@@ -141,8 +136,7 @@ dix_repair_abort()
 	local rc=0
 
 	repair_abort_trigger="$M0_SRC_DIR/sns/cm/st/m0repair -O $CM_OP_REPAIR_ABORT -t 1 -C ${lnet_nid}:${DIX_QUIESCE_CLI_EP} $ios_eps"
-	echo "$repair_abort_trigger"
-	eval "$repair_abort_trigger"
+	run "$repair_abort_trigger"
 	rc=$?
 	if [ $rc != 0 ]; then
 		echo "DIX Repair abort failed. rc=$rc"
@@ -164,8 +158,7 @@ dix_repair_or_rebalance_status_not_4()
 	done
 
 	repair_status="$M0_SRC_DIR/sns/cm/st/m0repair -O $op -t 1 -C ${lnet_nid}:${DIX_QUIESCE_CLI_EP} $ios_eps_not_4"
-	echo "$repair_status"
-	eval "$repair_status"
+	run "$repair_status"
 	rc=$?
 	if [ $rc != 0 ]; then
 		echo "DIX $1 status query failed. rc=$rc"
@@ -183,8 +176,7 @@ dix_repair_or_rebalance_status()
 	[ "$1" == "rebalance" ] && op=$CM_OP_REBALANCE_STATUS
 
 	repair_status="$M0_SRC_DIR/sns/cm/st/m0repair -O $op -t 1 -C ${lnet_nid}:${DIX_QUIESCE_CLI_EP} $ios_eps"
-	echo "$repair_status"
-	eval "$repair_status"
+	run "$repair_status"
 	rc=$?
 	if [ $rc != 0 ]; then
 		echo "DIX $1 status query failed. rc=$rc"

--- a/spiel/st/m0t1fs_spiel_dix_repair.sh
+++ b/spiel/st/m0t1fs_spiel_dix_repair.sh
@@ -120,8 +120,8 @@ main()
 
 	spiel_prepare
 
-	spiel_dix_repair_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
-	if [ ${PIPESTATUS[0]} -ne 0 ]; then
+	spiel_dix_repair_test 2>&1 | tee -a "$MOTR_TEST_LOGFILE"
+	if [ "${PIPESTATUS[0]}" -ne 0 ]; then
 		echo "Failed: DIX repair failed.."
 		rc=1
 	fi

--- a/spiel/st/m0t1fs_spiel_dix_repair.sh
+++ b/spiel/st/m0t1fs_spiel_dix_repair.sh
@@ -120,7 +120,8 @@ main()
 
 	spiel_prepare
 
-	if [[ $rc -eq 0 ]] && ! spiel_dix_repair_test ; then
+	spiel_dix_repair_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
+	if [ ${PIPESTATUS[0]} -ne 0 ]; then
 		echo "Failed: DIX repair failed.."
 		rc=1
 	fi

--- a/spiel/st/m0t1fs_spiel_dix_repair_quiesce.sh
+++ b/spiel/st/m0t1fs_spiel_dix_repair_quiesce.sh
@@ -114,10 +114,10 @@ main()
 		return 1
 	}
 
-
 	spiel_prepare
 
-	if [[ $rc -eq 0 ]] && ! spiel_dix_repair_quiesce_test ; then
+	spiel_dix_repair_quiesce_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
+	if [ ${PIPESTATUS[0]} -ne 0 ]; then
 		echo "Failed: DIX repair failed.."
 		rc=1
 	fi

--- a/spiel/st/m0t1fs_spiel_dix_repair_quiesce.sh
+++ b/spiel/st/m0t1fs_spiel_dix_repair_quiesce.sh
@@ -116,8 +116,8 @@ main()
 
 	spiel_prepare
 
-	spiel_dix_repair_quiesce_test 2>&1 | tee -a $MOTR_TEST_LOGFILE
-	if [ ${PIPESTATUS[0]} -ne 0 ]; then
+	spiel_dix_repair_quiesce_test 2>&1 | tee -a "$MOTR_TEST_LOGFILE"
+	if [ "${PIPESTATUS[0]}" -ne 0 ]; then
 		echo "Failed: DIX repair failed.."
 		rc=1
 	fi


### PR DESCRIPTION
# Problem Statement
- Motr system test 24motr-dix-repair test log file not found in the indicated folder after test failure.

# Design
-  The logging is added for motr and m0t1fs DIX repair tests. This will keep the test logs available in case of failure.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
