### PR TITLE
Suppress excess errors in kubectl logs due to Btree

### DIFF
--- a/be/extmap.c
+++ b/be/extmap.c
@@ -580,7 +580,7 @@ M0_INTERNAL void m0_be_emap_merge(struct m0_be_emap_cursor *it,
 	m0_rwlock_write_lock(emap_rwlock(it->ec_map));
 	rc = emap_it_pack(it, be_emap_delete_wrapper, tx);
 	if (rc != 0)
-		M0_RC(rc);
+		M0_ERR(rc);
 
 	if (rc == 0 && delta < m0_ext_length(&it->ec_seg.ee_ext)) {
 		it->ec_seg.ee_ext.e_end -= delta;
@@ -592,7 +592,7 @@ M0_INTERNAL void m0_be_emap_merge(struct m0_be_emap_cursor *it,
 		rc = emap_it_get(it) /* re-initialise cursor position */ ?:
 			update_next_segment(it, tx, delta, inserted);
 	else
-		M0_RC(rc);
+		M0_ERR(rc);
 	m0_rwlock_write_unlock(emap_rwlock(it->ec_map));
 
 	M0_ASSERT_EX(ergo(rc == 0, be_emap_invariant(it)));

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7240,7 +7240,7 @@ static int  btree_sibling_first_key(struct m0_btree_oimpl *oi, struct td *tree,
 			return 0;
 		}
 	}
-	return M0_ERR(-ENOENT);
+	return -ENOENT;
 }
 
 /**

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -4186,7 +4186,7 @@ static void fkvv_rec_del_credit(const struct nd *node, m0_bcount_t ksize,
  *  Variable Sized Keys and Values Node Structure
  *  --------------------------------------------
  *
- * Proposed internal node structure
+ * Internal node structure
  *
  * +----------+----+------+----+----------------+----+----+----+----+----+----+
  * |          |    |      |    |                |    |    |    |    |    |    |
@@ -4201,7 +4201,7 @@ static void fkvv_rec_del_credit(const struct nd *node, m0_bcount_t ksize,
  *                             |                  |
  *                             +------------------+
  *
- * For the internal nodes, the above structure will be used.
+ * For the internal nodes, the above structure is used.
  * The internal nodes will have keys of variable size whereas the values will be
  * of fixed size as they are pointers to child nodes.
  * The Keys will be added starting from the end of the node header in an
@@ -4211,7 +4211,7 @@ static void fkvv_rec_del_credit(const struct nd *node, m0_bcount_t ksize,
  * Using this structure, the overhead of maintaining a directory is reduced.
  *
  *
- * Proposed leaf node structure
+ * Leaf node structure
  *
  *                        +--------------------------+
  *                        |                          |
@@ -4235,8 +4235,8 @@ static void fkvv_rec_del_credit(const struct nd *node, m0_bcount_t ksize,
  *
  *
  *
- *  The above structure represents the way variable sized keys and values will
- *  be stored in memory.
+ *  The above structure represents the way variable sized keys and values are
+ *  stored in memory.
  *  Node Hdr or Node Header will store all the relevant info regarding this node
  *  type.
  *  The Keys will be added starting from the end of the node header in an
@@ -6650,12 +6650,12 @@ static int64_t btree_put_kv_tick(struct m0_sm_op *smop)
 		}
 		/** Fall through if path_check is successful. */
 	case P_SANITY_CHECK: {
-		int  rc = 0;
+		int rc = 0;
 		if (oi->i_key_found && bop->bo_opc == M0_BO_PUT)
-			rc = M0_ERR(-EEXIST);
+			rc = -EEXIST;
 		else if (!oi->i_key_found && bop->bo_opc == M0_BO_UPDATE &&
 			 !(bop->bo_flags & BOF_INSERT_IF_NOT_FOUND))
-			rc = M0_ERR(-ENOENT);
+			rc = -ENOENT;
 
 		if (rc) {
 			lock_op_unlock(tree);
@@ -7421,7 +7421,7 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 				bnode_rec(&s);
 			else if (bop->bo_flags & BOF_EQUAL) {
 				lock_op_unlock(tree);
-				return fail(bop, M0_ERR(-ENOENT));
+				return fail(bop, -ENOENT);
 			} else { /** bop->bo_flags & BOF_SLANT */
 				if (lev->l_idx < count)
 					bnode_rec(&s);
@@ -7444,7 +7444,7 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 			} else {
 				/** Only root node is present and is empty. */
 				lock_op_unlock(tree);
-				return fail(bop, M0_ERR(-ENOENT));
+				return fail(bop, -ENOENT);
 			}
 		}
 
@@ -7759,7 +7759,7 @@ static int64_t btree_iter_kv_tick(struct m0_sm_op *smop)
 		} else if (oi->i_pivot == -1) {
 			/* Handle rightmost/leftmost key case. */
 			lock_op_unlock(tree);
-			return fail(bop, M0_ERR(-ENOENT));
+			return fail(bop, -ENOENT);
 		} else {
 			/* Return sibling record based on flag. */
 			s.s_node = lev->l_sibling;
@@ -8232,7 +8232,7 @@ static int64_t btree_del_kv_tick(struct m0_sm_op *smop)
 
 		if (!oi->i_key_found) {
 			lock_op_unlock(tree);
-			return fail(bop, M0_ERR(-ENOENT));
+			return fail(bop, -ENOENT);
 		}
 
 		lev = &oi->i_level[oi->i_used];

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -3098,7 +3098,7 @@ static void ff_rec_del_credit(const struct nd *node, m0_bcount_t ksize,
 
 /**
  *
- * Proposed Node Structure for Fix Sized Keys and Variable Sized Value :
+ * Node Structure for Fix Sized Keys and Variable Sized Value :
  *
  * Leaf Node Structure :
  *

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -1160,10 +1160,10 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 			M0_ASSERT(rc == 0);
 		}
 		else
-			rc= M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
-						     m0_btree_put(btree, &rec,
-								  &cb, &kv_op,
-								  tx));
+			rc = M0_BTREE_OP_SYNC_WITH_RC(&kv_op,
+						      m0_btree_put(btree, &rec,
+								   &cb, &kv_op,
+								   tx));
 		m0_be_op_done(beop);
 		break;
 	case CTG_OP_COMBINE(CO_PUT, CT_META): {
@@ -1274,7 +1274,7 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 		m0_be_op_done(beop);
 		break;
 	}
-	ctg_op->co_rc = rc;
+	ctg_op->co_rc = M0_RC(rc);
 	return ctg_op_tick_ret(ctg_op, next_phase);
 }
 
@@ -2107,7 +2107,7 @@ M0_INTERNAL int m0_ctg_ctidx_delete_sync(const struct m0_cas_id *cid,
 							   &kv_op, tx));
 
 	m0_chan_broadcast_lock(&ctidx->cc_chan.bch_chan);
-	return rc;
+	return M0_RC(rc);
 }
 
 M0_INTERNAL int m0_ctg_mem_place(struct m0_ctg_op    *ctg_op,

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -1274,7 +1274,7 @@ static int ctg_op_exec(struct m0_ctg_op *ctg_op, int next_phase)
 		m0_be_op_done(beop);
 		break;
 	}
-	ctg_op->co_rc = M0_RC(rc);
+	ctg_op->co_rc = rc == 0 ? rc : M0_ERR(rc);
 	return ctg_op_tick_ret(ctg_op, next_phase);
 }
 
@@ -2084,7 +2084,8 @@ M0_INTERNAL int m0_ctg_ctidx_delete_sync(const struct m0_cas_id *cid,
 	/* Firstly we should free buffer allocated for imask ranges array. */
 	rc = m0_ctg_ctidx_lookup_sync(&cid->ci_fid, &layout);
 	if (rc != 0)
-		return rc;
+		return M0_ERR(rc);
+
 	imask = &layout->u.dl_desc.ld_imask;
 	if (!m0_dix_imask_is_empty(imask)) {
 		/** @todo Make it asynchronous. */
@@ -2107,7 +2108,7 @@ M0_INTERNAL int m0_ctg_ctidx_delete_sync(const struct m0_cas_id *cid,
 							   &kv_op, tx));
 
 	m0_chan_broadcast_lock(&ctidx->cc_chan.bch_chan);
-	return M0_RC(rc);
+	return rc == 0 ? rc : M0_ERR(rc);
 }
 
 M0_INTERNAL int m0_ctg_mem_place(struct m0_ctg_op    *ctg_op,

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1024,13 +1024,13 @@ M0_INTERNAL int m0_cob_domain_mkfs(struct m0_cob_domain *dom,
 	m0_buf_init(&rec, &omgrec, sizeof omgrec);
 	rc = cob_table_insert(dom->cd_fileattr_omg, tx, &key, &rec);
 	if (rc != 0)
-		return M0_RC(rc);
+		return M0_ERR(rc);
 	/**
 	   Create root cob where all namespace is stored.
 	 */
 	rc = m0_cob_alloc(dom, &cob);
 	if (rc != 0)
-		return M0_RC(rc);
+		return M0_ERR(rc);
 
 	rc = m0_cob_nskey_make(&nskey, &M0_COB_ROOT_FID, M0_COB_ROOT_NAME,
 			       strlen(M0_COB_ROOT_NAME));

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -2052,7 +2052,7 @@ M0_INTERNAL int m0_cob_name_update(struct m0_cob *cob,
 	/* here @val consists value to insert */
 	rc = cob_table_insert(cob->co_dom->cd_namespace, tx, &key, &val);
 	if (rc != 0)
-		return M0_RC(rc);
+		return M0_ERR(rc);
 	/*
 	 * Kill old record. Error will be returned if
 	 * nothing found.
@@ -2215,7 +2215,7 @@ M0_INTERNAL int m0_cob_ea_set(struct m0_cob *cob,
 	m0_buf_init(&val, earec, m0_cob_earec_size(earec));
 	rc = cob_table_insert(cob->co_dom->cd_fileattr_ea, tx, &key, &val);
 	if (rc != 0)
-		return M0_RC(rc);
+		return M0_ERR(rc);
 
 	return 0;
 }

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1022,8 +1022,9 @@ M0_INTERNAL int m0_cob_domain_mkfs(struct m0_cob_domain *dom,
 
 	m0_buf_init(&key, &omgkey, sizeof omgkey);
 	m0_buf_init(&rec, &omgrec, sizeof omgrec);
-	cob_table_insert(dom->cd_fileattr_omg, tx, &key, &rec);
-
+	rc = cob_table_insert(dom->cd_fileattr_omg, tx, &key, &rec);
+	if (rc != 0)
+		return M0_RC(rc);
 	/**
 	   Create root cob where all namespace is stored.
 	 */
@@ -2049,8 +2050,9 @@ M0_INTERNAL int m0_cob_name_update(struct m0_cob *cob,
 
 	m0_buf_init(&key, tgtkey, m0_cob_nskey_size(tgtkey));
 	/* here @val consists value to insert */
-	cob_table_insert(cob->co_dom->cd_namespace, tx, &key, &val);
-
+	rc = cob_table_insert(cob->co_dom->cd_namespace, tx, &key, &val);
+	if (rc != 0)
+		return M0_RC(rc);
 	/*
 	 * Kill old record. Error will be returned if
 	 * nothing found.
@@ -2200,6 +2202,7 @@ M0_INTERNAL int m0_cob_ea_set(struct m0_cob *cob,
 {
 	struct m0_buf key;
 	struct m0_buf val;
+	int           rc;
 
 	M0_PRE(cob != NULL);
 	M0_PRE(eakey != NULL);
@@ -2210,7 +2213,9 @@ M0_INTERNAL int m0_cob_ea_set(struct m0_cob *cob,
 
 	m0_buf_init(&key, eakey, m0_cob_eakey_size(eakey));
 	m0_buf_init(&val, earec, m0_cob_earec_size(earec));
-	cob_table_insert(cob->co_dom->cd_fileattr_ea, tx, &key, &val);
+	rc = cob_table_insert(cob->co_dom->cd_fileattr_ea, tx, &key, &val);
+	if (rc != 0)
+		return M0_RC(rc);
 
 	return 0;
 }


### PR DESCRIPTION
# Problem Statement
We observe a lot of expected ERRORs in kubectl logs. These errors make reading the logs a bit problematic, and might hide the errors. 
 
# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
