### PR TITLE
CORTX-29117: "server-restart-nomkfs", cas-service ut is failing in new btree

### DIFF
--- a/cas/ut/service_ut.c
+++ b/cas/ut/service_ut.c
@@ -115,8 +115,8 @@ static void reqh_init(bool mkfs, bool use_small_credits)
 {
 	struct m0_be_domain_cfg cfg = {};
 	int                     result;
-	struct m0_be_ut_seg     ut_seg;
-	m0_bcount_t             seg_size = 1 * 1024 * 1024 * 1024;
+	/** Increase default seg0 size to 16 MB for cas-service ut. */
+	m0_bcount_t             segment_size = 1 << 24;
 
 	M0_SET0(&reqh);
 	M0_SET0(&be);
@@ -132,10 +132,11 @@ static void reqh_init(bool mkfs, bool use_small_credits)
 	if (use_small_credits || m0_ut_small_credits())
 		cfg.bc_engine.bec_tx_size_max =
 			M0_BE_TX_CREDIT(6 << 10, 5 << 18);
+	cfg.bc_seg0_cfg.bsc_size = segment_size;
+	cfg.bc_seg0_cfg.bsc_addr = m0_be_ut_seg_allocate_addr(segment_size);
+
 	result = m0_be_ut_backend_init_cfg(&be, &cfg, mkfs);
 	M0_ASSERT(result == 0);
-	M0_SET0(&ut_seg);
-	m0_be_ut_seg_init(&ut_seg, &be, seg_size);
 }
 
 static void _init(bool mkfs, bool use_small_credits)


### PR DESCRIPTION
Problem:
Found issue while running cas-service ut with following command:
./utils/m0run m0ut --debugger=cgdb -- -t 'cas-service,be-ut:emap,balloc-ut'
Earlier 1GB segment were being used to run cas-service ut.

Fix:
Increase the seg0 size to 16MB for cas-service ut.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
