### PR TITLE
CORTX-27737 : Handle Metadata disk failure

### DIFF
--- a/be/ha.c
+++ b/be/ha.c
@@ -42,7 +42,7 @@ m0_be_io_err_send(uint32_t errcode, uint8_t location, uint8_t io_opcode)
 
 	M0_ENTRY("errcode=%d location=%u io_opcode=%u",
 		 errcode, location, io_opcode);
-	M0_PRE(errcode < 0);
+	M0_PRE(errcode > 0);
 	M0_PRE(M0_BE_LOC_NONE <= location && location <= M0_BE_LOC_SEGMENT_2);
 	M0_PRE(SIO_INVALID <= io_opcode && io_opcode <= SIO_SYNC);
 

--- a/be/io.c
+++ b/be/io.c
@@ -550,7 +550,6 @@ static void be_io_finished(struct m0_be_io *bio)
 				break;
 			}
 		}
-		M0_ASSERT_INFO(rc == 0, "m0_be_op can't fail, rc = %d", rc);
 		m0_be_op_rc_set(op, rc);
 		m0_be_op_done(op);
 	}
@@ -566,10 +565,6 @@ static bool be_io_cb(struct m0_clink *link)
 	int                   fd;
 	int                   rc;
 
-	/* XXX Temporary workaround. I/O error should be handled gracefully. */
-	M0_ASSERT_INFO(sio->si_rc == 0, "stob I/O operation failed: "
-		       "bio = %p, sio = %p, sio->si_rc = %d",
-		       bio, sio, sio->si_rc);
 	rc = sio->si_rc;
 
 	/* XXX temporary workaround:

--- a/be/io.c
+++ b/be/io.c
@@ -550,6 +550,8 @@ static void be_io_finished(struct m0_be_io *bio)
 				break;
 			}
 		}
+		if (rc != 0)
+			M0_LOG(M0_ERROR, "m0_be_op fails with rc = %d", rc);
 		m0_be_op_rc_set(op, rc);
 		m0_be_op_done(op);
 	}
@@ -565,6 +567,8 @@ static bool be_io_cb(struct m0_clink *link)
 	int                   fd;
 	int                   rc;
 
+	if (sio->si_rc != 0)
+		M0_LOG(M0_ERROR, "Stob I/O operation failed sio->si_rc = %d",sio->si_rc);
 	rc = sio->si_rc;
 
 	/* XXX temporary workaround:


### PR DESCRIPTION
If Metadata disk fails m0d process will crash due to signal SIGBUS.
After m0d process crashes, motr-monitor will keep restarting the failed m0d process which will keep crashing with signal SIGBUS.

Solution :  
    A signal handler for SIGBUS in motr/m0d.c
    When SIGBUS is signalled to m0d, m0d process will be paused till some other signal is received.

Problem analysis : https://jts.seagate.com/browse/CORTX-27736
Implementation : https://jts.seagate.com/browse/CORTX-27737

Signed-off-by: Jugal Patil <jugal.patil@seagate.com>