### PR TITLE
CORTX-27608 dix/dtm0: add support of transient failures for PUT

### DIFF
--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -506,20 +506,20 @@ M0_INTERNAL void m0_be_dtm0_volatile_log_update(struct m0_be_dtm0_log  *log,
 						struct m0_dtm0_log_rec *rec);
 
 /**
- * Deliver a persistent message to the log.
+ * Deletes the log record from the log and optionally finalizes
+ * that log record.
  *
  * @pre log is a volatile log
- * @pre fop->f_type == &dtm0_req_fop_fopt;
  * @post None
  *
- * @param log Pointer to the dtm0 log which we wish to destroy
- * @param fop This is a fop for the request carrying a PERSISTENT notice
- * @return None
- *
- * TODO: Only volatile log is supported so far.
+ * @param log Pointer to the volatile log where we want to delete the record.
+ * @param rec The record to be deleted from the volatile log.
+ * @param fini Specifies whether deleted record needs to be finalised.
+ * @return None.
  */
-M0_INTERNAL void m0_be_dtm0_log_pmsg_post(struct m0_be_dtm0_log *log,
-					  struct m0_fop         *fop);
+M0_INTERNAL void m0_be_dtm0_volatile_log_del(struct m0_be_dtm0_log  *log,
+					     struct m0_dtm0_log_rec *rec,
+					     bool                    fini);
 
 /** @} */ /* end DTM0Internals */
 

--- a/dtm0/dtx.c
+++ b/dtm0/dtx.c
@@ -128,10 +128,9 @@ static void dtx_log_update(struct m0_dtm0_dtx *dtx)
 	M0_PRE(dtx->dd_dtms != NULL);
 	log = dtx->dd_dtms->dos_log;
 	M0_PRE(log != NULL);
+	M0_PRE(m0_mutex_is_locked(&log->dl_lock));
 
-	m0_mutex_lock(&log->dl_lock);
 	m0_be_dtm0_volatile_log_update(log, record);
-	m0_mutex_unlock(&log->dl_lock);
 }
 
 static void dtx_init(struct m0_dtm0_dtx     *dtx,
@@ -162,15 +161,22 @@ static struct m0_dtm0_dtx *dtx_alloc(struct m0_dtm0_service *svc,
 
 static void dtx_fini(struct m0_dtm0_dtx *dtx)
 {
+	struct m0_be_dtm0_log  *log;
 	struct m0_dtm0_log_rec *rec;
+
 	M0_PRE(dtx != NULL);
+	M0_PRE(m0_mutex_is_locked(&dtx->dd_dtms->dos_log->dl_lock));
 	rec = M0_AMB(rec, dtx, dlr_dtx);
+	log = dtx->dd_dtms->dos_log;
 	M0_ASSERT_INFO(ergo(dtx->dd_sm.sm_state >= M0_DDS_INPROGRESS,
 			    rec->dlr_magic != 0),
 		       "A DTX in INPROGRESS+ state must be a part of the log.");
+
 	m0_sm_fini(&dtx->dd_sm);
 	m0_dtm0_tx_desc_fini(&dtx->dd_txd);
 	M0_SET0(dtx);
+	if (!log->dl_is_persistent)
+		m0_be_dtm0_volatile_log_del(log, rec, true);
 }
 
 static void dtx_prepare(struct m0_dtm0_dtx *dtx)
@@ -310,6 +316,7 @@ static void dtx_done(struct m0_dtm0_dtx *dtx)
 	M0_PRE(dtx != NULL);
 	M0_PRE(m0_sm_group_is_locked(dtx->dd_sm.sm_grp));
 	M0_PRE(dtx->dd_sm.sm_state == M0_DDS_STABLE);
+
 	m0_sm_state_set(&dtx->dd_sm, M0_DDS_DONE);
 	dtx_fini(dtx);
 	M0_LEAVE();
@@ -324,7 +331,7 @@ static void dtx_exec_all_ast_cb(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	M0_ASSERT(dtx->dd_sm.sm_state == M0_DDS_EXECUTED_ALL);
 	M0_ASSERT(dtx->dd_nr_executed == dtx->dd_txd.dtd_ps.dtp_nr);
 
-	if (m0_dtm0_tx_desc_state_eq(&dtx->dd_txd, M0_DTPS_PERSISTENT)) {
+	if (m0_dtm0_tx_desc_state_exists(&dtx->dd_txd, M0_DTPS_PERSISTENT)) {
 		m0_sm_state_set(&dtx->dd_sm, M0_DDS_STABLE);
 		M0_LOG(M0_DEBUG, "dtx " DTID0_F "is stable (EXEC_ALL)",
 		       DTID0_P(&dtx->dd_txd.dtd_id));
@@ -336,68 +343,86 @@ static void dtx_exec_all_ast_cb(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 static void dtx_persistent_ast_cb(struct m0_sm_group *grp,
 				  struct m0_sm_ast   *ast)
 {
+	struct m0_dtm0_log_rec       *rec;
+	struct m0_dtm0_dtx           *dtx;
 	struct m0_dtm0_pmsg_ast      *pma = ast->sa_datum;
-	struct m0_dtm0_dtx           *dtx = pma->p_dtx;
 	struct m0_fop                *fop = pma->p_fop;
+	struct m0_be_dtm0_log        *log = pma->p_log;
 	struct dtm0_req_fop          *req = m0_fop_data(fop);
 	const struct m0_dtm0_tx_desc *txd = &req->dtr_txr;
 
-	M0_ENTRY("dtx=%p, fop=%p", dtx, fop);
+	M0_ENTRY("fop=%p", fop);
 
-	if (M0_IS0(dtx)) {
-		M0_LOG(M0_DEBUG, "Dtx has already reached DONE state, "
-		       "ignoring P msg for " DTID0_F ".",
-		       DTID0_P(&txd->dtd_id));
-		goto out;
+	m0_mutex_lock(&log->dl_lock);
+	rec = m0_be_dtm0_log_find(log, &txd->dtd_id);
+
+	if (rec != NULL) {
+		dtx = &rec->dlr_dtx;
+		m0_dtm0_tx_desc_apply(&dtx->dd_txd, txd);
+		dtx_log_update(dtx);
+
+		if (dtx->dd_sm.sm_state == M0_DDS_EXECUTED_ALL &&
+		    m0_dtm0_tx_desc_state_exists(&dtx->dd_txd,
+						 M0_DTPS_PERSISTENT)) {
+			M0_ASSERT(dtx->dd_nr_executed ==
+				  dtx->dd_txd.dtd_ps.dtp_nr);
+			M0_LOG(M0_DEBUG, "dtx " DTID0_F "is stable (PMA)",
+			       DTID0_P(&dtx->dd_txd.dtd_id));
+			m0_sm_state_set(&dtx->dd_sm, M0_DDS_STABLE);
+		}
 	}
+	m0_mutex_unlock(&log->dl_lock);
 
-	m0_dtm0_tx_desc_apply(&dtx->dd_txd, txd);
-	dtx_log_update(dtx);
-
-	if (dtx->dd_sm.sm_state == M0_DDS_EXECUTED_ALL &&
-	    m0_dtm0_tx_desc_state_eq(&dtx->dd_txd, M0_DTPS_PERSISTENT)) {
-		M0_ASSERT(dtx->dd_nr_executed == dtx->dd_txd.dtd_ps.dtp_nr);
-		M0_LOG(M0_DEBUG, "dtx " DTID0_F "is stable (PMA)",
-		       DTID0_P(&dtx->dd_txd.dtd_id));
-		m0_sm_state_set(&dtx->dd_sm, M0_DDS_STABLE);
-	}
-
-out:
 	m0_free(pma);
 	m0_fop_put_lock(fop); /* it was taken in ::m0_dtm0_dtx_post_pmsg */
 	M0_LEAVE();
 }
 
-M0_INTERNAL void m0_dtm0_dtx_pmsg_post(struct m0_dtm0_dtx *dtx,
-				       struct m0_fop      *fop)
+M0_INTERNAL void m0_dtm0_dtx_pmsg_post(struct m0_be_dtm0_log *log,
+				       struct m0_fop         *fop)
 {
-	struct m0_dtm0_pmsg_ast *pma;
+	struct m0_dtm0_pmsg_ast      *pma;
+	struct m0_sm_group           *dtx_sm_grp;
+	struct m0_dtm0_log_rec       *rec;
+	struct dtm0_req_fop          *req = m0_fop_data(fop);
+	const struct m0_dtm0_tx_desc *txd = &req->dtr_txr;
 
 	M0_PRE(fop != NULL);
 	M0_PRE(fop->f_opaque != NULL);
 	M0_PRE(m0_fop_data(fop) != NULL);
-	M0_PRE(dtx->dd_sm.sm_grp != &fop->f_item.ri_rmachine->rm_sm_grp);
+	M0_PRE(fop->f_type == &dtm0_req_fop_fopt);
+	M0_PRE(!log->dl_is_persistent);
 
-	M0_ENTRY("dtx=%p, fop=%p", dtx, fop);
+	M0_ENTRY("fop=%p", fop);
+
 	/*
-	 * XXX: it is an uncommon case where f_opaque is used on the server
-	 * side (rather than on the client side) to associate a FOP with
-	 * a user-defined datum. It helps to connect the lifetime of the
-	 * AST that handles the notice with the lifetime of the FOP that
-	 * has delivered the notice.
+	 * This lookup is done to find the SM group that corresponds
+	 * to DTX SM to post AST. We can not use DTX itself here since
+	 * it can be cleared in another thread and the log lock does
+	 * not protect the DTX between current function and AST.
 	 */
-	pma = fop->f_opaque;
-	M0_ASSERT_INFO(M0_IS0(pma), "PMA cannot be re-used");
-	*pma = (struct  m0_dtm0_pmsg_ast) {
-		.p_dtx = dtx,
-		.p_fop = fop,
-		.p_ast = {
-			.sa_cb = dtx_persistent_ast_cb,
-			.sa_datum = pma,
-		},
-	};
-	m0_fop_get(fop); /* it will be put back by ::dtx_persistent_ast_cb */
-	m0_sm_ast_post(dtx->dd_sm.sm_grp, &pma->p_ast);
+	m0_mutex_lock(&log->dl_lock);
+	rec = m0_be_dtm0_log_find(log, &txd->dtd_id);
+	dtx_sm_grp = rec != NULL ? rec->dlr_dtx.dd_sm.sm_grp : NULL;
+	m0_mutex_unlock(&log->dl_lock);
+
+	if (rec != NULL) {
+		M0_ASSERT(fop->f_opaque != NULL);
+		pma = fop->f_opaque;
+		*pma = (struct m0_dtm0_pmsg_ast) {
+			.p_log = log,
+			.p_fop = fop,
+			.p_ast = {
+				.sa_cb = dtx_persistent_ast_cb,
+				.sa_datum = pma,
+			},
+		};
+		/* pma will be freed by ::dtx_persistent_ast_cb */
+		fop->f_opaque = NULL;
+		/* It will be put back by ::dtx_persistent_ast_cb */
+		m0_fop_get(fop);
+		m0_sm_ast_post(dtx_sm_grp, &pma->p_ast);
+	}
 	M0_LEAVE();
 }
 
@@ -449,7 +474,10 @@ static void dtx_executed(struct m0_dtm0_dtx *dtx, uint32_t idx)
 		m0_sm_ast_post(dtx->dd_sm.sm_grp, &dtx->dd_exec_all_ast);
 	}
 
+	m0_mutex_lock(&dtx->dd_dtms->dos_log->dl_lock);
 	dtx_log_update(dtx);
+	m0_mutex_unlock(&dtx->dd_dtms->dos_log->dl_lock);
+
 	M0_LEAVE();
 }
 
@@ -503,8 +531,14 @@ M0_INTERNAL void m0_dtx0_executed(struct m0_dtx *dtx, uint32_t pa_idx)
 
 M0_INTERNAL void m0_dtx0_done(struct m0_dtx *dtx)
 {
+	struct m0_be_dtm0_log *log;
+
 	M0_PRE(dtx != NULL);
+
+	log = dtx->tx_dtx->dd_dtms->dos_log;
+	m0_mutex_lock(&log->dl_lock);
 	dtx_done(dtx->tx_dtx);
+	m0_mutex_unlock(&log->dl_lock);
 }
 
 M0_INTERNAL int m0_dtx0_txd_copy(const struct m0_dtx    *dtx,

--- a/dtm0/dtx.h
+++ b/dtm0/dtx.h
@@ -76,12 +76,12 @@ struct m0_dtm0_dtx {
 
 /** An AST object for persistent message processing. */
 struct m0_dtm0_pmsg_ast {
-	/** AST where the update is applied */
+	/** AST where the update is applied. */
 	struct m0_sm_ast       p_ast;
 	/** A FOP that contains a partial update to be applied. */
 	struct m0_fop         *p_fop;
-	/** A dtx that has to be update */
-	struct m0_dtm0_dtx    *p_dtx;
+	/** A pointer to the DTM0 log. */
+	struct m0_be_dtm0_log *p_log;
 };
 
 M0_INTERNAL void m0_dtm0_dtx_domain_init(void);
@@ -147,11 +147,11 @@ M0_INTERNAL void m0_dtx0_done(struct m0_dtx *dtx);
 
 /**
  * Launches asynchronous processing of a persistent message.
- * @param dtx A DTX that is the context for the processing.
- * @param fop An FOP with the P message.
+ * @param log A pointer to the DTM0 log.
+ * @param fop A FOP with the P message.
  */
-M0_INTERNAL void m0_dtm0_dtx_pmsg_post(struct m0_dtm0_dtx *dtx,
-				       struct m0_fop      *fop);
+M0_INTERNAL void m0_dtm0_dtx_pmsg_post(struct m0_be_dtm0_log *log,
+				       struct m0_fop         *fop);
 
 /**
  * Puts a copy of dtx's transaction descriptor into "dst".

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -433,7 +433,7 @@ static int dtm0_pmsg_fom_tick(struct m0_fom *fom)
 			 * modifed right here. We have to post an AST
 			 * to ensure DTX is modifed under the group lock held.
 			 */
-			m0_be_dtm0_log_pmsg_post(svc->dos_log, fom->fo_fop);
+			m0_dtm0_dtx_pmsg_post(svc->dos_log, fom->fo_fop);
 			rep->dr_rc = 0;
 		} else {
 			rep->dr_rc = m0_dtm0_logrec_update(svc->dos_log,

--- a/dtm0/tx_desc.c
+++ b/dtm0/tx_desc.c
@@ -55,7 +55,6 @@ M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td)
 	 * if all PAs are moved past INIT state then
 	 * the descriptor should have a valid ID.
 	 */
-
 	return _0C(td->dtd_ps.dtp_pa != NULL) &&
 		_0C(m0_forall(i, td->dtd_ps.dtp_nr,
 			      td->dtd_ps.dtp_pa[i].p_state >= 0 &&
@@ -156,6 +155,14 @@ M0_INTERNAL bool m0_dtm0_tx_desc_state_eq(const struct m0_dtm0_tx_desc *txd,
 					  enum m0_dtm0_tx_pa_state      state)
 {
 	return m0_forall(i, txd->dtd_ps.dtp_nr,
+			 txd->dtd_ps.dtp_pa[i].p_state == state);
+}
+
+M0_INTERNAL
+bool m0_dtm0_tx_desc_state_exists(const struct m0_dtm0_tx_desc *txd,
+				  enum m0_dtm0_tx_pa_state      state)
+{
+	return m0_exists(i, txd->dtd_ps.dtp_nr,
 			 txd->dtd_ps.dtp_pa[i].p_state == state);
 }
 

--- a/dtm0/tx_desc.h
+++ b/dtm0/tx_desc.h
@@ -142,11 +142,20 @@ M0_INTERNAL bool m0_dtm0_tx_desc_is_none(const struct m0_dtm0_tx_desc *td);
 M0_INTERNAL bool m0_dtm0_tid__invariant(const struct m0_dtm0_tid *tid);
 M0_INTERNAL bool m0_dtm0_tx_desc__invariant(const struct m0_dtm0_tx_desc *td);
 
-/** Returns "true" iif the state of each participant equals to the given
+/**
+ * Returns "true" iif the state of each participant equals to the given
  * "state" value.
  */
 M0_INTERNAL bool m0_dtm0_tx_desc_state_eq(const struct m0_dtm0_tx_desc *txd,
 					  enum m0_dtm0_tx_pa_state      state);
+
+/**
+ * Returns "true" if the state of at least one participant equals to the given
+ * "state" value.
+ */
+M0_INTERNAL
+bool m0_dtm0_tx_desc_state_exists(const struct m0_dtm0_tx_desc *txd,
+				  enum m0_dtm0_tx_pa_state      state);
 
 /** Applies an update onto the given target value.
  * The state of the participants of the target modifed as per the following


### PR DESCRIPTION
Problem:
Currently there is no support for TRANSIENT failures on the DIX
and DTX levels for DIX PUT operations, only the happy path is
supported (with and without DTM0 enabled). In case of TRANSIENT
failure the DIX PUT operation hangs in awaiting of response from
the OFFLINE process as currently the requests are sent to OFFLINE
devices (as TRANSIENT notification is mapped to OFFLINE devices
state).

Solution:
In order to support transient failures for DIX PUT operations the
following changes have been introduced:
 - skip sending of CAS requests to OFFLINE devices;
 - add services that correspond to OFFLINE devices into
   participants list as they are still the cluster members, when
   they are back we need to restore missing info, that's why we
   need to add them also;
 - move transient participants into EXECUTED state right after
   CAS requests is sent (see comment below regarding EXECUTED-ALL
   logic);
 - move participants for those CAS requests that are failed to be
   sent into EXECUTED state (see comment below regarding EXECUTED-ALL
   logic);
 - move DTX into STABLE state when at least 1 PERSISTENT message
   received on the client side;
 - remove the log record from the volatile DTM0 log when DTX reaches
   the STABLE state, we can clean this up as currently the client
   (volatile log lives on the client side only) does not participate
   in recovery process, no need to keep stable transactions.

Moving of transient participants and those for which CAS requests
are failed to be sent into EXECUTED state is made to unblock the
EXECUTED-ALL logic. It allows to move transaction to the stable
state once the persistent message received (EXECUTED state
required for all participants). So EXECUTED participant state is
reused in case of failures.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>
