### PR TITLE
CORTX-29280 : Implement slow remapping of nodes in LRU list to avoid possible thrashing for random IO accesses.

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -1414,7 +1414,11 @@ static struct m0_rwlock list_lock;
 /**
  * Total space used by nodes in lru list.
  */
-static int64_t lru_space_used = 0;
+static int64_t lru_space_used;
+#ifndef __KERNEL__
+static bool lru_slow_purge;
+#endif
+
 
 /** Lru used space watermark default values. */
 enum lru_used_space_watermark{
@@ -1798,7 +1802,16 @@ struct mod {
 
 M0_INTERNAL void m0_btree_glob_init(void)
 {
-	/** Initialtise lru list, active list and lock. */
+	/* Initialize lru watermark levels and purge settings */
+	#ifndef __KERNEL__
+	lru_slow_purge      = false;
+	#endif
+	lru_space_used      = 0;
+	lru_space_wm_low    = LUSW_LOW;
+	lru_space_wm_target = LUSW_TARGET;
+	lru_space_wm_high   = LUSW_HIGH;
+
+	/* Initialtise lru list, active list and lock. */
 	ndlist_tlist_init(&btree_lru_nds);
 	ndlist_tlist_init(&btree_active_nds);
 	m0_rwlock_init(&list_lock);
@@ -2218,6 +2231,9 @@ static void bnode_put(struct node_op *op, struct nd *node)
 {
 	bool purge_check   = false;
 	bool is_root_node  = false;
+#ifndef __KERNEL__
+	uint64_t to_purge  = 0;
+#endif
 
 	M0_PRE(node != NULL);
 
@@ -2231,6 +2247,10 @@ static void bnode_put(struct node_op *op, struct nd *node)
 		 */
 		ndlist_tlist_del(node);
 		ndlist_tlist_add(&btree_lru_nds, node);
+		#ifndef __KERNEL__
+		to_purge  = lru_slow_purge ?
+			   ((m0_be_chunk_header_size() + node->n_size) * 2) : 0;
+		#endif
 		lru_space_used += (m0_be_chunk_header_size() + node->n_size);
 		purge_check = true;
 
@@ -2259,7 +2279,7 @@ static void bnode_put(struct node_op *op, struct nd *node)
 	m0_rwlock_write_unlock(&list_lock);
 #ifndef __KERNEL__
 	if (purge_check)
-		m0_btree_lrulist_purge_check(M0_PU_BTREE, 0);
+		m0_btree_lrulist_purge_check(M0_PU_BTREE, to_purge);
 #endif
 }
 
@@ -8610,7 +8630,10 @@ M0_INTERNAL int64_t m0_btree_lrulist_purge_check(enum m0_btree_purge_user user,
 	 * or size whichever is higher.
 	 */
 	size_to_purge = user == M0_PU_BTREE ?
-				(lru_space_used - lru_space_wm_target) :
+				(lru_slow_purge ?
+				min64(lru_space_used - lru_space_wm_target,
+									 size) :
+				(lru_space_used - lru_space_wm_target)) :
 				min64(lru_space_used - lru_space_wm_low, size);
 	purged_size = m0_btree_lrulist_purge(size_to_purge);
 	M0_LOG(M0_INFO, " Above critical purge, User=%s requested size="

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -575,7 +575,7 @@
 #endif
 
 #define AVOID_BE_SEGMENT                  0
-#define M0_BTREE_TRICKLE_MULTIPLIER       2
+#define M0_BTREE_TRICKLE_NUM_NODES        5
 #define M0_BTREE_TRICKLE_RELEASE_MODE_ON  true
 #define M0_BTREE_TRICKLE_RELEASE_MODE_OFF false
 /**
@@ -1445,12 +1445,6 @@ static int64_t lru_space_wm_target;
 static int64_t lru_space_wm_high;
 
 /**
- * LRU purging should be triggered if used space is above high used space
- * watermark.
- */
-static bool lrulist_trickle_release;
-
-/**
  * LRU trickle release configuration from sysconfig/motr.
  */
 static bool lru_trickle_release_en;
@@ -1821,11 +1815,8 @@ M0_INTERNAL void m0_btree_glob_init(void)
 	#ifndef __KERNEL__
 	lru_trickle_release_mode = M0_BTREE_TRICKLE_RELEASE_MODE_OFF;
 	#endif
-	lru_trickle_release_en   = false;
 	lru_space_used           = 0;
-	lru_space_wm_low         = LUSW_LOW;
-	lru_space_wm_target      = LUSW_TARGET;
-	lru_space_wm_high        = LUSW_HIGH;
+	m0_btree_lrulist_set_lru_config(0, 0, 0, 0);
 
 	/* Initialtise lru list, active list and lock. */
 	ndlist_tlist_init(&btree_lru_nds);
@@ -1881,7 +1872,7 @@ M0_INTERNAL void m0_btree_lrulist_set_lru_config(int64_t slow_lru_mem_release,
 						 int64_t wm_target,
 						 int64_t wm_high)
 {
-	lrulist_trickle_release = (slow_lru_mem_release != 0) ? true : false;
+	lru_trickle_release_en = (slow_lru_mem_release != 0) ? true : false;
 
 	lru_space_wm_low = (wm_low == 0) ? LUSW_LOW : wm_low;
 	lru_space_wm_target = (wm_target == 0) ? LUSW_TARGET : wm_target;
@@ -1894,7 +1885,7 @@ M0_INTERNAL void m0_btree_lrulist_set_lru_config(int64_t slow_lru_mem_release,
 	       "%"PRIi64" High - %"PRIi64" \n", lru_space_wm_low,
 	       lru_space_wm_target, lru_space_wm_high);
 	M0_LOG(M0_INFO, "Btree LRU List trickle release: %s \n",
-	       lrulist_trickle_release ? "true" : "false");
+	       lru_trickle_release_en ? "true" : "false");
 }
 
 /**
@@ -2245,11 +2236,8 @@ static void bnode_crc_validate(struct nd *node)
  */
 static void bnode_put(struct node_op *op, struct nd *node)
 {
-	bool purge_check         = false;
-	bool is_root_node        = false;
-#ifndef __KERNEL__
-	uint64_t bytes_to_purge  = 0;
-#endif
+	bool purge_check  = false;
+	bool is_root_node = false;
 
 	M0_PRE(node != NULL);
 
@@ -2263,11 +2251,6 @@ static void bnode_put(struct node_op *op, struct nd *node)
 		 */
 		ndlist_tlist_del(node);
 		ndlist_tlist_add(&btree_lru_nds, node);
-		#ifndef __KERNEL__
-		bytes_to_purge = lru_trickle_release_mode ?
-				 ((m0_be_chunk_header_size() + node->n_size) *
-			    	  M0_BTREE_TRICKLE_MULTIPLIER) : 0;
-		#endif
 		lru_space_used += (m0_be_chunk_header_size() + node->n_size);
 		purge_check = true;
 
@@ -2296,7 +2279,7 @@ static void bnode_put(struct node_op *op, struct nd *node)
 	m0_rwlock_write_unlock(&list_lock);
 #ifndef __KERNEL__
 	if (purge_check)
-		m0_btree_lrulist_purge_check(M0_PU_BTREE, bytes_to_purge);
+		m0_btree_lrulist_purge_check(M0_PU_BTREE, 0);
 #endif
 }
 
@@ -8554,7 +8537,7 @@ static int remap_node(void* addr, int64_t size, struct m0_be_seg *seg)
  *
  * @return int the total size in bytes that was freed.
  */
-M0_INTERNAL int64_t m0_btree_lrulist_purge(int64_t size)
+M0_INTERNAL int64_t m0_btree_lrulist_purge(int64_t size, int64_t num_nodes)
 {
 	struct nd              *node;
 	struct nd              *prev;
@@ -8565,9 +8548,12 @@ M0_INTERNAL int64_t m0_btree_lrulist_purge(int64_t size)
 	struct m0_be_allocator *a;
 	int                     rc;
 
+	M0_PRE(size >= 0 && num_nodes >=0);
+	M0_PRE(ergo(size == 0, num_nodes !=0));
+
 	m0_rwlock_write_lock(&list_lock);
 	node = ndlist_tlist_tail(&btree_lru_nds);
-	while (node != NULL && size > 0) {
+	while (node != NULL && (size > 0 || num_nodes > 0)) {
 		curr_size = 0;
 		prev      = ndlist_tlist_prev(&btree_lru_nds, node);
 		if (node->n_txref == 0 && node->n_ref == 0) {
@@ -8582,7 +8568,8 @@ M0_INTERNAL int64_t m0_btree_lrulist_purge(int64_t size)
 			if (rc == 0) {
 				rc = remap_node(rnode, curr_size, seg);
 				if (rc == 0) {
-					size       -= curr_size;
+					size       -= size > 0 ? curr_size : 0;
+					num_nodes  -= num_nodes > 0 ? 1 : 0;
 					total_size += curr_size;
 					ndlist_tlink_del_fini(node);
 					lru_space_used -= curr_size;
@@ -8642,8 +8629,10 @@ M0_INTERNAL int64_t m0_btree_lrulist_purge_check(enum m0_btree_purge_user user,
 			lru_trickle_release_mode =
 					      M0_BTREE_TRICKLE_RELEASE_MODE_OFF;
 
-		if (size_to_purge != 0) {
-			purged_size = m0_btree_lrulist_purge(size_to_purge);
+		if (size_to_purge != 0 || lru_trickle_release_mode) {
+			purged_size = m0_btree_lrulist_purge(size_to_purge,
+						size_to_purge != 0 ? 0 :
+						M0_BTREE_TRICKLE_NUM_NODES);
 			M0_LOG(M0_INFO, " Below critical External user Purge,"
 			       " requested size=%"PRId64" used space=%"PRId64
 			       " purged size=%"PRId64, size, lru_space_used,
@@ -8664,7 +8653,9 @@ M0_INTERNAL int64_t m0_btree_lrulist_purge_check(enum m0_btree_purge_user user,
 			 min64(lru_space_used - lru_space_wm_target, size) :
 			 (lru_space_used - lru_space_wm_target)) :
 			min64(lru_space_used - lru_space_wm_low, size);
-	purged_size = m0_btree_lrulist_purge(size_to_purge);
+	purged_size = m0_btree_lrulist_purge(size_to_purge,
+			      (lru_trickle_release_mode && size_to_purge == 0) ?
+			      M0_BTREE_TRICKLE_NUM_NODES : 0);
 	M0_LOG(M0_INFO, " Above critical purge, User=%s requested size="
 	       "%"PRId64" used space=%"PRIu64" purged size="
 	       "%"PRIu64, user == M0_PU_BTREE ? "btree" : "external", size,
@@ -12358,7 +12349,7 @@ static void ut_lru_test(void)
 
 	M0_ASSERT(ndlist_tlist_length(&btree_lru_nds) > 0);
 
-	mem_freed      = m0_btree_lrulist_purge(mem_increased/2);
+	mem_freed      = m0_btree_lrulist_purge(mem_increased/2, 0);
 	mem_after_free = sysconf(_SC_AVPHYS_PAGES) * sysconf(_SC_PAGESIZE);
 	M0_LOG(M0_INFO, "Mem After Free (%"PRId64") || Mem freed (%"PRId64").\n",
 	       mem_after_free, mem_freed);

--- a/btree/btree.h
+++ b/btree/btree.h
@@ -727,7 +727,7 @@ M0_INTERNAL int     m0_btree_mod_init(void);
 M0_INTERNAL void    m0_btree_mod_fini(void);
 M0_INTERNAL void    m0_btree_glob_init(void);
 M0_INTERNAL void    m0_btree_glob_fini(void);
-M0_INTERNAL int64_t m0_btree_lrulist_purge(int64_t size);
+M0_INTERNAL int64_t m0_btree_lrulist_purge(int64_t size, int64_t num_nodes);
 M0_INTERNAL int64_t m0_btree_lrulist_purge_check(enum m0_btree_purge_user user,
 						 int64_t size);
 M0_INTERNAL void    m0_btree_lrulist_set_lru_config(int64_t slow_lru_mem_release,


### PR DESCRIPTION
Added mechanism for slow purging of lru list.
Moved initialization of lru used space watermarks to m0_btree_glob_init().

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
