### PR TITLE
Cortx-29009: ENOBUFS and ENODATA are expected during SNS repair.

### DIFF
--- a/cm/sw_update_fom.c
+++ b/cm/sw_update_fom.c
@@ -119,7 +119,11 @@ static int cm_swu_fom_tick(struct m0_fom *fom)
 	m0_cm_lock(cm);
 	rc = swu_action[phase](swu);
 	if (rc != 0) {
-		M0_LOG(M0_ERROR, "SWU phase=%d rc=%d.", phase, rc);
+		if (!M0_IN(rc, (-ENOBUFS, -ENODATA)))
+			M0_LOG(M0_ERROR, "SWU phase=%d rc=%d.", phase, rc);
+		else
+			M0_LOG(M0_DEBUG, "SWU phase=%d rc=%d.", phase, rc);
+
 		m0_cm_sw_remote_update(cm);
 	}
 	if (rc < 0) {


### PR DESCRIPTION
Changed  log level to DEBUG, instead of ERROR for ENOBUFS and ENODATA

Signed-off-by: Naga Kishore Kommuri <nagakishore.kommuri@seagate.com>

# Problem Statement
- ENOBUFS and ENODATA errors are being treated as ERROR, which are expected errnos during SNS Repair

# Design
-  Changed log level of expected errnos to DEBUG
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ x] Jira and state/status is updated and JIRA is updated with PR link
- [x ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
