### PR TITLE
CORTX-29525: Ignore symbols specific to code coverage

### DIFF
--- a/motr/motr-pub.api
+++ b/motr/motr-pub.api
@@ -462,7 +462,7 @@ m0_iem
 m0_console_printf
 m0_console_flush
 m0_error_printf
-__gcov_dump
-__gcov_flush
-__gcov_reset
-__gcov_sort_n_vals
+*__gcov_dump
+*__gcov_flush
+*__gcov_reset
+*__gcov_sort_n_vals


### PR DESCRIPTION
As code coverage symbols are specific to gcov and are
available only when --coverage-enable option is set
while configuring. Hence we can safely ignore these
symbols when this configuration option is not used.

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
Build failure due to missing symbols

# Design
Ignore symbols specific to code coverage

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
