### PR TITLE
EOS-28989: Updated STs to use the transport specific address format.

### DIFF
--- a/m0t1fs/linux_kernel/st/m0t1fs_failure_after_sns_repair_quiesce.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_failure_after_sns_repair_quiesce.sh
@@ -69,7 +69,7 @@ sns_repair_rebalance_quiesce_test()
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	echo "****** Start failure after quiesce test ******"

--- a/m0t1fs/linux_kernel/st/m0t1fs_poolmach.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_poolmach.sh
@@ -31,12 +31,12 @@ pool_mach_test()
 
 	echo "Testing pool machine.."
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Query
 	trigger="$M0_SRC_DIR/pool/m0poolmach -O Query -N 1 -I 'k|1:1'
-                         -C ${lnet_nid}:${POOL_MACHINE_CLI_EP} $ios_eps"
+                         -C ${lnet_nid}${POOL_MACHINE_CLI_EP} $ios_eps"
 	echo $trigger
 	eval $trigger
 	rc=$?
@@ -48,7 +48,7 @@ pool_mach_test()
 
 ####### Set
 	trigger="$M0_SRC_DIR/pool/m0poolmach -O Set -N 1 -I 'k|1:1' -s 2
-                         -C ${lnet_nid}:${POOL_MACHINE_CLI_EP} $ios_eps"
+                         -C ${lnet_nid}${POOL_MACHINE_CLI_EP} $ios_eps"
 	echo $trigger
 	eval $trigger
 	rc=$?
@@ -60,7 +60,7 @@ pool_mach_test()
 
 ####### Query again
 	trigger="$M0_SRC_DIR/pool/m0poolmach -O Query -N 1 -I 'k|1:1'
-                         -C ${lnet_nid}:${POOL_MACHINE_CLI_EP} $ios_eps"
+                         -C ${lnet_nid}${POOL_MACHINE_CLI_EP} $ios_eps"
 	echo $trigger
 	eval $trigger
 	rc=$?
@@ -72,7 +72,7 @@ pool_mach_test()
 
 ####### Set again. This set request should get error
 	trigger="$M0_SRC_DIR/pool/m0poolmach -O Set -N 1 -I 'k|1:1' -s 1
-                         -C ${lnet_nid}:${POOL_MACHINE_CLI_EP} $ios_eps"
+                         -C ${lnet_nid}${POOL_MACHINE_CLI_EP} $ios_eps"
 	echo $trigger
 	eval $trigger
 	rc=$?
@@ -84,7 +84,7 @@ pool_mach_test()
 
 ####### Set again. This set request should get error
 	trigger="$M0_SRC_DIR/pool/m0poolmach -O Set -N 1 -I 'k|1:1' -s 2
-                         -C ${lnet_nid}:${POOL_MACHINE_CLI_EP} $ios_eps"
+                         -C ${lnet_nid}${POOL_MACHINE_CLI_EP} $ios_eps"
 	echo $trigger
 	eval $trigger
 	rc=$?
@@ -96,7 +96,7 @@ pool_mach_test()
 
 ####### Set again. This set request should get error
 	trigger="$M0_SRC_DIR/pool/m0poolmach -O Set -N 1 -I 'k|1:1' -s 3
-                         -C ${lnet_nid}:${POOL_MACHINE_CLI_EP} $ios_eps"
+                         -C ${lnet_nid}${POOL_MACHINE_CLI_EP} $ios_eps"
 	echo $trigger
 	eval $trigger
 	rc=$?
@@ -108,7 +108,7 @@ pool_mach_test()
 
 ####### Query again
 	trigger="$M0_SRC_DIR/pool/m0poolmach -O Query -N 1 -I 'k|1:1'
-                         -C ${lnet_nid}:${POOL_MACHINE_CLI_EP} $ios_eps"
+                         -C ${lnet_nid}${POOL_MACHINE_CLI_EP} $ios_eps"
 	echo $trigger
 	eval $trigger
 	rc=$?

--- a/m0t1fs/linux_kernel/st/m0t1fs_rpc_cancel_test.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_rpc_cancel_test.sh
@@ -146,11 +146,16 @@ rcancel_post()
 
 rcancel_change_controller_state()
 {
-	local lnet_nid=`sudo lctl list_nids | head -1`
-	local s_endpoint="$lnet_nid:12345:33:1"
-	local c_endpoint="$lnet_nid:$M0HAM_CLI_EP"
+	local nid=$(m0_local_nid_get)
+	local c_endpoint="$nid$M0HAM_CLI_EP"
 	local dev_fid=$1
 	local dev_state=$2
+	local XPRT=$(m0_default_xprt)
+	if [ "$XPRT" = "lnet" ]; then
+		local s_endpoint="$nid:12345:33:1"
+	else
+		local s_endpoint="$nid@3001"
+	fi
 
 	# Generate HA event
 	send_ha_events "$dev_fid" "$dev_state" "$s_endpoint" "$c_endpoint"

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1f.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1f.sh
@@ -66,7 +66,7 @@ sns_repair_test()
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Set Failure device

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1k_1f.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1k_1f.sh
@@ -51,7 +51,7 @@ sns_repair_test()
 	for i in 0:10{0..2}{1001..1020}; do _md5sum $i || return $? ; done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Set Failure device

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1n_1f.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1n_1f.sh
@@ -46,7 +46,7 @@ sns_repair_test()
 		_md5sum ${file[$i]} || return $?
 	done
 
-	ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[0]}"
+	ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[0]}"
 
 ####### Set Failure device
 	disk_state_set "failed" $fail_device1 || return $?

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort.sh
@@ -114,7 +114,7 @@ sns_repair_test()
 	verify || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	mount

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort_quiesce.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_abort_quiesce.sh
@@ -77,7 +77,7 @@ sns_repair_rebalance_quiesce_test()
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Set Failure device

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_ios_fail.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_ios_fail.sh
@@ -114,7 +114,7 @@ sns_repair_test()
 	verify || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	mount

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_mf.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_mf.sh
@@ -125,7 +125,7 @@ sns_repair_test()
 	verify 0 || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	mount

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_quiesce.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_quiesce.sh
@@ -69,7 +69,7 @@ sns_repair_rebalance_quiesce_test()
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Set Failure device

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_shutdown.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_shutdown.sh
@@ -68,7 +68,7 @@ sns_repair_test()
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Set Failure device

--- a/motr/st/utils/sns_repair_motr_1f.sh
+++ b/motr/st/utils/sns_repair_motr_1f.sh
@@ -42,7 +42,7 @@ sns_repair_motr_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Set Failure device

--- a/motr/st/utils/sns_repair_motr_1k_1f.sh
+++ b/motr/st/utils/sns_repair_motr_1k_1f.sh
@@ -43,7 +43,7 @@ sns_repair_motr_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ####### Set Failure device

--- a/motr/st/utils/sns_repair_motr_1n_1f.sh
+++ b/motr/st/utils/sns_repair_motr_1n_1f.sh
@@ -41,7 +41,7 @@ sns_repair_motr_test()
 	prepare_datafiles_and_objects || return $?
 	motr_read_verify 0          || return $?
 
-	ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[0]}"
+	ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[0]}"
 
 ####### Set Failure device
 	disk_state_set "failed" $fail_device1 || return $?

--- a/motr/st/utils/sns_repair_motr_abort.sh
+++ b/motr/st/utils/sns_repair_motr_abort.sh
@@ -49,7 +49,7 @@ sns_repair_motr_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	echo "Set Failure device: $fail_device1 $fail_device2"

--- a/motr/st/utils/sns_repair_motr_abort_quiesce.sh
+++ b/motr/st/utils/sns_repair_motr_abort_quiesce.sh
@@ -42,7 +42,7 @@ sns_repair_motr_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	echo "Set Failure device: $fail_device1 $fail_device2"

--- a/motr/st/utils/sns_repair_motr_ios_fail.sh
+++ b/motr/st/utils/sns_repair_motr_ios_fail.sh
@@ -43,7 +43,7 @@ sns_repair_motr_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	########################################################################

--- a/motr/st/utils/sns_repair_motr_mf.sh
+++ b/motr/st/utils/sns_repair_motr_mf.sh
@@ -58,7 +58,7 @@ sns_repair_motr_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 ######  Fail two disks

--- a/motr/st/utils/sns_repair_quiesce.sh
+++ b/motr/st/utils/sns_repair_quiesce.sh
@@ -40,7 +40,7 @@ sns_repair_rebalance_quiesce_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	####### Set Failure device

--- a/motr/st/utils/sns_repair_shutdown.sh
+++ b/motr/st/utils/sns_repair_shutdown.sh
@@ -42,7 +42,7 @@ sns_repair_motr_test()
 	motr_read_verify 0          || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	####### Set Failure device

--- a/spiel/st/m0t1fs_spiel_sns_repair.sh
+++ b/spiel/st/m0t1fs_spiel_sns_repair.sh
@@ -42,7 +42,7 @@ spiel_sns_repair_and_rebalance_test()
 	verify || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	mount | grep m0t1fs

--- a/spiel/st/m0t1fs_spiel_sns_repair_quiesce.sh
+++ b/spiel/st/m0t1fs_spiel_sns_repair_quiesce.sh
@@ -41,7 +41,7 @@ spiel_sns_repair_quiesce_test()
 	verify || return $?
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
-		ios_eps="$ios_eps -S ${lnet_nid}:${IOSEP[$i]}"
+		ios_eps="$ios_eps -S ${lnet_nid}${IOSEP[$i]}"
 	done
 
 	mount | grep m0t1fs


### PR DESCRIPTION
Following STs are updated:
08spiel-sns-repair
08spiel-sns-repair-quiesce
14poolmach
15sns-repair-shutdown
16sns-repair-multi
18sns-repair-quiesce
18sns-repair-quiesce-failure
19sns-repair-abort
20rpc-session-cancel
21fsync-single-node
22sns-repair-ios-fail
23sns-abort-quiesce
26motr-user-kernel-tests
34sns-repair-1n-1f
43motr-sync-replication
45motr-rmw
60sns-repair-motr-1f
61sns-repair-motr-1n-1f
62sns-repair-motr-mf
63sns-repair-motr-1k-1f
64sns-repair-motr-ios-fail
65sns-repair-motr-abort
66sns-repair-motr-abort-quiesce

Signed-off by: Ankit Yadav <ankit.yadav@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
