### PR TITLE
CORTX-29719: Set proper setup size for services other than ios and confd

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -238,6 +238,9 @@ def set_setup_size(self, service):
     ret = False
     sevices_limits = Conf.get(self._index, 'cortx>motr>limits')['services']
 
+    # Default self.setup_size  is "small"
+    self.setup_size = "small"
+
     # For services other then ioservice and confd, return True
     # It will set default setup size i.e. small
     if service not in ["ioservice", "ios", "io", "all", "confd"]:

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -1,4 +1,4 @@
-#!/usr/libexec/platform-python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/libexec/platform-python
 #
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #
@@ -248,7 +248,7 @@ def set_setup_size(self, service):
     #Provisioner passes io as parameter to motr_setup.
     #Ex: /opt/seagate/cortx/motr/bin/motr_setup config --config yaml:///etc/cortx/cluster.conf --services io
     #But in /etc/cortx/cluster.conf io is represented by ios. So first get the service names right
-    if service == "io":
+    if service in ["io", "ioservice"]:
          svc = "ios"
     else:
          svc = service
@@ -282,6 +282,8 @@ def set_setup_size(self, service):
     if ret == False:
         raise MotrError(errno.EINVAL, f"Setup size is not set properly for service {service}."
                                       f"Please update valid mem limits for {service}")
+    else:
+        self.logger.info(f"service={service} and setup_size={self.setup_size}\n")
     return ret
 
 def get_value(self, key, key_type):

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -234,9 +234,16 @@ def calc_size(self, sz):
         self.logger.error("Please use valid format Ex: 1024, 1Ki, 1Mi, 1Gi etc..\n")
         return ret
 
-def get_setup_size(self, service):
+def set_setup_size(self, service):
     ret = False
     sevices_limits = Conf.get(self._index, 'cortx>motr>limits')['services']
+
+    # For services other then ioservice and confd, return True
+    # It will set default setup size i.e. small
+    if service not in ["ioservice", "ios", "io", "all", "confd"]:
+        self.setup_size = "small"
+        self.logger.info(f"service is {service}. So seting setup size to {self.setup_size}\n")
+        return True
 
     #Provisioner passes io as parameter to motr_setup.
     #Ex: /opt/seagate/cortx/motr/bin/motr_setup config --config yaml:///etc/cortx/cluster.conf --services io
@@ -272,6 +279,9 @@ def get_setup_size(self, service):
                 self.logger.info(f"setup_size set to {self.setup_size}\n")
                 ret = True
                 break
+    if ret == False:
+        raise MotrError(errno.EINVAL, f"Setup size is not set properly for service {service}."
+                                      f"Please update valid mem limits for {service}")
     return ret
 
 def get_value(self, key, key_type):

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -63,7 +63,7 @@ class Cmd:
         self.logger = config_logger(self)
 
         # Default setup size is small
-        set_setup_size(self, self._services):
+        set_setup_size(self, self._services)
 
         # Fetch important data from Confstore
         self.cortx = get_value(self, 'cortx', dict)

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -63,10 +63,7 @@ class Cmd:
         self.logger = config_logger(self)
 
         # Default setup size is small
-        self.setup_size = "small"
-        if get_setup_size(self, self._services) == False:
-            self.logger.error("setup size not set properly\n")
-            return
+        set_setup_size(self, self._services):
 
         # Fetch important data from Confstore
         self.cortx = get_value(self, 'cortx', dict)


### PR DESCRIPTION
…nfd in mote mini provisioner

Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
Set proper setup size for services other than ios and confd

# Design
1: We set the setup size according to mem limits for each motr service. This mem limits are available in /etc/cortx/cluster.conf
2: Currently, these limits are available only for ios and confd motr services. 
3: If provisioner pass service parameter (to motr_setup command during deployment phases) is other than confd and ios, it tends to fail to set the setup_size. To overcome this, we ignore these (non ios and non confd) services and just set the setup_size to small to services other than ios and confd.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
 We deployed the cluster successfully. 
 In deployment,  we use (num_client_inst: 1) in solution.yaml to create motr clients.
 To create client pod, provisioner would pass service as 'client' to motr setup phases. In our fix, once we see service is client ( which is except ios, confd) we ignore it and set the setup size to small to avoid failures.  

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
