### PR TITLE
CORTX-29526: fix memleaks at data-path

### DIFF
--- a/dix/req.c
+++ b/dix/req.c
@@ -1799,6 +1799,7 @@ static int dix_cas_rops_send(struct m0_dix_req *req)
 		default:
 			M0_IMPOSSIBLE("Unknown req type %u", req->dr_type);
 		}
+		m0_cas_id_fini(&cctg_id);
 		if (rc != 0) {
 			m0_clink_del(&cas_rop->crp_clink);
 			m0_clink_fini(&cas_rop->crp_clink);

--- a/motr/client.c
+++ b/motr/client.c
@@ -428,7 +428,7 @@ void m0_obj_init(struct m0_obj *obj,
 
 #ifdef OSYNC
 	m0_mutex_init(&obj->ob_pending_tx_lock);
-	ospti_tlist_init(&obj->ob_pending_tx);
+	spti_tlist_init(&obj->ob_pending_tx);
 #endif
 
 	M0_LEAVE();
@@ -848,6 +848,7 @@ void m0_op_fini(struct m0_op *op)
 {
 	struct m0_op_common        *oc;
 	struct m0_sm_group         *grp;
+	struct m0_reqh_service_txid *iter;
 
 	M0_ENTRY();
 
@@ -861,6 +862,11 @@ void m0_op_fini(struct m0_op *op)
 	if (oc->oc_cb_fini != NULL)
 		oc->oc_cb_fini(oc);
 	m0_mutex_fini(&op->op_priv_lock);
+
+	m0_tl_teardown(spti, &op->op_pending_tx, iter)
+		m0_free0(&iter);
+	spti_tlist_fini(&op->op_pending_tx);
+	m0_mutex_fini(&op->op_pending_tx_lock);
 
 	grp = &op->op_sm_group;
 	m0_sm_group_lock(grp);

--- a/motr/cob.c
+++ b/motr/cob.c
@@ -1904,6 +1904,7 @@ M0_INTERNAL int m0__obj_namei_send(struct m0_op_obj *oo)
 			cob_complete_op(cr->cr_op);
 			m0_sm_group_lock(&cr->cr_op->op_sm_group);
 			rc = MOTR_MDCOB_LOOKUP_SKIP;
+			cob_req_free(cr);
 		}
 	}
 

--- a/motr/sync.c
+++ b/motr/sync.c
@@ -786,9 +786,9 @@ static void sync_pending_stx_update(struct m0_reqh_service_ctx *service,
  * obj may be NULL if the update has no associated inode.
  */
 void sync_record_update(struct m0_reqh_service_ctx *service,
-                                struct m0_entity    *ent,
-				struct m0_op        *op,
-                                struct m0_be_tx_remid      *btr)
+			struct m0_entity           *ent,
+			struct m0_op               *op,
+			struct m0_be_tx_remid      *btr)
 {
 	struct m0_reqh_service_txid *stx = NULL;
 
@@ -797,16 +797,14 @@ void sync_record_update(struct m0_reqh_service_ctx *service,
 	M0_PRE(service != NULL);
 
 	/* Updates pending transaction number in the entity. */
-	if ( ent!= NULL)
-		sync_pending_stx_update(
-			service, &ent->en_pending_tx_lock,
-			&ent->en_pending_tx, btr);
+	if (ent != NULL)
+		sync_pending_stx_update(service, &ent->en_pending_tx_lock,
+					&ent->en_pending_tx, btr);
 
 	/* Updates pending transaction number in the op. */
-	if ( op!= NULL)
-		sync_pending_stx_update(
-			service, &op->op_pending_tx_lock,
-			&op->op_pending_tx, btr);
+	if (op != NULL)
+		sync_pending_stx_update(service, &op->op_pending_tx_lock,
+					&op->op_pending_tx, btr);
 
 	/* update pending transaction number in the Client instance */
 	m0_mutex_lock(&service->sc_max_pending_tx_lock);
@@ -821,9 +819,9 @@ void sync_record_update(struct m0_reqh_service_ctx *service,
 	M0_LEAVE("Client sync record updated.");
 }
 
-/**----------------------------------------------------------------------------*
- *                           Client SYNC APIS                                  *
- *-----------------------------------------------------------------------------*/
+/**---------------------------------------------------------------------------*
+ *                           Client SYNC APIS                                 *
+ *----------------------------------------------------------------------------*/
 /**
  * Checks an SYNC operation is not malformed or corrupted.
  */
@@ -1051,7 +1049,7 @@ int m0_sync_op_add(struct m0_op *sop,
 
 	/* Adds service txid (if stx exists in the list, then merge.).*/
 	rc = sync_request_stx_add(sreq, &op->op_pending_tx,
-					 &op->op_pending_tx_lock);
+				        &op->op_pending_tx_lock);
 
 	return M0_RC(rc);
 }


### PR DESCRIPTION
# Problem Statement
There are memory leaks at `dix_cas_rops_send()` and `m0__obj_namei_send()` and `sync_pending_stx_update()` reported by valgrind when doing S3 object put/get/del operations with rgw:

```
+==15225== 144 bytes in 3 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBE98059: sync_pending_stx_update (sync.c:772)
+==15225==    by 0xBE987E4: sync_record_update (sync.c:807)
+==15225==    by 0xBE83435: ioreq_cc_bottom_half (io_req_fop.c:500)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:175)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:150)
+==15225==    by 0xBE1BAC1: loc_handler_thread (fom.c:925)
+==15225==    by 0xBE5174D: m0_thread_trampoline (thread.c:117)
+==15225==    by 0xBE5CDC0: uthread_trampoline (uthread.c:98)
+==15225==    by 0x8AE0179: start_thread (in /usr/lib64/libpthread-2.28.so)
+==15225==    by 0xA418DF2: clone (in /usr/lib64/libc-2.28.so)
+==15225== 
+==15225== 144 bytes in 3 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBE98059: sync_pending_stx_update (sync.c:772)
+==15225==    by 0xBE987E4: sync_record_update (sync.c:807)
+==15225==    by 0xBE83862: io_bottom_half (io_req_fop.c:333)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:175)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:150)
+==15225==    by 0xBE1BAC1: loc_handler_thread (fom.c:925)
+==15225==    by 0xBE5174D: m0_thread_trampoline (thread.c:117)
+==15225==    by 0xBE5CDC0: uthread_trampoline (uthread.c:98)
+==15225==    by 0x8AE0179: start_thread (in /usr/lib64/libpthread-2.28.so)
+==15225==    by 0xA418DF2: clone (in /usr/lib64/libc-2.28.so)
+==15225== 
+==15225== 720 bytes in 15 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBE98059: sync_pending_stx_update (sync.c:772)
+==15225==    by 0xBE987E4: sync_record_update (sync.c:807)
+==15225==    by 0xBDED25C: dix_cas_rop_clink_cb (req.c:1714)
+==15225==    by 0xBE4C22E: clink_signal (chan.c:135)
+==15225==    by 0xBE4C2A9: chan_signal_nr (chan.c:154)
+==15225==    by 0xBEF469F: state_set (sm.c:462)
+==15225==    by 0xBDAADEA: cas_req_state_set (client.c:246)
+==15225==    by 0xBDAC234: cas_req_replied_ast (client.c:1160)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:175)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:150)
+==15225==    by 0xBE1BAC1: loc_handler_thread (fom.c:925)
+==15225== 
+==15225== 1,299 (648 direct, 651 indirect) bytes in 3 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBE8C2AB: cob_req_alloc.isra.9 (cob.c:310)
+==15225==    by 0xBE8E52F: m0__obj_namei_send (cob.c:1825)
+==15225==    by 0xBE8F491: obj_namei_cb_launch (obj.c:263)
+==15225==    by 0xBE8F491: obj_namei_cb_launch (obj.c:219)
+==15225==    by 0xBE73142: m0_op_launch_one (client.c:719)
+==15225==    by 0xBE732BB: m0_op_launch (client.c:733)
+==15225==    by 0x5AC8F92: rgw::sal::MotrObject::open_mobj(DoutPrefixProvider const*) (rgw_sal_motr.cc:1745)
+==15225==    by 0x5ADB64A: rgw::sal::MotrObject::MotrReadOp::prepare(optional_yield, DoutPrefixProvider const*) (rgw_sal_motr.cc:1446)
+==15225==    by 0x57C5967: RGWGetObj::execute(optional_yield) (rgw_op.cc:2151)
+==15225==    by 0x53D7AB5: rgw_process_authenticated(RGWHandler_REST*, RGWOp*&, RGWRequest*, req_state*, optional_yield, rgw::sal::Store*, bool) (rgw_process.cc:254)
+==15225==    by 0x53DA564: process_request(rgw::sal::Store*, RGWREST*, RGWRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rgw::auth::StrategyRegistry const&, RGWRestfulIO*, OpsLogSink*, optional_yield, rgw::dmclock::Scheduler*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >*, std::shared_ptr<RateLimiter>, int*) (rgw_process.cc:394)
+==15225== 
+==15225== 1,299 (648 direct, 651 indirect) bytes in 3 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBE8C2AB: cob_req_alloc.isra.9 (cob.c:310)
+==15225==    by 0xBE8E52F: m0__obj_namei_send (cob.c:1825)
+==15225==    by 0xBE8F491: obj_namei_cb_launch (obj.c:263)
+==15225==    by 0xBE8F491: obj_namei_cb_launch (obj.c:219)
+==15225==    by 0xBE73142: m0_op_launch_one (client.c:719)
+==15225==    by 0xBE732BB: m0_op_launch (client.c:733)
+==15225==    by 0x5AC8F92: rgw::sal::MotrObject::open_mobj(DoutPrefixProvider const*) (rgw_sal_motr.cc:1745)
+==15225==    by 0x5AC97D2: rgw::sal::MotrObject::delete_mobj(DoutPrefixProvider const*) (rgw_sal_motr.cc:1775)
+==15225==    by 0x5ACACF5: rgw::sal::MotrObject::MotrDeleteOp::delete_obj(DoutPrefixProvider const*, optional_yield) (rgw_sal_motr.cc:1540)
+==15225==    by 0x57EC2BF: RGWDeleteObj::execute(optional_yield) (rgw_op.cc:5032)
+==15225==    by 0x53D7AB5: rgw_process_authenticated(RGWHandler_REST*, RGWOp*&, RGWRequest*, req_state*, optional_yield, rgw::sal::Store*, bool) (rgw_process.cc:254)
+==15225== 
+==15225== 1,542 (648 direct, 894 indirect) bytes in 3 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBE8C2AB: cob_req_alloc.isra.9 (cob.c:310)
+==15225==    by 0xBE8E52F: m0__obj_namei_send (cob.c:1825)
+==15225==    by 0xBE8F491: obj_namei_cb_launch (obj.c:263)
+==15225==    by 0xBE8F491: obj_namei_cb_launch (obj.c:219)
+==15225==    by 0xBE73142: m0_op_launch_one (client.c:719)
+==15225==    by 0xBE732BB: m0_op_launch (client.c:733)
+==15225==    by 0x5AB7E32: rgw::sal::MotrObject::create_mobj(DoutPrefixProvider const*, unsigned long) (rgw_sal_motr.cc:1688)
+==15225==    by 0x5ACB53A: rgw::sal::MotrAtomicWriter::write() (rgw_sal_motr.cc:2296)
+==15225==    by 0x5ACBBE3: rgw::sal::MotrAtomicWriter::process(ceph::buffer::v15_2_0::list&&, unsigned long) (rgw_sal_motr.cc:2364)
+==15225==    by 0x57D343D: RGWPutObj::execute(optional_yield) (rgw_op.cc:4089)
+==15225==    by 0x53D7AB5: rgw_process_authenticated(RGWHandler_REST*, RGWOp*&, RGWRequest*, req_state*, optional_yield, rgw::sal::Store*, bool) (rgw_process.cc:254)
+==15225== 
+==15225== 2,208 bytes in 46 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBDEB356: m0_dix_imask_copy (imask.c:178)
+==15225==    by 0xBDEE996: dix_cas_rops_send (req.c:1774)
+==15225==    by 0xBDEF843: dix__rop (req.c:1386)
+==15225==    by 0xBDEFE9E: dix_rop (req.c:1402)
+==15225==    by 0xBDEFE9E: dix_discovery_completed (req.c:1121)
+==15225==    by 0xBDF08DF: dix_layout_find_ast_cb (req.c:364)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:175)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:150)
+==15225==    by 0xBE1BAC1: loc_handler_thread (fom.c:925)
+==15225==    by 0xBE5174D: m0_thread_trampoline (thread.c:117)
+==15225==    by 0xBE5CDC0: uthread_trampoline (uthread.c:98)
+==15225==    by 0x8AE0179: start_thread (in /usr/lib64/libpthread-2.28.so)
+==15225== 
+==15225== 2,544 bytes in 53 blocks are definitely lost 
+==15225==    at 0x4C360A5: malloc (vg_replace_malloc.c:380)
+==15225==    by 0xBE4FE3C: m0_alloc (memory.c:133)
+==15225==    by 0xBDEB356: m0_dix_imask_copy (imask.c:178)
+==15225==    by 0xBDEE996: dix_cas_rops_send (req.c:1774)
+==15225==    by 0xBDEF843: dix__rop (req.c:1386)
+==15225==    by 0xBDEFE9E: dix_rop (req.c:1402)
+==15225==    by 0xBDEFE9E: dix_discovery_completed (req.c:1121)
+==15225==    by 0xBDF05F7: dix_discovery_ast (req.c:1140)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:175)
+==15225==    by 0xBEF2FFE: m0_sm_asts_run (sm.c:150)
+==15225==    by 0xBE1BAC1: loc_handler_thread (fom.c:925)
+==15225==    by 0xBE5174D: m0_thread_trampoline (thread.c:117)
+==15225==    by 0xBE5CDC0: uthread_trampoline (uthread.c:98)
+==15225==    by 0x8AE0179: start_thread (in /usr/lib64/libpthread-2.28.so)
```

# Solution
Fix the leaks by:
 - clean-up local `m0_cas_id` structure at `dix_cas_rops_send()`;
 - clean-up `struct cob_req` at `m0__obj_namei_send()` in case when metadata lookup is skipped and cob_req is not sent anywhere;
 - clean-up op_pending_tx at m0_op_fini().

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
