### PR TITLE
CORTX-29713: m0_conf_pver_status() now returns CRITICAL if max failures reached at any level

### DIFF
--- a/conf/pvers.c
+++ b/conf/pvers.c
@@ -46,6 +46,12 @@
 	       vector[M0_CONF_PVER_LVL_CTRLS],                         \
 	       vector[M0_CONF_PVER_LVL_DRIVES])
 
+enum {
+	MAX_FAILURES_NOT_REACHED,
+	MAX_FAILURES_REACHED,
+	MAX_FAILURES_EXCEEDED
+};
+
 /** Array of int values. */
 struct arr_int {
 	uint32_t ai_count;
@@ -805,19 +811,27 @@ err:
 }
 
 /**
- * Check if failures at any level has reached max allowed failures.
+ * Check if failures at any level has reached or exceeded max allowed failures.
  */
-static bool has_reached_max_failure(struct m0_conf_pver *pv,
-				    const uint32_t      *srecd)
+static int tolerance_failure_cmp(struct m0_conf_pver *pv,
+				 const uint32_t      *srecd)
 {
-	int i = 0;
+	int      i = 0;
+	int      result = MAX_FAILURES_NOT_REACHED;
+	uint32_t tolerance ;
 
 	while(i < M0_CONF_PVER_HEIGHT) {
-		if (srecd[i] == pv->pv_u.subtree.pvs_tolerance[i])
-			return true;
+		tolerance = pv->pv_u.subtree.pvs_tolerance[i];
+		/* Ignore the case of srecd[i] == tolerance == 0. */
+		if (srecd[i] > 0 && srecd[i] == tolerance)
+			result = MAX_FAILURES_REACHED;
+		else if (srecd[i] > tolerance) {
+			result = MAX_FAILURES_EXCEEDED;
+			break;
+		}
 		i++;
 	}
-	return false;
+	return result;
 }
 
 int m0_conf_pver_status(struct m0_fid *fid,
@@ -828,6 +842,7 @@ int m0_conf_pver_status(struct m0_fid *fid,
 	struct m0_conf_pver      *pver;
 	int                       rc;
 	int                       i = 0;
+	int                       failures_at_lvl;
 	uint32_t                  srecd[M0_CONF_PVER_HEIGHT];
 	uint32_t                  failures = 0;
 	uint32_t                  K;
@@ -854,21 +869,25 @@ int m0_conf_pver_status(struct m0_fid *fid,
 	while (i < M0_CONF_PVER_HEIGHT)
 		failures += srecd[i++];
 
+	failures_at_lvl = tolerance_failure_cmp(pver, srecd); 
+
 	/**
 	 * HEALTHY: if no failures in pver.
-	 * DEGRADED: if less than K failuresin pver and failures at any level
+	 * DEGRADED: if less than K failures in pver and failures at any level
 	 *           has not reached maximum supported failures.
 	 * CRITICAL: if we have K failures or any level has reached maximum
 	 *           supported failures.
-	 * DAMAGED: if we have any more failures after CRITICAL.
+	 * DAMAGED: if we have more than K failures or any level has exceeded
+	 *          maximum supported failures.
 	 */
 	if (failures == 0)
 		out_info->cpi_state = M0_CPS_HEALTHY;
-	else if (failures < K && !has_reached_max_failure(pver, srecd))
+	if (failures > 0 && failures < K &&
+	    failures_at_lvl == MAX_FAILURES_NOT_REACHED)
 		out_info->cpi_state = M0_CPS_DEGRADED;
-	else if (failures == K || has_reached_max_failure(pver, srecd))
+	if (failures == K || failures_at_lvl == MAX_FAILURES_REACHED)
 		out_info->cpi_state = M0_CPS_CRITICAL;
-	else
+	if (failures > K || failures_at_lvl == MAX_FAILURES_EXCEEDED)
 		out_info->cpi_state = M0_CPS_DAMAGED;
 
 	M0_LOG(M0_DEBUG, "state: %d, failures: %d", out_info->cpi_state, failures);

--- a/conf/pvers.c
+++ b/conf/pvers.c
@@ -846,6 +846,7 @@ int m0_conf_pver_status(struct m0_fid *fid,
 	uint32_t                  srecd[M0_CONF_PVER_HEIGHT];
 	uint32_t                  failures = 0;
 	uint32_t                  K;
+	uint32_t                 *tolerance;
 
 	M0_ENTRY();
 	M0_PRE(fid != NULL);
@@ -870,6 +871,7 @@ int m0_conf_pver_status(struct m0_fid *fid,
 		failures += srecd[i++];
 
 	failures_at_lvl = tolerance_failure_cmp(pver, srecd); 
+	tolerance = pver->pv_u.subtree.pvs_tolerance;
 
 	/**
 	 * HEALTHY: if no failures in pver.
@@ -891,7 +893,8 @@ int m0_conf_pver_status(struct m0_fid *fid,
 		out_info->cpi_state = M0_CPS_DAMAGED;
 
 	M0_LOG(M0_DEBUG, "state: %d, failures: %d", out_info->cpi_state, failures);
-	CONF_PVER_VECTOR_LOG("failvec", FID_P(&pver->pv_obj.co_id), srecd);
+	CONF_PVER_VECTOR_LOG("failed objs of", FID_P(&pver->pv_obj.co_id), srecd);
+	CONF_PVER_VECTOR_LOG("tolerance of", FID_P(&pver->pv_obj.co_id), tolerance);
 
 	return M0_RC(rc);
 } M0_EXPORTED(m0_conf_pver_status);


### PR DESCRIPTION
When the allowance was set to less than K at any level, and that many numbers of failures
was reached, then bytecount had become critical, but it was still marked as degraded
according to old logic as the failures were still less than K.

ex: in a 3 node cluster with SNS 4+2+0, we support at max 1 node failure.
So when a node failed, data should've become critical, but with old logic,
it was marked as degraded, as number of failures was 1 which is < K.

Updated the logic to check if failures at any level has reached it's max or not.
If it does then pool version is marked as CRITICAL even if failures < K.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
