### PR TITLE
cortx-29816: m0spiel: Fix error in displaying help

### DIFF
--- a/utils/spiel/m0spiel
+++ b/utils/spiel/m0spiel
@@ -30,7 +30,7 @@ import os
 import socket
 import fcntl
 import struct
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, check_output
 from motr import *
 from ctypes import *
 
@@ -44,17 +44,13 @@ def get_ip_address(ifname):
         struct.pack('256s', ifname[:15].encode('utf-8'))
     )[20:24])
 
-def address_get():
-    i = 0
-    for arg in sys.argv:
-        i = i+1
-        if format(str(arg)) == "-l":
-            break
+def get_motr_transport():
+    cmd = "whereis fi_info | cut -d ':' -f2"
+    output = check_output(cmd, shell=True).split()
+    return "libfab" if output else ''
 
-    path = format(str(sys.argv[i]))
-    path = path.rstrip(path.rsplit('/')[-1]) + "../../scripts/st.d/net_xpt"
-    f = open(path, "r")
-    xprt = f.read()
+def address_get():
+    xprt = get_motr_transport()
 
     if "libfab" in xprt :
         conf = open("/etc/libfab.conf", "r")
@@ -609,7 +605,7 @@ class SpielWrapper:
     def filesystem_stats_fetch(self, stats):
         return self.motr.m0_spiel_filesystem_stats_fetch(self.spiel,
                                                          byref(stats))
-    
+
     @require(fid=Fid,stats=ByteCountStats)
     def proc_counters_fetch(self, fid, stats):
         return self.motr.m0_spiel_proc_counters_fetch(self.spiel,byref(fid),


### PR DESCRIPTION
Problem:
Currently ./m0spiel -h displays error as it searches for -l option
always. It uses the path provided with -l to get to net_xpt file which
is then used to get the current transport being used. With -h option,
the -l option is not found and hence displays error.

Solution:
The solution is to use 'whereis fi_info' command to check whether
libfabric is installed or not. If it is installed then the default
transport is libfabric else other transport is being used. This solution
doesn't look for -l option.

Signed-off-by: Sanjog Vikram Naik <sanjog.naik@seagate.com>

# Problem Statement
- Currently ./m0spiel -h displays error as it searches for -l option always. It uses the path provided with -l to get to net_xpt file which is then used to get the current transport being used. With -h option, the -l option is not found and hence displays error.
```
# ./utils/spiel/m0spiel -h
Traceback (most recent call last):
  File "./utils/spiel/m0spiel", line 78, in <module>
    addr = address_get()
  File "./utils/spiel/m0spiel", line 54, in address_get
    path = format(str(sys.argv[i]))
IndexError: list index out of range
#
```

# Design
-  The solution is to use 'whereis fi_info' command to check whether libfabric is installed or not. If it is installed then the default
transport is libfabric else other transport is being used. This solution doesn't look for -l option.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
