### PR TITLE
CORTX-29855: Add support to specify build options in Jenkins code coverage job

### DIFF
--- a/scripts/jenkins/code-coverage.groovy
+++ b/scripts/jenkins/code-coverage.groovy
@@ -1,10 +1,15 @@
 pipeline { 
-    agent any
+
+    agent {
+        label "jenkins-client-for-cortx-motr"
+    }
+
     parameters {
         string(name: 'NODE_HOST', defaultValue: '', description: 'Node 1 Host FQDN', trim: true)
         string(name: 'NODE_USER', defaultValue: '', description: 'Host machine root user', trim: true)
         string(name: 'NODE_PASS', defaultValue: '', description: 'Host machine root user password', trim: true)
         string(name: 'BRANCH', defaultValue: '', description: 'Branch name', trim: true)
+        string(name: 'OPTIONS', defaultValue: '', description: 'Build options', trim: true)
         booleanParam(name: 'UT', defaultValue: true, description: 'Run UT')
         booleanParam(name: 'ST', defaultValue: false, description: 'Run ST')
     }
@@ -40,7 +45,7 @@ pipeline {
                     sshpass -p ${NODE_PASS} ssh -o StrictHostKeyChecking=no ${NODE_USER}@${NODE_HOST} "cd /root/ ; git clone --recursive -b ${BRANCH} https://github.com/Seagate/cortx-motr"
                     sshpass -p ${NODE_PASS} ssh -o StrictHostKeyChecking=no ${NODE_USER}@${NODE_HOST} "cd /root/cortx-motr ; sudo ./scripts/install-build-deps"
                     sshpass -p ${NODE_PASS} ssh -o StrictHostKeyChecking=no ${NODE_USER}@${NODE_HOST} "cd /root/cortx-motr ; ./autogen.sh"
-                    sshpass -p ${NODE_PASS} ssh -o StrictHostKeyChecking=no ${NODE_USER}@${NODE_HOST} "cd /root/cortx-motr ; ./configure --enable-coverage --enable-debug"
+                    sshpass -p ${NODE_PASS} ssh -o StrictHostKeyChecking=no ${NODE_USER}@${NODE_HOST} "cd /root/cortx-motr ; ./configure --enable-coverage --enable-debug ${OPTIONS}"
                     sshpass -p ${NODE_PASS} ssh -o StrictHostKeyChecking=no ${NODE_USER}@${NODE_HOST} "cd /root/cortx-motr ; make -j6"
 
                     if [ ${UT} == true ]


### PR DESCRIPTION
Added a field to specify different build parameters for Jenkins code coverage job.

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
The current code coverage job executes with the default build option, because of which we cannot run this for features like DTM. 

# Design
Added a field to provide build option while executing the job.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
