### PR TITLE
CORTX-29681: Fixes m0addb2dump utility to dump data based on timestamp

### DIFF
--- a/addb2/dump.c
+++ b/addb2/dump.c
@@ -391,7 +391,7 @@ static void file_dump(struct m0_stob_domain *dom, const char *fname,
 			err(EX_DATAERR, "Cannot initialise iterator: %d",
 			    result);
 		while ((result = m0_addb2_sit_next(sit, &rec)) > 0) {
-			if (start_time <= rec->ar_val.va_time &&
+			if (start_time >= rec->ar_val.va_time &&
 			    rec->ar_val.va_time <= stop_time) {
 				rec_dump(&(struct m0_addb2__context){}, rec);
 				if (rec->ar_val.va_id == M0_AVI_SIT)


### PR DESCRIPTION
# Problem Statement
m0addb2dump utility has been failing to collect data between 2 time range
of value. we are obtaining zero size for dumps_txt files.

# Design
-  We Identified the root cause of issues. So I fixed it to meet our
expectations for the timerange of value.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>
