### PR TITLE
Cortx 29834 storage on cortx 29739 cvg changes

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -456,9 +456,9 @@ def update_copy_motr_config_file(self):
 #              ['/dev/sdf'] is list of metadata disks of cvg[1]
 def get_md_disks_lists(self, node_info):
     md_disks_lists = []
-    cvg_count = node_info['storage']['cvg_count']
+    num_cvg = node_info['storage']['num_cvg']
     cvg = node_info['storage']['cvg']
-    for i in range(cvg_count):
+    for i in range(num_cvg):
         temp_cvg = cvg[i]
         if temp_cvg['devices']['metadata']:
             md_disks_lists.append(temp_cvg['devices']['metadata'])
@@ -795,11 +795,11 @@ def calc_lvm_min_size(self, lv_path, lvm_min_size):
 
 def get_cvg_cnt_and_cvg(self):
     try:
-        cvg_cnt = self.server_node['storage']['cvg_count']
+        cvg_cnt = self.server_node['storage']['num_cvg']
     except:
         raise MotrError(errno.EINVAL, "cvg_cnt not found\n")
 
-    check_type(cvg_cnt, str, "cvg_count")
+    check_type(cvg_cnt, str, "num_cvg")
 
     try:
         cvg = self.server_node['storage']['cvg']
@@ -1197,10 +1197,10 @@ def update_motr_hare_keys_for_all_nodes(self):
     retry_delay = 2
     for value in nodes_info.values():
         host = value["hostname"]
-        cvg_count = value["storage"]["cvg_count"]
+        num_cvg = value["storage"]["num_cvg"]
         name = value["name"]
         self.logger.info(f"update_motr_hare_keys for {host}\n")
-        for i in range(int(cvg_count)):
+        for i in range(int(num_cvg)):
             lv_path = None
             lv_md_name = f"lv_raw_md{i + 1}"
 

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -456,8 +456,16 @@ def update_copy_motr_config_file(self):
 #              ['/dev/sdf'] is list of metadata disks of cvg[1]
 def get_md_disks_lists(self, node_info):
     md_disks_lists = []
-    num_cvg = node_info['storage']['num_cvg']
-    cvg = node_info['storage']['cvg']
+
+    try:
+        cvg = node_info['cvg']
+    except:
+        raise MotrError(errno.EINVAL, "cvg not found\n")
+    check_type(cvg, dict, "cvg")
+
+    num_cvg = int(cvg['num_cvg'])
+    if num_cvg <= 0:
+        raise MotrError(errno.EINVAL, f"Invalid num_cvg{num_cvg}\n")
     for i in range(num_cvg):
         temp_cvg = cvg[i]
         if temp_cvg['devices']['metadata']:


### PR DESCRIPTION
# Problem Statement
CORTX-29834: Remove dependency from key storage, instead use cvg

# Design
/etc/cortx/cluster.conf framework has removed storage key from nodes. So now node data and metadata disks are in 
node:
    <machine_id>:
           cvg:
                  - devices:
                         data: [List of data disks]
                         metadata: [List of metadata disks]
                         num_data: 2
                         num_metadata: 1
                         name: cvg-01
                         type: ios
                  - devices:
                         data: [List of data disks]
                         metadata: [List of metadata disks]
                         num_data: 2
                         num_metadata: 1
                         name: cvg-01
                         type: ios
                 num_cvg: 2
# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
