### PR TITLE
CORTX-30717 motr_setup help typo

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -93,7 +93,7 @@ class Cmd:
             f"usage: {prog} [-h] <cmd> --config <url> <args>\n"
             f"where:\n"
             f"cmd           post_install, prepare, config, init, test, reset, cleanup,"
-            f" upgarde, backup, restore\n"
+            f" upgrade, backup, restore\n"
             f"url           Config URL\n")
 
     @staticmethod


### PR DESCRIPTION
- Fixed motr_setup help typo changed "upgarde" to "upgrade"
