### PR TITLE
CORTX-29739: Rename cvg_count and storage_set_count keys

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -56,6 +56,7 @@ MACHINE_ID_FILE = "/etc/machine-id"
 TEMP_FID_FILE= "/opt/seagate/cortx/motr/conf/service_fid.yaml"
 CMD_RETRY_COUNT = 5
 MEM_THRESHOLD = 4*1024*1024*1024
+CVG_COUNT_KEY = "num_cvg"
 
 class MotrError(Exception):
     """ Generic Exception with error code and output """
@@ -456,7 +457,7 @@ def update_copy_motr_config_file(self):
 #              ['/dev/sdf'] is list of metadata disks of cvg[1]
 def get_md_disks_lists(self, node_info):
     md_disks_lists = []
-    cvg_count = node_info['storage']['cvg_count']
+    cvg_count = node_info['storage'][CVG_COUNT_KEY]
     cvg = node_info['storage']['cvg']
     for i in range(cvg_count):
         temp_cvg = cvg[i]
@@ -795,11 +796,11 @@ def calc_lvm_min_size(self, lv_path, lvm_min_size):
 
 def get_cvg_cnt_and_cvg(self):
     try:
-        cvg_cnt = self.server_node['storage']['cvg_count']
+        cvg_cnt = self.server_node['storage'][CVG_COUNT_KEY]
     except:
         raise MotrError(errno.EINVAL, "cvg_cnt not found\n")
 
-    check_type(cvg_cnt, str, "cvg_count")
+    check_type(cvg_cnt, str, CVG_COUNT_KEY)
 
     try:
         cvg = self.server_node['storage']['cvg']
@@ -1197,7 +1198,7 @@ def update_motr_hare_keys_for_all_nodes(self):
     retry_delay = 2
     for value in nodes_info.values():
         host = value["hostname"]
-        cvg_count = value["storage"]["cvg_count"]
+        cvg_count = value["storage"][CVG_COUNT_KEY]
         name = value["name"]
         self.logger.info(f"update_motr_hare_keys for {host}\n")
         for i in range(int(cvg_count)):


### PR DESCRIPTION
# Problem Statement
Rename motr keys according to new key names (here cvg_count to num_cvg)

# Design
Created a macro for this key type so that in future, if  this key is again renamed then we just need to change the MACRO

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
Tested with cortx k8s deployment 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
