### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
@@ -54,8 +54,8 @@ valid_count_get()
 	local i=$((10-$j))
 	local bs=$1
 	input_file_size=`expr $i \* $bs`
-	echo $input_file_size
-	echo $ABCD_SOURCE_SIZE
+	echo "$input_file_size"
+	echo "$ABCD_SOURCE_SIZE"
 	while [ $input_file_size -gt $ABCD_SOURCE_SIZE ]
 	do
 		j=$((RANDOM%9))
@@ -121,7 +121,7 @@ fmio_truncation_module()
 	seek=`expr $cnt \+ 1`
 	echo "Ensure that truncating to a size larger than the
 	      current one succeeds"
-	fmio_files_write dd bs=$blk_size count=1 seek=$seek
+	fmio_files_write dd bs=$blk_size count=1 seek="$seek"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -155,17 +155,17 @@ fmio_truncation_module()
 
 fmio_source_files_create()
 {
-	if [ $pattern == $ABCD ] || [ $pattern == $ALTERNATE ]
+	if [ "$pattern" == "$ABCD" ] || [ "$pattern" == "$ALTERNATE" ]
 	then
-		$prog_file_pattern $source_abcd 2>&1 >> $MOTR_TEST_LOGFILE || {
+		$prog_file_pattern "$source_abcd" 2>&1 >> "$MOTR_TEST_LOGFILE" || {
 			echo "Failed: m0t1fs_io_file_pattern..."
 			return 1
 		}
 	fi
 
-	if [ $pattern == $RANDOM1 ] || [ $pattern == $ALTERNATE ]
+	if [ "$pattern" == "$RANDOM1" ] || [ "$pattern" == "$ALTERNATE" ]
 	then
-		dd if=/dev/urandom bs=$block_size count=$random_source_dd_count of=$source_random 2>&1 >> $MOTR_TEST_LOGFILE || {
+		dd if=/dev/urandom bs="$block_size" count=$random_source_dd_count of="$source_random" 2>&1 >> "$MOTR_TEST_LOGFILE" || {
 			echo "Failed: dd..."
 			return 1
 		}
@@ -181,7 +181,7 @@ fmio_files_write()
 
 	# Verify that 'the size of the file to be written' is not larger than
 	# 'the ABCD source file size'
-	bs=$(echo $2 | cut -d= -f2)
+	bs=$(echo "$2" | cut -d= -f2)
 
 	if [ $bs -lt 0 ]
 	then
@@ -207,13 +207,13 @@ fmio_files_write()
 
 	# Select source file from the sandbox, according to the configured
 	# pattern
-	if [ $pattern == $ABCD ]
+	if [ "$pattern" == "$ABCD" ]
 	then
 		source_sandbox=$source_abcd
-	elif [ $pattern == $RANDOM1 ]
+	elif [ "$pattern" == "$RANDOM1" ]
 	then
 		source_sandbox=$source_random
-	elif [ $pattern == $ALTERNATE ]
+	elif [ "$pattern" == "$ALTERNATE" ]
 	then
 		if [ `expr $dd_count % 2` == 0 ]
 		then
@@ -234,34 +234,34 @@ fmio_files_write()
 		file_to_compare_m0t1fs="$MOTR_M0T1FS_MOUNT_DIR/0:1000$dd_count"
 		echo "touch $file_to_compare_m0t1fs"
 		echo "setfattr -n lid -v 4 $file_to_compare_m0t1fs"
-		touch $file_to_compare_m0t1fs
-		setfattr -n lid -v 4 $file_to_compare_m0t1fs
-		getfattr -n pver $file_to_compare_m0t1fs
+		touch "$file_to_compare_m0t1fs"
+		setfattr -n lid -v 4 "$file_to_compare_m0t1fs"
+		getfattr -n pver "$file_to_compare_m0t1fs"
 	fi
 	echo -e "Write to the files from sandbox and m0t1fs (dd_count #$dd_count):"
 	echo -e "\t - $file_to_compare_sandbox \n\t - $file_to_compare_m0t1fs"
 
 
 	$@ \
-	   if=$source_sandbox of=$file_to_compare_sandbox >> $MOTR_TEST_LOGFILE || {
+	   if="$source_sandbox" of="$file_to_compare_sandbox" >> "$MOTR_TEST_LOGFILE" || {
 		echo "Failed: dd..."
 		return 1
 	}
 	$@ \
-	   if=$source_sandbox of=$file_to_compare_m0t1fs >> $MOTR_TEST_LOGFILE || {
+	   if="$source_sandbox" of="$file_to_compare_m0t1fs" >> "$MOTR_TEST_LOGFILE" || {
 		echo "Failed: dd..."
 		return 1
 	}
 
-	if [ $debug_level != $DEBUG_LEVEL_OFF ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_OFF" ]
 	then
 		echo "od -A d -c $file_to_compare_sandbox | tail"
-		od -A d -c $file_to_compare_sandbox | tail
+		od -A d -c "$file_to_compare_sandbox" | tail
 		echo "od -A d -c $file_to_compare_m0t1fs | tail"
-		od -A d -c $file_to_compare_m0t1fs | tail
+		od -A d -c "$file_to_compare_m0t1fs" | tail
 	fi
 
-	if [ $debug_level == $DEBUG_LEVEL_3 ]
+	if [ "$debug_level" == "$DEBUG_LEVEL_3" ]
 	then
 		echo "stob_read after dd execution (dd_count #$dd_count)"
 		fmio_stob_read_full
@@ -279,9 +279,9 @@ fmio_files_compare()
 	#Read file from m0t1fs with minimum possible count
 	local block_size=`expr $ABCD_SOURCE_SIZE \+ $random_source_size`
 	mount | grep m0t1
-	ls -l $file_to_compare_m0t1fs
-	dd if=$file_to_compare_m0t1fs bs=$block_size count=1 of=$fmio_sandbox/local_m0t1fs_cp
-	cmp $file_to_compare_sandbox $fmio_sandbox/local_m0t1fs_cp
+	ls -l "$file_to_compare_m0t1fs"
+	dd if="$file_to_compare_m0t1fs" bs="$block_size" count=1 of="$fmio_sandbox"/local_m0t1fs_cp
+	cmp "$file_to_compare_sandbox" "$fmio_sandbox"/local_m0t1fs_cp
 	rc=$?
 	if [ $rc -ne 0 ]
 	then
@@ -289,12 +289,12 @@ fmio_files_compare()
 		echo -e "\tparity group number may be calculated as:"
 		echo -e "\t\tpg_no = differing_offset / (unit_size * N)\n"
 		echo "od -A d -c $file_to_compare_sandbox | tail"
-		od -A d -c $file_to_compare_sandbox | tail
+		od -A d -c "$file_to_compare_sandbox" | tail
 		echo "od -A d -c $file_to_compare_m0t1fs | tail"
-		od -A d -c $file_to_compare_m0t1fs | tail
+		od -A d -c "$file_to_compare_m0t1fs" | tail
 
-		if [ $debug_level == $DEBUG_LEVEL_2 ] ||
-		   [ $debug_level == $DEBUG_LEVEL_3 ]
+		if [ "$debug_level" == "$DEBUG_LEVEL_2" ] ||
+		   [ "$debug_level" == "$DEBUG_LEVEL_3" ]
 		then
 			echo "stob_read after data discrepancy is encountered (dd_count #$dd_count)"
 			fmio_stob_read_full
@@ -302,11 +302,11 @@ fmio_files_compare()
 	fi
 
 	echo "cmp output (dd_count #$dd_count): $rc"
-	if [ $debug_level == $DEBUG_LEVEL_INTERACTIVE ]
+	if [ "$debug_level" == "$DEBUG_LEVEL_INTERACTIVE" ]
 	then
 		fmio_if_to_continue_check
 	fi
-	rm -f $fmio_sandbox/local_m0t1fs_cp
+	rm -f "$fmio_sandbox"/local_m0t1fs_cp
 	return $rc
 }
 
@@ -317,13 +317,13 @@ fmio_pool_mach_set_failure()
 		echo "parameter 'device' is required"
 		return 1
 	}
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
-		disk_state_set "failed" $device || {
+		disk_state_set "failed" "$device" || {
 			echo "Failed: disk_state_set failed for $device ..."
 			return 1
 		}
-		disk_state_get $fail_devices
+		disk_state_get "$fail_devices"
 	fi
 	return 0
 }
@@ -336,9 +336,9 @@ fmio_sns_repair()
 		return 1
 	}
 
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
-		disk_state_set "repair" $device || return 1
+		disk_state_set "repair" "$device" || return 1
 
 		sns_repair || {
 			echo "Failed: SNS repair..."
@@ -347,12 +347,12 @@ fmio_sns_repair()
 		echo "wait for sns repair"
 		wait_for_sns_repair_or_rebalance "repair" || return $?
 
-		disk_state_set "repaired" $device || return 1
+		disk_state_set "repaired" "$device" || return 1
 		echo "sns repair done"
-		disk_state_get $fail_devices
+		disk_state_get "$fail_devices"
 	fi
 
-	if [ $debug_level == $DEBUG_LEVEL_3 ]
+	if [ "$debug_level" == "$DEBUG_LEVEL_3" ]
 	then
 		echo "stob_read after repair (dd_count #$dd_count)"
 		fmio_stob_read_full
@@ -369,9 +369,9 @@ fmio_sns_rebalance()
 		return 1
 	}
 
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
-		disk_state_set "rebalance" $device || return 1
+		disk_state_set "rebalance" "$device" || return 1
 
 		sns_rebalance || {
 			echo "Failed: SNS rebalance..."
@@ -380,10 +380,10 @@ fmio_sns_rebalance()
 		echo "wait for sns rebalance"
 		wait_for_sns_repair_or_rebalance "rebalance" || return $?
 
-		disk_state_set "online" $device || return 1
+		disk_state_set "online" "$device" || return 1
 		echo "sns rebalance done"
 
-		disk_state_get $fail_devices
+		disk_state_get "$fail_devices"
 	fi
 	return 0
 }
@@ -411,7 +411,7 @@ fmio_stob_read_full()
 		return 0 # Not returning error intentionally
 	fi
 
-	if [ $file_kind != $SINGLE_FILE ]
+	if [ "$file_kind" != "$SINGLE_FILE" ]
 	then
 		echo "stob reading supported with $SINGLE_FILE kind only..."
 		return 0 # Not returning error intentionally
@@ -440,7 +440,7 @@ fmio_stob_read_full()
 		echo "stobid $stobid"
 
 		echo "od -A d -c $MOTR_M0T1FS_TEST_DIR/$ios/stobs/o/$stobid"
-		od -A d -c $MOTR_M0T1FS_TEST_DIR/$ios/stobs/o/$stobid
+		od -A d -c "$MOTR_M0T1FS_TEST_DIR"/$ios/stobs/o/"$stobid"
 		# Note: During development, the above can be quickly modified
 		# using 'sed' to read specific lines of interest from the stob
 		# output.
@@ -483,11 +483,11 @@ fmio_pre()
 	file_to_create2="$MOTR_M0T1FS_MOUNT_DIR/0:11112"
 	file_to_create3="$MOTR_M0T1FS_MOUNT_DIR/0:11113"
 
-	rm -rf $fmio_sandbox
-	mkdir -p $fmio_sandbox
-	if [ $debug_level == $DEBUG_LEVEL_STTEST ]
+	rm -rf "$fmio_sandbox"
+	mkdir -p "$fmio_sandbox"
+	if [ "$debug_level" == "$DEBUG_LEVEL_STTEST" ]
 	then
-		mkdir $fmio_sandbox/tmp
+		mkdir "$fmio_sandbox"/tmp
 	fi
 
 	echo "Creating source files"
@@ -511,9 +511,9 @@ fmio_io_test()
 	fi
 
 	echo "All the devices are online at this point"
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
-		disk_state_get $fail_devices
+		disk_state_get "$fail_devices"
 	fi
 
 	echo "Creating files initially"
@@ -549,9 +549,9 @@ fmio_io_test()
 	}
 
 	echo "Create a file after first $step: $file_to_create1"
-	touch $file_to_create1
+	touch "$file_to_create1"
 	rc=$?
-	getfattr -n pver $file_to_create1
+	getfattr -n pver "$file_to_create1"
 	if [ $rc -ne 0 ]
 	then
 		echo "Failed: create after first $step, rc $rc..."
@@ -570,7 +570,7 @@ fmio_io_test()
 		echo "Failed: IO or read after first $step, rc=$rc OOSTORE=$OOSTORE"
 		return 1
 	fi
-	if [ $single_file_test -eq 1 ]
+	if [ "$single_file_test" -eq 1 ]
 	then
 		echo -e "\n*** $test_name test 2.1: Another IO and read after first $step ***"
 		fmio_files_write dd bs=8821 count=5 seek=23 conv=notrunc
@@ -580,9 +580,9 @@ fmio_io_test()
 			return 1
 		fi
 	fi
-	if [ $OOSTORE -eq 1 ]
+	if [ "$OOSTORE" -eq 1 ]
 	then
-		rm -rf $file_to_create1
+		rm -rf "$file_to_create1"
 		rc=$?
 		if [ $rc -ne 0 ]
 		then
@@ -601,9 +601,9 @@ fmio_io_test()
 		fmio_sns_repair $fail_device2 || return 1
         fi
 	echo "Create a file after second $step: $file_to_create2"
-	touch $file_to_create2
+	touch "$file_to_create2"
 	rc=$?
-	getfattr -n pver $file_to_create2
+	getfattr -n pver "$file_to_create2"
 	if [ $rc -ne 0 ]
 	then
 		echo "Failed: create after second $step, rc $rc..."
@@ -658,9 +658,9 @@ fmio_io_test()
 	}
 
 	echo "Create a file after third $step: $file_to_create3"
-	touch $file_to_create3
+	touch "$file_to_create3"
 	rc=$?
-	getfattr -n pver $file_to_create3
+	getfattr -n pver "$file_to_create3"
 	if [ $rc -ne 0 ]
 	then
 		echo "Failed: create after third $step, rc $rc..."
@@ -683,7 +683,7 @@ fmio_io_test()
 
 fmio_failed_dev_test()
 {
-	if [ $failed_dev_test -eq 0 ]
+	if [ "$failed_dev_test" -eq 0 ]
 	then
 		return 1
 	fi
@@ -700,7 +700,7 @@ fmio_failed_dev_test()
 
 fmio_repaired_dev_test()
 {
-	if [ $failed_dev_test -eq 1 ]
+	if [ "$failed_dev_test" -eq 1 ]
 	then
 		return 1
 	fi
@@ -717,7 +717,7 @@ fmio_repaired_dev_test()
 
 fmio_motr_service_start()
 {
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
 		local multiple_pools=0
 		echo "About to start Motr service"
@@ -739,7 +739,7 @@ fmio_motr_service_start()
 
 fmio_motr_service_stop()
 {
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
 		echo "About to stop Motr service"
 		motr_service stop
@@ -763,19 +763,19 @@ fmio_m0t1fs_mount()
 		local mountopt="oostore,verify"
 	fi
 	echo "Mount options are $mountopt"
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
-		mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR $mountopt || return 1
+		mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" $mountopt || return 1
 	fi
 	return 0
 }
 
 fmio_m0t1fs_unmount()
 {
-	if [ $debug_level != $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_STTEST" ]
 	then
 		echo "unmounting and cleaning.."
-		unmount_and_clean &>> $MOTR_TEST_LOGFILE
+		unmount_and_clean &>> "$MOTR_TEST_LOGFILE"
 	fi
 	return 0
 }
@@ -783,9 +783,9 @@ fmio_m0t1fs_unmount()
 fmio_m0t1fs_clean()
 {
 	echo "cleaning Motr mountpoint.."
-	rm -f $file_to_create1
-	rm -f $file_to_create2
-	rm -f $file_to_create3
+	rm -f "$file_to_create1"
+	rm -f "$file_to_create2"
+	rm -f "$file_to_create3"
 	# Delete file created for single file io testing.
 	rm -f "$MOTR_M0T1FS_MOUNT_DIR/0:10000"
 	# Delete files created for separate file io testing.
@@ -803,12 +803,12 @@ failure_modes_test()
 		str="single file"
 		# Set the unit size for the file on m0t1fs to 32K. This is
 		# necessary for large IO.
-		touch $file_to_compare_m0t1fs
+		touch "$file_to_compare_m0t1fs"
 		# Currently server-side receives an issue while writing a
 		# large file after two repairs and one failure, when unit size
 		# is more than 32K.
-		setfattr -n lid -v 4 $file_to_compare_m0t1fs
-		getfattr -n pver $file_to_compare_m0t1fs
+		setfattr -n lid -v 4 "$file_to_compare_m0t1fs"
+		getfattr -n pver "$file_to_compare_m0t1fs"
 		if [ $? -ne "0" ]
 		then
 			echo "Setfattr failed."
@@ -818,7 +818,7 @@ failure_modes_test()
 		str="separate file"
 	fi
 
-	if [ $failure_mode == $FAILED_DEVICES ] || [ $failure_mode == $BOTH_DEVICES ]
+	if [ "$failure_mode" == "$FAILED_DEVICES" ] || [ "$failure_mode" == "$BOTH_DEVICES" ]
 	then
 		echo "--------------------------------------------------------"
 		echo "Start with the failed device IO testing ($str)"
@@ -841,7 +841,7 @@ failure_modes_test()
 			return 0
 		fi
 		echo "Mark the devices online again before the next test"
-		fmio_repair_n_rebalance $fail_devices || return 1
+		fmio_repair_n_rebalance "$fail_devices" || return 1
 	fi
 	#@todo Run sns_repair and rebalance tests in oostore mode only when MOTR-1166 lands.
 	# This is so because till then new pool version won't get created for
@@ -849,7 +849,7 @@ failure_modes_test()
 	# case.
 	return 0
 
-	if [ $failure_mode == $REPAIRED_DEVICES ] || [ $failure_mode == $BOTH_DEVICES ]
+	if [ "$failure_mode" == "$REPAIRED_DEVICES" ] || [ "$failure_mode" == "$BOTH_DEVICES" ]
 	then
 		echo "--------------------------------------------------------"
 		echo "Starting with the repaired device IO testing ($str)"
@@ -869,7 +869,7 @@ failure_modes_test()
 		echo "--------------------------------------------------------"
 
 		echo "Mark the devices online again before the next test"
-		fmio_sns_rebalance $fail_devices || {
+		fmio_sns_rebalance "$fail_devices" || {
 			echo "Failed: sns rebalance..."
 			return 1
 		}
@@ -883,7 +883,7 @@ main()
 
 	echo '*********************************************************'
 	echo -n 'Running '
-	[ $OOSTORE -eq 0 ] || echo -n 'non-'
+	[ "$OOSTORE" -eq 0 ] || echo -n 'non-'
 	echo 'oostore test.'
 	echo '*********************************************************'
 
@@ -896,14 +896,14 @@ main()
 	echo "*********************************************************"
 
 	# Override this variable so as to use linux stob, for debugging
-	if [ $debug_level != $DEBUG_LEVEL_OFF ]
+	if [ "$debug_level" != "$DEBUG_LEVEL_OFF" ]
 	then
 		MOTR_STOB_DOMAIN="linux"
 	fi
 
 	# Override these variables so as to test the ST framework without
 	# involving motr service and m0t1fs
-	if [ $debug_level == $DEBUG_LEVEL_STTEST ]
+	if [ "$debug_level" == "$DEBUG_LEVEL_STTEST" ]
 	then
 		MOTR_TEST_LOGFILE="$fmio_sandbox/log"
 		MOTR_M0T1FS_MOUNT_DIR="$fmio_sandbox/tmp"
@@ -923,13 +923,13 @@ main()
 
 	fmio_pre || return 1
 
-	fmio_m0t1fs_mount $OOSTORE || {
+	fmio_m0t1fs_mount "$OOSTORE" || {
 		fmio_motr_service_stop
 		return 1
 	}
 	echo -e "Done with preprocessing for failure modes IO testing\n"
 
-	if [ $file_kind == $SINGLE_FILE ] || [ $file_kind == $BOTH_FILE_KINDS ]
+	if [ "$file_kind" == "$SINGLE_FILE" ] || [ "$file_kind" == "$BOTH_FILE_KINDS" ]
 	then
 		echo "========================================================"
 		echo "Start with the single file IO testing"
@@ -945,7 +945,7 @@ main()
 		echo "========================================================"
 	fi
 
-	if [ $file_kind == $SEPARATE_FILE ] || [ $file_kind == $BOTH_FILE_KINDS ]
+	if [ "$file_kind" == "$SEPARATE_FILE" ] || [ "$file_kind" == "$BOTH_FILE_KINDS" ]
 	then
 		echo "========================================================"
 		echo "Start with the separate file IO testing"

--- a/m0t1fs/linux_kernel/st/m0t1fs_multi_clients.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_multi_clients.sh
@@ -61,7 +61,7 @@ main()
 	echo "Starting multi clients testing:"
 	echo "Test log will be stored in $MOTR_TEST_LOGFILE."
 
-	multi_clients 2>&1 | tee -a $MOTR_TEST_LOGFILE
+	multi_clients 2>&1 | tee -a "$MOTR_TEST_LOGFILE"
 	rc=${PIPESTATUS[0]}
 
 	if [ $rc -eq 0 ]; then

--- a/m0t1fs/linux_kernel/st/m0t1fs_server_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_server_inc.sh
@@ -30,12 +30,12 @@ conf_ios_device_setup()
 
 	if (($_id_count == 0))
 	then
-		eval $ids_out="'$ddev_id'"
+		eval "$ids_out"="'$ddev_id'"
 	else
-		eval $ids_out="'$_ids, $ddev_id'"
+		eval "$ids_out"="'$_ids, $ddev_id'"
 	fi
 
-	eval $id_count_out=$(( $_id_count + 1 ))
+	eval "$id_count_out"=$(( $_id_count + 1 ))
 
 	#dev conf obj
 	local ddev_obj="{0x64| (($ddev_id), $(($_DDEV_ID - 1)), 4, 1, 4096, 596000000000, 3, 4, \"/dev/loop$_DDEV_ID\")}"
@@ -179,19 +179,19 @@ servers_stop()
 
 	for pid in $pids; do
 		echo -n "----- $pid stopping--------"
-		if checkpid $pid 2>&1; then
+		if checkpid "$pid" 2>&1; then
 			# TERM first, then KILL if not dead
-			kill -TERM $pid &>/dev/null
-			proc=$(ps -o ppid= $pid)
+			kill -TERM "$pid" &>/dev/null
+			proc=$(ps -o ppid= "$pid")
 			if [[ $proc -eq $$ ]]; then
 				## $pid is spawned by current shell
 				wait $pid || rc=$?
 			else
 				sleep 5
-				if checkpid $pid && sleep 5 &&
-				   checkpid $pid && sleep $delay &&
-				   checkpid $pid ; then
-					kill -KILL $pid &>/dev/null
+				if checkpid "$pid" && sleep 5 &&
+				   checkpid "$pid" && sleep $delay &&
+				   checkpid "$pid" ; then
+					kill -KILL "$pid" &>/dev/null
 					sleep 1
 				fi
 			fi
@@ -247,13 +247,13 @@ motr_service()
 
 		# start confd
 		DIR=$MOTR_M0T1FS_TEST_DIR/confd
-		rm -rf $DIR
-		mkdir -p $DIR
+		rm -rf "$DIR"
+		mkdir -p "$DIR"
 		ulimit -c unlimited
 
 		local nr_mds=${#MDSEP[*]}
 		local nr_ios=${#IOSEP[*]}
-		if [ $SINGLE_NODE -eq 1 ] ; then
+		if [ "$SINGLE_NODE" -eq 1 ] ; then
 			nr_ios=1
 			nr_mds=1
 		fi
@@ -267,7 +267,7 @@ motr_service()
 			local ios=$(( $i + 1 ))
 			local nr_dev=$nr_dev_per_ios
 			DIR=$MOTR_M0T1FS_TEST_DIR/ios$ios
-			rm -rf $DIR
+			rm -rf "$DIR"
 			mkdir -p $DIR
 
 			if (($i < $remainder))
@@ -275,7 +275,7 @@ motr_service()
 				nr_dev=$(($nr_dev_per_ios + 1))
 			fi
 
-			mkiosloopdevs $ios $nr_dev $DIR || return 1
+			mkiosloopdevs $ios $nr_dev "$DIR" || return 1
 		done
 
 		mkiosmddevs $nr_ios $P || return 1
@@ -309,7 +309,7 @@ EOF
 
 		DIR=$MOTR_M0T1FS_TEST_DIR/confd
 		CONFDB="$DIR/conf.xc"
-		build_conf $N $K $S $P $multiple_pools | tee $DIR/conf.xc
+		build_conf "$N" "$K" "$S" "$P" "$multiple_pools" | tee $DIR/conf.xc
 		common_opts="-D db -S stobs -A linuxstob:addb-stobs \
 			     -w $P -m $MAX_RPC_MSG_SIZE \
 			     -q $TM_MIN_RECV_QUEUE_LEN -N 100663296 -C 262144 -K 100663296 -k 262144"
@@ -319,7 +319,7 @@ EOF
 		      -c $CONFDB"
 		cmd="cd $DIR && exec $prog_mkfs -F $opts |& tee -a m0mkfs.log"
 
-		echo $cmd
+		echo "$cmd"
 		(eval "$cmd")
 
 		# spawn confd
@@ -346,16 +346,16 @@ EOF
 		for ((i=0; i < $nr_mds; i++)) ; do
 			local mds=$(( $i + 1 ))
 			DIR=$MOTR_M0T1FS_TEST_DIR/mds$mds
-			rm -rf $DIR
-			mkdir -p $DIR
+			rm -rf "$DIR"
+			mkdir -p "$DIR"
 
-			tmid=$(echo ${MDSEP[$i]} | cut -d: -f3)
+			tmid=$(echo "${MDSEP[$i]}" | cut -d: -f3)
 			ulimit -c unlimited
 			cmd="cd $DIR && exec \
 			$prog_mkfs -F -T ad \
 			$common_opts -e $XPRT:${lnet_nid}:${MDSEP[$i]%:*:*}:$MKFS_PORTAL:$tmid \
 			-c $CONFDB |& tee -a m0mkfs.log"
-			echo $cmd
+			echo "$cmd"
 			eval "$cmd"
 		done
 
@@ -365,7 +365,7 @@ EOF
 			proc_fid="'<"$PROC_FID_CNTR:$i">'"
 			DIR=$MOTR_M0T1FS_TEST_DIR/ios$ios
 
-			tmid=$(echo ${IOSEP[$i]} | cut -d: -f3)
+			tmid=$(echo "${IOSEP[$i]}" | cut -d: -f3)
 			ulimit -c unlimited
 			cmd="cd $DIR && exec \
 			$prog_mkfs -F -T $MOTR_STOB_DOMAIN \
@@ -395,12 +395,12 @@ EOF
 		DIR=$MOTR_M0T1FS_TEST_DIR/ha
 		cmd="cd $DIR && exec $prog_start $opts |& tee -a m0d.log"
 		local m0d_log=$DIR/m0d.log
-		touch $m0d_log
-		echo $cmd
+		touch "$m0d_log"
+		echo "$cmd"
 		(eval "$cmd") &
 
 		# Wait for HA agent to start
-		while ! grep CTRL $MOTR_M0T1FS_TEST_DIR/ha/m0d.log > /dev/null;
+		while ! grep CTRL "$MOTR_M0T1FS_TEST_DIR"/ha/m0d.log > /dev/null;
 		do
 			sleep 2
 		done
@@ -429,7 +429,7 @@ EOF
 			echo $cmd
 
 			local m0d_log=$DIR/m0d.log
-			touch $m0d_log
+			touch "$m0d_log"
 			(eval "$cmd") &
 
 			# let instance with RMS be the first initialised one;
@@ -457,7 +457,7 @@ EOF
 			echo $cmd
 
 			local m0d_log=$DIR/m0d.log
-			touch $m0d_log
+			touch "$m0d_log"
 			(eval "$cmd") &
 			IOS4_CMD=$cmd
 		done
@@ -470,18 +470,18 @@ EOF
 			$common_opts -e $XPRT:${lnet_nid}:$IOS_PVER2_EP \
                         -f $proc_fid \
 			-H ${lnet_nid}:$HA_EP |& tee -a m0d.log"
-			echo $cmd
+			echo "$cmd"
 
 			local m0d_log=$DIR/m0d.log
-			touch $m0d_log
+			touch "$m0d_log"
 			#Save IOS5, to start it again after controller HA event.
 			IOS5_CMD=$cmd
 			(eval "$cmd") &
 		fi
 
 		# Wait for confd to start
-		local confd_log=$MOTR_M0T1FS_TEST_DIR/confd/m0d.log
-		while ! grep CTRL $confd_log > /dev/null; do
+		local confd_log="$MOTR_M0T1FS_TEST_DIR/confd/m0d.log"
+		while ! grep CTRL "$confd_log" > /dev/null; do
 			sleep 2
 		done
 		echo "Motr confd started."
@@ -492,7 +492,7 @@ EOF
 			local mds=$(( $i + 1 ))
 			DIR=$MOTR_M0T1FS_TEST_DIR/mds$mds
 			local m0d_log=$DIR/m0d.log
-			while ! grep CTRL $m0d_log > /dev/null; do
+			while ! grep CTRL "$m0d_log" > /dev/null; do
 				sleep 2
 			done
 		done
@@ -503,12 +503,12 @@ EOF
 			local ios=$(( $i + 1 ))
 			DIR=$MOTR_M0T1FS_TEST_DIR/ios$ios
 			local m0d_log=$DIR/m0d.log
-			while ! grep CTRL $m0d_log > /dev/null; do
+			while ! grep CTRL "$m0d_log" > /dev/null; do
 				sleep 2
 			done
 		done
 		if ((multiple_pools == 1)); then
-			while ! grep CTRL $MOTR_M0T1FS_TEST_DIR/ios5/m0d.log > /dev/null;
+			while ! grep CTRL "$MOTR_M0T1FS_TEST_DIR"/ios5/m0d.log > /dev/null;
 			do
 				sleep 2
 			done
@@ -519,7 +519,7 @@ EOF
 	}
 
 	stop() {
-		servers_stop $prog_start || rc=$?
+		servers_stop "$prog_start" || rc=$?
 		unprepare || rc=$?
 		return $rc
 	}

--- a/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1f.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_sns_repair_1f.sh
@@ -61,8 +61,8 @@ sns_repair_test()
 	local_write $src_bs $src_count || return $?
 
 	for ((i=0; i < ${#file[*]}; i++)) ; do
-		_dd ${file[$i]} $unit_size ${file_size[$i]} || return $?
-		_md5sum ${file[$i]} || return $?
+		_dd "${file[$i]}" $unit_size "${file_size[$i]}" || return $?
+		_md5sum "${file[$i]}" || return $?
 	done
 
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
@@ -184,7 +184,7 @@ main()
 	fi
 
 	echo "unmounting and cleaning.."
-	unmount_and_clean &>> $MOTR_TEST_LOGFILE
+	unmount_and_clean &>> "$MOTR_TEST_LOGFILE"
 
 	motr_service stop || {
 		echo "Failed to stop Motr Service."

--- a/motr/st/utils/motr_device_util.sh
+++ b/motr/st/utils/motr_device_util.sh
@@ -35,7 +35,7 @@ m0t1fs_st_dir=$motr_st_util_dir/../../../m0t1fs/linux_kernel/st
 
 motr_st_set_failed_devices()
 {
-	disk_state_set "failed" $1 || {
+	disk_state_set "failed" "$1" || {
 		echo "Failed: pool_mach_set_failure..."
 		return 1
 	}
@@ -43,7 +43,7 @@ motr_st_set_failed_devices()
 
 motr_st_query_devices()
 {
-	disk_state_get $1 || {
+	disk_state_get "$1" || {
 		echo "Failed: pool_mach_query..."
 		return 1
 	}
@@ -65,10 +65,10 @@ devices=$2
 
 case "$cmd" in
 	down)
-		motr_st_set_failed_devices $devices
+		motr_st_set_failed_devices "$devices"
 		;;
 	query)
-		motr_st_query_devices $devices
+		motr_st_query_devices "$devices"
 		;;
 	*)
 		usage

--- a/motr/st/utils/motr_dgmode_io_st.sh
+++ b/motr/st/utils/motr_dgmode_io_st.sh
@@ -72,14 +72,14 @@ main()
 	BLOCKSIZE=16384 #4096
 	BLOCKCOUNT=3
 	echo "dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of=$src_file"
-	dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of=$src_file \
-              2> $MOTR_TEST_LOGFILE || {
+	dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of="$src_file" \
+              2> "$MOTR_TEST_LOGFILE" || {
 		echo "Failed to create a source file"
 		motr_service_stop
 		return 1
 	}
 
-	mkdir $MOTR_TRACE_DIR
+	mkdir "$MOTR_TRACE_DIR"
 
 	motr_service_start $N $K $S $P $stride
 
@@ -90,7 +90,7 @@ main()
 	# object. It has to be checked with S3 level or in motr trace logs.
 
 	# write an object
-	io_conduct "WRITE" $src_file $OBJ_ID1 "false"
+	io_conduct "WRITE" "$src_file" $OBJ_ID1 "false"
 	if [ $rc -ne "0" ]
 	then
 		echo "Healthy mode, write failed."
@@ -99,14 +99,14 @@ main()
 	echo "Healthy mode write succeeds."
 
 	# read the written object
-	io_conduct "READ" $OBJ_ID1  $dest_file "false"
+	io_conduct "READ" $OBJ_ID1  "$dest_file" "false"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Healthy mode, read failed."
 		error_handling $rc
 	fi
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -115,14 +115,14 @@ main()
 	fi
 	echo "Healthy mode, read file succeeds."
 	# read the written object
-	io_conduct "READ" $OBJ_ID1  $dest_file $read_verify
+	io_conduct "READ" $OBJ_ID1  "$dest_file" $read_verify
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Healthy mode, read verify failed."
 		error_handling $rc
 	fi
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -142,8 +142,8 @@ main()
 	}
 
 	# Test degraded read
-	rm -f $dest_file
-	io_conduct "READ" $OBJ_ID1 $dest_file "false"
+	rm -f "$dest_file"
+	io_conduct "READ" $OBJ_ID1 "$dest_file" "false"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -151,17 +151,17 @@ main()
 		error_handling $rc
 	fi
 	echo "Dgmode Read of 1st obj succeeds."
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Obj read in degraded mode differs."
 		error_handling $rc
 	fi
-	rm -f $dest_file
+	rm -f "$dest_file"
 
 	#Dgmode read of with Parity Verify.
-	io_conduct "READ" $OBJ_ID1 $dest_file $read_verify
+	io_conduct "READ" $OBJ_ID1 "$dest_file" $read_verify
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -169,17 +169,17 @@ main()
 		error_handling $rc
 	fi
 	echo "Dgmode Parity verify Read of 1st obj succeeds."
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Obj read in degraded mode differs."
 		error_handling $rc
 	fi
-	rm -f $dest_file
+	rm -f "$dest_file"
 
 	# Test write, when a disk is failed
-	io_conduct "WRITE" $src_file $OBJ_ID2 "false"
+	io_conduct "WRITE" "$src_file" $OBJ_ID2 "false"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -187,7 +187,7 @@ main()
 		error_handling $rc
 	fi
 	echo "New Obj write succeeds."
-	rm -f $dest_file
+	rm -f "$dest_file"
 
 	echo "Fail another disk"
 	fail_device3=3
@@ -199,14 +199,14 @@ main()
 
 
 	# Read a file from the new pool version.
-	io_conduct "READ" $OBJ_ID2 $dest_file "false"
+	io_conduct "READ" $OBJ_ID2 "$dest_file" "false"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Reading a file from a new pool version failed."
 		error_handling $rc
 	fi
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -216,14 +216,14 @@ main()
 	echo "Motr: Dgmod mode read from new pver succeeds."
 
 	#Read in Parity Verify from new pool version.
-	io_conduct "READ" $OBJ_ID2 $dest_file $read_verify
+	io_conduct "READ" $OBJ_ID2 "$dest_file" $read_verify
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Reading a file from a new pool version failed."
 		error_handling $rc
 	fi
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -235,7 +235,7 @@ main()
 	motr_inst_cnt=`expr $cnt - 1`
 	for i in `seq 1 $motr_inst_cnt`
 	do
-		echo "motr pids=${motr_pids[$i]}" >> $MOTR_TEST_LOGFILE
+		echo "motr pids=${motr_pids[$i]}" >> "$MOTR_TEST_LOGFILE"
 	done
 
 	motr_service_stop || rc=1


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
We see 1688 occurrence of pattern, "Double quote to prevent globing and words splitting".

# Design
We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
