### PR TITLE
CORTX-30728 cas/client: fix memory corruption issue

### DIFF
--- a/cas/client.c
+++ b/cas/client.c
@@ -40,6 +40,8 @@
 #include "lib/finject.h"
 #include "cas/cas_addb2.h"
 #include "dtm0/dtx.h"   /* struct m0_dtm0_dtx */
+#include "dix/layout.h" /* m0_dix_ldesc_copy() */
+
 /**
  * @addtogroup cas-client
  * @{
@@ -187,6 +189,7 @@ static void creq_op_free(struct m0_cas_op *op)
 {
 	if (op != NULL) {
 		m0_dtm0_tx_desc_fini(&op->cg_txd);
+		m0_cas_id_fini(&op->cg_id);
 		m0_free(op->cg_rec.cr_rec);
 		m0_free(op);
 	}
@@ -1584,6 +1587,12 @@ static int cas_records_op_prepare(const struct m0_cas_req  *req,
 	if (rc != 0)
 		return M0_ERR(rc);
 	op->cg_id = *index;
+	if (m0_fid_type_getfid(&op->cg_id.ci_fid) == &m0_cctg_fid_type) {
+		M0_ASSERT(index->ci_layout.dl_type == DIX_LTYPE_DESCR);
+		rc = m0_dix_ldesc_copy(&op->cg_id.ci_layout.u.dl_desc,
+				       &index->ci_layout.u.dl_desc);
+	}
+
 	rec = op->cg_rec.cr_rec;
 	for (i = 0; i < keys_nr; i++) {
 		m0_rpc_at_init(&rec[i].cr_key);

--- a/dix/req.c
+++ b/dix/req.c
@@ -1769,7 +1769,6 @@ static int dix_cas_rops_send(struct m0_dix_req *req)
 					    &cctg_id.ci_fid, sdev_idx);
 		M0_ASSERT(layout->dl_type == DIX_LTYPE_DESCR);
 		cctg_id.ci_layout.dl_type = layout->dl_type;
-		/** @todo CAS request should copy cctg_id internally. */
 		rc = m0_dix_ldesc_copy(&cctg_id.ci_layout.u.dl_desc,
 				       &layout->u.dl_desc);
 		M0_LOG(M0_DEBUG, "Processing dix_req %p[%u] "FID_F


### PR DESCRIPTION
Problem:
Fix for memory leak introduced in commit 49ee796c0
lead to memory corruption related to m0_cas_id usage.
The m0_cas_id field of m0_cas_op may be finalized
before it's being sent to the server side.

Solution:
Have a copy of m0_cas_id (including layout) on a CAS
level to sync it with the CAS request lifetime.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>