### PR TITLE
motr/ut: use aligned free for aligned allocations.

### DIFF
--- a/motr/ut/client.h
+++ b/motr/ut/client.h
@@ -228,6 +228,9 @@ M0_INTERNAL void ut_dummy_data_buf_delete(struct data_buf *db);
  */
 M0_INTERNAL void ut_dummy_data_buf_init(struct data_buf *db);
 
+/** Frees the buffers of the data buf. */
+M0_INTERNAL void ut_dummy_data_buf_free(struct data_buf *db);
+
 /**
  * Finalises a UT dummy data_buf.
  */

--- a/motr/ut/io_dummy.c
+++ b/motr/ut/io_dummy.c
@@ -229,19 +229,21 @@ M0_INTERNAL void ut_dummy_data_buf_init(struct data_buf *db)
 	db->db_flags = PA_NONE;
 }
 
+M0_INTERNAL void ut_dummy_data_buf_free(struct data_buf *db)
+{
+	/*
+	 * We can't use m0_buf_free, because we allocated an aligned buffer...
+	 */
+	m0_free_aligned(db->db_buf.b_addr, UT_DEFAULT_BLOCK_SIZE,
+			UT_DEFAULT_BLOCK_SHIFT);
+}
+
 M0_INTERNAL void ut_dummy_data_buf_fini(struct data_buf *db)
 {
 	M0_UT_ASSERT(db != NULL);
 
 	data_buf_bob_fini(db);
-
-	/*
-	 * We can't use m0_buf_free, because we allocated
-	 * an aligned buffer...
-	 */
-	m0_free_aligned(db->db_buf.b_addr,
-			UT_DEFAULT_BLOCK_SIZE,
-			UT_DEFAULT_BLOCK_SHIFT);
+	ut_dummy_data_buf_free(db);
 }
 
 /*

--- a/motr/ut/io_nw_xfer.c
+++ b/motr/ut/io_nw_xfer.c
@@ -254,7 +254,8 @@ static void ut_test_target_ioreq_seg_add(void)
 	src->sa_unit = 1;
 	tgt->ta_frame = 1;
 	map = ut_dummy_pargrp_iomap_create(instance, 1);
-	m0_free(map->pi_databufs[0][0]->db_buf.b_addr);/* don't use this allocated buf*/
+	/* don't use this allocated buf*/
+	ut_dummy_data_buf_free(map->pi_databufs[0][0]);
 	map->pi_ioo = ioo;
 	map->pi_databufs[0][0]->db_buf.b_addr = NULL;
 	map->pi_databufs[0][0]->db_flags |= 777;


### PR DESCRIPTION
Memory allocated with m0_alloc_aligned() should be
freed with m0_free_aligned(). Existing m0_free()
happens to work correctly with memory allocated
by m0_alloc_aligned(), but this is against the
specification and will complicate the upcoming
allocation profiler.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>