### PR TITLE
lib/user_space: use sigsetjmp() and siglongjmp().

### DIFF
--- a/lib/user_space/thread.h
+++ b/lib/user_space/thread.h
@@ -52,9 +52,9 @@ struct m0_thread_handle {
 /** User space thread-local storage. */
 struct m0_thread_arch_tls {
 	/** Non-zero iff the thread is in awkward context. */
-	uint32_t   tat_awkward;
+	uint32_t    tat_awkward;
 	/** Stack context/environment, saved with setjmp(3). */
-	jmp_buf   *tat_jmp;
+	sigjmp_buf *tat_jmp;
 };
 
 /**

--- a/lib/user_space/ucookie.c
+++ b/lib/user_space/ucookie.c
@@ -46,12 +46,12 @@ static const struct m0_panic_ctx signal_panic = {
 static void sigsegv(int sig)
 {
 	struct m0_thread_tls *tls = m0_thread_tls();
-	jmp_buf              *buf = tls == NULL ? NULL : tls->tls_arch.tat_jmp;
+	sigjmp_buf           *buf = tls == NULL ? NULL : tls->tls_arch.tat_jmp;
 
 	if (buf == NULL)
 		m0_panic(&signal_panic, sig);
 	else
-		longjmp(*buf, 1);
+		siglongjmp(*buf, 1);
 }
 
 /**
@@ -61,14 +61,14 @@ static void sigsegv(int sig)
  */
 M0_INTERNAL bool m0_arch_addr_is_sane(const void *addr)
 {
-	jmp_buf           buf;
-	jmp_buf         **tls = &m0_thread_tls()->tls_arch.tat_jmp;
+	sigjmp_buf        buf;
+	sigjmp_buf      **tls = &m0_thread_tls()->tls_arch.tat_jmp;
 	int               ret;
 	volatile uint64_t dummy M0_UNUSED;
 	volatile bool     result = false;
 
 	*tls = &buf;
-	ret = setjmp(buf);
+	ret = sigsetjmp(buf, 1);
 	if (ret == 0) {
 		dummy = *(uint64_t *)addr;
 		result = true;


### PR DESCRIPTION
Cookie code (lib/user_space/ucookie.c) uses long jumps
to exit the signal handler. longjmp() restores the contents
of processor registers, including instruction and stack
pointers, to the state saved by setjmp(). longjmp() does
not restore the thread signal mask, which indicates how the
thread reacts to signals. But the signal mask is different
when the signal handler is executed (the signal being
handled is blocked), so longjmp() out of a signal handler
resumes execution with a wrong mask. Specifically, when the
cookie module jumps out of sigsegv(), the thread continues
with SIGSEGV blocked and the next receipt of SIGSEGV will
unconditionally terminate the process.

Fix this by using sigsetjmp() and siglogjmp().

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>