### PR TITLE
fdmi/ut: use m0_strdup().

### DIFF
--- a/fdmi/ut/sd_apply_filter.c
+++ b/fdmi/ut/sd_apply_filter.c
@@ -185,7 +185,7 @@ static void fdmi_sd_apply_filter_internal(const struct m0_filterc_ops *ops)
 
 	M0_ENTRY();
 
-	g_var_str = strdup("test");
+	g_var_str = m0_strdup("test");
 	M0_SET0(&g_conf_filter);
 
 	fdmi_serv_start_ut(ops);

--- a/fdmi/ut/sd_send_not.c
+++ b/fdmi/ut/sd_send_not.c
@@ -253,7 +253,7 @@ void fdmi_sd_send_notif(void)
 	int                           rc;
 
 	M0_SET0(&g_conf_filter);
-	g_var_str = strdup("test");
+	g_var_str = m0_strdup("test");
 	M0_SET0(&g_sem1);
 	M0_SET0(&g_sem2);
 	M0_SET0(&g_sem3);


### PR DESCRIPTION
Results of strdup() cannot be used in motr code that
assumes that strings are freed by m0_free().

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
