### PR TITLE
conf/confd_stob.c: use aligned free for aligned allocations.

### DIFF
--- a/conf/confd_stob.c
+++ b/conf/confd_stob.c
@@ -149,7 +149,7 @@ int m0_confd_stob_read(struct m0_stob *stob, char **str)
 
 	rc = m0_stob_io_bufvec_launch(stob, &bv, SIO_READ, 0);
 	if (rc != 0) {
-		m0_free(*str);
+		m0_free_aligned(*str, length + 1, m0_stob_block_shift(stob));
 		return M0_ERR(rc);
 	}
 


### PR DESCRIPTION
Memory allocated with m0_alloc_aligned() should be
freed with m0_free_aligned(). Existing m0_free()
happens to work correctly with memory allocated
by m0_alloc_aligned(), but this is against the
specification and will complicate the upcoming
allocation profiler.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>