### PR TITLE
m0ut.c: LNet unit tests should depend on ENABLE_LUSTRE.

### DIFF
--- a/ut/m0ut.c
+++ b/ut/m0ut.c
@@ -176,6 +176,12 @@ extern struct m0_ut_suite xcode_ut;
 extern struct m0_ut_suite sns_flock_ut;
 extern struct m0_ut_suite ut_suite_pi;
 
+#if defined(ENABLE_LUSTRE)
+#define LNET_ENABLED (true)
+#else
+#define LNET_ENABLED (false)
+#endif
+
 static void tests_add(struct m0_ut_module *m)
 {
 	/*
@@ -271,10 +277,7 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &m0_fom_stats_ut, true);
 	m0_ut_add(m, &m0_net_bulk_if_ut, true);
 	m0_ut_add(m, &m0_net_bulk_mem_ut, true);
-	if (USE_LIBFAB)
-		m0_ut_add(m, &m0_net_lnet_ut, false);
-	else
-		m0_ut_add(m, &m0_net_lnet_ut, true);
+	m0_ut_add(m, &m0_net_lnet_ut, LNET_ENABLED);
 	m0_ut_add(m, &m0_net_misc_ut, true);
 	m0_ut_add(m, &m0_net_module_ut, true);
 	m0_ut_add(m, &m0_net_test_ut, true);


### PR DESCRIPTION
Disable LNet unit tests when Lustre support was not
compiled in, not when libfabric support was compiled in.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
