### PR TITLE
Use unique stob domain pathname.

### DIFF
--- a/stob/ut/domain.c
+++ b/stob/ut/domain.c
@@ -85,7 +85,8 @@ void m0_stob_ut_stob_domain_null(void)
 #ifndef __KERNEL__
 void m0_stob_ut_stob_domain_linux(void)
 {
-	stob_ut_stob_domain("linuxstob:./__s", NULL, NULL);
+	/* Use unique name to avoid conflicts with other UTs. */
+	stob_ut_stob_domain("linuxstob:./__sdl", NULL, NULL);
 }
 
 void m0_stob_ut_stob_domain_perf(void)


### PR DESCRIPTION
./__s is the standard stob domain name and with the
randomised UT (m0ut -H0), it is possible that the
domain at this pathname already exists, leading to
assertions:

./utils/m0run -H0
...
stob-ut
  cache                                           3.06 sec    6 KiB
  cache-idle-size0                                1.94 sec    6 KiB
  null-stob-domain                                0.00 sec    1 KiB
  null-stob                                       0.00 sec    7 KiB
  linux-stob-domain  motr[3910443]:  7c20  FATAL  [lib/assert.c:50:m0_panic]  panic: Unit-test assertion failed: rc == -ENOENT at stob_ut_stob_domain() (stob/ut/domain.c:45) ...

Fix this by using a different pathname.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
