### PR TITLE
CORTX-30751: Codacy code cleanup (#1606).

### DIFF
--- a/addb2/st/addb2dump-plugin.sh
+++ b/addb2/st/addb2dump-plugin.sh
@@ -19,13 +19,13 @@
 #
 
 
-SCRIPT_PATH="$(readlink -f $0)"
+SCRIPT_PATH="$(readlink -f "$0")"
 MOTR_SRC_DIR="${SCRIPT_PATH%/*/*/*}"
 UT_SANDBOX_DIR="/var/motr/m0ut/ut-sandbox"
 ADDB2_STOB="/var/motr/m0ut/ut-sandbox/__s/o/100000000000000:2"
 PLUGIN_SO="${MOTR_SRC_DIR}/addb2/st/.libs/libaddb2dump-plugin-test.so"
 
-. ${MOTR_SRC_DIR}/utils/functions
+. "${MOTR_SRC_DIR}"/utils/functions
 
 function check_root() {
     [[ $UID -eq 0 ]] || {
@@ -35,12 +35,12 @@ function check_root() {
 }
 
 function generate_addb2_stob() {
-    ${MOTR_SRC_DIR}/utils/m0run -- "m0ut -k -t addb2-storage:write-many" > /dev/null
+    "${MOTR_SRC_DIR}"/utils/m0run -- "m0ut -k -t addb2-storage:write-many" > /dev/null
 }
 
 function dump_addb2_stob() {
-    ADDB2_DUMP=`${MOTR_SRC_DIR}/utils/m0addb2dump -f -p ${PLUGIN_SO} \
-    -- ${ADDB2_STOB} | grep "measurement"`
+    ADDB2_DUMP=`"${MOTR_SRC_DIR}"/utils/m0addb2dump -f -p "${PLUGIN_SO}" \
+    -- "${ADDB2_STOB}" | grep "measurement"`
 }
 
 function delete_ut_sandbox() {

--- a/cas/st/ctgdump_tesh.sh
+++ b/cas/st/ctgdump_tesh.sh
@@ -54,9 +54,9 @@ kvs_create_n_insert()
 	MOTR_PARAM="-l $cli_ep  -h $ha_ep -p $PROF_OPT \
 		    -f $M0T1FS_PROC_ID -s "
 
-	echo "$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM} index create "$DIX_FID"
+	echo "$M0_SRC_DIR/utils/m0kv" "${MOTR_PARAM}" index create "$DIX_FID"
 
-	"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                     \
+	"$M0_SRC_DIR/utils/m0kv" "${MOTR_PARAM}"                                     \
 				index create "$DIX_FID"                            \
 			 || {
 		rc=$?
@@ -64,7 +64,7 @@ kvs_create_n_insert()
 	}
 
 	for ((j=0; j<$num_of_kv; j++)); do
-		"$M0_SRC_DIR/utils/m0kv" ${MOTR_PARAM}                                       \
+		"$M0_SRC_DIR/utils/m0kv" "${MOTR_PARAM}"                                       \
 			index put    "$DIX_FID" "$key_prefix-$j" "$val_prefix-$j"
 	done
 	return $rc
@@ -95,7 +95,7 @@ ctgdump_comp()
 			       -A linuxstob:addb-stobs -w 4 -m 65536 -q 16 -N 100663296 -C 262144 -K 100663296 \
 			       -k 262144 -c ${dir}/confd/conf.xc -e ${cas_ep} -f ${proc_fid} str ${dix_fid} "
 		echo "running: $dump_cmd $dump_cmd_args"
-		$dump_cmd $dump_cmd_args | sort > "$SANDBOX_DIR/ios$i.dump"
+		$dump_cmd "$dump_cmd_args" | sort > "$SANDBOX_DIR/ios$i.dump"
 	done
 
 	# Compare each dump file
@@ -140,7 +140,7 @@ ctgdump_test()
 	}
 
 	if [ $rc == 0 ]; then
-		ctgdump_comp $SANDBOX_DIR ${XPRT}:${lnet_nid}:${IOSEP[0]} ${proc_fid} $DIX_FID
+		ctgdump_comp "$SANDBOX_DIR" "${XPRT}":"${lnet_nid}":"${IOSEP[0]}" "${proc_fid}" $DIX_FID
 		rc=$?
 	fi
 
@@ -157,7 +157,7 @@ case "$cmd" in
 		rc=$?
 		;;
 	comp)
-		ctgdump_comp $2 $3 $4 $5
+		ctgdump_comp "$2" "$3" "$4" "$5"
 		rc=$?
 		;;
 	   *)

--- a/console/st/console-st.sh
+++ b/console/st/console-st.sh
@@ -25,10 +25,10 @@ umask 0002
 ## CAUTION: This path will be removed by superuser.
 SANDBOX_DIR=${SANDBOX_DIR:-/var/motr/sandbox.console-st}
 
-M0_SRC_DIR=`readlink -f $0`
+M0_SRC_DIR=`readlink -f "$0"`
 M0_SRC_DIR=${M0_SRC_DIR%/*/*/*}
 
-. $M0_SRC_DIR/utils/functions # die, opcode, sandbox_init, report_and_exit
+. "$M0_SRC_DIR"/utils/functions # die, opcode, sandbox_init, report_and_exit
 
 CLIENT=$M0_SRC_DIR/console/m0console
 SERVER=$M0_SRC_DIR/console/st/server
@@ -43,7 +43,7 @@ CONF_FILE_PATH=$M0_SRC_DIR/ut/diter.xc
 CONF_PROFILE='<0x7000000000000001:0>'
 
 NODE_UUID=02e94b88-19ab-4166-b26b-91b51f22ad91  # required by `common.sh'
-. $M0_SRC_DIR/m0t1fs/linux_kernel/st/common.sh  # modload
+. "$M0_SRC_DIR"/m0t1fs/linux_kernel/st/common.sh  # modload
 
 XPRT=$(m0_default_xprt)
 
@@ -66,15 +66,15 @@ start_server()
 	## registers "ds1" and "ds2" service types, so we do not pass
 	## these services to m0mkfs.
 	##
-	$M0_SRC_DIR/utils/mkfs/m0mkfs -T AD -D console_st_srv.db \
+	"$M0_SRC_DIR"/utils/mkfs/m0mkfs -T AD -D console_st_srv.db \
 	    -S console_st_srv.stob -A linuxstob:console_st_srv-addb.stob \
 	    -w 10 -e "$XPRT:$SERVER_EP_ADDR" -H $SERVER_EP_ADDR \
 	    -q 2 -m $((1 << 17)) \
-	    -c $CONF_FILE_PATH  \
-	    &>$SANDBOX_DIR/mkfs.log || die 'm0mkfs failed'
+	    -c "$CONF_FILE_PATH"  \
+	    &>"$SANDBOX_DIR"/mkfs.log || die 'm0mkfs failed'
 	echo 'OK' >&2
 
-	$SERVER -v &>$SANDBOX_DIR/server.log 2>&1 &
+	$SERVER -v &>"$SANDBOX_DIR"/server.log 2>&1 &
 	SERVERPID=$!
 	sleep 1
 	pgrep $(basename "$SERVER") >/dev/null || die 'Service failed to start'
@@ -83,7 +83,7 @@ start_server()
 
 create_yaml_files()
 {
-	cat <<EOF >$YAML_FILE9
+	cat <<EOF >"$YAML_FILE9"
 server  : $SERVER_EP_ADDR
 client  : $CLIENT_EP_ADDR
 
@@ -98,7 +98,7 @@ EOF
 
 	## The content of `Write FOP' below should correspond to
 	## m0_fop_cob_writev definition (see ioservice/io_fops.h).
-	cat <<EOF >$YAML_FILE41
+	cat <<EOF >"$YAML_FILE41"
 server  : $SERVER_EP_ADDR
 client  : $CLIENT_EP_ADDR
 
@@ -144,7 +144,7 @@ stop_server()
 check_reply()
 {
 	expected="$1"
-	actual=`awk '/replied/ {print $5}' $OUTPUT_FILE`
+	actual=`awk '/replied/ {print $5}' "$OUTPUT_FILE"`
 	[ -z "$actual" ] && die 'Reply not found'
 	[ "$actual" -eq "$expected" ] || die 'Invalid reply'
 }
@@ -157,8 +157,8 @@ test_fop()
 	local reply="$1"; shift
 
 	echo -n "$message: " >&2
-	$CLIENT -f $request -v "$@" | tee $OUTPUT_FILE
-	check_reply $reply
+	$CLIENT -f "$request" -v "$@" | tee "$OUTPUT_FILE"
+	check_reply "$reply"
 	echo OK >&2
 }
 
@@ -172,7 +172,7 @@ run_st()
 
 	test_fop 'Console test fop, YAML input' \
 		$(opcode M0_CONS_TEST) $(opcode M0_CONS_FOP_REPLY_OPCODE) \
-		-i -y $YAML_FILE9
+		-i -y "$YAML_FILE9"
 
 	## This test case does not work: $SERVER crashes while
 	## processing the fop (m0_fop_cob_writev).
@@ -181,7 +181,7 @@ run_st()
 		test_fop 'Write request fop' \
 			$(opcode M0_IOSERVICE_WRITEV_OPCODE) \
 			$(opcode M0_IOSERVICE_WRITEV_REP_OPCODE) \
-			-i -y $YAML_FILE41
+			-i -y "$YAML_FILE41"
 	fi
 }
 

--- a/dix/cm/st/m0t1fs_dix_repair.sh
+++ b/dix/cm/st/m0t1fs_dix_repair.sh
@@ -116,7 +116,7 @@ main()
 
 	NODE_UUID=`uuidgen`
 	local multiple_pools=0
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		return 1
 	}

--- a/dix/cm/st/m0t1fs_dix_repair_quiesce.sh
+++ b/dix/cm/st/m0t1fs_dix_repair_quiesce.sh
@@ -112,7 +112,7 @@ main()
 
 	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		return 1
 	}

--- a/motr/st/utils/motr_conf_update_st.sh
+++ b/motr/st/utils/motr_conf_update_st.sh
@@ -18,18 +18,18 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-motr_st_util_dir=$(dirname $(readlink -f $0))
+motr_st_util_dir=$(dirname "$(readlink -f "$0")")
 m0t1fs_dir="$motr_st_util_dir/../../../m0t1fs/linux_kernel/st"
 
 M0_SRC_DIR="$motr_st_util_dir/../../../"
-. $M0_SRC_DIR/utils/functions # m0_default_xprt
+. "$M0_SRC_DIR"/utils/functions # m0_default_xprt
 
-. $m0t1fs_dir/common.sh
-. $m0t1fs_dir/m0t1fs_common_inc.sh
-. $m0t1fs_dir/m0t1fs_client_inc.sh
-. $m0t1fs_dir/m0t1fs_server_inc.sh
-. $motr_st_util_dir/motr_local_conf.sh
-. $motr_st_util_dir/motr_st_inc.sh
+. "$m0t1fs_dir"/common.sh
+. "$m0t1fs_dir"/m0t1fs_common_inc.sh
+. "$m0t1fs_dir"/m0t1fs_client_inc.sh
+. "$m0t1fs_dir"/m0t1fs_server_inc.sh
+. "$motr_st_util_dir"/motr_local_conf.sh
+. "$motr_st_util_dir"/motr_st_inc.sh
 
 
 MOTR_TEST_DIR=$SANDBOX_DIR
@@ -46,13 +46,13 @@ clean()
 		# unmounting the client file system, from next mount,
 		# fids are generated from same baseline which results
 		# in failure of cob_create fops.
-		local ios_index=`expr $i + 1`
-		rm -rf $MOTR_TEST_DIR/d$ios_index/stobs/o/*
+		local ios_index=`expr "$i" + 1`
+		rm -rf "$MOTR_TEST_DIR"/d"$ios_index"/stobs/o/*
 	done
 
-        if [ ! -z "$multiple_pools" ] && [ $multiple_pools == 1 ]; then
-		local ios_index=`expr $i + 1`
-		rm -rf $MOTR_TEST_DIR/d$ios_index/stobs/o/*
+        if [ ! -z "$multiple_pools" ] && [ "$multiple_pools" == 1 ]; then
+		local ios_index=`expr "$i" + 1`
+		rm -rf "$MOTR_TEST_DIR"/d"$ios_index"/stobs/o/*
         fi
 }
 
@@ -88,12 +88,12 @@ error_handling()
 {
 	rc=$1
 	msg=$2
-	clean 0 &>>$MOTR_TEST_LOGFILE
+	clean 0 &>>"$MOTR_TEST_LOGFILE"
 	motr_service_stop
-	echo $msg
+	echo "$msg"
 	echo "Test log file available at $MOTR_TEST_LOGFILE"
 	echo "motr trace files are available at: $MOTR_TRACE_DIR"
-	exit $1
+	exit "$1"
 }
 
 io_ops()
@@ -127,7 +127,7 @@ revoke_read_lock()
 	local c_ep="$lnet_nid:12345:34:*"
 	local delay=${1:-5}
 	echo "getting write lock..."
-	$M0_SRC_DIR/utils/m0rwlock -s $confd_ep -c $c_ep -d $delay
+	"$M0_SRC_DIR"/utils/m0rwlock -s "$confd_ep" -c "$c_ep" -d "$delay"
 }
 
 
@@ -145,13 +145,13 @@ main()
 	block_size=8192
 	block_count=4096
 
-	rm -f $src_file $dest_file
+	rm -f "$src_file" "$dest_file"
 
-	dd if=/dev/urandom bs=$block_size count=$block_count of=$src_file \
-	      2> $MOTR_TEST_LOGFILE || {
+	dd if=/dev/urandom bs=$block_size count=$block_count of="$src_file" \
+	      2> "$MOTR_TEST_LOGFILE" || {
 		error_handling $? "Failed to create a source file"
 	}
-	mkdir $MOTR_TRACE_DIR
+	mkdir "$MOTR_TRACE_DIR"
 
 	# Test IO while read lock revoked (configuration update going on).
 	motr_service_start
@@ -159,10 +159,10 @@ main()
 
 	revoke_read_lock 30 &
 	pid=$!
-	io_ops $object_id1 $block_size $block_count $src_file $dest_file1
+	io_ops $object_id1 $block_size $block_count "$src_file" "$dest_file1"
 	wait $pid
 
-	cmp $src_file $dest_file1 2> $MOTR_TEST_LOGFILE || {
+	cmp "$src_file" "$dest_file1" 2> "$MOTR_TEST_LOGFILE" || {
 		rc=$?
 		error_handling $rc "Files are different"
 	}
@@ -173,19 +173,19 @@ main()
 	# Test read lock revoke (configuration update) while IO going on.
 	motr_service_start
 	dix_init
-	io_ops $object_id2 $block_size $block_count $src_file $dest_file2  &
+	io_ops $object_id2 $block_size $block_count "$src_file" "$dest_file2"  &
 	pid=$!
 	# Let client start
 	sleep 10
 	revoke_read_lock 15
 	wait $pid
-	cmp $src_file $dest_file2 2> $MOTR_TEST_LOGFILE || {
+	cmp "$src_file" "$dest_file2" 2> "$MOTR_TEST_LOGFILE" || {
 		rc=$?
 		error_handling $rc "Files are different"
 	}
 
 	dix_destroy
-	clean &>>$MOTR_TEST_LOGFILE
+	clean &>>"$MOTR_TEST_LOGFILE"
 	motr_service_stop
 
 }

--- a/motr/st/utils/motr_device_util.sh
+++ b/motr/st/utils/motr_device_util.sh
@@ -23,15 +23,15 @@
 
 #set -x
 
-motr_st_util_dir=`dirname $0`
+motr_st_util_dir=`dirname "$0"`
 m0t1fs_st_dir=$motr_st_util_dir/../../../m0t1fs/linux_kernel/st
 
 # Re-use as many m0t1fs system scripts as possible
-. $m0t1fs_dir/common.sh
-. $m0t1fs_dir/m0t1fs_common_inc.sh
-. $m0t1fs_dir/m0t1fs_client_inc.sh
-. $m0t1fs_dir/m0t1fs_server_inc.sh
-. $m0t1fs_dir/m0t1fs_sns_common_inc.sh
+. "$m0t1fs_dir"/common.sh
+. "$m0t1fs_dir"/m0t1fs_common_inc.sh
+. "$m0t1fs_dir"/m0t1fs_client_inc.sh
+. "$m0t1fs_dir"/m0t1fs_server_inc.sh
+. "$m0t1fs_dir"/m0t1fs_sns_common_inc.sh
 
 motr_st_set_failed_devices()
 {

--- a/motr/st/utils/motr_fs.sh
+++ b/motr/st/utils/motr_fs.sh
@@ -19,10 +19,10 @@
 
 # m0t1fs related helper functions
 
-M0_SRC_DIR=$(dirname $(readlink -f $0))
+M0_SRC_DIR=$(dirname "$(readlink -f "$0")")
 M0_SRC_DIR="$M0_SRC_DIR/../../../"
 
-. $M0_SRC_DIR/utils/functions # m0_default_xprt
+. "$M0_SRC_DIR"/utils/functions # m0_default_xprt
 
 XPRT=$(m0_default_xprt)
 
@@ -38,7 +38,7 @@ mount_m0t1fs()
 	fi
 
 	# Create mount directory
-	sudo mkdir -p $m0t1fs_mount_dir || {
+	sudo mkdir -p "$m0t1fs_mount_dir" || {
 		echo "Failed to create mount directory."
 		return 1
 	}
@@ -53,8 +53,8 @@ mount_m0t1fs()
 	local cmd="sudo mount -t m0t1fs \
 	    -o profile='$PROF_OPT',confd='$CONFD_EP',$mountop \
 	    none $m0t1fs_mount_dir"
-	echo $cmd
-	eval $cmd || {
+	echo "$cmd"
+	eval "$cmd" || {
 		echo "Failed to mount m0t1fs file system."
 		return 1
 	}
@@ -70,19 +70,19 @@ umount_m0t1fs()
 
 	local m0t1fs_mount_dir=$1
 	echo "Unmounting file system ..."
-	umount $m0t1fs_mount_dir &>/dev/null
+	umount "$m0t1fs_mount_dir" &>/dev/null
 
 	sleep 2
 
 	echo "Cleaning up test directory..."
-	rm -rf $m0t1fs_mount_dir &>/dev/null
+	rm -rf "$m0t1fs_mount_dir" &>/dev/null
 }
 
 # main entry
 
 # Get the location of this script and look for the command in the
 # same directory
-dir=`dirname $0`
+dir=`dirname "$0"`
 
 # Get local address
 if [ "$XPRT" = "lnet" ]; then
@@ -100,11 +100,11 @@ cmd_args="$LOCAL_EP $CONFD_EP '$PROF_OPT' '$PROC_FID'"
 case "$1" in
 	mount)
 		echo "mount m0t1fs ... "
-		mount_m0t1fs $2
+		mount_m0t1fs "$2"
 		;;
 	umount)
 		echo "umount m0t1fs ... "
-		umount_m0t1fs $2
+		umount_m0t1fs "$2"
 		;;
 	*)
 		echo "Usage: $0 [mount|umount] dir}"

--- a/motr/st/utils/motr_local_conf.sh
+++ b/motr/st/utils/motr_local_conf.sh
@@ -18,10 +18,10 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-M0_SRC_DIR=$(dirname $(readlink -f $0))
+M0_SRC_DIR=$(dirname "$(readlink -f "$0")")
 M0_SRC_DIR="$M0_SRC_DIR/../../../"
 
-. $M0_SRC_DIR/utils/functions # m0_default_xprt
+. "$M0_SRC_DIR"/utils/functions # m0_default_xprt
 
 XPRT=$(m0_default_xprt)
 
@@ -32,26 +32,26 @@ if [ "$XPRT" = "lnet" ]; then
 fi
 LOCAL_NID=$(m0_local_nid_get)
 
-if [ X$LOCAL_NID == X ]; then
+if [ X"$LOCAL_NID" == X ]; then
 	echo "lnet is not up"
 	exit
 fi
 
-if [ X$MOTR_LOCAL_EP == X ]; then
+if [ X"$MOTR_LOCAL_EP" == X ]; then
 	MOTR_LOCAL_EP=$LOCAL_NID:12345:34:101
 	MOTR_LOCAL_EP2=$LOCAL_NID:12345:34:102
 	MOTR_LOCAL_EP3=$LOCAL_NID:12345:34:103
 	MOTR_LOCAL_EP4=$LOCAL_NID:12345:34:104
 fi
 
-if [ X$MOTR_HA_EP == X ]; then
+if [ X"$MOTR_HA_EP" == X ]; then
 	MOTR_HA_EP=$LOCAL_NID:12345:34:1
 fi
 
-if [ X$MOTR_PROF_OPT == X ]; then
+if [ X"$MOTR_PROF_OPT" == X ]; then
 	MOTR_PROF_OPT=0x7000000000000001:0
 fi
 
-if [ X$MOTR_PROC_FID == X ]; then
+if [ X"$MOTR_PROC_FID" == X ]; then
 	MOTR_PROC_FID=0x7200000000000000:0
 fi

--- a/motr/st/utils/motr_raid0_st.sh
+++ b/motr/st/utils/motr_raid0_st.sh
@@ -25,14 +25,14 @@ motr_st_util_dir=$( cd "$(dirname "$0")" ; pwd -P )
 m0t1fs_dir="$motr_st_util_dir/../../../m0t1fs/linux_kernel/st"
 
 # Re-use as many m0t1fs system scripts as possible
-. $m0t1fs_dir/common.sh
-. $m0t1fs_dir/m0t1fs_common_inc.sh
-. $m0t1fs_dir/m0t1fs_client_inc.sh
-. $m0t1fs_dir/m0t1fs_server_inc.sh
-. $m0t1fs_dir/m0t1fs_sns_common_inc.sh
+. "$m0t1fs_dir"/common.sh
+. "$m0t1fs_dir"/m0t1fs_common_inc.sh
+. "$m0t1fs_dir"/m0t1fs_client_inc.sh
+. "$m0t1fs_dir"/m0t1fs_server_inc.sh
+. "$m0t1fs_dir"/m0t1fs_sns_common_inc.sh
 
-. $motr_st_util_dir/motr_local_conf.sh
-. $motr_st_util_dir/motr_st_inc.sh
+. "$motr_st_util_dir"/motr_local_conf.sh
+. "$motr_st_util_dir"/motr_st_inc.sh
 
 N=1
 K=0
@@ -73,23 +73,23 @@ raid0_test()
 	dix_init
 
 	# write an object
-	io_conduct "WRITE" $src_file $OBJ_ID1 "false"
-	if [ $rc -ne "0" ]
+	io_conduct "WRITE" "$src_file" $OBJ_ID1 "false"
+	if [ "$rc" -ne "0" ]
 	then
 		echo "Healthy mode, write failed."
-		error_handling $rc
+		error_handling "$rc"
 	fi
 	echo "Healthy mode write succeeds."
 
 	# read the written object
-	io_conduct "READ" $OBJ_ID1  $dest_file "false"
+	io_conduct "READ" $OBJ_ID1  "$dest_file" "false"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Healthy mode, read failed."
 		error_handling $rc
 	fi
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -100,14 +100,14 @@ raid0_test()
 	# Read verification is meaningless
         # in case of RAID0 type layout, but the code should get
         # executed seamlessly.
-	io_conduct "READ" $OBJ_ID1  $dest_file $read_verify
+	io_conduct "READ" $OBJ_ID1  "$dest_file" $read_verify
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
 		echo "Healthy mode, read verify failed."
 		error_handling $rc
 	fi
-	diff $src_file $dest_file
+	diff "$src_file" "$dest_file"
 	rc=$?
 	if [ $rc -ne "0" ]
 	then
@@ -134,13 +134,13 @@ main()
 	BLOCKSIZE=4096
 	BLOCKCOUNT=25
 	echo "dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of=$src_file"
-	dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of=$src_file \
-              2> $MOTR_TEST_LOGFILE || {
+	dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of="$src_file" \
+              2> "$MOTR_TEST_LOGFILE" || {
 		echo "Failed to create a source file"
 		return 1
 	}
 
-	mkdir $MOTR_TRACE_DIR
+	mkdir "$MOTR_TRACE_DIR"
 
 	raid0_test false
 	rc=$?


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
Warning fixed: "Double quote to prevent globing and words splitting."

Signed-off-by: alfhad <fahadshah2411@gmail.com>
Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
We see 1688 occurrence of pattern, "Double quote to prevent globing and word splitting".

# Design
We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
