### PR TITLE
CORTX-30548: Load all required nodes before acquiring tree Lock in btree get op

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7366,9 +7366,9 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 				if ((lev->l_idx == bnode_count(lev->l_node)) &&
 				    (!oi->i_key_found) &&
 				    (bop->bo_flags & BOF_SLANT)) {
-						bnode_unlock(lev->l_node);
-						return P_SIBLING;
-					}
+					bnode_unlock(lev->l_node);
+					return P_SIBLING;
+				}
 				bnode_unlock(lev->l_node);
 				return P_LOCK;
 			}

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7384,9 +7384,8 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 			bnode_op_fini(&oi->i_nop);
 			return m0_sm_op_sub(&bop->bo_op, P_CLEANUP, P_SETUP);
 		} else if (rc == -ENOENT) {
-			bnode_op_fini(&oi->i_nop);
-			lock_op_unlock(tree);
-			return fail(bop, rc);
+			lev->l_sibling = NULL;
+			return P_LOCK;
 		}
 
 		bnode_lock(lev->l_sibling);

--- a/btree/btree.c
+++ b/btree/btree.c
@@ -7229,7 +7229,7 @@ static int  btree_sibling_first_key(struct m0_btree_oimpl *oi, struct td *tree)
 			s.s_node = oi->i_nop.no_node = lev->l_node;
 			s.s_idx = lev->l_idx + 1;
 			bnode_unlock(lev->l_node);
-			while (i != oi->i_used) {
+			while (i < oi->i_used) {
 				curr_node = oi->i_nop.no_node;
 				bnode_lock(curr_node);
 				bnode_child(&s, &child);
@@ -7364,7 +7364,8 @@ static int64_t btree_get_kv_tick(struct m0_sm_op *smop)
 						 P_NEXTDOWN);
 			} else {
 				if ((lev->l_idx == bnode_count(lev->l_node)) &&
-					(bop->bo_flags & BOF_SLANT)) {
+				    (!oi->i_key_found) &&
+				    (bop->bo_flags & BOF_SLANT)) {
 						bnode_unlock(lev->l_node);
 						return P_SIBLING;
 					}


### PR DESCRIPTION
Problem:
Btree Get Record changes to load all required nodes before acquiring tree Lock

Solution:
Implemented state P_SIBLING in btree_get_kv_tick state machine.
In P_SIBLING state, if slant operation flag is true, and we are at the last
record inside the current node, then try to find sibling by loading the
required nodes and store sibling in node descriptor.
If this operation successful, take tree lock and check sibling validity
then fetch the record in P_ACT state.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- Btree Get Record changes to load all required nodes before acquiring tree Lock

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
