### PR TITLE
Alloc profile leak

### DIFF
--- a/cas/ut/client_ut.c
+++ b/cas/ut/client_ut.c
@@ -2063,8 +2063,8 @@ static void next_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	next_common(&keys, &values, 0);
-	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk values. */
 	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
@@ -2073,7 +2073,7 @@ static void next_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	next_common(&keys, &values, 0);
 	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk keys. */
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
@@ -2082,7 +2082,7 @@ static void next_bulk(void)
 	m0_forall(i, values.ov_vec.v_nr, (*(uint64_t*)values.ov_buf[i] = i,
 					true));
 	next_common(&keys, &values, 0);
-	m0_bufvec_free(&keys);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
 	m0_bufvec_free(&values);
 
 	/* Bulk mix. */
@@ -2246,8 +2246,8 @@ static void next_multi_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	next_multi_common(&keys, &values);
-	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk values. */
 	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
@@ -2256,7 +2256,7 @@ static void next_multi_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	next_multi_common(&keys, &values);
 	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk keys. */
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
@@ -2265,7 +2265,7 @@ static void next_multi_bulk(void)
 	m0_forall(i, values.ov_vec.v_nr, (*(uint64_t*)values.ov_buf[i] = i,
 					true));
 	next_multi_common(&keys, &values);
-	m0_bufvec_free(&keys);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
 	m0_bufvec_free(&values);
 
 	/* Bulk mix. */
@@ -2689,8 +2689,8 @@ static void put_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	put_common(&keys, &values);
-	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk keys. */
 	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
@@ -2699,7 +2699,7 @@ static void put_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	put_common(&keys, &values);
 	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk values. */
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
@@ -2709,7 +2709,7 @@ static void put_bulk(void)
 					  true));
 
 	put_common(&keys, &values);
-	m0_bufvec_free(&keys);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
 	m0_bufvec_free(&values);
 
 	/* Bulk mix. */
@@ -2967,8 +2967,8 @@ static void put_bulk_fail(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	put_fail_common(&keys, &values);
-	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 }
 
 static void upd(void)
@@ -3186,8 +3186,8 @@ static void del_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	del_common(&keys, &values, 0, 0, 0, 0);
-	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 	casc_ut_fini(&casc_ut_sctx, &casc_ut_cctx);
 }
 
@@ -3422,8 +3422,8 @@ static void get_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	get_common(&keys, &values);
-	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk values. */
 	rc = m0_bufvec_alloc(&keys, COUNT, sizeof(uint64_t));
@@ -3432,7 +3432,7 @@ static void get_bulk(void)
 	vals_create(COUNT, COUNT_VAL_BYTES, &values);
 	get_common(&keys, &values);
 	m0_bufvec_free(&keys);
-	m0_bufvec_free(&values);
+	m0_bufvec_free_aligned(&values, m0_pageshift_get());
 
 	/* Bulk keys. */
 	vals_create(COUNT, COUNT_VAL_BYTES, &keys);
@@ -3441,7 +3441,7 @@ static void get_bulk(void)
 	m0_forall(i, values.ov_vec.v_nr, (*(uint64_t*)values.ov_buf[i] = i,
 					true));
 	get_common(&keys, &values);
-	m0_bufvec_free(&keys);
+	m0_bufvec_free_aligned(&keys, m0_pageshift_get());
 	m0_bufvec_free(&values);
 
 	/* Bulk mix. */

--- a/cas/ut/service_ut.c
+++ b/cas/ut/service_ut.c
@@ -450,6 +450,7 @@ static void meta_fop_submit(struct m0_fop_type *fopt,
 
 	for (i = 0; i < meta_recs_num; i++)
 		m0_rpc_at_fini(&recs[i].cr_key);
+	m0_free(recs);
 }
 
 static bool rec_check(const struct m0_cas_rec *rec, int rc, int key, int val)

--- a/conf/confd_stob.c
+++ b/conf/confd_stob.c
@@ -149,7 +149,7 @@ int m0_confd_stob_read(struct m0_stob *stob, char **str)
 
 	rc = m0_stob_io_bufvec_launch(stob, &bv, SIO_READ, 0);
 	if (rc != 0) {
-		m0_free(*str);
+		m0_free_aligned(*str, length + 1, m0_stob_block_shift(stob));
 		return M0_ERR(rc);
 	}
 

--- a/conf/ut/load.c
+++ b/conf/ut/load.c
@@ -93,13 +93,13 @@ static void conf_load_fom_create_fail(void)
 		    conf_fop_ut_release);
 	fop->f_item.ri_rmachine = &conf_reqh->cur_rmachine;
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_conf_load_fom_create(fop, &fom, reqh);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	rc = m0_conf_load_fom_create(fop, &fom, reqh);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	M0_UT_ASSERT(rc == -ENOMEM);
 
 	m0_free(fop);
@@ -127,13 +127,13 @@ static void conf_flip_fom_create_fail(void)
 		    conf_fop_ut_release);
 	fop->f_item.ri_rmachine = &conf_reqh->cur_rmachine;
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_conf_flip_fom_create(fop, &fom, reqh);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	rc = m0_conf_flip_fom_create(fop, &fom, reqh);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	M0_UT_ASSERT(rc == -ENOMEM);
 
 	m0_free(fop);
@@ -217,9 +217,9 @@ static void conf_save_load_fail(void)
 	rc = m0_confd_stob_read(stob, &str_read);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 0, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 0, 1);
 	rc = m0_confd_stob_read(stob, &str_read);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	M0_UT_ASSERT(rc == -ENOMEM);
 
 	rc = m0_confd_stob_read(stob, &str_read);

--- a/doc/fault-injection.md
+++ b/doc/fault-injection.md
@@ -42,11 +42,11 @@ do some action if fault point is enabled:
     }
 
 Fault point is defined in place of M0_FI_ENABLED() usage. In this example a
-fault point with tag "fake_error" is created in function "m0_alloc_profiled",
+fault point with tag "fake_error" is created in function "m0_alloc",
 which can be enabled/disabled from external code with something like the
 following:
 
-    m0_fi_enable_once("m0_alloc_profiled", "fake_error");
+    m0_fi_enable_once("m0_alloc", "fake_error");
 
 Fault injection is used mainly in UT to test error handling code paths. Usually
 such checks are consolidated in a dedicated test of particular test suite. One

--- a/dtm0/service.c
+++ b/dtm0/service.c
@@ -351,9 +351,7 @@ static void dtm0_service_stop(struct m0_reqh_service *service)
 
 	M0_PRE(service != NULL);
 	dtm0 = to_dtm(service);
-
-	m0_dtm0_fop_fini();
-	/**
+	/*
 	 * It is safe to remove any remaining entries from the log
 	 * when a process with volatile log is going to die.
 	 */
@@ -387,6 +385,7 @@ M0_INTERNAL void m0_dtm0_stype_fini(void)
 	extern struct m0_sm_conf m0_dtx_sm_conf;
 	m0_dtm0_rpc_link_mod_fini();
 	m0_reqh_service_type_unregister(&dtm0_service_type);
+	m0_dtm0_fop_fini();
 	m0_sm_addb2_fini(&m0_dtx_sm_conf);
 }
 

--- a/fd/ut/fd_tree.c
+++ b/fd/ut/fd_tree.c
@@ -120,12 +120,12 @@ static void test_fault_inj(void)
 	/* Maximum nodes in a tree. */
 	n    = m0_rnd(geometric_sum(TP_BINARY, M0_CONF_PVER_HEIGHT - 1),
 		      &seed);
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", n, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", n, 1);
 	M0_SET0(&tree);
 	rc = fd_ut_tree_init(&tree, M0_CONF_PVER_HEIGHT - 1) ?:
 	     m0_fd__tree_root_create(&tree, TP_BINARY) ?:
 	     tree_populate(&tree, TP_BINARY);
-	m0_fi_disable("m0_alloc_profiled","fail_allocation");
+	m0_fi_disable("m0_alloc","fail_allocation");
 	M0_UT_ASSERT(rc == -ENOMEM);
 	/*
 	 * NOTE: m0_fd__tree_root_create and tree_populate call

--- a/fdmi/ut/filter_eval.c
+++ b/fdmi/ut/filter_eval.c
@@ -288,9 +288,9 @@ static void flt_str_ops(void)
 	m0_fdmi_filter_root_set(&flt, root);
 
 	/* Conversion fail (malloc fail) */
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 0, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 0, 1);
 	res = m0_fdmi_flt_node_print(root, &str);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	M0_UT_ASSERT(res == -ENOMEM);
 
 	/* Conversion success when xcode print rc < FIRST_SIZE_GUESS*/
@@ -301,12 +301,12 @@ static void flt_str_ops(void)
 	M0_UT_ASSERT(res == 0);
 
 	/* Conversion fail (malloc failed) */
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	m0_fi_enable_off_n_on_m("m0_fdmi_flt_node_print",
 					"rc_bigger_than_size_guess", 0, 1);
 	res = m0_fdmi_flt_node_print(root, &str);
 	m0_fi_disable("m0_fdmi_flt_node_print", "rc_bigger_than_size_guess");
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	M0_UT_ASSERT(res == -ENOMEM);
 
 	/* Conversion success */

--- a/fdmi/ut/fol_ut.c
+++ b/fdmi/ut/fol_ut.c
@@ -258,9 +258,9 @@ static void fdmi_fol_test_ops(enum ffs_ut_test_op test_op)
 		/* inc ref */
 		src_reg->fs_get(dummy_rec_pointer);
 		/* encode failure #1 */
-		m0_fi_enable("m0_alloc_profiled", "fail_allocation");
+		m0_fi_enable("m0_alloc", "fail_allocation");
 		rc = src_reg->fs_encode(dummy_rec_pointer, &buf);
-		m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+		m0_fi_disable("m0_alloc", "fail_allocation");
 		M0_UT_ASSERT(rc == -ENOMEM);
 		M0_UT_ASSERT(buf.b_addr == NULL && buf.b_nob == 0);
 		/* encode failure #2 */
@@ -274,9 +274,9 @@ static void fdmi_fol_test_ops(enum ffs_ut_test_op test_op)
 		M0_UT_ASSERT(rc >= 0);
 		M0_UT_ASSERT(buf.b_nob > 0 && buf.b_addr != NULL);
 		/* decode failure #1 */
-		m0_fi_enable("m0_alloc_profiled", "fail_allocation");
+		m0_fi_enable("m0_alloc", "fail_allocation");
 		rc = src_reg->fs_decode(&buf, (void**)&fol_rec_cpy);
-		m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+		m0_fi_disable("m0_alloc", "fail_allocation");
 		M0_UT_ASSERT(rc == -ENOMEM);
 		M0_UT_ASSERT(fol_rec_cpy == NULL);
 		/* decode failure #2 */

--- a/fdmi/ut/pd_ut.c
+++ b/fdmi/ut/pd_ut.c
@@ -66,19 +66,19 @@ void fdmi_pd_register_filter(void)
 	rc = (pdo->fpo_register_filter)(&ffid, &fd, NULL);
 	M0_UT_ASSERT(rc == -EINVAL);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 0, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 0, 1);
 	rc = (pdo->fpo_register_filter)(&ffid, &fd, &pcb);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	rc = (pdo->fpo_register_filter)(&ffid, &fd, &pcb);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 2, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 2, 1);
 	rc = (pdo->fpo_register_filter)(&ffid, &fd, &pcb);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 
 	(pdo->fpo_enable_filters)(true, fids, ARRAY_SIZE(fids));
 
@@ -132,23 +132,23 @@ int detour_create(struct m0_fop *fop, struct m0_fom **out, struct m0_reqh *reqh)
 
 	M0_ENTRY();
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 0, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 0, 1);
 	rc = (*native_create)(fop, out, reqh);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	rc = (*native_create)(fop, out, reqh);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 2, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 2, 1);
 	rc = (*native_create)(fop, out, reqh);
 	M0_UT_ASSERT(rc == -ENOENT);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 3, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 3, 1);
 	rc = (*native_create)(fop, out, reqh);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 
 	rc = (*native_create)(fop, out, reqh);
 	M0_UT_ASSERT(m0_fop_data(fop)
@@ -618,7 +618,7 @@ void fdmi_pd_fake_release_nomem()
 	struct m0_rpc_conn_pool     *conn_pool = ut_pdock_conn_pool();
 	struct m0_rpc_conn_pool_item *pool_item;
 
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 
 	M0_ALLOC_PTR(rec);
 	M0_UT_ASSERT(rec != NULL);
@@ -653,7 +653,7 @@ void fdmi_pd_fake_release_nomem()
 	/* lock reg to not allow release to happen */
 	M0_UT_ASSERT(m0_ref_read(&rreg->frr_ref) == 1);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	(*pdo->fpo_release_fdmi_rec)(&rec->fr_rec_id, &ffid);
 
 	/* record remains registered */
@@ -661,7 +661,7 @@ void fdmi_pd_fake_release_nomem()
 	M0_UT_ASSERT(rreg_test != NULL);
 	M0_UT_ASSERT(m0_ref_read(&rreg_test->frr_ref) == 0);
 
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 
 
 	m0_fi_enable_off_n_on_m("m0_rpc_conn_pool_get", "fail_conn_get", 0, 1);
@@ -676,7 +676,7 @@ void fdmi_pd_fake_release_nomem()
 	m0_fi_disable("m0_rpc_conn_pool_get", "fail_conn_get");
 
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 0, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 0, 1);
 	m0_ref_get(&rreg->frr_ref);
 	(*pdo->fpo_release_fdmi_rec)(&rec->fr_rec_id, &ffid);
 
@@ -685,7 +685,7 @@ void fdmi_pd_fake_release_nomem()
 	M0_UT_ASSERT(rreg_test != NULL);
 	M0_UT_ASSERT(m0_ref_read(&rreg_test->frr_ref) == 0);
 
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 
 
 	m0_ref_get(&rreg->frr_ref);

--- a/fdmi/ut/sd_apply_filter.c
+++ b/fdmi/ut/sd_apply_filter.c
@@ -185,7 +185,7 @@ static void fdmi_sd_apply_filter_internal(const struct m0_filterc_ops *ops)
 
 	M0_ENTRY();
 
-	g_var_str = strdup("test");
+	g_var_str = m0_strdup("test");
 	M0_SET0(&g_conf_filter);
 
 	fdmi_serv_start_ut(ops);

--- a/fdmi/ut/sd_send_not.c
+++ b/fdmi/ut/sd_send_not.c
@@ -253,7 +253,7 @@ void fdmi_sd_send_notif(void)
 	int                           rc;
 
 	M0_SET0(&g_conf_filter);
-	g_var_str = strdup("test");
+	g_var_str = m0_strdup("test");
 	M0_SET0(&g_sem1);
 	M0_SET0(&g_sem2);
 	M0_SET0(&g_sem3);

--- a/ioservice/ut/storage_dev_ut.c
+++ b/ioservice/ut/storage_dev_ut.c
@@ -164,15 +164,15 @@ static void storage_dev_test(void)
 	m0_storage_dev_attach(dev2, &devs);
 	m0_fi_disable("m0_storage_dev_new_by_conf", "no-conf-dev");
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_storage_dev_new(&devs, 13, "../../some-file", total_size,
 				NULL, false, &dev3);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	rc = m0_storage_dev_new(&devs, 13, "../../some-file", total_size,
 				NULL, false, &dev3);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	M0_UT_ASSERT(rc == -ENOMEM);
 
 	/* find*/

--- a/lib/alloc_prof.c
+++ b/lib/alloc_prof.c
@@ -46,7 +46,7 @@ struct prof_rec {
 	}                         pr_s[AP_NR];
 };
 
-enum { SLOTS = 1000 };
+enum { SLOTS = 2000 };
 static __thread struct prof_rec recs[SLOTS];
 static struct m0_mutex guard;
 static int idx;

--- a/lib/alloc_prof.c
+++ b/lib/alloc_prof.c
@@ -34,59 +34,85 @@
 
 #if USE_ALLOC_PROF
 
-static __thread struct m0_alloc_prof_tls  ground;
-static __thread struct m0_alloc_prof_tls *anchor;
-
-static struct m0_alloc_prof  a_ground;
-static struct m0_alloc_prof *a_anchor = &a_ground;
-
-static struct m0_mutex guard;
-
 /**
- * Updates the local counters. On the first access, links the local counters
- * struct in per-thread single-linked list hanging off of anchor.
+ * An instance of this struct exists for each M0_ALLOC_{PTR,ARR}() call-site in
+ * each thread. Thread-local counters are accumulated there.
  */
-void m0_alloc_prof_update(struct m0_alloc_prof_tls *pt, size_t nob)
+struct prof_rec {
+	struct m0_alloc_callsite *pr_parent;
+	struct {
+		m0_bcount_t r_nob;
+		m0_bcount_t r_nr;
+	}                         pr_s[AP_NR];
+};
+
+enum { SLOTS = 1000 };
+static __thread struct prof_rec recs[SLOTS];
+static struct m0_mutex guard;
+static int idx;
+static bool initialised = false;
+static struct m0_alloc_callsite eol;
+static struct m0_alloc_callsite *head = &eol;
+
+static void init(void);
+
+void m0_alloc_callsite_init(struct m0_alloc_callsite *cs, int dir, size_t nob)
 {
-	pt->pt_nob += nob;
-	pt->pt_nr ++;
-	if (pt->pt_prev == NULL) {
-		pt->pt_prev = anchor;
-		anchor = pt;
+	struct prof_rec *rec;
+
+	if (cs->ap_idx == -1) {
+		init();
+		m0_mutex_lock(&guard);
+		if (cs->ap_idx == -1) {
+			M0_ASSERT(cs->ap_prev == NULL);
+			cs->ap_prev = head;
+			head = cs;
+			cs->ap_idx = idx++;
+		}
+		m0_mutex_unlock(&guard);
 	}
+	M0_ASSERT(IS_IN_ARRAY(cs->ap_idx, recs));
+	rec = &recs[cs->ap_idx];
+	M0_ASSERT(M0_IN(rec->pr_parent, (cs, NULL)));
+	M0_ASSERT(IS_IN_ARRAY(dir, rec->pr_s));
+	rec->pr_parent = cs;
+	rec->pr_s[dir].r_nob += nob;
+	rec->pr_s[dir].r_nr++;
 }
 
 M0_INTERNAL void m0_alloc_prof_thread_init(void)
 {
-	anchor = &ground;
 }
 
-/**
- * Merges local counters into global ones.
- *
- * On the first access, links the global counters structure in the global list
- * hanging off of a_anchor.
- */
 M0_INTERNAL void m0_alloc_prof_thread_fini(void)
 {
-	struct m0_alloc_prof_tls *scan;
+	m0_alloc_prof_thread_sync();
+}
+
+/** Merges local counters into global ones. */
+M0_INTERNAL void m0_alloc_prof_thread_sync(void)
+{
+	int i;
+	int j;
 
 	m0_mutex_lock(&guard);
-	for (scan = anchor; scan != &ground; scan = scan->pt_prev) {
-		struct m0_alloc_prof *ap = scan->pt_parent;
+	for (i = 0; i < ARRAY_SIZE(recs); ++i) {
+		struct prof_rec          *scan = &recs[i];
+		struct m0_alloc_callsite *ap   = scan->pr_parent;
 
-		ap->ap_nob += scan->pt_nob;
-		ap->ap_nr += scan->pt_nr;
-		if (scan->pt_nr > 0)
-			ap->ap_threads ++;
-		/*
-		 * This function can be executed multiple times for the same
-		 * thread, take care to count once.
-		 */
-		scan->pt_nob = scan->pt_nr = 0;
-		if (ap->ap_prev == NULL) {
-			ap->ap_prev = a_anchor;
-			a_anchor = ap;
+		if (ap == NULL)
+			continue;
+		M0_ASSERT(ap->ap_idx == i);
+		for (j = 0; j < AP_NR; ++j) {
+			ap->ap_s[j].s_nob += scan->pr_s[j].r_nob;
+			ap->ap_s[j].s_nr  += scan->pr_s[j].r_nr;
+			if (scan->pr_s[j].r_nr > 0)
+				ap->ap_s[j].s_threads++;
+			/*
+			 * This function can be executed multiple times for the
+			 * same thread, count only once.
+			 */
+			scan->pr_s[j].r_nob = scan->pr_s[j].r_nr = 0;
 		}
 	}
 	m0_mutex_unlock(&guard);
@@ -94,33 +120,42 @@ M0_INTERNAL void m0_alloc_prof_thread_fini(void)
 
 M0_INTERNAL int m0_alloc_prof_module_init(void)
 {
-	m0_mutex_init(&guard);
-	m0_alloc_prof_thread_init();
+	init();
 	return 0;
 }
 
 M0_INTERNAL void m0_alloc_prof_module_fini(void)
 {
-	m0_alloc_prof_thread_fini();
 	m0_alloc_prof_print();
 	m0_mutex_fini(&guard);
 }
 
 M0_INTERNAL void m0_alloc_prof_print(void)
 {
-	struct m0_alloc_prof *scan;
+	struct m0_alloc_callsite *scan;
 
-	m0_alloc_prof_thread_fini(); /* Merge current thread. */
-	printf("%10s %10s %10s %5s %s %s %s %s\n",
-	       "type", "nr", "nob", "threads", "file", "line", "func", "obj");
+	m0_alloc_prof_thread_sync();
 	m0_mutex_lock(&guard);
-	for (scan = a_anchor; scan != &a_ground; scan = scan->ap_prev) {
-		printf("%10s %10"PRId64" %10"PRId64" %5"PRId64" %s %i %s %s\n",
-		       scan->ap_type, scan->ap_nr, scan->ap_nob,
-		       scan->ap_threads, scan->ap_file,
+	for (scan = head; scan != &eol; scan = scan->ap_prev) {
+		printf("[%10"PRId64" - %10"PRId64" = %10"PRId64"] "
+		       "[%10"PRId64"] "
+		       "[%5"PRId64" - %5"PRId64"] %s %d %s %s\n",
+		       scan->ap_s[AP_ALLOC].s_nr, scan->ap_s[AP_FREE].s_nr,
+		       scan->ap_s[AP_ALLOC].s_nr - scan->ap_s[AP_FREE].s_nr,
+		       scan->ap_s[AP_ALLOC].s_nob,
+		       scan->ap_s[AP_ALLOC].s_threads,
+		       scan->ap_s[AP_FREE].s_threads, scan->ap_file,
 		       scan->ap_line, scan->ap_func, scan->ap_obj);
 	}
 	m0_mutex_unlock(&guard);
+}
+
+static void init(void)
+{
+	if (!initialised) {
+		initialised = true;
+		m0_mutex_init(&guard);
+	}
 }
 
 #else
@@ -129,6 +164,9 @@ M0_INTERNAL void m0_alloc_prof_thread_init(void)
 {;}
 
 M0_INTERNAL void m0_alloc_prof_thread_fini(void)
+{;}
+
+M0_INTERNAL void m0_alloc_prof_thread_sync(void)
 {;}
 
 M0_INTERNAL int  m0_alloc_prof_module_init(void)
@@ -142,8 +180,8 @@ M0_INTERNAL void m0_alloc_prof_module_fini(void)
 M0_INTERNAL void m0_alloc_prof_print(void)
 {;}
 
-struct m0_alloc_prof_tls;
-void m0_alloc_prof_update(struct m0_alloc_prof_tls *pt, size_t nob)
+struct m0_alloc_callsite;
+void m0_alloc_callsite_init(struct m0_alloc_callsite *cs, int dir, size_t nob)
 { /* Has to be defined: part of public API. */ ;}
 
 #endif

--- a/lib/alloc_prof.c
+++ b/lib/alloc_prof.c
@@ -47,19 +47,17 @@ struct prof_rec {
 };
 
 enum { SLOTS = 2000 };
-static __thread struct prof_rec recs[SLOTS];
-static struct m0_mutex guard;
-static int idx;
-static bool initialised = false;
-static struct m0_alloc_callsite eol;
-static struct m0_alloc_callsite *head = &eol;
+static __thread struct prof_rec  recs[SLOTS];
+static struct m0_mutex           guard;
+static int                       idx;
+static struct m0_alloc_callsite  eol;
+static struct m0_alloc_callsite *head        = &eol;
+static bool                      initialised = false;
 
 static void init(void);
 
-void m0_alloc_callsite_init(struct m0_alloc_callsite *cs, int dir, size_t nob)
+void m0_alloc_callsite_init(struct m0_alloc_callsite *cs)
 {
-	struct prof_rec *rec;
-
 	if (cs->ap_idx == -1) {
 		init();
 		m0_mutex_lock(&guard);
@@ -71,6 +69,13 @@ void m0_alloc_callsite_init(struct m0_alloc_callsite *cs, int dir, size_t nob)
 		}
 		m0_mutex_unlock(&guard);
 	}
+}
+
+M0_INTERNAL void m0_alloc_callsite_mod(struct m0_alloc_callsite *cs,
+				       int dir, size_t nob)
+{
+	struct prof_rec *rec;
+
 	M0_ASSERT(IS_IN_ARRAY(cs->ap_idx, recs));
 	rec = &recs[cs->ap_idx];
 	M0_ASSERT(M0_IN(rec->pr_parent, (cs, NULL)));
@@ -159,6 +164,10 @@ static void init(void)
 }
 
 #else
+
+M0_INTERNAL void m0_alloc_callsite_mod(struct m0_alloc_callsite *cs,
+				       int dir, size_t nob)
+{;}
 
 M0_INTERNAL void m0_alloc_prof_thread_init(void)
 {;}

--- a/lib/alloc_prof.h
+++ b/lib/alloc_prof.h
@@ -123,6 +123,7 @@ void m0_alloc_callsite_init(struct m0_alloc_callsite *cs);
 #define M0_ALLOC_CALLSITE(obj, flags) (NULL)
 #endif
 
+struct m0_alloc_callsite;
 M0_INTERNAL void m0_alloc_callsite_mod(struct m0_alloc_callsite *cs,
 				       int dir, size_t nob);
 M0_INTERNAL void m0_alloc_prof_thread_init(void);

--- a/lib/alloc_prof.h
+++ b/lib/alloc_prof.h
@@ -102,27 +102,29 @@ struct m0_alloc_callsite {
 	struct m0_alloc_callsite *ap_prev;
 };
 
-void m0_alloc_callsite_init(struct m0_alloc_callsite *cs, int dir, size_t nob);
+void m0_alloc_callsite_init(struct m0_alloc_callsite *cs);
 
-#define M0_ALLOC_CALLSITE(obj, flags, dir, nob)	\
+#define M0_ALLOC_CALLSITE(obj, flags)			\
 ({							\
 	static struct m0_alloc_callsite __cs = {	\
-		.ap_idx   = -1,			\
+		.ap_idx   = -1,				\
 		.ap_flags = (flags),			\
 		.ap_file  = __FILE__,			\
 		.ap_line  = __LINE__,			\
 		.ap_obj   = (obj),			\
 		.ap_func  = __func__			\
 	};						\
-	m0_alloc_callsite_init(&__cs, (dir), (nob));	\
+	m0_alloc_callsite_init(&__cs);			\
 	&__cs;						\
 })
 
 #else
 #define USE_ALLOC_PROF (0)
-#define M0_ALLOC_CALLSITE(obj, type) (NULL)
+#define M0_ALLOC_CALLSITE(obj, flags) (NULL)
 #endif
 
+M0_INTERNAL void m0_alloc_callsite_mod(struct m0_alloc_callsite *cs,
+				       int dir, size_t nob);
 M0_INTERNAL void m0_alloc_prof_thread_init(void);
 M0_INTERNAL void m0_alloc_prof_thread_sync(void);
 M0_INTERNAL void m0_alloc_prof_thread_fini(void);

--- a/lib/finject.h
+++ b/lib/finject.h
@@ -228,7 +228,16 @@ struct m0_fi_fpoint_data {
  * @return    true, if FP is enabled
  * @return    false otherwise
  */
-#define M0_FI_ENABLED(tag)				\
+#define M0_FI_ENABLED(tag)  M0_FI_ENABLED_IN(__func__, tag)
+
+/**
+ * Defines a more generic fault point and checks whether it is enabled.
+ *
+ * This is a version of @M0_FI_ENABLED(), that allows the user to pretend that
+ * the fault point is defined in a different function, for example, to keep
+ * fault point names stable across interface versions and build options.
+ */
+#define M0_FI_ENABLED_IN(func, tag)		\
 ({							\
 	static struct m0_fi_fault_point fp = {		\
 		.fp_state    = NULL,			\
@@ -236,7 +245,7 @@ struct m0_fi_fpoint_data {
 		.fp_module   = "UNKNOWN",		\
 		.fp_file     = __FILE__,		\
 		.fp_line_num = __LINE__,		\
-		.fp_func     = __func__,		\
+		.fp_func     = (func),			\
 		.fp_tag      = (tag),			\
 	};						\
 							\
@@ -495,4 +504,3 @@ M0_INTERNAL int m0_fi_enable_fault_point(const char *str);
 M0_INTERNAL int m0_fi_enable_fault_points_from_file(const char *file_name);
 /** @} end of finject group */
 #endif /* __MOTR_LIB_FINJECT_H__ */
-

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -139,11 +139,7 @@ enum { AP_MAGIX = 0x3332764287643377ULL };
 
 void *m0_alloc_profiled(size_t size, struct m0_alloc_callsite *cs)
 {
-	struct pad *area;
-
-	if (M0_FI_ENABLED("fail_allocation"))
-		return NULL;
-	area = alloc0(size + sizeof(struct pad));
+	struct pad *area = alloc0(size + sizeof(struct pad));
 	if (area != NULL) {
 		area[0] = (struct pad){ .p_cs = cs, .p_magic = AP_MAGIX };
 		area++;
@@ -181,8 +177,6 @@ void *m0_alloc(size_t size)
 
 void *(m0_alloc_profiled)(size_t size)
 {
-	if (M0_FI_ENABLED("fail_allocation"))
-		return NULL;
 	return alloc0(size);
 }
 
@@ -202,13 +196,13 @@ static void *alloc0(size_t size)
 	void *area;
 
 	M0_ENTRY("size=%zi", size);
-	if (M0_FI_ENABLED("fail_allocation"))
+	if (M0_FI_ENABLED_IN("m0_alloc", "fail_allocation"))
 		return NULL;
 	area = m0_arch_alloc(size);
 	alloc_tail(area, size);
 	if (area != NULL) {
 		m0_arch_allocated_zero(area, size);
-	} else if (!M0_FI_ENABLED("keep_quiet")) {
+	} else if (!M0_FI_ENABLED_IN("m0_alloc", "keep_quiet")) {
 		M0_LOG(M0_ERROR, "Failed to allocate %zi bytes.", size);
 		m0_backtrace();
 	}

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -186,9 +186,14 @@ M0_INTERNAL int m0_dont_dump(void *p, size_t size);
  * allocations.
  */
 void *m0_alloc_profiled(size_t size, struct m0_alloc_callsite *cs);
+M0_INTERNAL void *m0_alloc_aligned_profiled(size_t size, unsigned shift,
+					    struct m0_alloc_callsite *cs);
 #else
 void *(m0_alloc_profiled)(size_t size);
 #define m0_alloc_profiled(size, cs) (m0_alloc_profiled)(size)
+M0_INTERNAL void *(m0_alloc_aligned_profiled)(size_t size, unsigned shift);
+#define m0_alloc_aligned_profiled(size, shift, cs) \
+	(m0_alloc_aligned_profiled)(size, shift)
 #endif
 
 /** @} end of memory group */

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -82,10 +82,10 @@ M0_INTERNAL void m0_memory_pagein(void *addr, size_t size);
 		*__pptr = NULL;               \
 	} while (0)
 
-#define M0_ALLOC_ARR(arr, nr)  ({					\
-	size_t nob = (nr) * sizeof ((arr)[0]);				\
-	(arr) = M0_FI_ENABLED(#arr "-fail") ? NULL :			\
-	   m0_alloc_profiled(nob, M0_ALLOC_CALLSITE(#arr, 0, AP_ALLOC, nob)); \
+#define M0_ALLOC_ARR(arr, nr)  ({					       \
+	(arr) = M0_FI_ENABLED(#arr "-fail") ? NULL :			       \
+	   m0_alloc_profiled((nr) * sizeof ((arr)[0]), M0_ALLOC_CALLSITE(#arr, \
+									 0));  \
 })
 
 #define M0_ALLOC_PTR(ptr)      M0_ALLOC_ARR(ptr, 1)

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -84,8 +84,8 @@ M0_INTERNAL void m0_memory_pagein(void *addr, size_t size);
 
 #define M0_ALLOC_ARR(arr, nr)  ({					\
 	size_t nob = (nr) * sizeof ((arr)[0]);				\
-	M0_ALLOC_PROF("alloc", #arr, nob);				\
-	(arr) = M0_FI_ENABLED(#arr "-fail") ? NULL : m0_alloc_profiled(nob); \
+	(arr) = M0_FI_ENABLED(#arr "-fail") ? NULL :			\
+	   m0_alloc_profiled(nob, M0_ALLOC_CALLSITE(#arr, 0, AP_ALLOC, nob)); \
 })
 
 #define M0_ALLOC_PTR(ptr)      M0_ALLOC_ARR(ptr, 1)
@@ -180,11 +180,16 @@ M0_INTERNAL bool m0_is_poisoned(const void *p);
  */
 M0_INTERNAL int m0_dont_dump(void *p, size_t size);
 
+#if USE_ALLOC_PROF
 /**
  * Allocator entry point used within M0_ALLOC_{PTR,ARR}() for already profiled
  * allocations.
  */
-void *m0_alloc_profiled(size_t size);
+void *m0_alloc_profiled(size_t size, struct m0_alloc_callsite *cs);
+#else
+void *(m0_alloc_profiled)(size_t size);
+#define m0_alloc_profiled(size, cs) (m0_alloc_profiled)(size)
+#endif
 
 /** @} end of memory group */
 #endif /* __MOTR_LIB_MEMORY_H__ */

--- a/lib/string.c
+++ b/lib/string.c
@@ -19,6 +19,7 @@
  *
  */
 
+#include <stdarg.h>
 
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_LIB
 #include "lib/trace.h"
@@ -40,6 +41,28 @@ const char *m0_bcount_with_suffix(char *buf, size_t size, m0_bcount_t c)
 		;
 	snprintf(buf, size, "%3" PRId64 " %s", c, suffix[i]);
 	return buf;
+}
+
+M0_INTERNAL char *m0_strdup(const char *s)
+{
+	char *copy = m0_alloc(strlen(s) + 1);
+	if (copy != NULL)
+		strcpy(copy, s);
+	return copy;
+}
+
+M0_INTERNAL void m0_asprintf(char **ret, const char *format, ...)
+{
+	va_list args;
+	char   *s;
+
+	va_start(args, format);
+	if (vasprintf(&s, format, args) > 0) {
+		*ret = m0_strdup(s);
+		free(s);
+	} else
+		*ret = NULL;
+	va_end(args);
 }
 
 M0_INTERNAL void m0_strings_free(const char **arr)

--- a/lib/string.h
+++ b/lib/string.h
@@ -40,15 +40,8 @@
 # include <stdlib.h>
 # include <string.h>
 
-#define m0_strdup(s) strdup((s))
-#define m0_asprintf(s, fmt, ...)                          \
-	({                                                \
-		int __nr;                                 \
-		char **__s = (s);                         \
-		__nr = asprintf(__s, (fmt), __VA_ARGS__); \
-		if (__nr <= 0)                            \
-			*__s = NULL;                      \
-	})
+M0_INTERNAL char *m0_strdup(const char *s);
+M0_INTERNAL void  m0_asprintf(char **ret, const char *format, ...);
 
 #else
 # include <linux/ctype.h>

--- a/lib/user_space/thread.h
+++ b/lib/user_space/thread.h
@@ -52,9 +52,9 @@ struct m0_thread_handle {
 /** User space thread-local storage. */
 struct m0_thread_arch_tls {
 	/** Non-zero iff the thread is in awkward context. */
-	uint32_t   tat_awkward;
+	uint32_t    tat_awkward;
 	/** Stack context/environment, saved with setjmp(3). */
-	jmp_buf   *tat_jmp;
+	sigjmp_buf *tat_jmp;
 };
 
 /**

--- a/lib/user_space/ucookie.c
+++ b/lib/user_space/ucookie.c
@@ -46,12 +46,12 @@ static const struct m0_panic_ctx signal_panic = {
 static void sigsegv(int sig)
 {
 	struct m0_thread_tls *tls = m0_thread_tls();
-	jmp_buf              *buf = tls == NULL ? NULL : tls->tls_arch.tat_jmp;
+	sigjmp_buf           *buf = tls == NULL ? NULL : tls->tls_arch.tat_jmp;
 
 	if (buf == NULL)
 		m0_panic(&signal_panic, sig);
 	else
-		longjmp(*buf, 1);
+		siglongjmp(*buf, 1);
 }
 
 /**
@@ -61,14 +61,14 @@ static void sigsegv(int sig)
  */
 M0_INTERNAL bool m0_arch_addr_is_sane(const void *addr)
 {
-	jmp_buf           buf;
-	jmp_buf         **tls = &m0_thread_tls()->tls_arch.tat_jmp;
+	sigjmp_buf        buf;
+	sigjmp_buf      **tls = &m0_thread_tls()->tls_arch.tat_jmp;
 	int               ret;
 	volatile uint64_t dummy M0_UNUSED;
 	volatile bool     result = false;
 
 	*tls = &buf;
-	ret = setjmp(buf);
+	ret = sigsetjmp(buf, 1);
 	if (ret == 0) {
 		dummy = *(uint64_t *)addr;
 		result = true;

--- a/lib/ut/buf.c
+++ b/lib/ut/buf.c
@@ -66,7 +66,7 @@ void m0_ut_lib_buf_test(void)
 
 #ifdef ENABLE_FAULT_INJECTION
 	struct m0_buf inj_copy = M0_BUF_INIT0;
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_buf_copy(&inj_copy, &test[0].buf);
 	M0_UT_ASSERT(rc == -ENOMEM);
 #endif

--- a/lib/ut/locality.c
+++ b/lib/ut/locality.c
@@ -383,7 +383,7 @@ void test_locality_chore(void)
 	M0_UT_ASSERT(left == nr_loc);
 
 	M0_SET0(&chore);
-	m0_fi_enable_once("m0_alloc_profiled", "keep_quiet");
+	m0_fi_enable_once("m0_alloc", "keep_quiet");
 	result = m0_locality_chore_init(&chore, &ops, &lock,
 					M0_MKTIME(1, 0), 1ULL << 60);
 	M0_UT_ASSERT(result == -ENOMEM);
@@ -408,7 +408,7 @@ void test_locality_chore(void)
 	M0_UT_ASSERT(entered == nr_loc);
 	M0_UT_ASSERT(left == nr_loc);
 	m0_locality_data_free(keyother);
-	m0_fi_enable_once("m0_alloc_profiled", "keep_quiet");
+	m0_fi_enable_once("m0_alloc", "keep_quiet");
 	result = m0_locality_data_alloc(1ULL << 60, NULL, NULL, NULL);
 	M0_UT_ASSERT(result == -ENOMEM);
 	m0_ut__reqh_fini();

--- a/lib/ut/varr.c
+++ b/lib/ut/varr.c
@@ -168,13 +168,13 @@ static void test_init(void)
 	/* Test fault injection. */
 	seed = m0_time_now();
 	n = m0_rnd(MAX_BUFFERS, &seed);
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", n, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", n, 1);
 	M0_SET0(&varr);
 	rc = m0_varr_init(&varr, MAX_OBJ_NR, size_get(DT_POWTWO),
 			  BUFF_SIZE);
 	if (rc == 0)
 		m0_varr_fini(&varr);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 }
 
 static void test_size(void)

--- a/lib/ut/zerovec.c
+++ b/lib/ut/zerovec.c
@@ -86,7 +86,7 @@ static void zerovec_init_bvec(void)
 		M0_UT_ASSERT(zvec.z_index[i] == indices[i]);
 	}
 
-	m0_bufvec_free(&bufvec);
+	m0_bufvec_free_aligned(&bufvec, M0_0VEC_SHIFT);
 	m0_0vec_fini(&zvec);
 }
 
@@ -123,7 +123,7 @@ static void zerovec_init_bufs(void)
 	M0_UT_ASSERT(zvec.z_bvec.ov_vec.v_nr == ZEROVEC_UT_SEGS_NR);
 
 	for (i = 0; i < ZEROVEC_UT_SEGS_NR; ++i)
-		m0_free(bufs[i]);
+		m0_free_aligned(bufs[i], ZEROVEC_UT_SEG_SIZE, M0_0VEC_SHIFT);
 	m0_free(bufs);
 	m0_0vec_fini(&zvec);
 }
@@ -163,7 +163,8 @@ static void zerovec_init_cbuf(void)
 	M0_UT_ASSERT(zvec.z_bvec.ov_vec.v_nr == ZEROVEC_UT_SEGS_NR);
 
 	for (i = 0; i < ZEROVEC_UT_SEGS_NR; ++i)
-		m0_free(bufs[i].b_addr);
+		m0_free_aligned(bufs[i].b_addr, ZEROVEC_UT_SEG_SIZE,
+				M0_0VEC_SHIFT);
 	m0_0vec_fini(&zvec);
 }
 #else

--- a/m0t1fs/linux_kernel/ut/file.c
+++ b/m0t1fs/linux_kernel/ut/file.c
@@ -946,16 +946,16 @@ static void target_ioreq_test(void)
 
 skip:
 	/* Checks allocation failure. */
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 1, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 1, 1);
 	rc = target_ioreq_iofops_prepare(ti, PA_DATA);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
 	/* Checks allocation failure in m0_rpc_bulk_buf_add(). */
 
-	m0_fi_enable_off_n_on_m("m0_alloc_profiled", "fail_allocation", 2, 1);
+	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 2, 1);
 	rc = target_ioreq_iofops_prepare(ti, PA_DATA);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 
 	/* Finalisation */
 	req.ir_nwxfer.nxr_state = NXS_COMPLETE;
@@ -969,9 +969,9 @@ skip:
 	rc = io_request_init(&req, &lfile, iovec_arr, ivv, IRT_WRITE);
 	M0_UT_ASSERT(rc == 0);
 
-	m0_fi_enable_random("m0_alloc_profiled", "fail_allocation", 5);
+	m0_fi_enable_random("m0_alloc", "fail_allocation", 5);
 	rc = ioreq_iomaps_prepare(&req);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	if (rc == -ENOMEM)
 		rc = ioreq_iomaps_prepare(&req);
 	M0_UT_ASSERT(rc == 0);

--- a/motr/magic.h
+++ b/motr/magic.h
@@ -69,6 +69,16 @@ enum m0_magic_satchel {
 	/* Leo falabella */
 	M0_ADDB2_SOURCE_HEAD_MAGIC   = 0x331e0fa1abe11a77,
 
+/* [memory] Allocator */
+	/* Allocator profiler magic. */
+	M0_MEMORY_AP_MAGIX           = 0x3332764287643377,
+	/* Allocator profiler magic for an aligned allocation. */
+	M0_MEMORY_AA_MAGIX           = 0x3376767574737277,
+	/* Allocator profiler freed magic. */
+	M0_MEMORY_AP_FREE_MAGIX      = 0x33ff76ff87ff3377,
+	/* Allocator profiler magic for an aligned free block. */
+	M0_MEMORY_AA_FREE_MAGIX      = 0x3376ff75ff73ff77,
+
 /* balloc */
 	/* m0_balloc_super_block::bsb_magic (blessed baloc) */
 	M0_BALLOC_SB_MAGIC = 0x33b1e55edba10c77,

--- a/motr/motr-pub.api
+++ b/motr/motr-pub.api
@@ -77,7 +77,7 @@ m0_addb2_sys_submit
 m0_addb2_trace_done
 m0_alloc
 m0_alloc_profiled
-m0_alloc_prof_update
+m0_alloc_callsite_init
 m0_backtrace
 m0_bcount_with_suffix
 m0_build_info_get

--- a/motr/ut/client.c
+++ b/motr/ut/client.c
@@ -215,7 +215,7 @@ static void ut_test_m0_client_init(void)
 	struct m0_client        *instance;
 
 	/* Check -ENOMEM will be returned */
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	instance = NULL;
 	rc = INIT(&instance);
 	M0_UT_ASSERT(rc == -ENOMEM);

--- a/motr/ut/client.h
+++ b/motr/ut/client.h
@@ -228,6 +228,9 @@ M0_INTERNAL void ut_dummy_data_buf_delete(struct data_buf *db);
  */
 M0_INTERNAL void ut_dummy_data_buf_init(struct data_buf *db);
 
+/** Frees the buffers of the data buf. */
+M0_INTERNAL void ut_dummy_data_buf_free(struct data_buf *db);
+
 /**
  * Finalises a UT dummy data_buf.
  */

--- a/motr/ut/io_dummy.c
+++ b/motr/ut/io_dummy.c
@@ -229,19 +229,21 @@ M0_INTERNAL void ut_dummy_data_buf_init(struct data_buf *db)
 	db->db_flags = PA_NONE;
 }
 
+M0_INTERNAL void ut_dummy_data_buf_free(struct data_buf *db)
+{
+	/*
+	 * We can't use m0_buf_free, because we allocated an aligned buffer...
+	 */
+	m0_free_aligned(db->db_buf.b_addr, UT_DEFAULT_BLOCK_SIZE,
+			UT_DEFAULT_BLOCK_SHIFT);
+}
+
 M0_INTERNAL void ut_dummy_data_buf_fini(struct data_buf *db)
 {
 	M0_UT_ASSERT(db != NULL);
 
 	data_buf_bob_fini(db);
-
-	/*
-	 * We can't use m0_buf_free, because we allocated
-	 * an aligned buffer...
-	 */
-	m0_free_aligned(db->db_buf.b_addr,
-			UT_DEFAULT_BLOCK_SIZE,
-			UT_DEFAULT_BLOCK_SHIFT);
+	ut_dummy_data_buf_free(db);
 }
 
 /*

--- a/motr/ut/io_nw_xfer.c
+++ b/motr/ut/io_nw_xfer.c
@@ -254,7 +254,8 @@ static void ut_test_target_ioreq_seg_add(void)
 	src->sa_unit = 1;
 	tgt->ta_frame = 1;
 	map = ut_dummy_pargrp_iomap_create(instance, 1);
-	m0_free(map->pi_databufs[0][0]->db_buf.b_addr);/* don't use this allocated buf*/
+	/* don't use this allocated buf*/
+	ut_dummy_data_buf_free(map->pi_databufs[0][0]);
 	map->pi_ioo = ioo;
 	map->pi_databufs[0][0]->db_buf.b_addr = NULL;
 	map->pi_databufs[0][0]->db_flags |= 777;

--- a/motr/ut/obj.c
+++ b/motr/ut/obj.c
@@ -551,7 +551,7 @@ static void ut_test_obj_op_prepare(void)
 		    m0_client_layout_id(instance));
 
 	/* OP Allocation fails */
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = obj_op_prepare(&obj.ob_entity, &op, M0_EO_CREATE);
 	M0_UT_ASSERT(rc != 0);
 	M0_UT_ASSERT(op == NULL);

--- a/rpc/ut/conn.c
+++ b/rpc/ut/conn.c
@@ -78,7 +78,7 @@ static int conn_ut_fini(void)
 	m0_fi_disable("m0_rpc__fop_post", "do_nothing");
 
 	m0_fi_disable("rpc_chan_get", "fake_error");
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	m0_fi_disable("m0_rpc__fop_post", "fake_error");
 	return 0;
 }
@@ -193,7 +193,7 @@ static void conn_init_fail_test(void)
 {
 	int rc;
 	/* Checks for m0_rpc_conn_init() failure due to allocation failure */
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_rpc_conn_init(&conn, NULL, &ep, &machine, 1);
 	M0_UT_ASSERT(rc == -ENOMEM);
 
@@ -219,7 +219,7 @@ static void conn_establish_fail_test(void)
 	/* Allocation failure */
 	conn_init();
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_rpc_conn_establish(&conn, m0_time_from_now(2, 0));
 	M0_UT_ASSERT(rc == -ENOMEM);
 	M0_UT_ASSERT(conn_state(&conn) == M0_RPC_CONN_FAILED);
@@ -264,7 +264,7 @@ static void conn_terminate_fail_test(void)
 	conn_init_and_establish();
 	conn_establish_reply();
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_rpc_conn_terminate(&conn, m0_time_from_now(2, 0));
 	M0_UT_ASSERT(rc == -ENOMEM);
 	M0_UT_ASSERT(conn_state(&conn) == M0_RPC_CONN_FAILED);

--- a/rpc/ut/formation2.c
+++ b/rpc/ut/formation2.c
@@ -499,7 +499,7 @@ static void frm_test6(void)
 	flags_reset();
 	item = new_item(TIMEDOUT, NORMAL);
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 
 	m0_rpc_frm_enq_item(frm, item);
 	M0_UT_ASSERT(!packet_ready_called);

--- a/rpc/ut/session.c
+++ b/rpc/ut/session.c
@@ -93,7 +93,7 @@ static int session_ut_fini(void)
 	m0_sm_group_fini(&machine.rm_sm_grp);
 	m0_fi_disable("m0_rpc__fop_post", "do_nothing");
 	m0_fi_disable("m0_rpc__fop_post", "fake_error");
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	return 0;
 }
 
@@ -240,7 +240,7 @@ static void session_establish_fail_test(void)
 	/* Allocation failure */
 	session_init();
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_rpc_session_establish(&session, m0_time_from_now(2, 0));
 	M0_UT_ASSERT(rc == -ENOMEM);
 	M0_UT_ASSERT(session_state(&session) == M0_RPC_SESSION_FAILED);

--- a/spiel/ut/spiel_ci_ut.c
+++ b/spiel/ut/spiel_ci_ut.c
@@ -161,7 +161,7 @@ static void test_spiel_process_cmds(void)
 	rc = m0_spiel_process_reconfig(&spiel, &process_invalid_fid);
 	M0_UT_ASSERT(rc == -EINVAL);
 
-	m0_fi_enable_once("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable_once("m0_alloc", "fail_allocation");
 	rc = m0_spiel_process_reconfig(&spiel, &process_fid);
 	M0_UT_ASSERT(rc == -ENOMEM);
 

--- a/spiel/ut/spiel_conf_ut.c
+++ b/spiel/ut/spiel_conf_ut.c
@@ -1063,13 +1063,13 @@ static void spiel_conf_create_fail(void)
 	 * those threads can still get -ENOMEM in the interim but that
 	 * is acceptable for now.
 	 **/
-	m0_fi_enable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable("m0_alloc", "fail_allocation");
 	rc = m0_spiel_root_add(&tx,
 			       &spiel_obj_fid[SPIEL_UT_OBJ_PROFILE],
 			       &spiel_obj_fid[SPIEL_UT_OBJ_POOL],
 			       &spiel_obj_fid[SPIEL_UT_OBJ_PVER],
 			       10, params);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 	M0_UT_ASSERT(rc == -ENOMEM);
 
 	/* alloc fail for rt_params */
@@ -1300,13 +1300,13 @@ static void spiel_conf_create_fail(void)
 	M0_UT_ASSERT(rc == -EINVAL);
 
 	/* Check copy endpoints parameter */
-	m0_fi_enable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_enable("m0_alloc", "fail_allocation");
 	rc = m0_spiel_service_add(&tx,
 				  &spiel_obj_fid[SPIEL_UT_OBJ_SERVICE],
 				  &spiel_obj_fid[SPIEL_UT_OBJ_PROCESS],
 				  &service_info);
 	M0_UT_ASSERT(rc == -ENOMEM);
-	m0_fi_disable("m0_alloc_profiled", "fail_allocation");
+	m0_fi_disable("m0_alloc", "fail_allocation");
 
 	/* Check copy cs_u parameter & switch by type */
 	service_info.svi_type = M0_CST_MDS;

--- a/stob/ut/domain.c
+++ b/stob/ut/domain.c
@@ -85,7 +85,8 @@ void m0_stob_ut_stob_domain_null(void)
 #ifndef __KERNEL__
 void m0_stob_ut_stob_domain_linux(void)
 {
-	stob_ut_stob_domain("linuxstob:./__s", NULL, NULL);
+	/* Use unique name to avoid conflicts with other UTs. */
+	stob_ut_stob_domain("linuxstob:./__sdl", NULL, NULL);
 }
 
 void m0_stob_ut_stob_domain_perf(void)

--- a/stob/ut/stob.c
+++ b/stob/ut/stob.c
@@ -251,8 +251,8 @@ void m0_stob_ut_stob_null(void)
 #ifndef __KERNEL__
 void m0_stob_ut_stob_linux(void)
 {
-	stob_ut_stob_single(NULL, "linuxstob:./__s", NULL, NULL, NULL);
-	stob_ut_stob_multi(NULL, "linuxstob:./__s", NULL, NULL, NULL,
+	stob_ut_stob_single(NULL, "linuxstob:./__ss", NULL, NULL, NULL);
+	stob_ut_stob_multi(NULL, "linuxstob:./__sm", NULL, NULL, NULL,
 			   M0_STOB_UT_THREAD_NR, M0_STOB_UT_STOB_NR);
 }
 

--- a/ut/m0ut.c
+++ b/ut/m0ut.c
@@ -176,6 +176,12 @@ extern struct m0_ut_suite xcode_ut;
 extern struct m0_ut_suite sns_flock_ut;
 extern struct m0_ut_suite ut_suite_pi;
 
+#if defined(ENABLE_LUSTRE)
+#define LNET_ENABLED (true)
+#else
+#define LNET_ENABLED (false)
+#endif
+
 static void tests_add(struct m0_ut_module *m)
 {
 	/*
@@ -271,10 +277,7 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &m0_fom_stats_ut, true);
 	m0_ut_add(m, &m0_net_bulk_if_ut, true);
 	m0_ut_add(m, &m0_net_bulk_mem_ut, true);
-	if (USE_LIBFAB)
-		m0_ut_add(m, &m0_net_lnet_ut, false);
-	else
-		m0_ut_add(m, &m0_net_lnet_ut, true);
+	m0_ut_add(m, &m0_net_lnet_ut, LNET_ENABLED);
 	m0_ut_add(m, &m0_net_misc_ut, true);
 	m0_ut_add(m, &m0_net_module_ut, true);
 	m0_ut_add(m, &m0_net_test_ut, true);


### PR DESCRIPTION
Updates:
    - add leak profiling
    - record allocation callsite in the allocated memory block
    - fixes for some issues uncovered by the profiler: m0_free_aligned(), m0_strdup(), Lnet-ut, sigsetjmp(), dtm0 fop types, stob domain pathnames.

-----
[View rendered doc/fault-injection.md](https://github.com/Seagate/cortx-motr/blob/alloc-profile-leak/doc/fault-injection.md)