### PR TITLE
CORTX-30423: M0_ENF_META support for m0kv

### DIFF
--- a/motr/m0kv/cmd_main.c
+++ b/motr/m0kv/cmd_main.c
@@ -107,8 +107,6 @@ static int opts_get(struct params *par, int *argc, char ***argv)
 	char **arg = *(argv);
 	int    common_args = 9;
 	char  *pv = NULL; 
-	char  *pv_token;
-	bool   pv_token_flag = 0;
 
 	par->cp_local_addr = NULL;
 	par->cp_ha_addr    = NULL;
@@ -164,16 +162,7 @@ static int opts_get(struct params *par, int *argc, char ***argv)
 
 	if (pv != NULL) {
 		common_args += 2;
-		pv_token = strtok(pv, ":");
-		while (pv_token != NULL) {
-			if (pv_token_flag == 0) {
-				dix_pool_ver.f_container = strtoul(pv_token, NULL, 16);
-				pv_token_flag = true;
-			} else {
-				dix_pool_ver.f_key = strtoul(pv_token, NULL, 16);
-			}
-			pv_token = strtok(NULL, ":");	
-		}
+		rc = m0_fid_sscanf(pv, &dix_pool_ver);
 	}
 
 	*argc -= common_args;

--- a/motr/m0kv/cmd_main.c
+++ b/motr/m0kv/cmd_main.c
@@ -95,6 +95,8 @@ static void usage(void)
 		"\n"
 		"-s  Enable string format and it is optional.\n"
 		"-e  Enable M0_ENF_META flag and it is optional.\n"
+		"-v 7600000000000001:30 it is mandatory with -e for "
+		"PUT, GET, DEL and NEXT operations.\n"
 		"Available subsystems and subsystem-specific commands are "
 		"listed below.\n");
 	for (i = 0; i < ARRAY_SIZE(subsystems); i++)

--- a/motr/m0kv/index.h
+++ b/motr/m0kv/index.h
@@ -68,6 +68,8 @@ struct index_ctx
 };
 
 extern bool is_str;
+extern bool is_enf_meta;
+extern struct m0_fid dix_pool_ver;
 
 int  index_execute(int argc, char** argv);
 int  index_init(struct params *params);

--- a/motr/m0kv/index_op.c
+++ b/motr/m0kv/index_op.c
@@ -75,6 +75,17 @@ static int index_op_tail(struct m0_entity *ce,
 	return M0_RC(rc);
 }
 
+void set_enf_meta_flag(struct m0_idx *idx)
+{
+	idx->in_entity.en_flags |= M0_ENF_META;
+	if (dix_pool_ver.f_container != 0) {
+		idx->in_attr.idx_layout_type = DIX_LTYPE_DESCR;
+		idx->in_attr.idx_pver = dix_pool_ver;
+		m0_console_printf("DIX pool version: "FID_F" \n", 
+				  FID_P(&idx->in_attr.idx_pver));
+	}
+}
+
 int index_create(struct m0_realm *parent, struct m0_fid_arr *fids)
 {
 	int i;
@@ -89,8 +100,15 @@ int index_create(struct m0_realm *parent, struct m0_fid_arr *fids)
 		m0_fid_tassume(&fids->af_elems[i], &m0_dix_fid_type);
 		m0_idx_init(&idx, parent,
 				   (struct m0_uint128 *)&fids->af_elems[i]);
+
+		if (is_enf_meta)
+			set_enf_meta_flag(&idx);
+
 		rc = m0_entity_create(NULL, &idx.in_entity, &op);
 		rc = index_op_tail(&idx.in_entity, op, rc, NULL);
+		if (rc == 0 && is_enf_meta)
+			m0_console_printf("DIX pool version: "FID_F" \n",
+					  FID_P(&idx.in_attr.idx_pver));
 	}
 	return M0_RC(rc);
 }
@@ -191,6 +209,10 @@ static int index_op(struct m0_realm    *parent,
 
 	m0_fid_tassume(fid, &m0_dix_fid_type);
 	m0_idx_init(&idx, parent, (struct m0_uint128 *)fid);
+
+	if (is_enf_meta)
+		set_enf_meta_flag(&idx);
+
 	rc = m0_idx_op(&idx, opcode, keys, vals, rcs,
 	               opcode == M0_IC_PUT ? M0_OIF_OVERWRITE : 0,
 		       &op);

--- a/motr/m0kv/index_op.c
+++ b/motr/m0kv/index_op.c
@@ -210,8 +210,14 @@ static int index_op(struct m0_realm    *parent,
 	m0_fid_tassume(fid, &m0_dix_fid_type);
 	m0_idx_init(&idx, parent, (struct m0_uint128 *)fid);
 
-	if (is_enf_meta)
-		set_enf_meta_flag(&idx);
+	if (is_enf_meta) {
+		if (m0_fid_is_valid(&dix_pool_ver) && m0_fid_is_set(&dix_pool_ver))
+			set_enf_meta_flag(&idx);
+		else
+			return M0_ERR(-EINVAL);
+	} else if (m0_fid_is_set(&dix_pool_ver)) {
+		return M0_ERR(-EINVAL);
+	}	
 
 	rc = m0_idx_op(&idx, opcode, keys, vals, rcs,
 	               opcode == M0_IC_PUT ? M0_OIF_OVERWRITE : 0,

--- a/motr/m0kv/index_parser.c
+++ b/motr/m0kv/index_parser.c
@@ -479,8 +479,14 @@ void index_parser_print_command_help(void)
 		"\t\t>m0kv [common args] -s index put \"1:5\" \"Department\" "
 		"\"Testing\" \n"
 		"\t\tNote: If key already exists put over-write the old value.\n"
-		"\t\t>m0kv [common args] -s index get \"1:5\" \"Department\" "
-		"\n");
+		"\t\t>m0kv [common args] -s index get \"1:5\" \"Department\" \n"
+		"\t\tNote: DIX pool version info on console if pass -e \n" 
+		"\t\t flag for index create.\n"
+		"\t\t>m0kv [common args] -e index create \"1:5\" \n"
+		"\t\tNote: Pass pool version info for PUT/GET/DEL/NEXT \n"
+		"\t\t operations if pass -e flag \n"
+		"\t\t>m0kv [common args] -e -v 7600000000000001:30 -s index" 
+		" put \"1:5\" \"Department\" \"Testing\" \n" );
 }
 
 #undef M0_TRACE_SUBSYSTEM


### PR DESCRIPTION
Analysis:
Pool version info will be stored by the client(S3 server/m0kv/m0client)
if the M0_ENF_META flag is true. That support was not available
for m0kv.

Fix:
Added the "-e" flag to support M0_ENF_META. Pool version info
will be available on console when run "m0kv index create" operation.
m0kv needs to pass the pool version info as an argument for
PUT/GET/DEL/NEXT if the "-e" flag is added.

Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>

MO_ENF_META flag Ref:
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/297862297/md-path+optimization+by+avoiding+internal+dix+layout+lookups
