### PR TITLE
Revert "motr/client: fix some index ops api documentation"

### DIFF
--- a/motr/client.h
+++ b/motr/client.h
@@ -552,13 +552,13 @@ enum m0_idx_opcode {
 	M0_IC_GET = M0_OC_NR + 1,  /* 15 */
 	/** Insert or update the value, given a key. */
 	M0_IC_PUT,                 /* 16 */
-	/** Delete the record, if any, for the given key. */
+	/** Delete the value, if any, for the given key. */
 	M0_IC_DEL,                 /* 17 */
-	/** Given a key, return the next keys and their values. */
+	/** Given a key, return the next key and its value. */
 	M0_IC_NEXT,                /* 18 */
-	/** Check the given index for existence. */
+	/** Check an index for an existence. */
 	M0_IC_LOOKUP,              /* 19 */
-	/** Given a key, return the list of next keys. */
+	/** Given an index id, get the list of next indices. */
 	M0_IC_LIST,                /* 20 */
 	M0_IC_NR                   /* 21 */
 } M0_XCA_ENUM;


### PR DESCRIPTION
Reverts Seagate/cortx-motr#1593.
There was an open conversation ongoing when this was merged. Hence reverting.