### PR TITLE
layout-access-plan-ut: make it repeatable

### DIFF
--- a/layout/ut/plan.c
+++ b/layout/ut/plan.c
@@ -59,8 +59,11 @@ static struct m0_rpc_server_ctx lap_ut_sctx = {
 	.rsx_log_file_name = SERVER_LOGFILE,
 };
 
+static struct m0_rpc_server_ctx lap_ut_sctx0;
+
 static int lap_ut_server_start(void)
 {
+	lap_ut_sctx0 = lap_ut_sctx;
 	lap_ut_sctx.rsx_xprts    = m0_net_all_xprt_get();
 	lap_ut_sctx.rsx_xprts_nr = m0_net_xprt_nr();
 
@@ -70,6 +73,7 @@ static int lap_ut_server_start(void)
 static void lap_ut_server_stop(void)
 {
 	m0_rpc_server_stop(&lap_ut_sctx);
+	lap_ut_sctx = lap_ut_sctx0;
 }
 
 static struct m0_idx_dix_config dix_conf = {
@@ -119,6 +123,7 @@ static void lap_ut_client_stop(void)
 	m0_fi_enable("ha_process_event", "no-link");
 	m0_client_fini(client_inst, false);
 	m0_fi_disable("ha_process_event", "no-link");
+	client_inst = NULL;
 }
 
 static void test_plan_build_fini(void)


### PR DESCRIPTION
UT suites should be repeatable (see m0ut -n option). This means that
m0_ut_suite::ts_fini() should leave the system in the state that
m0_ut_suite::ts_init() expects.

layout-access-plan-ut initialisation changes some global variable and trips on
this on the next iteration:

```
layout-access-plan-ut [Andriy T.]
motr[2348461]:  c7d0  FATAL  [lib/assert.c:50:m0_panic]  panic: (({ unsigned __nr = (sizeof *(ha)); unsigned i; for (i = 0; i < __nr && ({ ((char *)ha)[i] == 0 ; }); ++i) ; i == __nr; })) at m0_ha_init() (ha/ha.c:647)  [git: 2.0.0-670-45-g87fc0d31-dirty] /var/motr/m0ut/m0trace.2348461
(gdb) bt
m0_arch_panic (c=0x7fffec337b40 <__pctx.15696>, ap=0x7ffffffec868) at lib/user_space/uassert.c:131
m0_panic (ctx=0x7fffec337b40 <__pctx.15696>) at lib/assert.c:52
m0_ha_init (ha=0x7fffedb1e000 <lap_ut_sctx+43168>, ha_cfg=0x7ffffffeca10) at ha/ha.c:647
motr_ha_level_enter (module=0x7fffedb1cec8 <lap_ut_sctx+38760>) at motr/ha.c:392
module_up (module=0x7fffedb1cec8 <lap_ut_sctx+38760>, level=2) at module/module.c:121
m0_module_init (module=0x7fffedb1cec8 <lap_ut_sctx+38760>, level=2) at module/module.c:137
m0_motr_ha_init (mha=0x7fffedb1ce98 <lap_ut_sctx+38712>, mha_cfg=0x7ffffffecc30) at motr/ha.c:528
cs_ha_init (cctx=0x7fffedb13788 <lap_ut_sctx+40>) at cortx-motr/motr/setup.c:605
cs_level_enter (module=0x7fffedb22220 <lap_ut_sctx+60096>) at cortx-motr/motr/setup.c:2569
module_up (module=0x7fffedb22220 <lap_ut_sctx+60096>, level=33) at module/module.c:121
m0_module_init (module=0x7fffedb22220 <lap_ut_sctx+60096>, level=33) at module/module.c:137
m0_cs_setup_env (cctx=0x7fffedb13788 <lap_ut_sctx+40>, argc=21, argv=0x7fffedb136a0 <lap_ut_server_args>) at cortx-motr/motr/setup.c:2981
m0_rpc_server_start (sctx=0x7fffedb13760 <lap_ut_sctx>) at rpc/rpclib.c:68
lap_ut_server_start () at layout/ut/plan.c:67
lap_ut_init () at layout/ut/plan.c:309
run_suite (suite=0x68eac0 <layout_access_plan_ut>, max_name_len=43) at ut/ut.c:448
tests_run_all (m=0x7ffff7dc02e0 <ut>) at ut/ut.c:513
m0_ut_run () at ut/ut.c:539
main (argc=3, argv=0x7ffffffed728) at ut/m0ut.c:533
```

Solution: reset everything to the original state.

Closes https://github.com/Seagate/cortx-motr/issues/1668.