### PR TITLE
parity-math-ut: fix repeated execution

### DIFF
--- a/sns/parity_math.c
+++ b/sns/parity_math.c
@@ -1401,7 +1401,7 @@ static int isal_gen_recov_coeff_tbl(uint32_t data_count, uint32_t parity_count,
 	/* Invert matrix to get recovery matrix. */
 	ret = gf_invert_matrix(temp_mat, invert_mat, data_count);
 	if (ret != 0) {
-		ret = M0_ERR_INFO(ret, "failed to construct an %u x %u "
+		ret = M0_ERR_INFO(-EDOM, "failed to construct an %u x %u "
 				  "inverse of the input matrix",
 				  data_count, data_count);
 		goto exit;

--- a/sns/ut/parity_math_ut.c
+++ b/sns/ut/parity_math_ut.c
@@ -56,12 +56,12 @@ static uint8_t expected[DATA_UNIT_COUNT_MAX][UNIT_BUFF_SIZE_MAX];
 static uint8_t data    [DATA_UNIT_COUNT_MAX][UNIT_BUFF_SIZE_MAX];
 static uint8_t parity  [DATA_UNIT_COUNT_MAX][UNIT_BUFF_SIZE_MAX];
 static uint8_t fail    [DATA_UNIT_COUNT_MAX+PARITY_UNIT_COUNT_MAX];
-static int32_t duc = DATA_UNIT_COUNT_MAX;
-static int32_t puc = PARITY_UNIT_COUNT_MAX;
-static int32_t fuc = PARITY_UNIT_COUNT_MAX;
-static uint32_t UNIT_BUFF_SIZE = 256;
+static int32_t duc;
+static int32_t puc;
+static int32_t fuc;
+static uint32_t UNIT_BUFF_SIZE;
 static int32_t fail_index_xor;
-static uint64_t seed = 42;
+static uint64_t seed;
 
 struct mat_collection {
 	struct m0_matrix mc_mat;
@@ -102,6 +102,7 @@ static void test_matrix_inverse(void);
 static void test_incr_recov_init(void);
 static void test_incr_recov(void);
 static void test_invalid_input(void);
+static void test_init(void);
 static int matrix_init(struct mat_collection*);
 static void mat_fill(struct m0_matrix *mat, int N, int K,
 		     enum ir_matrix_type mt);
@@ -365,6 +366,7 @@ static void test_recovery(const enum m0_parity_cal_algo algo,
 
 static void test_rs_fv_recover(void)
 {
+	test_init();
 	test_recovery(M0_PARITY_CAL_ALGO_REED_SOLOMON, FAIL_VECTOR);
 }
 
@@ -381,6 +383,7 @@ static void test_rs_fv_rand_recover(void)
 	struct m0_parity_math math;
 	int		      ret;
 
+	test_init();
 	duc = DATA_UNIT_COUNT_MAX;
 	puc = PARITY_UNIT_COUNT_MAX;
 	fuc = PARITY_UNIT_COUNT_MAX;
@@ -415,6 +418,7 @@ static void test_rs_fv_rand_recover(void)
 
 static void test_xor_fv_recover(void)
 {
+	test_init();
 	duc = DATA_UNIT_COUNT_MAX;
 	fail_index_xor = DATA_UNIT_COUNT_MAX + 1;
 	test_recovery(M0_PARITY_CAL_ALGO_XOR, FAIL_VECTOR);
@@ -422,6 +426,7 @@ static void test_xor_fv_recover(void)
 
 static void test_xor_fail_idx_recover(void)
 {
+	test_init();
 	duc = DATA_UNIT_COUNT_MAX;
 	fail_index_xor = DATA_UNIT_COUNT_MAX + 1;
 	test_recovery(M0_PARITY_CAL_ALGO_XOR, FAIL_INDEX);
@@ -436,6 +441,7 @@ static void test_buffer_xor(void)
 	struct m0_buf buf1;
 	struct m0_buf buf2;
 
+	test_init();
 	duc = 3;
 	fail_index_xor = 0;
 	generated = config_generate(&data_count, &parity_count, &buff_size,
@@ -535,12 +541,14 @@ static void test_parity_math_diff(uint32_t parity_cnt)
 
 static void test_parity_math_diff_xor(void)
 {
+	test_init();
 	test_parity_math_diff(PARITY_UNIT_COUNT);
 }
 
 static void test_parity_math_diff_rs(void)
 {
 	uint32_t i;
+	test_init();
 	for (i = 2; i <= RS_MAX_PARITY_UNIT_COUNT; ++i) {
 		test_parity_math_diff(i);
 	}
@@ -548,6 +556,7 @@ static void test_parity_math_diff_rs(void)
 
 static void test_incr_recov_rs(void)
 {
+	test_init();
 	test_matrix_inverse();
 	test_incr_recov_init();
 	test_incr_recov();
@@ -1400,6 +1409,20 @@ static bool bufvec_eq(struct m0_bufvec *bvec_1, struct m0_bufvec *bvec_2)
 static inline uint32_t block_nr(const struct m0_sns_ir *ir)
 {
 	return ir->si_data_nr + ir->si_parity_nr;
+}
+
+static void test_init(void)
+{
+	M0_SET_ARR0(expected);
+	M0_SET_ARR0(data);
+	M0_SET_ARR0(parity);
+	M0_SET_ARR0(fail);
+	duc = DATA_UNIT_COUNT_MAX;
+	puc = PARITY_UNIT_COUNT_MAX;
+	fuc = PARITY_UNIT_COUNT_MAX;
+	UNIT_BUFF_SIZE = 256;
+	fail_index_xor = 0;
+	seed = 42;
 }
 
 #define _TESTS									\


### PR DESCRIPTION
Unit tests must be ready for repeated execution (see m0ut -n option). Reset
static variables in parity math UT. This fixes sporadic UT failures, see
https://github.com/Seagate/cortx-motr/issues/1661.

Also, gf_invert_matrix() does not return error code, it returns -1. Use EDOM
instead.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
