### PR TITLE
CORTX-30965 Add NODTM per-operation flag to MOTR client interface

### DIFF
--- a/cas/cas.h
+++ b/cas/cas.h
@@ -338,6 +338,10 @@ enum m0_cas_op_flags {
 	 * In other words, it might be used in degraded mode.
 	 */
 	COF_SHOW_DEAD = 1 << 10,
+	/**
+	 * NO DTM is needed for this operation.
+	 */
+	COF_NO_DTM = 1 << 11,
 };
 
 enum m0_cas_opcode {

--- a/cas/client.c
+++ b/cas/client.c
@@ -1673,7 +1673,7 @@ M0_INTERNAL int m0_cas_put(struct m0_cas_req      *req,
  	 */
 	M0_PRE((flags &
 		~(COF_CREATE | COF_OVERWRITE | COF_CROW | COF_SYNC_WAIT | 
-		  COF_SKIP_LAYOUT | COF_VERSIONED)) == 0);
+		  COF_SKIP_LAYOUT | COF_VERSIONED | COF_NO_DTM)) == 0);
 	M0_PRE(m0_cas_id_invariant(index));
 
 	rc = cas_req_prep(req, index, keys, values, keys->ov_vec.v_nr, flags,

--- a/cas/service.c
+++ b/cas/service.c
@@ -1179,7 +1179,7 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	struct m0_cas_ctg  *ctidx   = m0_ctg_ctidx();
 	struct m0_cas_rec  *rec     = NULL;
 	bool                is_dtm0_used = ENABLE_DTM0 &&
-		!m0_dtm0_tx_desc_is_none(&op->cg_txd);
+					   !m0_dtm0_tx_desc_is_none(&op->cg_txd);
 	bool                is_index_drop;
 	bool                do_ctidx;
 	int                 next_phase;
@@ -1190,6 +1190,12 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	M0_PRE(ctidx != NULL);
 	M0_PRE(cas_fom_invariant(fom));
 	M0_PRE(ergo(is_dtm0_used, m0_dtm0_tx_desc__invariant(&op->cg_txd)));
+	/*
+	 * If COF_NO_DTM is set, no DTM is needed for this operation.
+	 * CAS service may take more special actions based on this flag.
+	 */
+	M0_PRE(ergo(op->cg_flags & COF_NO_DTM,
+		    m0_dtm0_tx_desc_is_none(&op->cg_txd)));
 
 	if (!M0_IS0(&op->cg_txd) && phase == M0_FOPH_INIT)
 		M0_LOG(M0_DEBUG, "Got CAS with txid: " DTID0_F,

--- a/dix/req.c
+++ b/dix/req.c
@@ -2334,9 +2334,11 @@ M0_INTERNAL int m0_dix_put(struct m0_dix_req      *req,
 
 	M0_PRE(keys->ov_vec.v_nr == vals->ov_vec.v_nr);
 	M0_PRE(keys_nr != 0);
-	/* Only overwrite, crow, sync_wait and skip_layout flags are allowed. */
+	/*
+	 * Only the following flags are allowed.
+	 */
 	M0_PRE((flags & ~(COF_OVERWRITE | COF_CROW | COF_SYNC_WAIT |
-	       COF_SKIP_LAYOUT)) == 0);
+	       COF_SKIP_LAYOUT | COF_NO_DTM)) == 0);
 	rc = dix_req_indices_copy(req, index, 1);
 	if (rc != 0)
 		return M0_ERR(rc);

--- a/motr/idx.c
+++ b/motr/idx.c
@@ -215,7 +215,8 @@ static int idx_op_init(struct m0_idx *idx, int opcode,
 	m0_op_idx_bob_init(oi);
 	m0_ast_rc_bob_init(&oi->oi_ar);
 
-	if (ENABLE_DTM0 && M0_IN(op->op_code, (M0_IC_PUT, M0_IC_DEL))) {
+	if (ENABLE_DTM0 && !(flags & M0_OIF_NO_DTM) &&
+	    M0_IN(op->op_code, (M0_IC_PUT, M0_IC_DEL))) {
 		M0_ASSERT(m0c->m0c_dtms != NULL);
 		oi->oi_dtx = m0_dtx0_alloc(m0c->m0c_dtms, oi->oi_sm_grp);
 		if (oi->oi_dtx == NULL)

--- a/motr/idx.h
+++ b/motr/idx.h
@@ -99,7 +99,13 @@ enum m0_op_idx_flags {
 	 * For M0_EO_CREATE/M0_EO_DELETE operations, instructs to create
 	 * btree on write during PUT operation.
 	 */
-        M0_OIF_CROW = 1 << 4
+        M0_OIF_CROW = 1 << 4,
+	/**
+	 * No DTM for this operation. This flag is set by the motr user (e.g.,
+	 * s3 server), passed through layers of motr client stack and is sent to
+	 * the server.
+	 */
+	M0_OIF_NO_DTM = 1 << 5
 };
 
 /**

--- a/motr/idx_dix.c
+++ b/motr/idx_dix.c
@@ -456,10 +456,17 @@ static void cas_put_ast(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 
 	M0_ENTRY();
 	cas_req_prepare(dix_req, &idx, oi);
+	/*
+	 * FIXME: why don't we call `flags = dix_set_cas_flags(oi);`
+	 * instead of the following code?
+	 */
 	if (oi->oi_flags & M0_OIF_OVERWRITE)
 		flags |= COF_OVERWRITE;
 	if (oi->oi_flags & M0_OIF_SYNC_WAIT)
 		flags |= COF_SYNC_WAIT;
+	if (oi->oi_flags & M0_OIF_NO_DTM)
+		flags |= COF_NO_DTM;
+
 	rc = m0_cas_put(creq, &idx, oi->oi_keys, oi->oi_vals, NULL, flags);
 	if (rc != 0)
 		dix_req_immed_failure(dix_req, M0_ERR(rc));
@@ -1013,6 +1020,8 @@ static uint32_t dix_set_cas_flags(struct m0_op_idx *oi)
 		flags |= COF_CROW;
 	if (oi->oi_flags & M0_OIF_SKIP_LAYOUT)
 		flags |= COF_SKIP_LAYOUT;
+	if (oi->oi_flags & M0_OIF_NO_DTM)
+		flags |= COF_NO_DTM;
 	return flags;
 } 
 

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -446,7 +446,8 @@ static uint64_t dix_val(uint64_t i)
 	return 100 + i * i;
 }
 
-static void ut_dix_record_ops(bool dist, uint32_t flags)
+static void ut_dix_record_ops(bool dist, uint32_t cr_get_flags,
+			      uint32_t put_del_flags)
 {
 	struct m0_container  realm;
 	struct m0_idx        idx;
@@ -468,7 +469,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	general_ifid_fill(&ifid, dist);
 	m0_container_init(&realm, NULL, &M0_UBER_REALM, ut_m0c);
 	m0_idx_init(&idx, &realm.co_realm, (struct m0_uint128 *)&ifid);
-	if (flags & M0_OIF_SKIP_LAYOUT)
+	if (cr_get_flags & M0_OIF_SKIP_LAYOUT)
 		idx.in_entity.en_flags |= M0_ENF_META;
 
 	/* Create index. */
@@ -476,7 +477,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	M0_UT_ASSERT(rc == 0);
 	oc = M0_AMB(oc, op, oc_op);
 	oi = M0_AMB(oi, oc, oi_oc);
-	oi->oi_flags = flags;
+	oi->oi_flags = cr_get_flags;
 	m0_op_launch(&op, 1);
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
 	M0_UT_ASSERT(rc == 0);
@@ -489,8 +490,8 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	     m0_bufvec_empty_alloc(&vals, 1);
 	M0_UT_ASSERT(rc == 0);
 	*(uint64_t*)keys.ov_buf[0] = dix_key(10);
-	rc = m0_idx_op(&idx, M0_IC_GET, &keys, &vals, rcs, flags,
-			      &op);
+	rc = m0_idx_op(&idx, M0_IC_GET, &keys, &vals, rcs, cr_get_flags,
+			     &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
@@ -514,7 +515,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 		*(uint64_t *)keys.ov_buf[i] = dix_key(i);
 		*(uint64_t *)vals.ov_buf[i] = dix_val(i);
 	}
-	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs, 0,
+	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs, put_del_flags,
 		       &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
@@ -529,7 +530,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 
 	/* Try to add recs again without OVERWRITE flag. */
 	rcs = rcs_alloc(CNT);
-	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs, 0,
+	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs, put_del_flags,
 			      &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
@@ -546,7 +547,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 		*(uint64_t *)vals.ov_buf[i] = dix_val(i * 10);
 
 	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs,
-		       M0_OIF_OVERWRITE, &op);
+		       M0_OIF_OVERWRITE | put_del_flags, &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
@@ -677,7 +678,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	}
 
 	rc = m0_idx_op(&idx, M0_IC_PUT, &keys, &vals, rcs,
-		       M0_OIF_OVERWRITE, &op);
+		       M0_OIF_OVERWRITE | put_del_flags, &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
@@ -751,7 +752,7 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 	M0_UT_ASSERT(rc == 0);
 	for (i = 0; i < keys.ov_vec.v_nr; i++)
 		*(uint64_t *)keys.ov_buf[i] = dix_key(i);
-	rc = m0_idx_op(&idx, M0_IC_DEL, &keys, NULL, rcs, 0, &op);
+	rc = m0_idx_op(&idx, M0_IC_DEL, &keys, NULL, rcs, put_del_flags, &op);
 	M0_UT_ASSERT(rc == 0);
 	m0_op_launch(&op, 1);
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
@@ -777,25 +778,36 @@ static void ut_dix_record_ops(bool dist, uint32_t flags)
 
 static void ut_dix_record_ops_dist_skip_layout(void)
 {
-	uint32_t flags = M0_OIF_SKIP_LAYOUT;
-	ut_dix_record_ops(true, flags);
+	uint32_t cr_get_flags = M0_OIF_SKIP_LAYOUT;
+	ut_dix_record_ops(true, cr_get_flags, 0);
 }
 
 static void ut_dix_record_ops_dist_skip_layout_enable_crow(void)
 {
-	uint32_t flags = M0_OIF_SKIP_LAYOUT | M0_OIF_CROW;
-	ut_dix_record_ops(true, flags);
+	uint32_t cr_get_flags = M0_OIF_SKIP_LAYOUT | M0_OIF_CROW;
+	ut_dix_record_ops(true, cr_get_flags, 0);
 }
 
 static void ut_dix_record_ops_dist(void)
 {
-	ut_dix_record_ops(true, 0);
+	ut_dix_record_ops(true, 0, 0);
 }
 
 static void ut_dix_record_ops_non_dist(void)
 {
-	ut_dix_record_ops(false, 0);
+	ut_dix_record_ops(false, 0, 0);
 }
+
+static void ut_dix_record_ops_dist_no_dtm(void)
+{
+	ut_dix_record_ops(true, 0, M0_OIF_NO_DTM);
+}
+
+static void ut_dix_record_ops_non_dist_no_dtm(void)
+{
+	ut_dix_record_ops(false, 0, M0_OIF_NO_DTM);
+}
+
 
 struct m0_ut_suite ut_suite_idx_dix = {
 	.ts_name   = "idx-dix",
@@ -824,6 +836,10 @@ struct m0_ut_suite ut_suite_idx_dix = {
 		{ "record-ops-dist-skip-layout-enable-crow",
 		  ut_dix_record_ops_dist_skip_layout_enable_crow,
 		  "Venky" },
+		{ "record-ops-dist-no-dtm",
+		   ut_dix_record_ops_dist_no_dtm,     "Huang Hua" },
+		{ "record-ops-non-dist-no-dtm",
+		   ut_dix_record_ops_non_dist_no_dtm, "Huang Hua" },
 		{ NULL, NULL }
 	}
 };


### PR DESCRIPTION
Adding a flag disabling use of dtm for a particular operation.
This flag is set by the motr user (e.g., s3 server), passed through
layers of motr client stack and is sent to the server.

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
