### PR TITLE
Add CAS FOM state name in m0trace

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -1184,7 +1184,9 @@ static int cas_fom_tick(struct m0_fom *fom0)
 	bool                do_ctidx;
 	int                 next_phase;
 
-	M0_ENTRY("fom %p phase %d op_flag=0x%x", fom, phase, op->cg_flags);
+	M0_ENTRY("fom %p phase %d (%s) op_flag=0x%x", fom, phase,
+		 m0_fom_phase_name(fom0, phase), op->cg_flags);
+
 	M0_PRE(ctidx != NULL);
 	M0_PRE(cas_fom_invariant(fom));
 	M0_PRE(ergo(is_dtm0_used, m0_dtm0_tx_desc__invariant(&op->cg_txd)));


### PR DESCRIPTION
cas_fom_tick ENTRY record in m0trace includes numerical state ID. This commit adds state name as text to that m0trace record.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- cas_fom_tick ENTRY record in m0trace includes numerical state ID.  It is inconvenient to debug, as there is no easy way to convert number state name.

# Design
-  There's a function already implemented which can convert state ID to its name -- `m0_fom_phase_name`.  I'm using it in M0_ENTRY to produce state name.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
