### PR TITLE
Fix crash of all ios processes in some write scenarios

### DIFF
--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -1705,6 +1705,7 @@ static int ioreq_dgmode_read(struct m0_op_io *ioo, bool rmw)
 	rc = xfer->nxr_ops->nxo_dispatch(xfer);
 	if (rc != 0)
 		return M0_ERR(rc);
+
 	ioo->ioo_dgmode_io_sent = true;
 
 	return M0_RC(rc);
@@ -1733,7 +1734,7 @@ static int ioreq_dgmode_write(struct m0_op_io *ioo, bool rmw)
 	if (ioo->ioo_dgmode_io_sent)
 		return M0_RC(xfer->nxr_rc);
 
-	/* -E2BIG: see commit 52c1072141d*/
+	/* -E2BIG: see commit 52c1072141d */
 	if (M0_IN(xfer->nxr_rc, (0, -E2BIG)))
 		return M0_RC(xfer->nxr_rc);
 

--- a/motr/st/utils/motr_utils_st.sh
+++ b/motr/st/utils/motr_utils_st.sh
@@ -170,6 +170,33 @@ EOF
 	echo "motr r/w test with m0cp and m0cat is successful"
 	rm -f $dest_file
 
+	echo "motr r/w test with update of m0cp and m0cat"
+	$motr_st_util_dir/m0cp $MOTR_PARAMS_V -o $object_id1 $src_file \
+				-s $block_size -c $block_count -L 1 \
+				-b $blks_per_io || {
+		error_handling $? "Failed to copy object"
+	}
+	$motr_st_util_dir/m0cp $MOTR_PARAMS_V -o $object_id1 $src_file \
+				-s $block_size -c $block_count -L 1 \
+				-b $blks_per_io -u || {
+		error_handling $? "Failed to copy object"
+	}
+	$motr_st_util_dir/m0cat $MOTR_PARAMS_V -o $object_id1 \
+				-s $block_size -c $block_count -L 1 \
+				-b $blks_per_io $dest_file || {
+		error_handling $? "Failed to read object"
+	}
+	$motr_st_util_dir/m0unlink $MOTR_PARAMS -o $object_id1 || {
+		error_handling $? "Failed to delete object"
+	}
+	diff $src_file $dest_file || {
+		rc=$?
+		error_handling $rc "Files are different"
+	}
+
+       echo "motr r/w test with update of m0cp and m0cat is successful"
+       rm -f $dest_file
+
 	# Test m0cp_mt
 	echo "m0cp_mt test"
 	$motr_st_util_dir/m0cp_mt $MOTR_PARAMS_V -o $object_id4 \

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1175,24 +1175,11 @@ static void stob_ad_write_credit(const struct m0_stob_domain *dom,
 	 */
 	m0_be_emap_credit(&adom->sad_adata, M0_BEO_PASTE, frags + 1, accum);
 
-	/*
-	 * Commenting out below part of code with #if 0, earlier it was based
-	 * on assumption that that adom->sad_overwrite will be always false,
-	 * Now we have set it to True by default to fix EOS-25302 hence
-	 * disabling it with "#if 0"
-	 * TODO: Probably sad_overwrite is introduced for COW(Copy on Write) and
-	 * for Object versioning in Motr, which is not implemented yet. Need to
-	 * revisit this part while implementing COW and object versioning.
-	 * We do not know whether bo_free_credit should be commented out or not,
-	 * but this is done to maintain existing behavior as the code was
-	 * anyway redundant earlier.
-	 */
-#if 0
 	if (adom->sad_overwrite && ballroom->ab_ops->bo_free_credit != NULL) {
 		/* for each emap_paste() seg_free() could be called 3 times */
 		ballroom->ab_ops->bo_free_credit(ballroom, 3 * frags, accum);
 	}
-#endif
+
 	m0_stob_io_credit(io, m0_stob_dom_get(adom->sad_bstore), accum);
 }
 


### PR DESCRIPTION
Panic: `((cr->tc_balance[cu]) != 0) at btree_save() (be/btree.c:1393)`

Stack is the same in all processes core files:

    #3  0x00007f9454ccbe37 in m0_panic (ctx=ctx@entry=0x7f94550e15a0 <__pctx.8664>) at lib/assert.c:52
    #4  0x00007f9454c0747c in btree_save (tree=tree@entry=0x40000010ed80, tx=tx@entry=0x7f94200a7f90, op=op@entry=0x7f944ca77ec0,
        val=val@entry=0x7f944ca77e70, anchor=0x0, optype=BTREE_SAVE_UPDATE, zonemask=2, key=<optimized out>, key=<optimized out>)
        at be/btree.c:339
    #5  0x00007f9454c086f7 in m0_be_btree_update (tree=tree@entry=0x40000010ed80, tx=tx@entry=0x7f94200a7f90,
        op=op@entry=0x7f944ca77ec0, key=key@entry=0x7f944ca77e60, val=val@entry=0x7f944ca77e70) at be/btree.c:1952
    #6  0x00007f9454bfd62b in btree_update_sync (val=0x7f944ca77e70, key=0x7f944ca77e60, tx=0x7f94200a7f90, tree=0x40000010ed80)
        at balloc/balloc.c:95
    #7  balloc_gi_sync (cb=cb@entry=0x40000010eb40, tx=tx@entry=0x7f94200a7f90, gi=gi@entry=0x13ff860) at balloc/balloc.c:928
    #8  0x00007f9454bfe36e in balloc_free_db_update (motr=motr@entry=0x40000010eb40, tx=tx@entry=0x7f94200a7f90,
        grp=grp@entry=0x13ff860, tgt=tgt@entry=0x7f944ca78470, alloc_flag=<optimized out>) at balloc/balloc.c:1934
    #9  0x00007f9454bff9c6 in balloc_free_internal (req=<synthetic pointer>, req=<synthetic pointer>, tx=0x7f94200a7f90,
        ctx=0x40000010eb40) at balloc/balloc.c:2716
    #10 balloc_free (ballroom=0x40000010ec68, tx=0x7f94200a7f88, ext=0x7f944ca78560) at balloc/balloc.c:2929
    #11 0x00007f9454d97681 in stob_ad_bfree (adom=<optimized out>, adom=<optimized out>, ext=0x7f944ca78530, ext=0x7f944ca78530,
        tx=0x7f94200a7f88) at stob/ad.c:1098
    #12 stob_ad_seg_free (tx=0x7f94200a7f88, adom=<optimized out>, ext=ext@entry=0x7f944ca79160, val=1594, seg=<optimized out>)
        at stob/ad.c:1647
    #13 0x00007f9454d9783d in __lambda (seg=0x7f944ca79150) at stob/ad.c:1719
    #14 0x00007f9454c10802 in m0_be_emap_paste (it=it@entry=0x7f944ca79140, tx=0x7f94200a7f90, ext=ext@entry=0x7f944ca78a90,
        val=1794, del=del@entry=0x7f944ca78b1c, cut_left=cut_left@entry=0x7f944ca78b38, cut_right=0x7f944ca78b54)
        at be/extmap.c:628
    #15 0x00007f9454d9a546 in stob_ad_write_map_ext (orig=<optimized out>, off=464, adom=0x4000001120d8) at stob/ad.c:1731
    #16 stob_ad_write_map (map=0x7f944ca78900, frags=18, wc=0x7f944ca78920, dst=0x7f944ca789b0, adom=0x4000001120d8,
        io=0x7f94340b4298) at stob/ad.c:1858
    #17 stob_ad_write_prepare (map=0x7f944ca78900, src=0x7f944ca78970, adom=0x4000001120d8, io=<optimized out>) at stob/ad.c:2006
    #18 stob_ad_io_launch_prepare (io=<optimized out>) at stob/ad.c:2052
    #19 0x00007f9454d9ca47 in m0_stob_io_prepare (io=io@entry=0x7f94340b4298, obj=obj@entry=0x7f94341170a0,
        tx=tx@entry=0x7f94200a7f88, scope=scope@entry=0x0) at stob/io.c:178
    #20 0x00007f9454d9ce92 in m0_stob_io_prepare_and_launch (io=io@entry=0x7f94340b4298, obj=0x7f94341170a0,
        tx=tx@entry=0x7f94200a7f88, scope=scope@entry=0x0) at stob/io.c:226
    #21 0x00007f9454cb702c in io_launch (fom=0x7f94200a7ec0) at ioservice/io_foms.c:1837
    #22 0x00007f9454cb47a0 in m0_io_fom_cob_rw_tick (fom=0x7f94200a7ec0) at ioservice/io_foms.c:2333
    #23 0x00007f9454c9edf1 in fom_exec (fom=0x7f94200a7ec0) at fop/fom.c:791
    #24 loc_handler_thread (th=0x11ed150) at fop/fom.c:931

Setup: 1 node, 10 disks data pool with 4+2+0 EC.
Scenario: write the same object twice like this:
```
$ m0cp <motr-conn-params> -s 1m -c 40 -L 4 /dev/zero -o 0x12345678:0x678900207
$ m0cp <motr-conn-params> -s 1m -c 40 -L 4 /dev/zero -o 0x12345678:0x678900207 -u
```

RCA: the regression of BE credit calculation in `stob_ad_write_credit()` code was introduced at commit ab22d23fbc.

Solution: rollback the regression change.

Closes https://github.com/Seagate/cortx-motr/issues/1678.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
