### PR TITLE
snscm_net-ut, snscm_xform-ut: use local m0_motr instance

### DIFF
--- a/sns/cm/repair/ut/net.c
+++ b/sns/cm/repair/ut/net.c
@@ -544,20 +544,23 @@ static void cm_ready(struct m0_cm *cm)
 	m0_cm_unlock(cm);
 }
 
+static struct m0_motr sctx_net;
+
 static void receiver_init(void)
 {
 	int rc;
 
 	M0_SET0(&rag);
 	M0_SET0(&fctx);
+	M0_SET0(&sctx_net);
 
 	rc = m0_cm_type_register(&sender_cm_cmt);
 	M0_UT_ASSERT(rc == 0);
 
-	rc = cs_init(&sctx);
+	rc = cs_init(&sctx_net);
 	M0_UT_ASSERT(rc == 0);
 
-	s0_reqh = m0_cs_reqh_get(&sctx);
+	s0_reqh = m0_cs_reqh_get(&sctx_net);
 	scm_service = m0_reqh_service_find(
 		m0_reqh_service_type_find("M0_CST_SNS_REP"), s0_reqh);
 	M0_UT_ASSERT(scm_service != NULL);
@@ -838,7 +841,7 @@ static void receiver_fini()
 	m0_ios_cdom_get(s0_reqh, &cdom);
 	cob_delete(cdom, s0_reqh->rh_beseg->bs_domain, 0, &gob_fid);
 	m0_free(r_rag.rag_fc);
-	cs_fini(&sctx);
+	cs_fini(&sctx_net);
 	m0_cm_type_deregister(&sender_cm_cmt);
 }
 

--- a/sns/cm/repair/ut/xform.c
+++ b/sns/cm/repair/ut/xform.c
@@ -640,6 +640,8 @@ static void test_multi_cp_multi_failures(void)
 	m0_fi_disable("m0_sns_cm_tgt_ep", "local-ep");
 }
 
+static struct m0_motr sctxx;
+
 /*
  * Initialises the request handler since copy packet fom has to be tested using
  * request handler infrastructure.
@@ -650,6 +652,7 @@ static int xform_init(void)
 
 	M0_SET0(&gob_fid);
 	M0_SET0(&cob_fid);
+	M0_SET0(&sctxx);
 
 	reqh = NULL;
 	pdlay = NULL;
@@ -692,13 +695,13 @@ static int xform_init(void)
 	M0_SET_ARR0(n_buf);
 	M0_SET_ARR0(n_acc_buf);
 
-	rc = cs_init(&sctx);
+	rc = cs_init(&sctxx);
 	M0_ASSERT(rc == 0);
 
 	m0_fid_gob_make(&gob_fid, 0, 4);
 	m0_fid_convert_gob2cob(&gob_fid, &cob_fid, 1);
 
-	reqh = m0_cs_reqh_get(&sctx);
+	reqh = m0_cs_reqh_get(&sctxx);
 	layout_gen(&pdlay, reqh);
 	tgt_fid_cob_create(reqh);
 
@@ -736,7 +739,7 @@ static int xform_fini(void)
 	m0_ios_cdom_get(reqh, &cdom);
 	cob_delete(cdom, reqh->rh_beseg->bs_domain, 0, &gob_fid);
 	layout_destroy(pdlay);
-        cs_fini(&sctx);
+        cs_fini(&sctxx);
         return 0;
 }
 


### PR DESCRIPTION
To prevent randomised UT-s from stepping on each other, use a separate m0_motr
for snscm_net-ut and snscm_xform-ut (sns/cm/repair/ut/{xform,net}.c).

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
