### PR TITLE
detour_create(): fix unreliable UT.

### DIFF
--- a/fdmi/ut/pd_ut.c
+++ b/fdmi/ut/pd_ut.c
@@ -142,11 +142,15 @@ int detour_create(struct m0_fop *fop, struct m0_fom **out, struct m0_reqh *reqh)
 
 	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 2, 1);
 	rc = (*native_create)(fop, out, reqh);
-	M0_UT_ASSERT(rc == -ENOENT);
+	/*
+	 * Cannot be precise, because of concurrent allocations in other
+	 * threads.
+	 */
+	M0_UT_ASSERT(M0_IN(rc, (-ENOENT, -ENOMEM)));
 
 	m0_fi_enable_off_n_on_m("m0_alloc", "fail_allocation", 3, 1);
 	rc = (*native_create)(fop, out, reqh);
-	M0_UT_ASSERT(rc == -ENOMEM);
+	M0_UT_ASSERT(M0_IN(rc, (-ENOENT, -ENOMEM)));
 
 	m0_fi_disable("m0_alloc", "fail_allocation");
 


### PR DESCRIPTION
Memory allocations happen asynchronously with the
test (from other threads), so fault-point activation
is not deterministic.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
