### PR TITLE
Reduce compilation time by re-arranging xcode definitions

### DIFF
--- a/be/tx.h
+++ b/be/tx.h
@@ -424,14 +424,6 @@ struct m0_be_tx {
 	struct m0_sm_ast       t_fdmi_put_ast;
 };
 
-/**
- * Transaction identifier for remote nodes.
- */
-struct m0_be_tx_remid {
-	uint64_t tri_txid;
-	uint64_t tri_locality;
-} M0_XCA_RECORD M0_XCA_DOMAIN(be|rpc);
-
 #if M0_DEBUG_BE_CREDITS == 1
 
 /**

--- a/cas/cas.c
+++ b/cas/cas.c
@@ -26,6 +26,7 @@
 #include "lib/finject.h"     /* M0_FI_ENABLED */
 #include "fid/fid.h"         /* m0_fid_type_register */
 #include "fop/fop.h"
+#include "fop/wire_xc.h"
 #include "rpc/rpc_opcodes.h"
 #include "cas/cas.h"
 #include "cas/cas_xc.h"

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -36,7 +36,7 @@
 #include "rpc/at.h"             /* m0_rpc_at_buf */
 #include "rpc/at_xc.h"          /* m0_rpc_at_buf_xc */
 #include "fop/fom_generic.h"    /* m0_fop_mod_rep */
-#include "fop/fom_generic_xc.h" /* m0_fop_mod_rep */
+#include "fop/wire_xc.h"        /* m0_fop_mod_rep */
 #include "fop/fom_interpose.h"  /* m0_fom_thralldom */
 #include "dix/layout.h"
 #include "dix/layout_xc.h"

--- a/debian/cortx-motr-dev.install
+++ b/debian/cortx-motr-dev.install
@@ -237,13 +237,11 @@ usr/include/motr/fol/fol_private.h
 usr/include/motr/fol/fol_xc.h
 usr/include/motr/fop/fom.h
 usr/include/motr/fop/fom_generic.h
-usr/include/motr/fop/fom_generic_xc.h
 usr/include/motr/fop/fom_interpose.h
 usr/include/motr/fop/fom_long_lock.h
 usr/include/motr/fop/fom_simple.h
 usr/include/motr/fop/fop.h
 usr/include/motr/fop/fop_item_type.h
-usr/include/motr/fop/fop_xc.h
 usr/include/motr/fop/ut/iterator_test_xc.h
 usr/include/motr/format/format.h
 usr/include/motr/format/format_xc.h

--- a/fol/fol.c
+++ b/fol/fol.c
@@ -31,7 +31,7 @@
 #include "fol/fol_private.h"
 #include "fol/fol_xc.h"       /* m0_xc_fol_init */
 #include "fop/fop.h"          /* m0_fop_fol_frag_type */
-#include "fop/fop_xc.h"       /* m0_fop_fol_frag_xc */
+#include "fop/wire_xc.h"      /* m0_fop_fol_frag_xc */
 
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_FOL
 #include "lib/trace.h"

--- a/fop/Kbuild.sub
+++ b/fop/Kbuild.sub
@@ -1,9 +1,7 @@
 m0tr_objects += fop/fop.o \
                   fop/fop_item_type.o \
-                  fop/fop_xc.o \
                   fop/fom.o \
                   fop/fom_generic.o \
                   fop/fom_simple.o \
-                  fop/fom_generic_xc.o \
                   fop/fom_long_lock.o \
                   fop/fom_interpose.o

--- a/fop/Makefile.sub
+++ b/fop/Makefile.sub
@@ -4,7 +4,8 @@ nobase_motr_include_HEADERS += fop/fop.h \
                                fop/fom_generic.h \
                                fop/fom_long_lock.h \
                                fop/fom_simple.h \
-                               fop/fom_interpose.h
+                               fop/fom_interpose.h \
+                               fop/wire.h
 
 motr_libmotr_la_SOURCES  += fop/fop.c \
                             fop/fom.c \
@@ -15,7 +16,6 @@ motr_libmotr_la_SOURCES  += fop/fop.c \
                             fop/fom_interpose.c
 
 nodist_motr_libmotr_la_SOURCES  += \
-                            fop/fop_xc.c \
-                            fop/fom_generic_xc.c
+                            fop/wire_xc.c
 
-XC_FILES   += fop/fom_generic_xc.h fop/fop_xc.h
+XC_FILES   += fop/wire_xc.h

--- a/fop/fom_generic.c
+++ b/fop/fom_generic.c
@@ -37,7 +37,7 @@
 #include "rpc/item_internal.h"  /* m0_rpc_item_is_update */
 #include "reqh/reqh.h"
 #include "fop/fom_generic.h"
-#include "fop/fom_generic_xc.h"
+#include "fop/wire_xc.h"
 #include "addb2/addb2.h"
 #include "addb2/identifier.h"
 #include "dtm0/service.h"	/* m0_dtm0_is_a_volatile_dtm */

--- a/fop/fom_generic.h
+++ b/fop/fom_generic.h
@@ -26,8 +26,8 @@
 #define __MOTR_FOP_FOM_GENERIC_H__
 
 #include "fop/fom.h"
+#include "fop/wire.h"
 #include "lib/types.h"
-#include "xcode/xcode_attr.h"
 #include "lib/string.h"
 #include "lib/string_xc.h"
 #include "be/tx.h"
@@ -219,29 +219,9 @@ extern struct m0_sm_trans_descr
 m0_generic_phases_trans[M0_FOM_GENERIC_TRANS_NR];
 extern const struct m0_sm_conf m0_generic_conf;
 
-/**
-   Generic reply.
-
-   RPC operations that return nothing but error code to sender can use
-   this generic reply fop. Request handler uses this type of fop to
-   report operation failure in generic fom phases.
- */
-struct m0_fop_generic_reply {
-	int32_t           gr_rc;
-	struct m0_fop_str gr_msg;
-} M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
-
 extern struct m0_fop_type m0_fop_generic_reply_fopt;
 
 bool m0_rpc_item_is_generic_reply_fop(const struct m0_rpc_item *item);
-
-/**
- * m0_fop_mod_rep contains common reply values for an UPDATE fop.
- */
-struct m0_fop_mod_rep {
-	/** Remote ID assigned to this UPDATE operation */
-	struct m0_be_tx_remid fmr_remid;
-} M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 M0_INTERNAL void m0_fom_mod_rep_fill(struct m0_fop_mod_rep *rep,
 				     struct m0_fom *fom);

--- a/fop/fop.c
+++ b/fop/fop.c
@@ -30,11 +30,10 @@
 #include "rpc/rpc_machine.h"     /* m0_rpc_machine, m0_rpc_machine_lock */
 #include "rpc/addb2.h"
 #include "fop/fop.h"
-#include "fop/fop_xc.h"
 #include "fop/fom.h"
 #include "fop/fom_generic.h"
-#include "fop/fom_generic_xc.h"
 #include "fop/fom_long_lock.h"   /* m0_fom_ll_global_init */
+#include "fop/wire_xc.h"
 #include "addb2/identifier.h"
 #include "reqh/reqh.h"
 

--- a/fop/fop.h
+++ b/fop/fop.h
@@ -31,6 +31,7 @@
 #include "lib/errno.h"
 #include "fol/fol.h"
 #include "fop/fom.h"
+#include "fop/wire.h"
 #include "rpc/item.h"
 #include "net/net_otw_types.h"
 
@@ -345,18 +346,6 @@ M0_INTERNAL int m0_fop_xc_type(const struct m0_xcode_obj   *par,
 
 M0_INTERNAL int m0_fop_rep_xc_type(const struct m0_xcode_obj   *par,
 				   const struct m0_xcode_type **out);
-
-/**
- * fol record fragment for a fop.
- */
-struct m0_fop_fol_frag {
-	/** m0_fop_type::ft_rpc_item_type::rit_opcode of fop. */
-	uint32_t  ffrp_fop_code;
-	/** m0_fop_type::ft_rpc_item_type::rit_opcode of fop. */
-	uint32_t  ffrp_rep_code;
-	void	 *ffrp_fop M0_XCA_OPAQUE("m0_fop_xc_type");
-	void	 *ffrp_rep M0_XCA_OPAQUE("m0_fop_rep_xc_type");
-} M0_XCA_RECORD;
 
 /**
  * Adds fol record fragment for this fop (m0_fop_fol_frag)

--- a/fop/wire.h
+++ b/fop/wire.h
@@ -1,0 +1,94 @@
+/* -*- C -*- */
+/*
+ * Copyright (c) 2012-2022 Seagate Technology LLC and/or its Affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ *
+ */
+
+
+#pragma once
+
+#ifndef __MOTR_FOP_WIRE_H__
+#define __MOTR_FOP_WIRE_H__
+
+#include "lib/types.h"
+#include "xcode/xcode_attr.h"
+
+/**
+   @defgroup fop File operation packet
+
+   On-wire structures for fops.
+   @{
+*/
+
+/**
+ * fol record fragment for a fop.
+ */
+struct m0_fop_fol_frag {
+	/** m0_fop_type::ft_rpc_item_type::rit_opcode of fop. */
+	uint32_t  ffrp_fop_code;
+	/** m0_fop_type::ft_rpc_item_type::rit_opcode of fop. */
+	uint32_t  ffrp_rep_code;
+	void	 *ffrp_fop M0_XCA_OPAQUE("m0_fop_xc_type");
+	void	 *ffrp_rep M0_XCA_OPAQUE("m0_fop_rep_xc_type");
+} M0_XCA_RECORD;
+
+struct m0_fop_str {
+	uint32_t s_len;
+	uint8_t *s_buf;
+} M0_XCA_SEQUENCE M0_XCA_DOMAIN(rpc);
+
+/**
+   Generic reply.
+
+   RPC operations that return nothing but error code to sender can use
+   this generic reply fop. Request handler uses this type of fop to
+   report operation failure in generic fom phases.
+ */
+struct m0_fop_generic_reply {
+	int32_t           gr_rc;
+	struct m0_fop_str gr_msg;
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
+
+/**
+ * Transaction identifier for remote nodes.
+ */
+struct m0_be_tx_remid {
+	uint64_t tri_txid;
+	uint64_t tri_locality;
+} M0_XCA_RECORD M0_XCA_DOMAIN(be|rpc);
+
+/**
+ * m0_fop_mod_rep contains common reply values for an UPDATE fop.
+ */
+struct m0_fop_mod_rep {
+	/** Remote ID assigned to this UPDATE operation */
+	struct m0_be_tx_remid fmr_remid;
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
+
+/** @} end of fop group */
+#endif /* __MOTR_FOP_WIRE_H__ */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */

--- a/ioservice/io_fops.h
+++ b/ioservice/io_fops.h
@@ -26,9 +26,7 @@
 #define __MOTR_IOSERVICE_IO_FOPS_H__
 
 #include "fop/fop.h"
-#include "fop/fop_xc.h"
 #include "fop/fom_generic.h"
-#include "fop/fom_generic_xc.h"
 #include "lib/types.h"
 #include "rpc/rpc.h"
 #include "xcode/xcode_attr.h"

--- a/lib/string.h
+++ b/lib/string.h
@@ -67,11 +67,6 @@ static inline char *strerror(int errnum)
 
 #include "lib/types.h"
 
-struct m0_fop_str {
-	uint32_t s_len;
-	uint8_t *s_buf;
-} M0_XCA_SEQUENCE M0_XCA_DOMAIN(rpc);
-
 /**
  * Converts m0_bcount_t number into a reduced string representation, calculating
  * a magnitude and representing it as standard suffix like "Ki", "Mi", "Gi" etc.

--- a/mdservice/fsync_fops.h
+++ b/mdservice/fsync_fops.h
@@ -30,6 +30,8 @@
 #include "fop/fom.h"
 #include "be/tx.h"
 #include "be/tx_xc.h"
+#include "fop/wire.h"
+#include "fop/wire_xc.h"
 
 /*
  * A fsync fop is sent to a mdservice/ioservice instance to guarantee all the

--- a/mdservice/md_fops.h
+++ b/mdservice/md_fops.h
@@ -25,16 +25,11 @@
 #ifndef __MOTR_MDSERVICE_MD_FOPS_H__
 #define __MOTR_MDSERVICE_MD_FOPS_H__
 
-#include "fop/fop.h"
-#include "fop/fop_xc.h"
-#include "fop/fom_generic.h"
-#include "fop/fom_generic_xc.h"
-#include "lib/types.h"
-#include "xcode/xcode_attr.h"
-#include "fid/fid_xc.h"
+#include "fop/wire.h"
+#include "fop/wire_xc.h"
 #include "fid/fid.h"
-#include "lib/string.h"
-#include "lib/string_xc.h"
+#include "fid/fid_xc.h"
+#include "xcode/xcode_attr.h"
 
 extern struct m0_fop_type m0_fop_create_fopt;
 extern struct m0_fop_type m0_fop_lookup_fopt;

--- a/reqh/reqh_service.h
+++ b/reqh/reqh_service.h
@@ -37,6 +37,7 @@
 #include "fid/fid.h"
 #include "rpc/link.h"    /* m0_rpc_link */
 #include "sm/sm.h"
+#include "fop/wire.h"
 
 struct m0_fop;
 struct m0_fom;

--- a/reqh/ut/reqh_fom_ut.c
+++ b/reqh/ut/reqh_fom_ut.c
@@ -37,7 +37,6 @@
 #include "rpc/item.h"
 #include "rpc/rpc_internal.h"
 #include "fop/fom_generic.h"
-#include "fop/fom_generic_xc.h"
 #include "reqh/ut/io_fop_xc.h"
 #include "reqh/ut/io_fop.h"
 #include "rpc/rpc_opcodes.h"

--- a/rm/rm_fops.h
+++ b/rm/rm_fops.h
@@ -31,7 +31,6 @@
 #include "lib/cookie_xc.h"
 
 #include "fop/fom_generic.h"
-#include "fop/fom_generic_xc.h"
 #include "fop/fop.h"
 #include "xcode/xcode_attr.h"
 

--- a/xcode/string.c
+++ b/xcode/string.c
@@ -27,6 +27,7 @@
 #include "lib/string.h"                         /* sscanf */
 
 #include "xcode/xcode.h"
+#include "fop/wire.h"                           /* m0_fop_str */
 
 #define M0_TRACE_SUBSYSTEM M0_TRACE_SUBSYS_XCODE
 #include "lib/trace.h"


### PR DESCRIPTION
Compilation of mdservice/md_fops_xc.h by GCCXML2XC or CASTXML2XC takes a long
time, because mdservice/md_fops.h includes a lot of system and motr headers.

Create a dedicated fop/wire.h with little more than xcode definitions, that can
be compiled faster. Adjust #include-s.

$ time make -j32 # from scratch

Without the patch:

real	2m52.460s
user	7m10.125s
sys	1m2.583s

With the patch:

real	1m23.514s
user	5m56.185s
sys	1m4.003s

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
