### PR TITLE
CORTX-30429: M0_ENF_META support for m0crate

### DIFF
--- a/motr/m0crate/crate_client.h
+++ b/motr/m0crate/crate_client.h
@@ -55,6 +55,7 @@ struct crate_conf {
 	int col_family;
 	int log_level;
 	uint64_t addb_size;
+	bool is_enf_meta;
 };
 
 enum m0_operation_type {

--- a/motr/m0crate/crate_index.c
+++ b/motr/m0crate/crate_index.c
@@ -996,14 +996,14 @@ static int cr_execute_query(struct m0_fid *id,
 
 	m0_idx_init(&idx, crate_uber_realm(), (struct m0_uint128 *) id);
 
-	if (conf->is_enf_meta && (m0_fid_is_valid(&dix_pool_ver))) {
+	if (conf->is_enf_meta && m0_fid_is_valid(&dix_pool_ver) && 
+	    m0_fid_is_set(&dix_pool_ver)) {
 		idx.in_entity.en_flags |= M0_ENF_META;
 		idx.in_attr.idx_layout_type = DIX_LTYPE_DESCR;
 		idx.in_attr.idx_pver = dix_pool_ver;
+		crlog(CLL_DEBUG, "DIX pool version: "FID_F"",
+		      FID_P(&idx.in_attr.idx_pver));
 	}	
-
-	crlog(CLL_DEBUG, "DIX pool version: "FID_F"",
-	      FID_P(&idx.in_attr.idx_pver));
 
 	rc = m0_idx_op(&idx, op->m0_op, p->k, p->v, rcs, flags, &ops[0]);
 	if (rc != 0) {
@@ -1400,7 +1400,7 @@ static int create_index(struct m0_uint128 id)
 				rc = ops[0]->op_sm.sm_rc;
 		}
 
-		if (rc == 0) {
+		if (rc == 0 && conf->is_enf_meta) {
 			crlog(CLL_DEBUG, "DIX pool version: "FID_F"",
 			      FID_P(&idx.in_attr.idx_pver));
 			dix_pool_ver = idx.in_attr.idx_pver;

--- a/motr/m0crate/crate_index.c
+++ b/motr/m0crate/crate_index.c
@@ -28,7 +28,10 @@
 #include "motr/m0crate/crate_client.h"
 #include "motr/m0crate/crate_client_utils.h"
 
-/** @defgroup crate Crate
+struct m0_fid dix_pool_ver;
+extern struct crate_conf *conf;
+
+/* @nefgroup crate Crate
  * Utility for executing simple performance tests.
  */
 
@@ -993,6 +996,15 @@ static int cr_execute_query(struct m0_fid *id,
 
 	m0_idx_init(&idx, crate_uber_realm(), (struct m0_uint128 *) id);
 
+	if (conf->is_enf_meta && (m0_fid_is_valid(&dix_pool_ver))) {
+		idx.in_entity.en_flags |= M0_ENF_META;
+		idx.in_attr.idx_layout_type = DIX_LTYPE_DESCR;
+		idx.in_attr.idx_pver = dix_pool_ver;
+	}	
+
+	crlog(CLL_DEBUG, "DIX pool version: "FID_F"",
+	      FID_P(&idx.in_attr.idx_pver));
+
 	rc = m0_idx_op(&idx, op->m0_op, p->k, p->v, rcs, flags, &ops[0]);
 	if (rc != 0) {
 		crlog(CLL_ERROR, "Unable to init Client idx op: %s",
@@ -1368,6 +1380,9 @@ static int create_index(struct m0_uint128 id)
 	/* Set an index creation operation. */
 	m0_idx_init(&idx, crate_uber_realm(), &id);
 
+	if (conf->is_enf_meta)
+		idx.in_entity.en_flags |= M0_ENF_META;
+
 	rc = m0_entity_create(NULL, &idx.in_entity, &ops[0]);
 	if (rc == 0) {
 		/* Launch and wait for op to complete */
@@ -1383,6 +1398,12 @@ static int create_index(struct m0_uint128 id)
 				crlog(CLL_WARN, "Index alredy exists.");
 			else
 				rc = ops[0]->op_sm.sm_rc;
+		}
+
+		if (rc == 0) {
+			crlog(CLL_DEBUG, "DIX pool version: "FID_F"",
+			      FID_P(&idx.in_attr.idx_pver));
+			dix_pool_ver = idx.in_attr.idx_pver;
 		}
 	} else
 		crlog(CLL_ERROR, "Unable to set index create operation.");

--- a/motr/m0crate/crate_io.c
+++ b/motr/m0crate/crate_io.c
@@ -100,6 +100,7 @@
 #include "motr/m0crate/crate_client.h"
 #include "motr/m0crate/crate_client_utils.h"
 
+extern struct crate_conf *conf;
 
 void integrity(struct m0_uint128 object_id, unsigned char **md5toverify,
 		int block_count, int idx_op);

--- a/motr/m0crate/parser.c
+++ b/motr/m0crate/parser.c
@@ -54,6 +54,7 @@ enum config_key_val {
 	CASS_COL_FAMILY,
 	ADDB_INIT,
 	ADDB_SIZE,
+	IS_ENF_META,
 	LOG_LEVEL,
 	/*
 	 * All parameters below are workload-specific,
@@ -156,6 +157,7 @@ struct key_lookup_table lookuptable[] = {
 	{"STARTING_OBJ_ID", START_OBJ_ID},
 	{"MODE", MODE},
 	{"MAX_NR_OPS", MAX_NR_OPS},
+	{"IS_ENF_META", IS_ENF_META},
 	{"NR_ROUNDS", NR_ROUNDS},
 };
 
@@ -592,6 +594,9 @@ int copy_value(struct workload *load, int max_workload, int *index,
 			w = &load[*index];
 			cw = workload_io(w);
 			cw->cwi_rounds = atoi(value);
+			break;
+		case IS_ENF_META:
+			conf->is_enf_meta = atoi(value);
 			break;
 		default:
 			break;

--- a/motr/st/utils/m0crate_st_workloads.yaml
+++ b/motr/st/utils/m0crate_st_workloads.yaml
@@ -30,6 +30,9 @@ MOTR_CONFIG:
    PROCESS_FID: 0x7200000000000000:0
    IDX_SERVICE_ID: 1
    ADDB_INIT: 1
+   IS_ENF_META: 0                # Pool version info will be stored by client and pass
+                                 # the pool version for PUT/GET/DEL/NEXT operations if
+                                 # IS_ENF_META enabled.
 
 WORKLOAD_SPEC:                   # Workload specification section
    WORKLOAD:                     # First Workload


### PR DESCRIPTION
# Problem Statement
M0_ENF_META support for m0crate

# Design
Analysis:
Pool version info will be stored by the client(S3 server/m0kv/m0crate)
if the M0_ENF_META flag is true. That support was not available
for m0crate.

Fix:
Added the "IS_ENF_META" flag to support M0_ENF_META. m0crate needs
to pass the pool version info for PUT/GET/DEL/NEXT if the
"IS_ENF_META" flag is enabled.
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [X] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
