### PR TITLE
CORTX-31076: Add a unique name to m0trace to avoid overwriting same file

### DIFF
--- a/lib/user_space/utrace.c
+++ b/lib/user_space/utrace.c
@@ -52,6 +52,10 @@
    @{
  */
 
+enum {
+	UTRACE_HIGH_32BIT=0xFFFFFFFFULL
+};
+
 pid_t m0_pid_cached;
 
 static int  logfd;
@@ -80,7 +84,8 @@ static int logbuf_map()
 		int available_bytes = sizeof trace_file_path -
 				      strlen(trace_file_path);
 		rc = snprintf(trace_file_path + strlen(trace_file_path),
-			available_bytes, "m0trace.%u", m0_pid_cached);
+			available_bytes, "m0trace.%u.%"PRIu32, m0_pid_cached,
+                                          (uint32_t )m0_time_now() & UTRACE_HIGH_32BIT);
 		if (rc < 0) {
 			warn("failed to construct trace file path");
 			return rc;


### PR DESCRIPTION
Problem: On k8s environment, process will restart with same pid,
m0trace file will be overwritten and we loose the previous run traces

Solution: Append a unique identifier to save m0traces on k8s across
restart.

Signed-off-by: Yeshpal Jain <yeshpal.jain@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
