### PR TITLE
CORTX-29834: Remove dependency from key storage, instead use cvg

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -326,11 +326,6 @@ def get_logical_node_class(self):
     check_type(logical_node_class, list, "logical_node_class")
     return logical_node_class
 
-def get_storage(self):
-    storage = self.node['storage']
-    check_type(storage, dict, "storage")
-    return storage
-
 def restart_services(self, services):
     for service in services:
         self.logger.info(f"Restarting {service} service\n")
@@ -459,8 +454,8 @@ def update_copy_motr_config_file(self):
 #              ['/dev/sdf'] is list of metadata disks of cvg[1]
 def get_md_disks_lists(self, node_info):
     md_disks_lists = []
-    cvg_count = node_info['storage'][CVG_COUNT_KEY]
-    cvg = node_info['storage']['cvg']
+    cvg_count = node_info[CVG_COUNT_KEY]
+    cvg = node_info['cvg']
     for i in range(cvg_count):
         temp_cvg = cvg[i]
         if temp_cvg['devices']['metadata']:
@@ -829,14 +824,14 @@ def calc_lvm_min_size(self, lv_path, lvm_min_size):
 
 def get_cvg_cnt_and_cvg(self):
     try:
-        cvg_cnt = self.server_node['storage'][CVG_COUNT_KEY]
+        cvg_cnt = self.server_node[CVG_COUNT_KEY]
     except:
         raise MotrError(errno.EINVAL, "cvg_cnt not found\n")
 
     check_type(cvg_cnt, str, CVG_COUNT_KEY)
 
     try:
-        cvg = self.server_node['storage']['cvg']
+        cvg = self.server_node['cvg']
     except:
         raise MotrError(errno.EINVAL, "cvg not found\n")
 
@@ -871,16 +866,6 @@ def validate_storage_schema(storage):
                 sz = len(val)
                 for i in range(sz):
                     check_type(val[i], str, f"data_devices[{i}]")
-
-def get_cvg_cnt_and_cvg_k8(self):
-    try:
-        cvg = self.storage['cvg']
-        cvg_cnt = len(cvg)
-    except:
-        raise MotrError(errno.EINVAL, "cvg not found\n")
-    # Check if cvg type is list
-    check_type(cvg, list, "cvg")
-    return cvg_cnt, cvg
 
 def align_val(val, size):
     return (int(val/size) * size)
@@ -1231,7 +1216,7 @@ def update_motr_hare_keys_for_all_nodes(self):
     retry_delay = 2
     for value in nodes_info.values():
         host = value["hostname"]
-        cvg_count = value["storage"][CVG_COUNT_KEY]
+        cvg_count = value[CVG_COUNT_KEY]
         name = value["name"]
         self.logger.info(f"update_motr_hare_keys for {host}\n")
         for i in range(int(cvg_count)):

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -74,8 +74,6 @@ class Cmd:
         self.nodes = get_value(self, 'node', dict)
         self.node = get_server_node(self)
         self.storage_nodes = get_data_nodes(self)
-        if self.machine_id in self.storage_nodes:
-            self.storage = get_storage(self)
         Conf.load(self._index_motr_hare, self._url_motr_hare)
     @property
     def args(self) -> str:


### PR DESCRIPTION
Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
- Since 'storage' has no item other than "cvg', the hierarchy 'storage'>'cvg' can be merged to 'cvg' in GConf and changes need to be aligned accordingly wherever it is being used.
1: Current Structure:
storage:
      cvg:
      - devices:
          data:
          - /dev/sdc
          - /dev/sdd
          metadata:
          - /dev/sdb
        name: cvg-01
        type: ios
      - devices:
          data:
          - /dev/sdf
          - /dev/sdg
          metadata:
          - /dev/sde
        name: cvg-02
        type: ios
      num_cvg: 2

2: New Structure
 cvg:
    - name: cvg-02
      type: ios
      devices:
        metadata:
        - /dev/sdb
        data:
        - /dev/sdc
    - name: cvg-01
      type: ios
      devices:
        metadata:
        - /dev/sde
        data:
        - /dev/sdf
    num_cvg: 2.            
      

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
