### PR TITLE
go/mio: use M0_OOF_NOHOLE flag for read

### DIFF
--- a/bindings/go/mio/mio.go
+++ b/bindings/go/mio/mio.go
@@ -618,7 +618,7 @@ func (mio *Mio) read(p []byte, off *int64) (n int, err error) {
         rc := C.m0_obj_op(mio.obj, C.M0_OC_READ,
                           &v.ext[slot.idx],
                           &v.buf[slot.idx],
-                          &v.attr[slot.idx], 0, 0, &op)
+                          &v.attr[slot.idx], 0, C.M0_OOF_NOHOLE, &op)
         if rc != 0 {
             err = fmt.Errorf("creating m0_op failed: rc=%v", rc)
             break


### PR DESCRIPTION
When it happens that object is written in the degraded mode,
some cobs might miss some units. Normally, zero data will be
returned for such units without any errors on reads. This, in
turn, will result in a broken user data returned without any
error. So the user will not even know about the problem.

Solution: use M0_OOF_NOHOLE for read, so that the server
will return EIO error for the missing data, which will trigger
the degraded read mode and the user data is reconstructed
automatically.

Relates to #1598.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
