### PR TITLE
CORTX-29418 : Add support for libfabric v1.14.x and v1.15.x

### DIFF
--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -2362,7 +2362,6 @@ static int libfab_txep_init(struct m0_fab__active_ep *aep,
 	struct fi_info        *info;
 	struct fi_info        *hints = NULL;
 	int                    rc;
-	bool                   is_verbs = libfab_is_verbs(tm);
 	char                   ip[LIBFAB_ADDR_LEN_MAX] = {};
 	char                   port[LIBFAB_PORT_LEN_MAX] = {};
 
@@ -2379,38 +2378,34 @@ static int libfab_txep_init(struct m0_fab__active_ep *aep,
 	aep->aep_txq_full = false;
 	ep->fep_connlink = FAB_CONNLINK_DOWN;
 
-	if (is_verbs) {
-		hints = fi_allocinfo();
-		if (hints == NULL)
-			return M0_ERR(-ENOMEM);
-		hints->ep_attr->type = FI_EP_MSG;
-		hints->caps = FI_MSG | FI_RMA;
+	hints = fi_allocinfo();
+	if (hints == NULL)
+		return M0_ERR(-ENOMEM);
+	hints->ep_attr->type = FI_EP_MSG;
+	hints->caps = FI_MSG | FI_RMA;
 
-		hints->mode |= FI_RX_CQ_DATA;
-		hints->domain_attr->cq_data_size = 4;
-		hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED |
-					      FI_MR_PROV_KEY | FI_MR_VIRT_ADDR;
-		hints->fabric_attr->prov_name =
-					    fab->fab_fi->fabric_attr->prov_name;
+	hints->mode |= FI_RX_CQ_DATA;
+	hints->domain_attr->cq_data_size = 4;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED |
+					FI_MR_PROV_KEY | FI_MR_VIRT_ADDR;
+	hints->fabric_attr->prov_name =
+					fab->fab_fi->fabric_attr->prov_name;
 
-		libfab_straddr_gen(&en->nia_n, ip);
-		snprintf(port, ARRAY_SIZE(port), "%d", en->nia_n.nip_port);
-		rc = fi_getinfo(LIBFAB_VERSION, ip, port, 0,
-				hints, &info);
-		if (rc != 0)
-			return M0_ERR(rc);
-	} else
-		info = tm->ftm_fab->fab_fi;
+	libfab_straddr_gen(&en->nia_n, ip);
+	snprintf(port, ARRAY_SIZE(port), "%d", en->nia_n.nip_port);
+	rc = fi_getinfo(LIBFAB_VERSION, ip, port, 0, hints, &info);
+	if (rc != 0) {
+		fi_freeinfo(hints);
+		return M0_ERR(rc);
+	}
 
 	rc = fi_endpoint(fab->fab_dom, info, &aep->aep_txep, NULL) ? :
 	     libfab_ep_txres_init(aep, tm, ctx) ? :
 	     fi_enable(aep->aep_txep);
 
-	if (is_verbs) {
-		hints->fabric_attr->prov_name = NULL;
-		fi_freeinfo(hints);
-		fi_freeinfo(info);
-	}
+	hints->fabric_attr->prov_name = NULL;
+	fi_freeinfo(hints);
+	fi_freeinfo(info);
 
 	return M0_RC(rc);
 }

--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -2387,14 +2387,14 @@ static int libfab_txep_init(struct m0_fab__active_ep *aep,
 	hints->mode |= FI_RX_CQ_DATA;
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED |
-					FI_MR_PROV_KEY | FI_MR_VIRT_ADDR;
-	hints->fabric_attr->prov_name =
-					fab->fab_fi->fabric_attr->prov_name;
+				      FI_MR_PROV_KEY | FI_MR_VIRT_ADDR;
+	hints->fabric_attr->prov_name = fab->fab_fi->fabric_attr->prov_name;
 
 	libfab_straddr_gen(&en->nia_n, ip);
 	snprintf(port, ARRAY_SIZE(port), "%d", en->nia_n.nip_port);
 	rc = fi_getinfo(LIBFAB_VERSION, ip, port, 0, hints, &info);
 	if (rc != 0) {
+		hints->fabric_attr->prov_name = NULL;
 		fi_freeinfo(hints);
 		return M0_ERR(rc);
 	}


### PR DESCRIPTION
Add support for libfabric v1.14.x and v1.15.x.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
- Adapting libfab.c file due to change in behavior of some API's of the libfabric library.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
