### PR TITLE
client: use no hole mode by default

### DIFF
--- a/motr/client.h
+++ b/motr/client.h
@@ -573,15 +573,16 @@ enum m0_idx_opcode {
  */
 enum m0_op_obj_flags {
 	/**
-	 * Read operation should not see any holes. If a hole is met during
-	 * read, return error instead.
+	 * If a hole is met during read, return zeros instead of error.
+	 * WARNING: this might result in a corrupted data, when the hole was
+	 * caused by some error during write. So it's better to verify it.
 	 */
-	M0_OOF_NOHOLE = 1 << 0,
+	M0_OOF_HOLE = 1 << 0,
 	/**
 	 * Write, alloc and free operations wait for the transaction to become
 	 * persistent before returning.
 	 */
-	M0_OOF_SYNC   = 1 << 1
+	M0_OOF_SYNC = 1 << 1
 } M0_XCA_ENUM;
 
 /**
@@ -1451,7 +1452,7 @@ void m0_obj_idx_init(struct m0_idx       *idx,
  *                       (m0_vec_count(&ext->iv_vec) >> obj->ob_attr.oa_bshift)
  * @pre ergo(M0_IN(opcode, (M0_OC_ALLOC, M0_OC_FREE)),
  *           data == NULL && attr == NULL && mask == 0)
- * @pre ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE)))
+ * @pre ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_HOLE)))
  * @pre ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC)))
  *
  * @post ergo(*op != NULL, *op->op_code == opcode &&

--- a/motr/io.c
+++ b/motr/io.c
@@ -734,7 +734,7 @@ int m0_obj_op(struct m0_obj       *obj,
 		  opcode == M0_OC_FREE ? "free" : "");
 	M0_PRE(obj != NULL);
 	M0_PRE(op != NULL);
-	M0_PRE(ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_NOHOLE))));
+	M0_PRE(ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_HOLE))));
 	M0_PRE(ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC))));
 	if (M0_FI_ENABLED("fail_op"))
 		return M0_ERR(-EINVAL);

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -873,7 +873,7 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 	m0_bindex_t                  offset;
 	uint32_t                     segnext;
 	uint32_t                     ndom_max_segs;
-	struct m0_client             *instance;
+	struct m0_client            *instance;
 
 	M0_ENTRY("prepare io fops for target ioreq %p filter 0x%x, tfid "FID_F,
 		 ti, filter, FID_P(&ti->ti_fid));
@@ -891,7 +891,8 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 			(IRS_READING, IRS_DEGRADED_READING,
 			 IRS_WRITING, IRS_DEGRADED_WRITING)));
 
-	if (ioo->ioo_oo.oo_oc.oc_op.op_code == M0_OC_WRITE &&
+	if (M0_IN(ioo->ioo_oo.oo_oc.oc_op.op_code, (M0_OC_WRITE,
+						    M0_OC_FREE)) &&
 	    M0_IN(ioreq_sm_state(ioo), (IRS_READING, IRS_DEGRADED_READING)))
 		read_in_write = true;
 
@@ -1074,14 +1075,28 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 		rw_fop->crw_fid = ti->ti_fid;
 		rw_fop->crw_pver = ioo->ioo_pver;
 		rw_fop->crw_index = ti->ti_obj;
-		/* In case of partially spanned units in a parity group,
-		 * degraded read and read-verify mode expects zero-filled
-		 * units from server side.
+
+		/*
+		 * Use NOHOLE by default (i.e. return error for missing
+		 * units instead of zeros), unless we are in read-verify
+		 * mode or in the degraded-read mode. Otherwise, in case of
+		 * partially spanned parity groups (last groups, usually),
+		 * we will get a lot of bogus errors when all data units
+		 * of the group are read.
+		 *
+		 * Note: parity units are always present in the groups, even
+		 * in the partially spanned ones. So we always use NOHOLE
+		 * for them. Otherwise, the user may get corrupted data.
 		 */
 		instance = m0__op_instance(&ioo->ioo_oo.oo_oc.oc_op);
-		if (ioreq_sm_state(ioo) != IRS_DEGRADED_READING &&
-		    !instance->m0c_config->mc_is_read_verify &&
-		    ioo->ioo_flags & M0_OOF_NOHOLE)
+		if (ioreq_sm_state(ioo) == IRS_READING && !read_in_write &&
+		    (filter == PA_PARITY ||
+		     (!instance->m0c_config->mc_is_read_verify &&
+		      !(ioo->ioo_flags & M0_OOF_HOLE))))
+			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
+
+		if (ioreq_sm_state(ioo) == IRS_DEGRADED_READING &&
+		    !read_in_write && filter == PA_PARITY)
 			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
 
 		/* Assign the checksum buffer for traget */
@@ -1833,7 +1848,7 @@ static int nw_xfer_req_dispatch(struct nw_xfer_request *xfer)
 			continue;
 		}
 		rc = ti->ti_ops->tio_iofops_prepare(ti, PA_DATA) ?:
-			ti->ti_ops->tio_iofops_prepare(ti, PA_PARITY);
+		     ti->ti_ops->tio_iofops_prepare(ti, PA_PARITY);
 		if (rc != 0)
 			return M0_ERR(rc);
 	} m0_htable_endfor;

--- a/motr/st/utils/cat.c
+++ b/motr/st/utils/cat.c
@@ -74,7 +74,7 @@ static void cat_usage(FILE *file, char *prog_name)
 "  -O, --offset         INT       Updates the exisiting object from given "
 				 "offset.\n%*c Default=0 if not provided. "
 				 "Offset should be multiple of 4k.\n"
-"  -N, --no-hole                  Report read error on hole in object\n"
+"  -z, --fill-zeros               Fill holes with zeros.\n"
 "  -h, --help                     Shows this help text and exit.\n"
 , prog_name, WIDTH, ' ', WIDTH, ' ', WIDTH, ' ', WIDTH, ' ', WIDTH, ' ',
 WIDTH, ' ');

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -950,6 +950,7 @@ int m0_utility_args_init(int argc, char **argv,
 				{"object",        required_argument, NULL, 'o'},
 				{"block-size",    required_argument, NULL, 's'},
 				{"block-count",   required_argument, NULL, 'c'},
+				{"block-index",   required_argument, NULL, 'i'},
 				{"trunc-len",     required_argument, NULL, 't'},
 				{"layout-id",     required_argument, NULL, 'L'},
 				{"pver",          required_argument, NULL, 'v'},
@@ -961,11 +962,11 @@ int m0_utility_args_init(int argc, char **argv,
 				{"update_mode",   no_argument,       NULL, 'u'},
 				{"enable-locks",  no_argument,       NULL, 'e'},
 				{"read-verify",   no_argument,       NULL, 'r'},
+				{"fill-zeros",    no_argument,       NULL, 'z'},
 				{"help",          no_argument,       NULL, 'h'},
-				{"no-hole",       no_argument,       NULL, 'N'},
 				{0,               0,                 0,     0 }};
 
-        while ((c = getopt_long(argc, argv, ":l:H:p:P:o:s:c:t:L:v:n:S:q:b:O:uerhN",
+        while ((c = getopt_long(argc, argv, ":l:H:p:P:o:s:c:i:t:L:v:n:S:q:b:O:uerzh",
 				l_opts, &option_index)) != -1)
 	{
 		switch (c) {
@@ -1014,6 +1015,7 @@ int m0_utility_args_init(int argc, char **argv,
 					exit(EXIT_FAILURE);
 				  }
 				  continue;
+			case 'i':
 			case 'c': if (m0_bcount_get(optarg,
 						    &params->cup_block_count) ==
 						    0) {
@@ -1098,10 +1100,10 @@ int m0_utility_args_init(int argc, char **argv,
 				  continue;
 			case 'u': params->cup_update_mode = true;
 				  continue;
+			case 'z': params->flags |= M0_OOF_HOLE;
+				  continue;
 			case 'h': utility_usage(stderr, basename(argv[0]));
 				  exit(EXIT_FAILURE);
-			case 'N': params->flags |= M0_OOF_NOHOLE;
-				  continue;
 			case '?': fprintf(stderr, "Unsupported option '%c'\n",
 					  optopt);
 				  utility_usage(stderr, basename(argv[0]));

--- a/motr/st/utils/motr_utils_st.sh
+++ b/motr/st/utils/motr_utils_st.sh
@@ -80,7 +80,7 @@ test_with_N_K()
 	block_count=5120
 	obj_count=5
 	trunc_len=2560
-	trunc_count=17
+	trunc_idx=17
 	read_verify="false"
 	blks_per_io=100
 	MOTR_PARAMS="-l $MOTR_LOCAL_EP -H $MOTR_HA_EP -p $MOTR_PROF_OPT \
@@ -97,7 +97,7 @@ test_with_N_K()
 		error_handling $? "Failed to create a source file"
 	}
 	dd if=$source_abcd bs=$block_size \
-	   count=$(($block_count + $trunc_count)) of=$src_file_extra \
+	   count=$(($block_count + $trunc_idx)) of=$src_file_extra \
 	   2> $MOTR_TEST_LOGFILE || {
 		error_handling $? "Failed to create a source file"
 	}
@@ -231,21 +231,20 @@ EOF
 		error_handling $? "Failed to copy object"
 	}
 	$motr_st_util_dir/m0trunc $MOTR_PARAMS -o $object_id1 \
-				    -c $trunc_count -t $trunc_len \
+				    -i $trunc_idx -t $trunc_len \
 				    -s $block_size -L 9 -b $blks_per_io || {
 		error_handling $? "Failed to truncate object"
 	}
 	$motr_st_util_dir/m0cat $MOTR_PARAMS_V -o $object_id1 \
 				  -s $block_size -c $block_count -L 9 \
-                                  -b $blks_per_io \
-				  $dest_file-full || {
+				  -b $blks_per_io -z $dest_file-full || {
 		error_handling $? "Failed to read object"
 	}
 	$motr_st_util_dir/m0unlink $MOTR_PARAMS -o $object_id1 || {
 		error_handling $? "Failed to delete object"
 	}
 	cp $src_file $src_file-punch
-	fallocate -p -o $(($trunc_count * $block_size)) \
+	fallocate -p -o $(($trunc_idx * $block_size)) \
 		  -l $(($trunc_len * $block_size)) -n $src_file-punch
 	diff -q $src_file-punch $dest_file-full || {
 		rc=$?
@@ -260,14 +259,14 @@ EOF
                                  -b $blks_per_io || {
 		error_handling $? "Failed to copy object"
 	}
-	$motr_st_util_dir/m0trunc $MOTR_PARAMS -o $object_id1 -c 0 \
+	$motr_st_util_dir/m0trunc $MOTR_PARAMS -o $object_id1 -i 0 \
                                    -t $block_count -s $block_size -L 9 \
                                    -b $blks_per_io || {
 		error_handling $? "Failed to truncate object"
 	}
 	$motr_st_util_dir/m0cat $MOTR_PARAMS_V -o $object_id1 \
 				  -s $block_size -c $block_count -L 9 \
-                                  -b $blks_per_io \
+                                  -b $blks_per_io -z \
 				  $dest_file || {
 		error_handling $? "Failed to read from truncated object"
 	}
@@ -290,21 +289,21 @@ EOF
 		error_handling $? "Failed to copy object"
 	}
 	$motr_st_util_dir/m0trunc $MOTR_PARAMS -o $object_id1 \
-				    -c $trunc_count -t $block_count \
+				    -i $trunc_idx -t $block_count \
 				    -s $block_size -L 9 -b $blks_per_io || {
 		error_handling $? "Failed to truncate object"
 	}
 	$motr_st_util_dir/m0cat $MOTR_PARAMS_V -o $object_id1 \
 				  -s $block_size \
-				  -c $(($block_count + $trunc_count)) -L 9 \
-                                  -b $blks_per_io \
+				  -c $(($block_count + $trunc_idx)) -L 9 \
+                                  -b $blks_per_io -z \
 				  $dest_file || {
 		error_handling $? "Failed to read from truncated object"
 	}
 	$motr_st_util_dir/m0unlink $MOTR_PARAMS -o $object_id1 || {
 		error_handling $? "Failed to delete object"
 	}
-	fallocate -p -o $(($trunc_count * $block_size)) \
+	fallocate -p -o $(($trunc_idx * $block_size)) \
 		  -l $(($block_count  * $block_size)) -n $src_file_extra
 	diff -q $src_file_extra $dest_file || {
 		rc=$?
@@ -317,7 +316,7 @@ EOF
 	$motr_st_util_dir/m0touch $MOTR_PARAMS -o $object_id1 -L 9|| {
 		error_handling $? "Failed to create a object"
 	}
-	$motr_st_util_dir/m0trunc $MOTR_PARAMS -o $object_id1 -c 0 \
+	$motr_st_util_dir/m0trunc $MOTR_PARAMS -o $object_id1 -i 0 \
 				    -t $block_count -s $block_size -L 9 \
                                     -b $blks_per_io || {
 		error_handling $? "Failed to truncate object"

--- a/motr/st/utils/truncate.c
+++ b/motr/st/utils/truncate.c
@@ -56,7 +56,7 @@ static void trunc_usage(FILE *file, char *prog_name)
 "  -s, --block-size     INT       Block size multiple of 4k in bytes or with "
 				 "suffix b/k/m/g.\n%*c Ex: 1k=1024, "
 				 "1m=1024*1024. Range: [4k-32m].\n"
-"  -c, --block-count    INT       Number of blocks (>0) to copy, can give with "
+"  -i, --block-index    INT       Block to truncate from (starting from 0) "
 				 "suffix b/k/m/g/K/M/G.\n%*c Ex: 1k=1024, "
 				 "1m=1024*1024, 1K=1000 1M=1000*1000.\n"
 "  -t, --trunc-len      INT       Number of blocks (>0) to punch out,"


### PR DESCRIPTION
Use no hole mode by default and rename M0_OOF_NOHOLE flag to M0_OOF_HOLE, which user should set to enable hole mode.

This will help to avoid returning corrupted data to the user in case there are no units at the server side in parity groups (for some reason) by automatically enabling degraded read mode in such cases.

Relates to https://github.com/Seagate/cortx-motr/issues/1598.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
