### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/m0t1fs/linux_kernel/st/m0t1fs_client_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_client_inc.sh
@@ -40,7 +40,7 @@ touch_file()
 	local file=$1
 	local unitsz_id=${unit2id_map[$2]}
 
-	if [ x$unitsz_id = x ]; then
+	if [ x"$unitsz_id" = x ]; then
 		echo "Invalid unit_size: $2"
 		return 1
 	fi
@@ -63,7 +63,7 @@ mount_m0t1fs()
 	local mountop=$2
 
 	# Create mount directory
-	sudo mkdir -p $m0t1fs_mount_dir || {
+	sudo mkdir -p "$m0t1fs_mount_dir" || {
 		echo "Failed to create mount directory."
 		return 1
 	}
@@ -78,8 +78,8 @@ mount_m0t1fs()
 	local cmd="sudo mount -t m0t1fs \
 	    -o pfid='$M0T1FS_PROC_ID',profile='$PROF_OPT',ha='$lnet_nid:$HA_EP',$mountop \
 	    none $m0t1fs_mount_dir"
-	echo $cmd
-	eval $cmd || {
+	echo "$cmd"
+	eval "$cmd" || {
 		echo "Failed to mount m0t1fs file system."
 		return 1
 	}
@@ -88,7 +88,7 @@ mount_m0t1fs()
 	mount | grep m0t1fs
 	local retcode=$?
 	if [ $retcode = 0 ]; then
-	    time df $m0t1fs_mount_dir
+	    time df "$m0t1fs_mount_dir"
 	fi
 	return $retcode
 }
@@ -98,7 +98,7 @@ unmount_and_clean()
 	m0t1fs_mount_dir=$MOTR_M0T1FS_MOUNT_DIR
         multiple_pools=$1
 	echo "Unmounting file system ..."
-	umount $m0t1fs_mount_dir &>/dev/null
+	umount "$m0t1fs_mount_dir" &>/dev/null
 
 	sleep 2
 
@@ -106,7 +106,7 @@ unmount_and_clean()
 	mount | grep m0t1fs
 
 	echo "Cleaning up mount test directory..."
-	rm -rf $m0t1fs_mount_dir &>/dev/null
+	rm -rf "$m0t1fs_mount_dir" &>/dev/null
 
 	local i=0
 	for ((i=0; i < ${#IOSEP[*]}; i++)) ; do
@@ -115,13 +115,13 @@ unmount_and_clean()
 		# unmounting the client file system, from next mount,
 		# fids are generated from same baseline which results
 		# in failure of cob_create fops.
-		local ios_index=$(($i + 1))
-		rm -rf $MOTR_M0T1FS_TEST_DIR/d$ios_index/stobs/o/*
+		local ios_index=$(("$i" + 1))
+		rm -rf "$MOTR_M0T1FS_TEST_DIR"/d"$ios_index"/stobs/o/*
 	done
 
-        if [ ! -z "$multiple_pools" ] && [ $multiple_pools == 1 ]; then
-		local ios_index=$(($i + 1))
-		rm -rf $MOTR_M0T1FS_TEST_DIR/d$ios_index/stobs/o/*
+        if [ ! -z "$multiple_pools" ] && [ "$multiple_pools" == 1 ]; then
+		local ios_index=$(("$i" + 1))
+		rm -rf "$MOTR_M0T1FS_TEST_DIR"/d"$ios_index"/stobs/o/*
         fi
 }
 
@@ -135,12 +135,12 @@ unmount_m0t1fs()
 
 	local m0t1fs_mount_dir=$1
 	echo "Unmounting file system ..."
-	umount $m0t1fs_mount_dir &>/dev/null
+	umount "$m0t1fs_mount_dir" &>/dev/null
 
 	sleep 2
 
 	echo "Cleaning up test directory..."
-	rm -rf $m0t1fs_mount_dir &>/dev/null
+	rm -rf "$m0t1fs_mount_dir" &>/dev/null
 }
 
 
@@ -159,7 +159,7 @@ bulkio_test()
 	local mode=$4
 	local mountopt=$5
 
-	mount_m0t1fs $m0t1fs_mount_dir "$mode,$mountopt" || return 1
+	mount_m0t1fs "$m0t1fs_mount_dir" "$mode,$mountopt" || return 1
 
 	echo "Creating local input file of I/O size ..."
 	run "dd if=/dev/urandom of=$local_input bs=$io_size count=$io_counts"
@@ -170,7 +170,7 @@ bulkio_test()
 	fi
 
 	echo "Writing data to m0t1fs file ..."
-	touch_file $m0t1fs_file $unit_size &&
+	touch_file "$m0t1fs_file" "$unit_size" &&
 	run "dd if=$local_input of=$m0t1fs_file bs=$io_size count=$io_counts"
 	if [ $? -ne 0 ]; then
 		echo "Failed to write data on m0t1fs file."
@@ -179,13 +179,13 @@ bulkio_test()
 	fi
 
 	echo -n "Reading data from m0t1fs file "
-	if [ $io_counts -gt 1 ]; then
+	if [ "$io_counts" -gt 1 ]; then
 		trigger=$((( ${trigger:-0} + 1 ) % 2))
 		# run 50% of such tests with different io_size
 		if [ $trigger -eq 0 ]; then
 			echo -n "with different io_size "
 			io_suffix=${io_size//[^KM]}
-			io_size=$((${io_size%[KM]} '*' $io_counts))$io_suffix
+			io_size=$((${io_size%[KM]} '*' "$io_counts"))$io_suffix
 			io_counts=1
 		fi
 	fi
@@ -198,7 +198,7 @@ bulkio_test()
 	fi
 
 	echo "Comparing data written and data read from m0t1fs file ..."
-	if ! cmp $local_input $local_output
+	if ! cmp "$local_input" "$local_output"
 	then
 		echo -n "Failed: data written and data read from m0t1fs file "
 		echo    "are not same."
@@ -217,7 +217,7 @@ bulkio_test()
 
 show_write_speed()
 {
-	cat $MOTR_TEST_LOGFILE | grep copied | tail -2 | head -1 | \
+	grep copied "$MOTR_TEST_LOGFILE" | tail -2 | head -1 | \
 		awk -F, '{print $3}'
 }
 
@@ -233,8 +233,8 @@ io_combinations()
 	spare_units=$4
 	mode=$5
 
-	p=$(($data_units + $parity_units + $spare_units))
-	if [ $p -gt $pool_width ]
+	p=$(("$data_units" + "$parity_units" + "$spare_units"))
+	if [ $p -gt "$pool_width" ]
 	then
 		echo "Error: pool_width should be >= data_units + parity_units + spare_units."
 		return 1
@@ -243,18 +243,18 @@ io_combinations()
 	# unit size in K
 	for unit_size in 4 8 32 128 512 2048 4096
 	do
-	    stripe_size=$(($unit_size '*' $data_units))
+	    stripe_size=$(($unit_size '*' "$data_units"))
 
 	    for io_size in 1 2 4
 	    do
-		io_size=$(($io_size '*' $stripe_size))
+		io_size=$(($io_size '*' "$stripe_size"))
 		io_size=${io_size}K
 
 		for io_count in 1 2
 		do
 			echo -n "Test: I/O for stripe = ${stripe_size}K," \
 			     "bs = $io_size, count = $io_count... "
-			bulkio_test $unit_size $io_size $io_count $mode "" &>> $MOTR_TEST_LOGFILE
+			bulkio_test $unit_size "$io_size" $io_count "$mode" "" &>> "$MOTR_TEST_LOGFILE"
 			if [ $? -ne "0" ]
 			then
 				return 1
@@ -274,11 +274,11 @@ file_creation_test()
 	local SFILE=/tmp/source.txt
 	local DFILE=/tmp/dest.txt
 	local START_FID=15     # Added to skip root and other system fids.
-	local BS=$((4 * $NR_DATA * 2))K
+	local BS=$((4 * "$NR_DATA" * 2))K
 
 	for i in {a..z} {A..Z}; do
 		for c in $(seq 1 4095);
-			do echo -n $i ;
+			do echo -n "$i" ;
 		done;
 		echo;
 	done > $SFILE
@@ -286,13 +286,13 @@ file_creation_test()
 	NR_FILES=$[ $nr_files - $START_FID ]
 	NR_FILES=$[ $NR_FILES * $NR_FILES ]
 
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR $mode || return 1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "$mode" || return 1
 	echo "Test: Creating $NR_FILES files on m0t1fs ..."
 	for ((i=$START_FID; i<$nr_files; ++i)); do
 		for ((j=$START_FID; j<$nr_files; ++j)); do
-			touch $MOTR_M0T1FS_MOUNT_DIR/$j:$i || break
+			touch "$MOTR_M0T1FS_MOUNT_DIR"/"$j":"$i" || break
 			run "dd if=$SFILE of=$MOTR_M0T1FS_MOUNT_DIR/$j:$i bs=$BS" || break
-			dd if=$MOTR_M0T1FS_MOUNT_DIR/$j:$i of=$DFILE bs=$BS 2>/dev/null || break
+			dd if="$MOTR_M0T1FS_MOUNT_DIR"/"$j":"$i" of=$DFILE bs=$BS 2>/dev/null || break
 			diff -C 0 $SFILE $DFILE || {
 				echo "file content differ!!!!!!!!!!!!!!!!! at $j:$i file. "
 				break;
@@ -324,9 +324,9 @@ file_creation_test()
 	echo "Test: Creating new $NR_FILES files on m0t1fs..."
 	for ((i=$START_FID; i<$nr_files; ++i)); do
 		for ((j=$START_FID; j<$nr_files; ++j)); do
-			touch $MOTR_M0T1FS_MOUNT_DIR/1$j:$i || break
+			touch "$MOTR_M0T1FS_MOUNT_DIR"/1"$j":"$i" || break
 			run "dd if=$SFILE of=$MOTR_M0T1FS_MOUNT_DIR/1$j:$i bs=$BS" || break
-			dd if=$MOTR_M0T1FS_MOUNT_DIR/1$j:$i of=$DFILE bs=$BS 2>/dev/null || break
+			dd if="$MOTR_M0T1FS_MOUNT_DIR"/1"$j":"$i" of=$DFILE bs=$BS 2>/dev/null || break
 			diff -C 0 $SFILE $DFILE || {
 				echo "file content differ!!!!!!!!!!!!!!!!! at $j:$i file. "
 				break;
@@ -361,22 +361,22 @@ file_creation_test()
 		return 0
 	fi
 
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "verify" || {
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "verify" || {
                 return 1
         }
 	for ((i=0; i<$nr_files; ++i)); do
 		#arbitrary file size. "1021" is a prime close to 1024.
-		touch $MOTR_M0T1FS_MOUNT_DIR/file$i || break
-		dd if=$SFILE of=/tmp/src bs=1021 count=$(($i + 1)) >/dev/null 2>&1 || break
-		cp -v /tmp/src $MOTR_M0T1FS_MOUNT_DIR/file$i      || break
-		cp -v $MOTR_M0T1FS_MOUNT_DIR/file$i /tmp/dest     || break
+		touch "$MOTR_M0T1FS_MOUNT_DIR"/file"$i" || break
+		dd if=$SFILE of=/tmp/src bs=1021 count=$(("$i" + 1)) >/dev/null 2>&1 || break
+		cp -v /tmp/src "$MOTR_M0T1FS_MOUNT_DIR"/file"$i"      || break
+		cp -v "$MOTR_M0T1FS_MOUNT_DIR"/file"$i" /tmp/dest     || break
 		diff -C 0 /tmp/src /tmp/dest || {
 			echo "file content differ at file$i file. "
 			break;
 		}
 	done
 
-	if [ $i -eq $nr_files ]; then
+	if [ "$i" -eq "$nr_files" ]; then
 		echo "success."
 	else
 		echo "failed."
@@ -384,9 +384,9 @@ file_creation_test()
 	fi
 
 	for ((i=0; i<$nr_files; ++i)); do
-		rm -vf $MOTR_M0T1FS_MOUNT_DIR/file$i      || break
+		rm -vf "$MOTR_M0T1FS_MOUNT_DIR"/file"$i"      || break
 	done
-	if [ $i -eq $nr_files ]; then
+	if [ "$i" -eq "$nr_files" ]; then
 		echo "success."
 	else
 		echo "failed."
@@ -404,70 +404,70 @@ multi_client_test()
 
 	local rc=0
 
-	mount_m0t1fs ${mount_dir_1} "fid_start=65536" ||
+	mount_m0t1fs "${mount_dir_1}" "fid_start=65536" ||
 		return 1
 	mount | grep m0t1fs
-	mount_m0t1fs ${mount_dir_2} "fid_start=66536" || {
-		unmount_m0t1fs ${mount_dir_1}
+	mount_m0t1fs "${mount_dir_2}" "fid_start=66536" || {
+		unmount_m0t1fs "${mount_dir_1}"
 		return 1
 	}
 	mount | grep m0t1fs
-	mount_m0t1fs ${mount_dir_3} "fid_start=67536" || {
-		unmount_m0t1fs ${mount_dir_1}
-		unmount_m0t1fs ${mount_dir_2}
+	mount_m0t1fs "${mount_dir_3}" "fid_start=67536" || {
+		unmount_m0t1fs "${mount_dir_1}"
+		unmount_m0t1fs "${mount_dir_2}"
 		return 1
 	}
 	echo "Three clients mounted:"
 	mount | grep m0t1fs
-	cp -av /bin/ls ${mount_dir_1}/obj1 || rc=1
-	cp -av /bin/ls ${mount_dir_2}/obj2 || rc=1
-	cp -av /bin/ls ${mount_dir_3}/obj3 || rc=1
-	ls -liR ${mount_dir_1} || rc=1
-	ls -liR ${mount_dir_2} || rc=1
-	ls -liR ${mount_dir_3} || rc=1
+	cp -av /bin/ls "${mount_dir_1}"/obj1 || rc=1
+	cp -av /bin/ls "${mount_dir_2}"/obj2 || rc=1
+	cp -av /bin/ls "${mount_dir_3}"/obj3 || rc=1
+	ls -liR "${mount_dir_1}" || rc=1
+	ls -liR "${mount_dir_2}" || rc=1
+	ls -liR "${mount_dir_3}" || rc=1
 
-	diff /bin/ls ${mount_dir_1}/obj1 || rc=1
-	diff /bin/ls ${mount_dir_1}/obj2 || rc=1
-	diff /bin/ls ${mount_dir_1}/obj3 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj1 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj2 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj3 || rc=1
 
-	diff /bin/ls ${mount_dir_1}/obj1 || rc=1
-	diff /bin/ls ${mount_dir_2}/obj2 || rc=1
-	diff /bin/ls ${mount_dir_3}/obj3 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj1 || rc=1
+	diff /bin/ls "${mount_dir_2}"/obj2 || rc=1
+	diff /bin/ls "${mount_dir_3}"/obj3 || rc=1
 
-	unmount_m0t1fs ${mount_dir_1}
-	unmount_m0t1fs ${mount_dir_2}
-	unmount_m0t1fs ${mount_dir_3}
+	unmount_m0t1fs "${mount_dir_1}"
+	unmount_m0t1fs "${mount_dir_2}"
+	unmount_m0t1fs "${mount_dir_3}"
 	echo "First round done."
-	mount_m0t1fs ${mount_dir_1} "fid_start=65536" || {
+	mount_m0t1fs "${mount_dir_1}" "fid_start=65536" || {
 		return 1
 	}
-	mount_m0t1fs ${mount_dir_2} "fid_start=66536" || {
-		unmount_m0t1fs ${mount_dir_1}
+	mount_m0t1fs "${mount_dir_2}" "fid_start=66536" || {
+		unmount_m0t1fs "${mount_dir_1}"
 		return 1
 	}
-	mount_m0t1fs ${mount_dir_3} "fid_start=67536" || {
-		unmount_m0t1fs ${mount_dir_1}
-		unmount_m0t1fs ${mount_dir_2}
+	mount_m0t1fs "${mount_dir_3}" "fid_start=67536" || {
+		unmount_m0t1fs "${mount_dir_1}"
+		unmount_m0t1fs "${mount_dir_2}"
 		return 1
 	}
 	echo "Three clients mounted:"
 	mount | grep m0t1fs
-	ls -liR ${mount_dir_1} || rc=1
-	ls -liR ${mount_dir_2} || rc=1
-	ls -liR ${mount_dir_3} || rc=1
+	ls -liR "${mount_dir_1}" || rc=1
+	ls -liR "${mount_dir_2}" || rc=1
+	ls -liR "${mount_dir_3}" || rc=1
 
-	diff /bin/ls ${mount_dir_1}/obj1 || rc=1
-	diff /bin/ls ${mount_dir_2}/obj2 || rc=1
-	diff /bin/ls ${mount_dir_3}/obj3 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj1 || rc=1
+	diff /bin/ls "${mount_dir_2}"/obj2 || rc=1
+	diff /bin/ls "${mount_dir_3}"/obj3 || rc=1
 
 	# Completely repeat the first round of the test.
-	diff /bin/ls ${mount_dir_1}/obj1 || rc=1
-	diff /bin/ls ${mount_dir_1}/obj2 || rc=1
-	diff /bin/ls ${mount_dir_1}/obj3 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj1 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj2 || rc=1
+	diff /bin/ls "${mount_dir_1}"/obj3 || rc=1
 
-	unmount_m0t1fs ${mount_dir_1}
-	unmount_m0t1fs ${mount_dir_2}
-	unmount_m0t1fs ${mount_dir_3}
+	unmount_m0t1fs "${mount_dir_1}"
+	unmount_m0t1fs "${mount_dir_2}"
+	unmount_m0t1fs "${mount_dir_3}"
 	echo "Second round done"
 	mount | grep m0t1fs
 	return $rc
@@ -489,7 +489,7 @@ rmw_test()
 			do
 				echo -n "IORMW Test: I/O for unit ="\
 				     "${unit_size}K, bs = $io_size, count = $io_count ... "
-				bulkio_test $unit_size $io_size $io_count $mode $mountopt &>> $MOTR_TEST_LOGFILE || return 1
+				bulkio_test $unit_size $io_size $io_count "$mode" "$mountopt" &>> "$MOTR_TEST_LOGFILE" || return 1
 				show_write_speed
 			done
 		done
@@ -511,14 +511,14 @@ obf_test()
 	local rc=0
 
 	echo "Test: obf..."
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "oostore" || {
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "oostore" || {
 		return 1
 	}
-	touch $MOTR_M0T1FS_MOUNT_DIR/0:30000 || rc=1
-	stat $MOTR_M0T1FS_MOUNT_DIR/0:30000 || rc=1
-	ls -la $MOTR_M0T1FS_MOUNT_DIR/0:30000 || rc=1
-	rm $MOTR_M0T1FS_MOUNT_DIR/0:30000 || rc=1
-	unmount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/0:30000 || rc=1
+	stat "$MOTR_M0T1FS_MOUNT_DIR"/0:30000 || rc=1
+	ls -la "$MOTR_M0T1FS_MOUNT_DIR"/0:30000 || rc=1
+	rm "$MOTR_M0T1FS_MOUNT_DIR"/0:30000 || rc=1
+	unmount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR"
 	if [ $rc -eq 0 ]; then
 		echo "Success: Open-by-fid test."
 	else
@@ -535,58 +535,58 @@ m0t1fs_crud()
 	local fsname2=$2
 	local fsname3=$3
 	local mode=$4
-	touch $MOTR_M0T1FS_MOUNT_DIR/$fsname1 || rc=1
-	touch $MOTR_M0T1FS_MOUNT_DIR/$fsname2 || rc=1
-	touch $MOTR_M0T1FS_MOUNT_DIR/$fsname3 || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname1 || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname2 || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname3 || rc=1
-	chmod 567 $MOTR_M0T1FS_MOUNT_DIR/$fsname1 || rc=1
-	chmod 123 $MOTR_M0T1FS_MOUNT_DIR/$fsname2 || rc=1
-	chmod 345 $MOTR_M0T1FS_MOUNT_DIR/$fsname3 || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname1 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname2 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname3 -c "%n: %a %s" || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname1 bs=4K   count=1 || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname2 bs=128K count=1 || rc=1
-	touch_file $MOTR_M0T1FS_MOUNT_DIR/$fsname3 64 &&
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname3 bs=1M   count=1 || rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" || rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" || rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" || rc=1
+	chmod 567 "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" || rc=1
+	chmod 123 "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" || rc=1
+	chmod 345 "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" -c "%n: %a %s" || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" bs=4K   count=1 || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" bs=128K count=1 || rc=1
+	touch_file "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" 64 &&
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" bs=1M   count=1 || rc=1
 	sync
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname1 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname2 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname3 -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" -c "%n: %a %s" || rc=1
 	echo 3 > /proc/sys/vm/drop_caches
-	dd of=/dev/zero if=$MOTR_M0T1FS_MOUNT_DIR/$fsname1 bs=4K   count=1 || rc=1
-	dd of=/dev/zero if=$MOTR_M0T1FS_MOUNT_DIR/$fsname2 bs=128K count=1 || rc=1
-	dd of=/dev/zero if=$MOTR_M0T1FS_MOUNT_DIR/$fsname3 bs=1M   count=1 || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname1 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname2 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname3 -c "%n: %a %s" || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname1 bs=4K   count=1 || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname2 bs=128K count=1 || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname3 bs=1M   count=1 || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname1 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname2 -c "%n: %a %s" || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname3 -c "%n: %a %s" || rc=1
+	dd of=/dev/zero if="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" bs=4K   count=1 || rc=1
+	dd of=/dev/zero if="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" bs=128K count=1 || rc=1
+	dd of=/dev/zero if="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" bs=1M   count=1 || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" -c "%n: %a %s" || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" bs=4K   count=1 || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" bs=128K count=1 || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" bs=1M   count=1 || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" -c "%n: %a %s" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" -c "%n: %a %s" || rc=1
 	if [ "$mode" != "oostore" ]; then
-		ls -l $MOTR_M0T1FS_MOUNT_DIR || rc=1
+		ls -l "$MOTR_M0T1FS_MOUNT_DIR" || rc=1
 	fi
 	unmount_and_clean
 	echo "Remount and perform write on already created file"
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "$mode" || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname1 bs=4K   count=1 || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname2 bs=128K count=1 || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname3 bs=1M   count=1 || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$fsname1 || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$fsname2 || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$fsname3 || rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname1 2>/dev/null && rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname2 2>/dev/null && rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname3 2>/dev/null && rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "$mode" || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" bs=4K   count=1 || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" bs=128K count=1 || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" bs=1M   count=1 || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" || rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" 2>/dev/null && rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" 2>/dev/null && rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname3" 2>/dev/null && rc=1
 
 	# Test for CROW
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fsname1 bs=4K   count=1 || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$fsname1 || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" bs=4K   count=1 || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" || rc=1
 	return $rc
 }
 
@@ -597,7 +597,7 @@ m0t1fs_basic()
 	local fsname2="890"
 	local fsname3="xyz0"
 	echo "Test: basic..."
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR || rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" || rc=1
 	mount | grep m0t1fs
 	m0t1fs_crud $fsname1 $fsname2 $fsname3 || rc=1
 	unmount_and_clean
@@ -619,26 +619,26 @@ m0t1fs_large_dir()
 	local count=512
 
 	echo "Test: larde_dir: mode=$1 fsname_prefix=$2..."
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "$mode" || rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "$mode" || rc=1
 	mount | grep m0t1fs                                 || rc=1
 	for i in $(seq 1 $count); do
-		touch $MOTR_M0T1FS_MOUNT_DIR/$fsname_prex$i || rc=1
-		stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname_prex$i -c "%n: %a %s" || rc=1
+		touch "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname_prex$i" || rc=1
+		stat  "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname_prex$i" -c "%n: %a %s" || rc=1
 	done
 
-	local dirs=$(/bin/ls $MOTR_M0T1FS_MOUNT_DIR -U)
-	local dirs_count=$(echo $dirs | wc -w)
+	local dirs=$(/bin/ls "$MOTR_M0T1FS_MOUNT_DIR" -U)
+	local dirs_count=$(echo "$dirs" | wc -w)
 	echo "readdir count: result $dirs_count, expected $count"
-	if [ ! $dirs_count -eq $count ] ; then
+	if [ ! "$dirs_count" -eq $count ] ; then
 		rc=1
 	fi
 	for i in $(seq 1 $count); do
-		local match=$(echo $dirs | grep -c "\<$fsname_prex$i\>")
-		if [ ! $match -eq 1 ] ; then
+		local match=$(echo "$dirs" | grep -c "\<$fsname_prex$i\>")
+		if [ ! "$match" -eq 1 ] ; then
 			echo "match $fsname_prex$i failed: $match"
 			rc=1
 		else
-			rm -v $MOTR_M0T1FS_MOUNT_DIR/$fsname_prex$i || rc=1
+			rm -v "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname_prex""$i" || rc=1
 		fi
 	done
 
@@ -655,13 +655,13 @@ m0t1fs_oostore_mode()
 	local mode="oostore"
 
 	echo "Test: oostore_mode..."
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR $mode || rc=1
-	mount | grep m0t1fs                              || rc=1
-	m0t1fs_crud $fsname1 $fsname2 $fsname3 $mode || rc=1
-	touch $MOTR_M0T1FS_MOUNT_DIR/123456 2>/dev/null && rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/123456 2>/dev/null && rc=1
-	touch $MOTR_M0T1FS_MOUNT_DIR/abcdef 2>/dev/null && rc=1
-	stat  $MOTR_M0T1FS_MOUNT_DIR/abcdef 2>/dev/null && rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "$mode"        || rc=1
+	mount | grep m0t1fs                                  || rc=1
+	m0t1fs_crud "$fsname1" "$fsname2" "$fsname3" "$mode" || rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/123456 2>/dev/null && rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/123456 2>/dev/null && rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/abcdef 2>/dev/null && rc=1
+	stat  "$MOTR_M0T1FS_MOUNT_DIR"/abcdef 2>/dev/null && rc=1
 	unmount_and_clean
 
 	return $rc
@@ -684,48 +684,48 @@ m0t1fs_oostore_mode_basic()
 
 	for i in {a..z} {A..Z} ; do
 		for c in $(seq 1 4095);
-			do echo -n $i ;
+			do echo -n "$i" ;
 		done;
 		echo;
 	done > $SOURCE_TXT
 
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "oostore" || rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "oostore" || rc=1
 	mount | grep m0t1fs                                 || rc=1
-	cp -v $SOURCE_TXT $MOTR_M0T1FS_MOUNT_DIR/$fsname1   || rc=1
-	cat $MOTR_M0T1FS_MOUNT_DIR/$fsname1 > /tmp/$fsname1 || rc=1
+	cp -v "$SOURCE_TXT" "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1"   || rc=1
+	cat "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" > /tmp/"$fsname1" || rc=1
 	# sleep two seconds, so the {a,c,m}time are different
 	sleep 2
-	cp -v $SOURCE_TXT $MOTR_M0T1FS_MOUNT_DIR/$fsname2   || rc=1
-	cat $MOTR_M0T1FS_MOUNT_DIR/$fsname2 > /tmp/$fsname2 || rc=1
-	diff $SOURCE_TXT /tmp/$fsname1                      || rc=1
-	diff $SOURCE_TXT /tmp/$fsname2                      || rc=1
+	cp -v "$SOURCE_TXT" "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2"   || rc=1
+	cat   "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" > /tmp/"$fsname2" || rc=1
+	diff  "$SOURCE_TXT" /tmp/"$fsname1"                      || rc=1
+	diff  "$SOURCE_TXT" /tmp/"$fsname2"                      || rc=1
 
-	chmod 123 $MOTR_M0T1FS_MOUNT_DIR/$fsname1           || rc=1
-	chmod 456 $MOTR_M0T1FS_MOUNT_DIR/$fsname2           || rc=1
+	chmod 123 "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1"           || rc=1
+	chmod 456 "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2"           || rc=1
 
-	cat $MOTR_M0T1FS_MOUNT_DIR/$fsname1 > /dev/null     || rc=1
-	cat $MOTR_M0T1FS_MOUNT_DIR/$fsname2 > /dev/null     || rc=1
+	cat "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1" > /dev/null     || rc=1
+	cat "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2" > /dev/null     || rc=1
 
-	stat $MOTR_M0T1FS_MOUNT_DIR/$fsname1                || rc=1
-	stat $MOTR_M0T1FS_MOUNT_DIR/$fsname2                || rc=1
+	stat "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1"                || rc=1
+	stat "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2"                || rc=1
 
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$fsname1               || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$fsname2               || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1"               || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname2"               || rc=1
 
 	# Recreate and remove the file
-	touch $MOTR_M0T1FS_MOUNT_DIR/$fsname1               || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$fsname1               || rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1"               || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$fsname1"               || rc=1
 
-	cp -v $SOURCE_TXT $MOTR_M0T1FS_MOUNT_DIR/$file                   || rc=1
-	cp -v $MOTR_M0T1FS_MOUNT_DIR/$file $MOTR_M0T1FS_MOUNT_DIR/$file1 || rc=1
-	cp -v $MOTR_M0T1FS_MOUNT_DIR/$file $MOTR_M0T1FS_MOUNT_DIR/$file2 || rc=1
-	cp -v $MOTR_M0T1FS_MOUNT_DIR/$file $MOTR_M0T1FS_MOUNT_DIR/$file3 || rc=1
-	cp -v $MOTR_M0T1FS_MOUNT_DIR/$file $MOTR_M0T1FS_MOUNT_DIR/$file4 || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$file                               || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$file1                              || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$file2                              || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$file3                              || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$file4                              || rc=1
+	cp -v "$SOURCE_TXT" "$MOTR_M0T1FS_MOUNT_DIR"/"$file"                   || rc=1
+	cp -v "$MOTR_M0T1FS_MOUNT_DIR"/"$file" "$MOTR_M0T1FS_MOUNT_DIR"/"$file1" || rc=1
+	cp -v "$MOTR_M0T1FS_MOUNT_DIR"/"$file" "$MOTR_M0T1FS_MOUNT_DIR"/"$file2" || rc=1
+	cp -v "$MOTR_M0T1FS_MOUNT_DIR"/"$file" "$MOTR_M0T1FS_MOUNT_DIR"/"$file3" || rc=1
+	cp -v "$MOTR_M0T1FS_MOUNT_DIR"/"$file" "$MOTR_M0T1FS_MOUNT_DIR"/"$file4" || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$file"                               || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$file1"                              || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$file2"                              || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$file3"                              || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/"$file4"                              || rc=1
 
 	unmount_and_clean
 
@@ -737,21 +737,21 @@ m0t1fs_parallel_io_test()
 	local mode=$1
 	BS=$((10 * 1024 * 1024))
 	echo "Parallel IO test"
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "$mode" || rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "$mode" || rc=1
 	mount | grep m0t1fs                         || rc=1
 	echo "Create files"
 	for i in 0:100{0..4}000; do
-		touch $MOTR_M0T1FS_MOUNT_DIR/$i     || rc=1
+		touch "$MOTR_M0T1FS_MOUNT_DIR"/$i     || rc=1
 	done
 
 	for i in 0:100{0..4}000; do
-		setfattr -n writesize -v $BS $MOTR_M0T1FS_MOUNT_DIR/$i || rc=1
+		setfattr -n writesize -v $BS "$MOTR_M0T1FS_MOUNT_DIR"/$i || rc=1
 	done
 	echo "Spawn parallel dd's"
 	for i in $(seq 1 4)
 	do
 		fid="0:100"$i"000"
-		dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fid \
+		dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/"$fid" \
 			bs=$BS count=10 &
 		dd_pid[$i]=$!
 	done
@@ -762,7 +762,7 @@ m0t1fs_parallel_io_test()
 		wait ${dd_pid[$i]}
 	done
 	for i in 0:100{0..4}000; do
-		rm -f $MOTR_M0T1FS_MOUNT_DIR/$i      || rc=1
+		rm -f "$MOTR_M0T1FS_MOUNT_DIR"/$i      || rc=1
 	done
 	unmount_and_clean
 
@@ -774,19 +774,19 @@ m0t1fs_big_bs_io_test()
 	local mode=$1
 	echo "Big BS IO test"
 	rc=0
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "$mode" || rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" "$mode" || rc=1
 	mount | grep m0t1fs                         || rc=1
 	echo "Create file"
 	i=0:1000000
-	touch $MOTR_M0T1FS_MOUNT_DIR/$i                        || rc=1
-	setfattr -n writesize -v 65536 $MOTR_M0T1FS_MOUNT_DIR/$i || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$i bs=32M count=1  || rc=1
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$i                                || rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/$i                        || rc=1
+	setfattr -n writesize -v 65536 "$MOTR_M0T1FS_MOUNT_DIR"/$i || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/$i bs=32M count=1  || rc=1
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/$i                                || rc=1
 	echo "Test the error case"
-	touch $MOTR_M0T1FS_MOUNT_DIR/$i                        || rc=1
-	setfattr -n writesize -v 4096 $MOTR_M0T1FS_MOUNT_DIR/$i || rc=1
-	dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$i bs=32M count=1  || rc=0
-	rm -f $MOTR_M0T1FS_MOUNT_DIR/$i                                || rc=1
+	touch "$MOTR_M0T1FS_MOUNT_DIR"/$i                        || rc=1
+	setfattr -n writesize -v 4096 "$MOTR_M0T1FS_MOUNT_DIR"/$i || rc=1
+	dd if=/dev/zero of="$MOTR_M0T1FS_MOUNT_DIR"/$i bs=32M count=1  || rc=0
+	rm -f "$MOTR_M0T1FS_MOUNT_DIR"/$i                                || rc=1
 	unmount_and_clean
 
 	return $rc
@@ -800,32 +800,32 @@ m0t1fs_big_bs_io_test()
 m0t1fs_test_MOTR_2099()
 {
 	local rc=0
-	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR || rc=1
+	mount_m0t1fs "$MOTR_M0T1FS_MOUNT_DIR" || rc=1
 
-	df $MOTR_M0T1FS_MOUNT_DIR
-	used_before=$(df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1)
+	df "$MOTR_M0T1FS_MOUNT_DIR"
+	used_before=$(df "$MOTR_M0T1FS_MOUNT_DIR" --output=used | tail -n 1)
 	for i in 0:00{0..9}{0..1}; do
 		# This is to create 20 files, 200MB each, 8GB in total.
 		m0t1fs_file=$MOTR_M0T1FS_MOUNT_DIR/${i}
-		touch_file $m0t1fs_file 8192 && run "dd if=/dev/zero of=$m0t1fs_file bs=200M count=1" || rc=1
+		touch_file "$m0t1fs_file" 8192 && run "dd if=/dev/zero of=$m0t1fs_file bs=200M count=1" || rc=1
 	done
-	df $MOTR_M0T1FS_MOUNT_DIR
-	used_after=$(df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1)
+	df "$MOTR_M0T1FS_MOUNT_DIR"
+	used_after=$(df "$MOTR_M0T1FS_MOUNT_DIR" --output=used | tail -n 1)
 	for i in 0:00{0..9}{0..1}; do
 		m0t1fs_file=$MOTR_M0T1FS_MOUNT_DIR/${i}
-		rm -f $m0t1fs_file
+		rm -f "$m0t1fs_file"
 	done
-	df $MOTR_M0T1FS_MOUNT_DIR
-	used_delete=$(df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1)
+	df "$MOTR_M0T1FS_MOUNT_DIR"
+	used_delete=$(df "$MOTR_M0T1FS_MOUNT_DIR" --output=used | tail -n 1)
 	echo "used_before used_after used_delete $used_before $used_after $used_delete"
-	if [ $used_before -ne $used_delete ] ; then
+	if [ "$used_before" -ne "$used_delete" ] ; then
 		echo "balloc space leak? After deletion, used blocks are not the same as before."
 		rc=1
 	fi
 
-	total_blocks=$((200 * 20 * 1024)) #in 1K blocks
+	total_blocks=`expr 200 \* 20 \* 1024` #in 1K blocks
 	echo "total_blocks = $total_blocks"
-	if [ $used_after -le $total_blocks ] ; then
+	if [ "$used_after" -le "$total_blocks" ] ; then
 		echo "Are you kidding? The used blocks are less than expected."
 		rc=1
 	fi
@@ -846,12 +846,12 @@ m0t1fs_system_tests()
 		return 1
 	}
 
-	file_creation_test $MAX_NR_FILES || {
+	file_creation_test "$MAX_NR_FILES" || {
 		echo "Failed: File creation test failed."
 		return 1
 	}
 
-	file_creation_test $MAX_NR_FILES "oostore" || {
+	file_creation_test "$MAX_NR_FILES" "oostore" || {
 		echo "Failed: File creation test failed."
 		return 1
 	}
@@ -891,12 +891,12 @@ m0t1fs_system_tests()
 		return 1
 	}
 
-	io_combinations $POOL_WIDTH $NR_DATA $NR_PARITY $NR_SPARE || {
+	io_combinations "$POOL_WIDTH" "$NR_DATA" "$NR_PARITY" "$NR_SPARE" || {
 		echo "Failed: IO failed.."
 		return 1
 	}
 
-	io_combinations $POOL_WIDTH $NR_DATA $NR_PARITY $NR_SPARE "oostore"|| {
+	io_combinations "$POOL_WIDTH" "$NR_DATA" "$NR_PARITY" "$NR_SPARE" "oostore"|| {
 		echo "Failed: IO failed oostore mode.."
 		return 1
 	}


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>
Signed-off-by: alfhad <fahadshah2411@gmail.com>

# Problem Statement
We see 1688 occurrence of pattern, "Double quote to prevent globing and word splitting".

# Design
We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
