### PR TITLE
CORTX-31248: Initialize m0_idx_op with zeroes in m0kv index_op.

### DIFF
--- a/motr/m0kv/index_op.c
+++ b/motr/m0kv/index_op.c
@@ -196,7 +196,7 @@ static int index_op(struct m0_realm    *parent,
 		    struct m0_bufvec   *keys,
 		    struct m0_bufvec   *vals)
 {
-	struct m0_idx  idx;
+	struct m0_idx  idx = {};
 	struct m0_op  *op = NULL;
 	int32_t       *rcs;
 	int            rc;


### PR DESCRIPTION
When ENF_META flag was not used, m0_idx_op::in_attr was not properly
initialized.  Which lead to precondition check failure when trying to
run PUT KV with m0kv.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- See #1741 for issue description.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
