### PR TITLE
CORTX-31264: fix SNS system tests regression

### DIFF
--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -1596,6 +1596,7 @@ static int ioreq_dgmode_read(struct m0_op_io *ioo, bool rmw)
 	pm = ioo_to_poolmach(ioo);
 	M0_ASSERT(pm != NULL);
 
+	rc = 0;
 	m0_htable_for(tioreqht, ti, &xfer->nxr_tioreqs_hash) {
 		/*
 		 * Data was retrieved successfully, so no need to check the


### PR DESCRIPTION
The regression was introduced at 570645319 after which
SNS system tests started failing.

RCA: rc is not reset after device_check() at ioreq_dgmode_read().
As result, in some conditions, it may be interpreted as failed
degraded read.

Solution: reset rc after device_check() call.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
