### PR TITLE
Fix a deadlock between rpc link and confc_ready_async_ast() ast.

### DIFF
--- a/conf/helpers.c
+++ b/conf/helpers.c
@@ -510,6 +510,8 @@ M0_INTERNAL void m0_confc_ready_cb(struct m0_rconfc *rconfc)
 	 * Clink callbacks are going to use m0_rconfc::rc_confc for reading the
 	 * updated conf. Therefore, the locality where reading conf occurs must
 	 * be other than locality0 used with m0_reqh::rh_rconfc::rc_confc.
+	 *
+	 * Also, see the comment in rpc_link_fom_locality().
 	 */
 	m0_sm_ast_post(m0_locality_get(1)->lo_grp, &reqh->rh_conf_cache_ast);
 	M0_LEAVE();

--- a/rpc/link.c
+++ b/rpc/link.c
@@ -95,9 +95,29 @@ static const struct m0_fom_type_ops rpc_link_disc_fom_type_ops = {
 	.fto_create = NULL,
 };
 
+/**
+ * Locality function for rpc link connect and disconnect foms.
+ */
 static size_t rpc_link_fom_locality(const struct m0_fom *fom)
 {
-	return 1;
+	/*
+	 * This fom must be scheduled on a different locality than the locality
+	 * to which confc_ready_async_ast() ast is posted by
+	 * m0_confc_ready_cb(), because that ast waits the establishment of the
+	 * for rpc connection initiated by connect_to_confd().
+	 *
+	 * @see m0_confc_ready_cb().
+	 *
+	 * Note: this is not a satisfactory solution for many reasons:
+	 *
+	 *     - it won't work if there are too few localities,
+	 *
+	 *     - it is difficult to maintain and test,
+	 *
+	 *     - blocking ast is wrong in the first place.
+	 */
+	M0_ASSERT(m0_locality_get(1)->lo_grp != m0_locality_get(2)->lo_grp);
+	return 2;
 }
 
 /* Routines for connection */


### PR DESCRIPTION
The stack traces are below, see the comments for the explanation.

Locality 1: Thread 5
    m0_semaphore_down (semaphore=0x7ff3927fb840) at lib/user_space/semaphore.c:62
    m0_chan_wait (link=0x7ff3927fb818) at lib/chan.c:342
    sm_waiter_wait (w=0x7ff3927fb600, result=0x7ff3927fb9a8) at conf/confc.c:833
    m0_confc__open_sync (result=0x7ff3927fb9a8, origin=0x7ff28c0cff70, path=0x7ff3927fb9b0) at conf/confc.c:914
    pool_mds_map_init (pc=0x7ff3a93d9ec0 <ut_reqh+15136>) at pool/pool.c:407
    pools_common_refresh_locked (pc=0x7ff3a93d9ec0 <ut_reqh+15136>) at pool/pool.c:1508
    pools_common__update_by_conf (pc=0x7ff3a93d9ec0 <ut_reqh+15136>) at pool/pool.c:1346
    m0_pools_common_conf_ready_async_cb (clink=0x7ff3a93da138 <ut_reqh+15768>) at pool/pool.c:1396
    clink_signal (clink=0x7ff3a93da138 <ut_reqh+15768>) at lib/chan.c:135
    chan_signal_nr (chan=0x7ff3a93e34b0 <ut_reqh+53520>, nr=0) at lib/chan.c:154
    m0_chan_broadcast (chan=0x7ff3a93e34b0 <ut_reqh+53520>) at lib/chan.c:174
    m0_chan_broadcast_lock (chan=0x7ff3a93e34b0 <ut_reqh+53520>) at lib/chan.c:181
    confc_ready_async_ast (grp=0x8fac00, ast=0x7ff3a93e34e0 <ut_reqh+53568>) at conf/helpers.c:484
    m0_sm_asts_run (grp=0x8fac00) at sm/sm.c:175
    loc_handler_thread (th=0x93ec90) at fop/fom.c:925

locality 0: Thread 2
    m0_semaphore_down (semaphore=0x7ff390ff89f8) at lib/user_space/semaphore.c:62
    m0_chan_wait (link=0x7ff390ff89d0) at lib/chan.c:342
    rpc_link_call_sync (rlink=0x7ff3a93ebd18 <spiel+152>, abs_timeout=1651297249378186846, cb=0x7ff39d4c9808 <m0_rpc_link_connect_async>) at rpc/link.c:704
    m0_rpc_link_connect_sync (rlink=0x7ff3a93ebd18 <spiel+152>, abs_timeout=1651297249378186846) at rpc/link.c:726
    connect_to_confd (confc=0x7ff3a93ebca0 <spiel+32>, confd_addr=0x7ff28c053e10 "0@lo:12345:34:1", rpc_mach=0x7ff3a93d96a8 <ut_reqh+13064>) at conf/confc.c:1670
    m0_confc_reconnect (confc=0x7ff3a93ebca0 <spiel+32>, rpc_mach=0x7ff3a93d96a8 <ut_reqh+13064>, confd_addr=0x7ff28c053e10 "0@lo:12345:34:1") at conf/confc.c:504
    rconfc_conductor_connect (rconfc=0x7ff3a93ebca0 <spiel+32>, lnk=0x7ff28c0725a0) at conf/rconfc.c:1780
    rconfc_conductor_iterate (rconfc=0x7ff3a93ebca0 <spiel+32>) at conf/rconfc.c:1833
    rconfc_conductor_engage (rconfc=0x7ff3a93ebca0 <spiel+32>) at conf/rconfc.c:2520
    rconfc_version_elected (grp=0x8b3dc0, ast=0x7ff3a93ecac0 <spiel+3648>) at conf/rconfc.c:2598
    m0_sm_asts_run (grp=0x8b3dc0) at sm/sm.c:173
    m0_sm_group_lock (grp=0x8b3dc0) at sm/sm.c:86
    locs_ast_handler (__unused=0x0) at lib/locality.c:198

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
