### PR TITLE
Fix a race between flip fom processing and asts

### DIFF
--- a/ha/note.c
+++ b/ha/note.c
@@ -246,6 +246,7 @@ M0_INTERNAL void m0_ha_msg_accept(const struct m0_ha_msg *msg,
 				    false,
 				    M0_HA_NVEC_SET, hl);
 	} else {
+		m0_mutex_lock(&hl->hln_cfg.hlc_reqh->rh_rconfc_guard);
 		confc = m0_reqh2confc(hl->hln_cfg.hlc_reqh);
 		cache = &confc->cc_cache;
 		nvec_req = &msg->hm_data.u.hed_nvec;
@@ -267,6 +268,7 @@ M0_INTERNAL void m0_ha_msg_accept(const struct m0_ha_msg *msg,
 			}
 		}
 		m0_conf_cache_unlock(cache);
+		m0_mutex_unlock(&hl->hln_cfg.hlc_reqh->rh_rconfc_guard);
 		m0_ha_msg_nvec_send(&nvec,
 		                    msg->hm_data.u.hed_nvec.hmnv_id_of_get,
 				    false,

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -422,9 +422,7 @@ static int cs_reqh_ctx_init(struct m0_motr *cctx)
 
 	M0_ENTRY();
 
-	*rctx = (struct m0_reqh_context) {
-		.rc_motr = cctx
-	};
+	rctx->rc_motr = cctx;
 	M0_ALLOC_ARR(rctx->rc_services,     M0_CST_NR);
 	M0_ALLOC_ARR(rctx->rc_service_fids, M0_CST_NR);
 	if (rctx->rc_services == NULL || rctx->rc_service_fids == NULL) {

--- a/pool/pool.c
+++ b/pool/pool.c
@@ -898,7 +898,11 @@ static int __service_ctx_create(struct m0_pools_common *pc,
 	int                          rc = 0;
 
 	M0_PRE(m0_conf_service_type_is_valid(cs->cs_type));
+	M0_PRE(m0_mutex_is_locked(&pc->pc_mutex));
 	M0_PRE((pc->pc_rmach != NULL) == services_connect);
+
+	if (pc->pc_shutdown) /* See m0_reqh_service_ctxs_shutdown_prepare(). */
+		return M0_ERR(-ENOENT);
 
 	for (endpoint = cs->cs_endpoints; *endpoint != NULL; ++endpoint) {
 		M0_ASSERT_INFO(endpoint == cs->cs_endpoints,

--- a/pool/pool.h
+++ b/pool/pool.h
@@ -235,6 +235,8 @@ struct m0_pools_common {
 	struct m0_clink                   pc_conf_ready_async;
 	/** Pool of cas services used to store dix. */
 	struct m0_pool                   *pc_dix_pool;
+	/** Set by m0_reqh_service_ctxs_shutdown_prepare(). */
+	bool                              pc_shutdown;
 };
 
 M0_TL_DESCR_DECLARE(pools_common_svc_ctx, M0_EXTERN);

--- a/reqh/reqh.c
+++ b/reqh/reqh.c
@@ -252,6 +252,7 @@ m0_reqh_init(struct m0_reqh *reqh, const struct m0_reqh_init_args *reqh_args)
 		   &reqh->rh_sm_grp);
 
 	m0_mutex_init(&reqh->rh_guard);
+	m0_mutex_init(&reqh->rh_rconfc_guard);
 	m0_mutex_init(&reqh->rh_guard_async);
 	m0_chan_init(&reqh->rh_conf_cache_exp, &reqh->rh_guard);
 	m0_chan_init(&reqh->rh_conf_cache_ready, &reqh->rh_guard);
@@ -315,6 +316,7 @@ static void __reqh_fini(struct m0_reqh *reqh)
 	m0_chan_fini_lock(&reqh->rh_conf_cache_ready_async);
 	m0_mutex_fini(&reqh->rh_guard);
 	m0_mutex_fini(&reqh->rh_guard_async);
+	m0_mutex_fini(&reqh->rh_rconfc_guard);
 }
 
 M0_INTERNAL void m0_reqh_fini(struct m0_reqh *reqh)

--- a/reqh/reqh.h
+++ b/reqh/reqh.h
@@ -160,6 +160,9 @@ struct m0_reqh {
 	 */
 	struct m0_reqh_lockers        rh_lockers;
 
+	/** Guard for rconfc re-initialisation. */
+	struct m0_mutex               rh_rconfc_guard;
+
 	/**
 	 * Rconfc instance.
 	 */

--- a/rm/rm_foms.c
+++ b/rm/rm_foms.c
@@ -534,7 +534,8 @@ static int rfom_debtor_subscribe(struct rm_request_fom *rfom,
 	/* get confc instance HA to be notifying on */
 	confc = m0_reqh2confc(item->ri_rmachine->rm_reqh);
 	rc = m0_rm_ha_subscriber_init(&rfom->rf_sbscr, &fom->fo_loc->fl_group,
-				confc, ep, &debtor->rem_tracker);
+				      confc, ep, &debtor->rem_tracker,
+				      item->ri_rmachine->rm_reqh);
 	if (rc == 0) {
 		m0_fom_phase_set(fom, FOPH_RM_REQ_DEBTOR_SUBSCRIBE);
 		m0_fom_wait_on(fom, &rfom->rf_sbscr.rhs_sm.sm_chan,

--- a/rm/rm_ha.h
+++ b/rm/rm_ha.h
@@ -137,6 +137,7 @@ struct m0_rm_ha_subscriber {
 	struct m0_conf_diter     rhs_diter;    /**< Directory iterator */
 	struct m0_clink          rhs_clink;    /**< Clink tracking rhs_cctx */
 	struct m0_sm_ast         rhs_ast;      /**< AST to schedule sm action */
+	struct m0_reqh          *rhs_reqh;     /**< Ambient request handler. */
 };
 
 /**
@@ -179,7 +180,8 @@ M0_INTERNAL int m0_rm_ha_subscriber_init(struct m0_rm_ha_subscriber *sbscr,
 					 struct m0_sm_group         *grp,
 					 struct m0_confc            *confc,
 					 const char                 *rem_ep,
-					 struct m0_rm_ha_tracker    *tracker);
+					 struct m0_rm_ha_tracker    *tracker,
+					 struct m0_reqh             *reqh);
 
 /**
  * Start asynchronous subscription process.

--- a/rpc/link.c
+++ b/rpc/link.c
@@ -749,7 +749,7 @@ M0_INTERNAL int m0_rpc_link_disconnect_sync(struct m0_rpc_link *rlink,
 
 M0_INTERNAL bool m0_rpc_link_is_connected(const struct m0_rpc_link *rlink)
 {
-	return rlink->rlk_connected;
+	return rlink->rlk_connected && rlink->rlk_rc == 0;
 }
 
 M0_INTERNAL const char *m0_rpc_link_end_point(const struct m0_rpc_link *rlink)

--- a/spiel/ut/spiel_ut_common.c
+++ b/spiel/ut/spiel_ut_common.c
@@ -44,10 +44,18 @@ static int m0_spiel__ut_rms_start(struct m0_reqh *reqh)
 M0_INTERNAL int m0_spiel__ut_reqh_init(struct m0_spiel_ut_reqh *spl_reqh,
 		                       const char              *ep_addr)
 {
+	struct m0_rconfc *rconfc = &spl_reqh->sur_confd_srv.rsx_motr_ctx
+		.cc_reqh_ctx.rc_reqh.rh_rconfc;
+	struct m0_confc  *confc  = &rconfc->rc_confc;
 	enum { NR_TMS = 1 };
 	int rc;
 
 	M0_SET0(spl_reqh);
+	/* Copied from m0_confc_init_wait(). */
+	m0_mutex_init(&confc->cc_lock);
+	m0_confc_bob_init(confc);
+	m0_conf_cache_init(&confc->cc_cache, &confc->cc_lock);
+
 	rc = m0_net_domain_init(&spl_reqh->sur_net_dom,
 				 m0_net_xprt_default_get());
 	if (rc != 0)
@@ -131,8 +139,6 @@ M0_INTERNAL int m0_spiel__ut_rpc_server_start(struct m0_rpc_server_ctx *rpc_srv,
 		"-c", (char *)confdb_path
 	};
 #undef NAME
-
-	M0_SET0(rpc_srv);
 
 	rpc_srv->rsx_xprts    = m0_net_all_xprt_get();
 	rpc_srv->rsx_xprts_nr = m0_net_xprt_nr();


### PR DESCRIPTION
To process confd flip fom, conf cache is destroyed and re-initialised. And
concurrent activity that tries to access the cache will see the cache in
half-destructed state.

Fix: introduce a new per-reqh lock and use it for synchronisation.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
