### PR TITLE
spiel_tx_write_lock_put(): fix a race with concurrent REVOKE foms

### DIFF
--- a/spiel/conf_mgmt.c
+++ b/spiel/conf_mgmt.c
@@ -584,7 +584,16 @@ static void spiel_tx_write_lock_put(struct m0_spiel_tx *tx)
 	wlock_ctx_destroy(wlx);
 	wlock_ctx_disconnect(wlx);
 	m0_free0(&wlx->wlc_rm_addr);
-	m0_free0(&tx->spt_spiel->spl_wlock_ctx);
+	/*
+	 * @todo Freeing ->spl_wlock_ctx is not safe here, because incoming
+	 * revoke foms can be processed concurrently. Just leak the context for
+	 * the time being.
+	 */
+	if (0) {
+		m0_free0(&tx->spt_spiel->spl_wlock_ctx);
+	} else {
+		tx->spt_spiel->spl_wlock_ctx = NULL;
+	}
 	M0_LEAVE();
 }
 


### PR DESCRIPTION
Problem: spiel_tx_write_lock_put() releases the distributed lock, taken by
spiel_tx_write_lock_get(). It also finalises and frees "write lock
context" (m0_spiel_wlock_ctx) that contains all the information necessary to
interact with resource manager. But it is possible that requests the revoke this
lock are processed concurrently (and, worse, they can arrive later).

Fix: possible solutions are: (0) synchronise with concurrent foms and only
release the context after making sure no new foms will use it, or (1) provide a
mechanism to "register" an owner and a resource with the resource manager, so
that they will remain useful for the future requests and will be cleaned up when
RM finalises. There are mechanisms for neither (0) nor (1) at the moment, so
just leak the context.

Signed-off-by: Nikita Danilov <nikita.danilov@seagate.com>
