### PR TITLE
CORTX-31292: fix m0tr.ko build regression

### DIFF
--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -1734,9 +1734,9 @@ static int ioreq_dgmode_write(struct m0_op_io *ioo, bool rmw)
 		ioo->ioo_rc = 0;
 
 		M0_LOG(M0_NOTICE, "user data written with degraded redundancy: "
-				  "off=%lu len=%lu failed_devs=%d",
-				  INDEX(&ioo->ioo_ext, 0),
-				  m0_vec_count(&ioo->ioo_ext.iv_vec), rc);
+		       "off=%" PRIu64 " len=%" PRIu64 " failed_devs=%d",
+		       INDEX(&ioo->ioo_ext, 0),
+		       m0_vec_count(&ioo->ioo_ext.iv_vec), rc);
 
 		return M0_RC(0);
 	}


### PR DESCRIPTION
The regression was introduced at commit 446fe0372:

    motr/io_req.c:1736:21: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘m0_bcount_t’ {aka ‘long long unsigned int’} [-Werror=format=]
       M0_LOG(M0_NOTICE, "user data written with degraded redundancy: "
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Solution: use PRIu64 format for printing m0_bcount_t.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
