### PR TITLE
CORTX-31299: Memory leak in spiel bytecount function

### DIFF
--- a/spiel/cmd.c
+++ b/spiel/cmd.c
@@ -2308,6 +2308,7 @@ sem_fini:
 	m0_semaphore_fini(&proc->sci_barrier);
 obj_close:
 	m0_confc_close(proc_obj);
+	m0_free(proc);
 	return M0_RC(rc);
 }
 M0_EXPORTED(m0_spiel_proc_counters_fetch);


### PR DESCRIPTION
proc pointer is not freed in m0_spiel_proc_counters_fetch

# Problem Statement
- As part of hax memory issue, identified that proc pointer in bytecount function 
- is not freed 

Testing with alloc-profile branch
Before applying this patch
`[         3 -          1 =          2] [       112] [    3 -     1] fid/fid.c 308 m0_fid_arr_copy to->af_elems
[         2 -          1 =          1] [       496] [    2 -     1] rpc/session_foms.c 349 m0_rpc_fom_session_establish_tick session
[      4770 -       4766 =          4] [  16126602] [ 2160 -  1140] lib/memory.c 131 m0_alloc alloc
profile = <0x700000000000000:0>
[         1 -          0 =          1] [         0] [    1 -     0] spiel/cmd.c 2275 m0_spiel_proc_counters_fetch count_stats->pc_bcrec
[         1 -          0 =          1] [         0] [    1 -     0] spiel/cmd.c 2270 m0_spiel_proc_counters_fetch count_stats->pc_bckey
[         1 -          0 =          1] [      4704] [    1 -     0] spiel/cmd.c 2239 m0_spiel_proc_counters_fetch proc
[         3 -          1 =          2] [       112] [    3 -     1] fid/fid.c 308 m0_fid_arr_copy to->af_elems
[         2 -          1 =          1] [       496] [    2 -     1] rpc/session_foms.c 349 m0_rpc_fom_session_establish_tick session
[      1076 -       1072 =          4] [   8593162] [  210 -    72] lib/memory.c 131 m0_alloc alloc
`
After applying this patch
`[         3 -          1 =          2] [       112] [    3 -     1] fid/fid.c 308 m0_fid_arr_copy to->af_elems
[         2 -          1 =          1] [       496] [    2 -     1] rpc/session_foms.c 349 m0_rpc_fom_session_establish_tick session
[      4770 -       4766 =          4] [  16126602] [ 2160 -  1140] lib/memory.c 131 m0_alloc alloc
profile = <0x700000000000000:0>
[         1 -          0 =          1] [         0] [    1 -     0] spiel/cmd.c 2275 m0_spiel_proc_counters_fetch count_stats->pc_bcrec
[         1 -          0 =          1] [         0] [    1 -     0] spiel/cmd.c 2270 m0_spiel_proc_counters_fetch count_stats->pc_bckey
[         3 -          1 =          2] [       112] [    3 -     1] fid/fid.c 308 m0_fid_arr_copy to->af_elems
[         2 -          1 =          1] [       496] [    2 -     1] rpc/session_foms.c 349 m0_rpc_fom_session_establish_tick session
[      1076 -       1072 =          4] [   8593162] [  210 -    72] lib/memory.c 131 m0_alloc alloc
`