### PR TITLE
remove ruby lib from motr repo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -784,7 +784,6 @@ bin_SCRIPTS   += utils/m0confgen \
                  utils/m0hagen
 
 sbin_SCRIPTS  += utils/m0gendisks \
-                 utils/m0genfacts \
                  utils/m0reportbug \
                  utils/m0run \
                  utils/m0setup \

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -162,9 +162,7 @@ Requires:       perl-autodie
 Requires:       perl-Try-Tiny
 Requires:       perl-Sereal
 Requires:       perl-MCE
-Requires:       ruby
 Requires:       facter
-Requires:       rubygem-net-ssh
 %if %{rhel} < 8
 Requires:       python36-ply
 %else

--- a/scripts/provisioning/roles/motr-runtime/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-runtime/vars/RedHat.yml
@@ -35,8 +35,6 @@ motr_runtime_deps_pkgs:
   - perl-YAML-LibYAML
   - perl-autodie
   - pkgconfig
-  - ruby
-  - rubygem-net-ssh
   - libedit
   - openssl
 

--- a/utils/Makefile.sub
+++ b/utils/Makefile.sub
@@ -1,6 +1,5 @@
 EXTRA_DIST += utils/m0confgen \
               utils/m0gendisks \
-              utils/m0genfacts \
               utils/m0hagen \
               utils/m0mount \
               utils/m0reportbug \


### PR DESCRIPTION
removed ruby references from motr repo
removed m0genfacts reference from makefile

Signed-off-by: Parikshit Dharmale <parikshit.dharmale@seagate.com>

# Problem Statement
- [CORTX-30762](https://jts.seagate.com/browse/CORTX-30762)
- cortx-motr repository installs Ruby and related libraries, a security_vulnerability is tagged because all the ruby packages installed with the image has known vulnerabilities in it. 

# Design
references to ruby are removed 
reference to m0genfacts are removed which causes  ruby installation

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Tested with custom build 6048, motr rpm does not have ruby dependency 
- Tested in deployed cluster, all the motr containers does not have ruby lib installation 


# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
