### PR TITLE
CORTX-30921: Add spiel support for dix repair and rebalance in m0_ha_sim

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/common/m0_dix_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_dix_utils_common.sh
@@ -28,7 +28,7 @@ dix_repair_or_rebalance_status()
         [ "$1" == "repair" ] && op=$CM_OP_REPAIR_STATUS
         [ "$1" == "rebalance" ] && op=$CM_OP_REBALANCE_STATUS
 
-        repair_status=$(get_m0repair_utils_cmd DIX "$op")
+        repair_status=$(get_m0repair_utils_cmd "$op")
         run "$repair_status"
         rc=$?
         if [ $rc != 0 ]; then
@@ -46,7 +46,7 @@ wait_for_dix_repair_or_rebalance()
         [ "$1" == "repair" ] && op=$CM_OP_REPAIR_STATUS
         [ "$1" == "rebalance" ] && op=$CM_OP_REBALANCE_STATUS
 
-        status_cmd=$(get_m0repair_utils_cmd DIX "$op")
+        status_cmd=$(get_m0repair_utils_cmd "$op")
         while true ; do
                 sleep 5
                 echo "$status_cmd"
@@ -71,7 +71,7 @@ dix_repair()
 {
         local rc=0
 
-        repair_trigger=$(get_m0repair_utils_cmd DIX "$CM_OP_REPAIR")
+        repair_trigger=$(get_m0repair_utils_cmd "$CM_OP_REPAIR")
         run "$repair_trigger"
         rc=$?
         if [ $rc != 0 ]; then
@@ -85,7 +85,7 @@ dix_rebalance()
 {
         local rc=0
 
-        rebalance_trigger=$(get_m0repair_utils_cmd DIX "$CM_OP_REBALANCE")
+        rebalance_trigger=$(get_m0repair_utils_cmd "$CM_OP_REBALANCE")
         run "$rebalance_trigger"
         rc=$?
         if [ $rc != 0 ]; then

--- a/scripts/install/opt/seagate/cortx/motr/common/m0_sns_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_sns_utils_common.sh
@@ -28,7 +28,7 @@ sns_repair_or_rebalance_status()
         [ "$1" == "repair" ] && op=$CM_OP_REPAIR_STATUS
         [ "$1" == "rebalance" ] && op=$CM_OP_REBALANCE_STATUS
 
-        status_cmd=$(get_m0repair_utils_cmd SNS "$op")
+        status_cmd=$(get_m0repair_utils_cmd "$op")
         run "$status_cmd"
         rc=$?
         if [ $rc != 0 ]; then
@@ -46,7 +46,7 @@ wait_for_sns_repair_or_rebalance()
         [ "$1" == "repair" ] && op=$CM_OP_REPAIR_STATUS
         [ "$1" == "rebalance" ] && op=$CM_OP_REBALANCE_STATUS
 
-        status_cmd=$(get_m0repair_utils_cmd SNS "$op")
+        status_cmd=$(get_m0repair_utils_cmd "$op")
         while true ; do
                 sleep 5
                 echo "$status_cmd"
@@ -71,7 +71,7 @@ sns_repair()
 {
         local rc=0
 
-        repair_trigger=$(get_m0repair_utils_cmd SNS "$CM_OP_REPAIR")
+        repair_trigger=$(get_m0repair_utils_cmd "$CM_OP_REPAIR")
         run "$repair_trigger"
         rc=$?
         if [ $rc != 0 ]; then
@@ -84,7 +84,7 @@ sns_rebalance()
 {
         local rc=0
 
-        rebalance_trigger=$(get_m0repair_utils_cmd SNS "$CM_OP_REBALANCE")
+        rebalance_trigger=$(get_m0repair_utils_cmd "$CM_OP_REBALANCE")
         run "$rebalance_trigger"
         rc=$?
         if [ $rc != 0 ]; then

--- a/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+. /opt/seagate/cortx/motr/common/m0_utils_common.sh
+
+spiel_dix_repair_start()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+rc = spiel.dix_repair_start(fids['pool'])
+print ("dix repair start rc: " + str(rc))
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_wait_for_dix_repair()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+import time
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+active = 0
+while (1):
+    active = 0
+    rc = spiel.dix_repair_status(fids['pool'], ppstatus)
+    print ("dix repair status responded servers: " + str(rc))
+    for i in range(0, rc):
+        print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+            print ("dix is still active on ", ppstatus[i].sss_fid)
+            active = 1
+    if (active == 0):
+        break;
+    time.sleep(3)
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_dix_repair_status()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+rc = spiel.dix_repair_status(fids['pool'], ppstatus)
+print ("dix repair status responded servers: " + str(rc))
+for i in range(0, rc):
+        print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+                print("dix repair is still active on ", ppstatus[i].sss_fid)
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_dix_rebalance_start()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+rc = spiel.dix_rebalance_start(fids['pool'])
+print ("dix rebalance start rc: " + str(rc))
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_wait_for_dix_rebalance()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+import time
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+active = 0
+while (1):
+    active = 0
+    rc = spiel.dix_rebalance_status(fids['pool'], ppstatus)
+    print ("dix rebalance status responded servers: " + str(rc))
+    for i in range(0, rc):
+        print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+            print ("dix is still active on ", ppstatus[i].sss_fid)
+            active = 1
+    if (active == 0):
+        break;
+    time.sleep(3)
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_dix_rebalance_status()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+rc = spiel.dix_rebalance_status(fids['pool'], ppstatus)
+print ("dix rebalance status responded servers: " + str(rc))
+for i in range(0, rc):
+        print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+                print("dix rebalance is still active on ", ppstatus[i].sss_fid)
+
+$SPIEL_RCONF_STOP
+EOF
+}

--- a/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,9 +49,9 @@ ppstatus = pointer(one_status)
 active = 0
 while (1):
     active = 0
-    rc = spiel.dix_repair_status(fids['pool'], ppstatus)
-    print ("dix repair status responded servers: " + str(rc))
-    for i in range(0, rc):
+    nr = spiel.dix_repair_status(fids['pool'], ppstatus)
+    print ("dix repair status responded servers: " + str(nr))
+    for i in range(0, nr):
         print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
             print ("dix is still active on ", ppstatus[i].sss_fid)
@@ -75,9 +75,9 @@ $SPIEL_RCONF_START
 
 one_status = SpielSnsStatus()
 ppstatus = pointer(one_status)
-rc = spiel.dix_repair_status(fids['pool'], ppstatus)
-print ("dix repair status responded servers: " + str(rc))
-for i in range(0, rc):
+nr = spiel.dix_repair_status(fids['pool'], ppstatus)
+print ("dix repair status responded servers: " + str(nr))
+for i in range(0, nr):
         print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
                 print("dix repair is still active on ", ppstatus[i].sss_fid)
@@ -115,9 +115,9 @@ ppstatus = pointer(one_status)
 active = 0
 while (1):
     active = 0
-    rc = spiel.dix_rebalance_status(fids['pool'], ppstatus)
-    print ("dix rebalance status responded servers: " + str(rc))
-    for i in range(0, rc):
+    nr = spiel.dix_rebalance_status(fids['pool'], ppstatus)
+    print ("dix rebalance status responded servers: " + str(nr))
+    for i in range(0, nr):
         print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
             print ("dix is still active on ", ppstatus[i].sss_fid)
@@ -141,9 +141,9 @@ $SPIEL_RCONF_START
 
 one_status = SpielSnsStatus()
 ppstatus = pointer(one_status)
-rc = spiel.dix_rebalance_status(fids['pool'], ppstatus)
-print ("dix rebalance status responded servers: " + str(rc))
-for i in range(0, rc):
+nr = spiel.dix_rebalance_status(fids['pool'], ppstatus)
+print ("dix rebalance status responded servers: " + str(nr))
+for i in range(0, nr):
         print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
                 print("dix rebalance is still active on ", ppstatus[i].sss_fid)

--- a/scripts/install/opt/seagate/cortx/motr/common/m0_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_utils_common.sh
@@ -32,6 +32,8 @@ M0_HAGEN_UTILS=/usr/sbin/m0hagen
 MOTR_COPY=/usr/bin/m0cp
 MOTR_CAT=/usr/bin/m0cat
 
+export M0_SPIEL_UTILS=/usr/bin/m0spiel
+
 SERVICE_TYPE=0   # SNS = 0, DIX = 1
 
 M0_NC_UNKNOWN=1
@@ -95,17 +97,21 @@ _get_client_endpoints()
         fi
 
         if [ "$XPRT" = "lnet" ]; then
-                SNS_CLI_EP=":12345:33:1000"
-                M0HAM_CLI_EP=":12345:33:1001"
+                M0HAM_CLI_EP=":12345:33:1000"
+                SNS_CLI_EP=":12345:33:1001"
                 SNS_QUIESCE_CLI_EP=":12345:33:1002"
-                DIX_CLI_EP=":12345:33:1003"
-                DIX_QUIESCE_CLI_EP=":12345:33:1004"
+                SNS_SPIEL_CLI_EP=":12345:33:1003"
+                DIX_CLI_EP=":12345:33:1004"
+                DIX_QUIESCE_CLI_EP=":12345:33:1005"
+                DIX_SPIEL_CLI_EP=":12345:33:1006"
         else
-                SNS_CLI_EP="@3400"
                 M0HAM_CLI_EP="@10003"
+                SNS_CLI_EP="@3400"
                 SNS_QUIESCE_CLI_EP="@10002"
-                DIX_CLI_EP="@3401"
+                SNS_SPIEL_CLI_EP="@3401"
+                DIX_CLI_EP="@3402"
                 DIX_QUIESCE_CLI_EP="@10004"
+                DIX_SPIEL_CLI_EP="@3403"
         fi
 }
 
@@ -465,17 +471,38 @@ run()
         eval "$*"
 }
 
+set_service_type()
+{
+        [[ "$1" == "DIX" ]] && SERVICE_TYPE=1 || SERVICE_TYPE=0
+}
+
 # input parameters:
-# (i) type of repair (SNS / DIX)
-# (iI) Operation to perform
+# (i) File name with path for conf.cg
+generate_conf_cg()
+{
+        local conf_cg_file=$1
+
+        CONF_FILE=$(find / -name confd.xc | head -n 1)
+        if [ ! -f "$CONF_FILE" ]; then
+                echo "confd.xc doesn't seem to be present, can't get device id"
+                exit
+        fi
+        # Generate conf.cg from confd.xc
+        m0confgen -f xcode -t confgen "$CONF_FILE" > "$conf_cg_file"
+        if [ $? -ne 0 ]; then
+                echo "Failed to generate $conf_cg_file from conf.xc"
+                exit
+        fi
+}
+
+# input parameters:
+# (i) Operation to perform
 get_m0repair_utils_cmd()
 {
         local cli_ep=""
-        local op=$2
+        local op=$1
 
-        [[ "$1" == "DIX" ]] && SERVICE_TYPE=1 || SERVICE_TYPE=0
-
-        if [ "$SERVICE_TYPE" -eq 1 ]; then
+        if [ "$SERVICE_TYPE" -eq 1 ]; then # DIX
                 if [ "$op" == $CM_OP_REPAIR_STATUS ] ||
                    [ "$op" == $CM_OP_REBALANCE_STATUS ]; then
                         cli_ep=$DIX_QUIESCE_CLI_EP
@@ -493,4 +520,86 @@ get_m0repair_utils_cmd()
 
         cmd_trigger="$M0_REPAIR_UTILS -O $op -t $SERVICE_TYPE -C ${LOCAL_NID}${cli_ep} $IOS_EP "
         echo "$cmd_trigger"
+}
+
+get_dix_pool_fid()
+{
+        local conf_cg="/tmp/conf.cg"
+
+        generate_conf_cg "$conf_cg"
+        if [ ! -f "$conf_cg" ]; then
+                echo "$conf_cg not present, can't get dix pool fid"
+                exit
+        fi
+
+        # Get pool version and then pool fid from conf.cg
+        pver=$(grep imeta_pver "$conf_cg" | grep -o -P '(?<=imeta_pver=).*?(?= )')
+        pool=$(grep "$pver" "$conf_cg" | grep -v imeta_pver | grep "pool-" | grep -o -P '(?<=pool-).*?(?= )')
+
+        pool="0x6f00000000000001:$pool"
+        rm -f "$conf_cg"
+        echo "$pool"
+}
+
+get_fids_list()
+{
+        local HCTL_STATUS_FILE="/tmp/hctl_status.log"
+        hctl status > "$HCTL_STATUS_FILE"
+
+        host=$(hostname)
+        if [ "$SERVICE_TYPE" -eq 1 ]; then # DIX
+                POOL_FID=$(get_dix_pool_fid)
+        else
+                POOL_FID=$(grep -A2 'Data pool:' "$HCTL_STATUS_FILE" | awk '{print $1}' | tail -n 1)
+        fi
+        PROFILE_FID=$(grep -A2 'Profile:' "$HCTL_STATUS_FILE" | awk '{print $1}' | tail -n 1)
+        HA_ENDPOINT_ADDR=$(grep -A 50 "$host" "$HCTL_STATUS_FILE" | grep -m 1 hax | awk '{print $4}')
+
+        rm -f "$HCTL_STATUS_FILE"
+}
+
+_create_fid_list()
+{
+        IFS=':'
+        read -ra arrFID <<< "$1"
+        echo "Fid(${arrFID[0]}, ${arrFID[1]})"
+}
+
+spiel_prepare() {
+        local cli_ep=""
+        local prof_fid_str=""
+        local pool_fid_str=""
+
+        _get_client_endpoints
+        get_fids_list
+
+        [ "$SERVICE_TYPE" -eq 1 ] && cli_ep=$DIX_SPIEL_CLI_EP || cli_ep=$SNS_SPIEL_CLI_EP
+
+        LIBMOTR_SO="/usr/lib64/libmotr.so"
+        SPIEL_OPTS=" -l $LIBMOTR_SO --client ${LOCAL_NID}${cli_ep} --ha $HA_ENDPOINT_ADDR"
+
+        prof_fid_str=$(_create_fid_list "$PROFILE_FID")
+        pool_fid_str=$(_create_fid_list "$POOL_FID")
+        SPIEL_FIDS_LIST="fids = {'profile' : $prof_fid_str, 'pool' : $pool_fid_str,}"
+
+        export SPIEL_OPTS=$SPIEL_OPTS
+        export SPIEL_FIDS_LIST=$SPIEL_FIDS_LIST
+
+        echo "SPIEL_OPTS=$SPIEL_OPTS"
+        echo "SPIEL_FIDS_LIST=$SPIEL_FIDS_LIST"
+
+        export SPIEL_RCONF_START="
+print ('Hello, start to run Motr embedded python')
+
+if spiel.cmd_profile_set(str(fids['profile'])):
+        sys.exit('cannot set profile {0}'.format(fids['profile']))
+
+if spiel.rconfc_start():
+        sys.exit('cannot start rconfc')
+"
+
+        export SPIEL_RCONF_STOP="
+spiel.rconfc_stop()
+print ('----------Done------------')
+"
 }

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
@@ -1,6 +1,7 @@
 #!/bin/bash
 . /opt/seagate/cortx/motr/common/m0_sns_utils_common.sh
 . /opt/seagate/cortx/motr/common/m0_dix_utils_common.sh
+. /opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
 
 # Device id to failed. This parameter will override by
 # command line --device option
@@ -9,10 +10,102 @@ DEV_STATE=""
 DEV_PATH=""
 TYPE=""
 OPERATION=""
-REC_TYPE=""
+REC_TYPE="SNS"
+UTILITY="m0repair"
 
-CONF_FILE=$(find / -name confd.xc | head -n 1)
 READ_VERIFY=0
+
+_dix_repair_start() {
+	local rc
+	if [ "$UTILITY" == "m0spiel" ]; then
+		spiel_dix_repair_start
+	else
+		dix_repair # Using m0repair
+	fi
+	rc=$?
+	if [ $rc != 0 ]
+	then
+		echo "DIX repair start failed with rc = $rc."
+	fi
+	return $rc
+}
+
+_dix_repair_wait() {
+	local rc
+	if [ "$UTILITY" == "m0spiel" ]; then
+		spiel_wait_for_dix_repair
+	else
+		wait_for_dix_repair_or_rebalance "repair"
+	fi
+	rc=$?
+	if [ $rc != 0 ]
+	then
+		echo "Wait for DIX repair failed with rc = $rc."
+	fi
+	return $rc
+}
+
+_dix_repair_status()
+{
+	local rc
+	if [ "$UTILITY" == "m0spiel" ]; then
+		spiel_dix_repair_status
+	else
+		dix_repair_or_rebalance_status "repair"
+	fi
+	rc=$?
+	if [ $rc != 0 ]
+	then
+		echo "DIX repair status failed with rc = $rc."
+	fi
+	return $rc
+}
+
+_dix_rebalance_start() {
+	local rc
+	if [ "$UTILITY" == "m0spiel" ]; then
+		spiel_dix_rebalance_start
+	else
+		dix_rebalance # Using m0repair
+	fi
+	rc=$?
+	if [ $rc != 0 ]
+	then
+		echo "DIX rebalance start failed with rc = $rc."
+	fi
+	return $rc
+}
+
+_dix_rebalance_wait() {
+	local rc
+	if [ "$UTILITY" == "m0spiel" ]; then
+		spiel_wait_for_dix_rebalance
+	else
+		wait_for_dix_repair_or_rebalance "rebalance"
+	fi
+	rc=$?
+	if [ $rc != 0 ]
+	then
+		echo "Wait for DIX rebalance failed with rc = $rc."
+	fi
+	return $rc
+}
+
+_dix_rebalance_status()
+{
+	local rc
+	if [ "$UTILITY" == "m0spiel" ]; then
+		spiel_dix_rebalance_status
+	else
+		dix_repair_or_rebalance_status "rebalance"
+	fi
+	rc=$?
+	if [ $rc != 0 ]
+	then
+		echo "DIX rebalance status failed with rc = $rc."
+	fi
+	return $rc
+}
 
 _motr_trigger_sns_rebalance()
 {
@@ -65,7 +158,6 @@ _motr_trigger_sns_repair()
 
         echo "wait for sns repair"
         wait_for_sns_repair_or_rebalance "repair" || return $?
-        disk_state_set "repaired" "$fail_device" || return $?
 
         echo "query sns repair status"
         sns_repair_or_rebalance_status "repair" || return $?
@@ -91,15 +183,16 @@ _motr_trigger_dix_rebalance()
 
         disk_state_set "rebalance" "$fail_device" || return $?
         echo "Starting DIX Re-balance.."
-        dix_rebalance || return $?
+        _dix_rebalance_start || return $?
 
         # Make sure rebalance is complete.
-        wait_for_dix_repair_or_rebalance "rebalance" || return $?
+        echo "Wait for DIX Re-balance.."
+        _dix_rebalance_wait || return $?
 
         disk_state_set "online" "$fail_device" || return $?
 
         echo "Query DIX rebalance status"
-        dix_repair_or_rebalance_status "rebalance" || return $?
+        _dix_rebalance_status || return $?
 
         disk_state_get "$fail_device"
 
@@ -124,14 +217,13 @@ _motr_trigger_dix_repair()
 
         disk_state_set "repair" "$fail_device" || return $?
         echo "trigger DIX repair"
-        dix_repair || return $?
+        _dix_repair_start || return $?
 
         echo "Wait for DIX repair"
-        wait_for_dix_repair_or_rebalance "repair" || return $?
-        disk_state_set "repaired" "$fail_device" || return $?
+        _dix_repair_wait || return $?
 
         echo "Query DIX repair status"
-        dix_repair_or_rebalance_status "repair" || return $?
+        _dix_repair_status || return $?
 
         disk_state_set "repaired" "$fail_device" || return $?
 
@@ -142,7 +234,7 @@ _motr_trigger_dix_repair()
 
 motr_trigger_repair()
 {
-        if [ "$1" == "DIX" ]; then
+        if [ "$REC_TYPE" == "DIX" ]; then
                 _motr_trigger_dix_repair || return 1
         else
                 _motr_trigger_sns_repair || return 1
@@ -151,7 +243,7 @@ motr_trigger_repair()
 
 motr_trigger_rebalance()
 {
-        if [ "$1" == "DIX" ]; then
+        if [ "$REC_TYPE" == "DIX" ]; then
                 _motr_trigger_dix_rebalance || return 1
         else
                 _motr_trigger_sns_rebalance || return 1
@@ -161,31 +253,28 @@ motr_trigger_rebalance()
 motr_trigger_repair_and_rebalance()
 {
         # Trigger repair first
-        motr_trigger_repair "$1" || return 1
+        motr_trigger_repair || return 1
         # Trigger rebalance if repair is successful
-        motr_trigger_rebalance "$1" || return 1
+        motr_trigger_rebalance || return 1
 }
 
 get_dev_id_from_dev_name()
 {
         local dev_idx=""
+        local conf_cg="/opt/conf.cg"
 
         if [ ! -b "$DEV_PATH" ]; then
                 echo "$DEV_PATH doesn't seem valid block device"
                 exit
         fi
 
-        if [ ! -f "$CONF_FILE" ]; then
-                echo "confd.xc doesn't seem to be present, can't get device id"
+        generate_conf_cg "$conf_cg"
+        if [ ! -f "$conf_cg" ]; then
+                echo "$conf_cg not present, can't get device id"
                 exit
         fi
-        # Generate conf.cg from confd.xc
-        m0confgen -f xcode -t confgen "$CONF_FILE" > /opt/conf.cg
-        if [ $? -ne 0 ]; then
-                echo "Failed to generate conf.cg from conf.xc"
-                exit
-        fi
-        dev_idx=$(cat /opt/conf.cg | grep "$DEV_PATH" | head -1 | awk '{print $1}' | cut -d '-' -f2)
+
+        dev_idx=$(grep "$DEV_PATH" "$conf_cg" | head -1 | awk '{print $1}' | cut -d '-' -f2)
         if [ ! -z "$dev_idx" ]; then
                 DEVICE_ID=$(cat "$CONF_FILE" | grep "\^d|1:${dev_idx}," | cut -d : -f 2 | cut -d ')' -f1)
         fi
@@ -193,7 +282,12 @@ get_dev_id_from_dev_name()
                 echo "Couldn't retrieve device id for $DEV_PATH"
                 exit
         fi
+        if [[ $DEVICE_ID == "0x"* ]]; then
+                DEVICE_ID=$(echo $DEVICE_ID | cut -d 'x' -f 2)
+                DEVICE_ID=$((16#$DEVICE_ID))
+        fi
         echo "Device id for $DEV_PATH is : $DEVICE_ID"
+        rm -f "$conf_cg"
 }
 
 main()
@@ -205,7 +299,14 @@ main()
 
         sandbox_init
         get_lnet_nid
-        get_ios_endpoints
+
+        set_service_type "$REC_TYPE"
+
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_prepare
+        else
+                get_ios_endpoints
+        fi
 
         if [ -z "$DEVICE_ID" ] && [ ! -z "$DEV_PATH" ]; then
                 get_dev_id_from_dev_name
@@ -230,7 +331,7 @@ main()
                         disk_state_set "$DEV_STATE" "$DEVICE_ID" || return $?
                 else
                         state_recv=""
-                        echo "Getting $DEVICE_ID state to $DEV_STATE"
+                        echo "Getting $DEVICE_ID state"
                         disk_state_get "$DEVICE_ID"
                         if [ -z "$state_recv" ]; then
                                 echo "Could not retrieve state for $DEVICE_ID"
@@ -240,15 +341,15 @@ main()
                 fi
         elif [ "$TYPE" == "repair" ]; then
                 echo "Running $REC_TYPE Repair "
-                motr_trigger_repair "$REC_TYPE"
+                motr_trigger_repair
                 rc=$?
-        elif ["$TYPE" == "rebalance" ]; then
+        elif [ "$TYPE" == "rebalance" ]; then
                 echo "Running $REC_TYPE Rebalance "
-                motr_trigger_rebalance "$REC_TYPE"
+                motr_trigger_rebalance
                 rc=$?
         elif [ "$TYPE" == "repreb" ]; then
                 echo "Running $REC_TYPE Repair and Rebalance "
-                motr_trigger_repair_and_rebalance "$REC_TYPE"
+                motr_trigger_repair_and_rebalance
                 rc=$?
         else
                 echo "Invalid or no operation is provided"
@@ -283,6 +384,8 @@ usage()
         echo "-i, --dev-id      : Device id of to failed/replaced device"
         echo "-d, --dev-path    : Dev path of to failed/replaced device"
         echo "-s, --state       : State of the device to set(failed/replaced)"
+        echo "-u, --utility     : Utility to use for repair/rebalance"
+        echo "                    (m0repair (default) / m0spiel)"
         echo "-v, --read-verify : Do IO operations before repair/rebalance and verify"
         echo "-h, --help        : To see this help options"
         exit 0
@@ -291,7 +394,7 @@ usage()
 if [ $# -eq 0 ]; then
         usage
 fi
-OPTS=`getopt -o t:o::r:i:d:s:vh --long type:,ops:,recover-type:,dev-id:,dev-path:,:state,read-verify,help -n 'parse-options' -- "$@"`
+OPTS=`getopt -o t:o::r:i:d:s:u:vh --long type:,ops:,recover-type:,dev-id:,dev-path:,:state,:utility,read-verify,help -n 'parse-options' -- "$@"`
 
 if [ $? != 0 ]; then echo "Failed parsing options." >&2; exit 1; fi
 eval set -- "$OPTS"
@@ -303,6 +406,7 @@ while true; do
         -i | --dev-id ) DEVICE_ID=$2; shift; shift;;
         -d | --dev-path )  DEV_PATH=$2; shift; shift;;
         -s | --state )  DEV_STATE=$2; shift; shift;;
+        -u | --utility ) UTILITY=$2; shift; shift;;
         -v | --read-verify ) READ_VERIFY=1; shift;;
         -h | --help )   usage; shift;;
         * ) break;;
@@ -319,6 +423,21 @@ fi
 if [ ! -z "$OPERATION" ]; then
         echo "Sub operations are not supported yet"
         usage
+fi
+
+if [ ! -z "$REC_TYPE" ]; then
+        if [[ ! "$REC_TYPE" =~ ^(SNS|DIX)$ ]]; then
+                echo "Valid recover types are only (SNS/DIX)"
+                usage
+        fi
+fi
+
+if [ ! -z "$UTILITY" ]; then
+        if [[ ! "$UTILITY" =~ ^(m0repair|m0spiel)$ ]]; then
+                echo "Valid utilities for repair / rebalance are only \
+                      (m0repair/m0spiel)"
+                usage
+        fi
 fi
 
 main

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
@@ -274,16 +274,16 @@ get_dev_id_from_dev_name()
                 exit
         fi
 
-        dev_idx=$(grep "$DEV_PATH" "$conf_cg" | head -1 | awk '{print $1}' | cut -d '-' -f2)
+        dev_idx=$(grep "$DEV_PATH" "$conf_cg" | head -1 | awk '{print $1}' | cut -d '(' -f2)
         if [ ! -z "$dev_idx" ]; then
-                DEVICE_ID=$(cat "$CONF_FILE" | grep "\^d|1:${dev_idx}," | cut -d : -f 2 | cut -d ')' -f1)
+                DEVICE_ID=$(grep "${dev_idx}" "$conf_cg" | grep drive | awk '{print $1}' | cut -d '-' -f2)
         fi
         if [ -z "$DEVICE_ID" ]; then
                 echo "Couldn't retrieve device id for $DEV_PATH"
                 exit
         fi
         if [[ $DEVICE_ID == "0x"* ]]; then
-                DEVICE_ID=$(echo $DEVICE_ID | cut -d 'x' -f 2)
+                DEVICE_ID=$(echo $DEVICE_ID | cut -d 'x' -f2)
                 DEVICE_ID=$((16#$DEVICE_ID))
         fi
         echo "Device id for $DEV_PATH is : $DEVICE_ID"

--- a/spiel/st/m0t1fs_spiel_dix_common_inc.sh
+++ b/spiel/st/m0t1fs_spiel_dix_common_inc.sh
@@ -196,9 +196,9 @@ while (1):
     rc = spiel.dix_repair_status(fids['pool'], ppstatus)
     print ("dix repair status responded servers: " + str(rc))
     for i in range(0, rc):
-        print "status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state
+        print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
-            print "dix is still active on ", ppstatus[i].sss_fid
+            print ("dix is still active on ", ppstatus[i].sss_fid)
             active = 1
     if (active == 0):
         break;
@@ -270,9 +270,9 @@ while (1):
     rc = spiel.dix_rebalance_status(fids['pool'], ppstatus)
     print ("dix rebalance status responded servers: " + str(rc))
     for i in range(0, rc):
-        print "status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state
+        print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
-            print "dix is still active on ", ppstatus[i].sss_fid
+            print ("dix is still active on ", ppstatus[i].sss_fid)
             active = 1
     if (active == 0):
         break;


### PR DESCRIPTION
# Problem Statement
- The m0_ha_sim utility by default supports m0repair utility for SNS and DIX repair / rebalance. There was no support to use m0spiel for SNS and DIX repair / rebalance.

# Design
-  Added new option -u for m0_ha_sim to get the utility from user. m0repair is used by default. Based on the utility selected, the repair and rebalance functions are called.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
