### PR TITLE
CORTX-30920: Add m0spiel support in m0_ha_sim for SNS Rep/Reb.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1038,7 +1038,9 @@ motr_common_SCRIPTS = \
     scripts/install$(motr_commondir)/core-traces \
     scripts/install$(motr_commondir)/m0_sns_utils_common.sh \
     scripts/install$(motr_commondir)/m0_dix_utils_common.sh \
-    scripts/install$(motr_commondir)/m0_utils_common.sh
+    scripts/install$(motr_commondir)/m0_utils_common.sh \
+    scripts/install$(motr_commondir)/m0_spiel_sns_utils_common.sh \
+    scripts/install$(motr_commondir)/m0_spiel_dix_utils_common.sh
 EXTRA_DIST += $(motr_common_SCRIPTS)
 
 deb_pkg_files = \

--- a/debian/cortx-motr.install
+++ b/debian/cortx-motr.install
@@ -97,6 +97,8 @@ opt/seagate/cortx/motr/common/cortx_error_codes.sh
 opt/seagate/cortx/motr/common/m0_sns_utils_common.sh
 opt/seagate/cortx/motr/common/m0_dix_utils_common.sh
 opt/seagate/cortx/motr/common/m0_utils_common.sh
+opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
+opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
 opt/seagate/cortx/motr/common/cortx_util_funcs.sh
 opt/seagate/cortx/motr/common/core-traces
 opt/seagate/cortx/motr/bin/motr_mini_prov.py

--- a/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+. /opt/seagate/cortx/motr/common/m0_utils_common.sh
+
+spiel_sns_repair_start()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+rc = spiel.sns_repair_start(fids['pool'])
+print ("sns repair start rc: " + str(rc))
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_wait_for_sns_repair()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+import time
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+active = 0
+while (1):
+    active = 0
+    nr = spiel.sns_repair_status(fids['pool'], ppstatus)
+    print ("sns repair status responded servers: " + str(rc))
+    for i in range(0, nr):
+        print ("status of ", ppstatus[{}].sss_fid, " is: {}".format(i, ppstatus[i].sss_state))
+        if (ppstatus[i].sss_state == 2) :
+            print ("sns is still active on ", ppstatus[i].sss_fid)
+            active = 1
+    if (active == 0):
+        break;
+    time.sleep(3)
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_sns_repair_status()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+$SPIEL_FIDS_LIST
+$SPIEL_RCONF_START
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+nr = spiel.sns_repair_status(fids['pool'], ppstatus)
+print ("sns repair status responded servers: " + str(rc))
+for i in range(0, nr):
+        print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+                print("sns repair is still active on ", ppstatus[i].sss_fid)
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_sns_rebalance_start()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+rc = spiel.sns_rebalance_start(fids['pool'])
+print ("sns rebalance start rc: " + str(rc))
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_wait_for_sns_rebalance()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+import time
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+active = 0
+while (1):
+    active = 0
+    nr = spiel.sns_rebalance_status(fids['pool'], ppstatus)
+    print ("sns rebalance status responded servers: " + str(rc))
+    for i in range(0, nr):
+        print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+            print ("sns is still active on ", ppstatus[i].sss_fid)
+            active = 1
+    if (active == 0):
+        break;
+    time.sleep(3)
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_sns_rebalance_status()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+nr = spiel.sns_rebalance_status(fids['pool'], ppstatus)
+print ("sns rebalance status responded servers: " + str(rc))
+for i in range(0, nr):
+        print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+                print("sns rebalance is still active on ", ppstatus[i].sss_fid)
+
+$SPIEL_RCONF_STOP
+EOF
+}

--- a/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
@@ -50,7 +50,7 @@ active = 0
 while (1):
     active = 0
     nr = spiel.sns_repair_status(fids['pool'], ppstatus)
-    print ("sns repair status responded servers: " + str(rc))
+    print ("sns repair status responded servers: " + str(nr))
     for i in range(0, nr):
         print ("status of ", ppstatus[{}].sss_fid, " is: {}".format(i, ppstatus[i].sss_state))
         if (ppstatus[i].sss_state == 2) :
@@ -73,7 +73,7 @@ $SPIEL_RCONF_START
 one_status = SpielSnsStatus()
 ppstatus = pointer(one_status)
 nr = spiel.sns_repair_status(fids['pool'], ppstatus)
-print ("sns repair status responded servers: " + str(rc))
+print ("sns repair status responded servers: " + str(nr))
 for i in range(0, nr):
         print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
@@ -112,7 +112,7 @@ active = 0
 while (1):
     active = 0
     nr = spiel.sns_rebalance_status(fids['pool'], ppstatus)
-    print ("sns rebalance status responded servers: " + str(rc))
+    print ("sns rebalance status responded servers: " + str(nr))
     for i in range(0, nr):
         print ("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :
@@ -138,7 +138,7 @@ $SPIEL_RCONF_START
 one_status = SpielSnsStatus()
 ppstatus = pointer(one_status)
 nr = spiel.sns_rebalance_status(fids['pool'], ppstatus)
-print ("sns rebalance status responded servers: " + str(rc))
+print ("sns rebalance status responded servers: " + str(nr))
 for i in range(0, nr):
         print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
         if (ppstatus[i].sss_state == 2) :

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
@@ -480,7 +480,6 @@ usage()
         echo "./m0_ha_sim [OPTIONS]"
         echo "[OPTIONS]"
         echo "-t, --type        : Type of operation (drive/repair/rebalance/repreb)"
-	echo "-u, --utility     : Utility to be used for repair/rebalance (m0spiel / m0repair (Default))"
         echo "-o, --ops         : Sub operation of type (abort/pause/resume)"
         echo "-r, --recover-type: Type of recover (SNS (Default) / DIX)"
         echo "-i, --dev-id      : Device id of to failed/replaced device"
@@ -503,7 +502,6 @@ eval set -- "$OPTS"
 while true; do
         case "$1" in
         -t | --type )   TYPE=$2; shift; shift;;
-        -u | --utility )   UTILITY=$2; shift; shift;;
         -o | --ops )   OPERATION=$2; shift; shift;;
         -r | --recover-type)  REC_TYPE=$2; shift; shift;;
         -i | --dev-id ) DEVICE_ID=$2; shift; shift;;

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
@@ -1,6 +1,7 @@
 #!/bin/bash
 . /opt/seagate/cortx/motr/common/m0_sns_utils_common.sh
 . /opt/seagate/cortx/motr/common/m0_dix_utils_common.sh
+. /opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
 
 # Device id to failed. This parameter will override by
 # command line --device option
@@ -10,9 +11,102 @@ DEV_PATH=""
 TYPE=""
 OPERATION=""
 REC_TYPE=""
+UTILITY=""
 
 CONF_FILE=$(find / -name confd.xc | head -n 1)
 READ_VERIFY=0
+
+_sns_repair_start() {
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_sns_repair_start
+        else
+                sns_repair # Using m0repair
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "SNS repair start failed with rc = $rc."
+        fi
+        return $rc
+}
+
+_sns_repair_wait() {
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_wait_for_sns_repair
+        else
+                wait_for_sns_repair_or_rebalance "repair"
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "Wait for SNS repair failed with rc = $rc."
+        fi
+        return $rc
+}
+
+_sns_repair_status()
+{
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_sns_repair_status
+        else
+                sns_repair_or_rebalance_status "repair"
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "SNS repair status failed with rc = $rc."
+        fi
+        return $rc
+}
+
+_sns_rebalance_start() {
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_sns_rebalance_start
+        else
+                sns_rebalance # Using m0repair
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "SNS rebalance start failed with rc = $rc."
+        fi
+        return $rc
+}
+
+_sns_rebalance_wait() {
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_wait_for_sns_rebalance
+        else
+                wait_for_sns_repair_or_rebalance "rebalance"
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "Wait for SNS rebalance failed with rc = $rc."
+        fi
+        return $rc
+}
+
+_sns_rebalance_status()
+{
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_sns_rebalance_status
+        else
+                sns_repair_or_rebalance_status "rebalance"
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "SNS rebalance status failed with rc = $rc."
+        fi
+        return $rc
+}
 
 _motr_trigger_sns_rebalance()
 {
@@ -28,15 +122,15 @@ _motr_trigger_sns_rebalance()
 
         disk_state_set "rebalance" "$fail_device" || return $?
         echo "Starting SNS Re-balance.."
-        sns_rebalance || return $?
+        _sns_rebalance_start || return $?
 
         # Make sure rebalance is complete.
-        wait_for_sns_repair_or_rebalance "rebalance" || return $?
+        _sns_rebalance_wait || return $?
 
         disk_state_set "online" "$fail_device" || return $?
 
         echo "query sns rebalance status"
-        sns_repair_or_rebalance_status "rebalance" || return $?
+        _sns_rebalance_status || return $?
 
         disk_state_get "$fail_device"
 
@@ -61,14 +155,13 @@ _motr_trigger_sns_repair()
 
         disk_state_set "repair" "$fail_device" || return $?
         echo "trigger sns repair"
-        sns_repair || return $?
+        _sns_repair_start || return $?
 
         echo "wait for sns repair"
-        wait_for_sns_repair_or_rebalance "repair" || return $?
-        disk_state_set "repaired" "$fail_device" || return $?
+        _sns_repair_wait || return $?
 
         echo "query sns repair status"
-        sns_repair_or_rebalance_status "repair" || return $?
+        _sns_repair_status || return $?
 
         disk_state_set "repaired" "$fail_device" || return $?
 
@@ -205,7 +298,14 @@ main()
 
         sandbox_init
         get_lnet_nid
-        get_ios_endpoints
+
+        set_service_type "$REC_TYPE"
+
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_prepare
+        else
+                get_ios_endpoints
+        fi
 
         if [ -z "$DEVICE_ID" ] && [ ! -z "$DEV_PATH" ]; then
                 get_dev_id_from_dev_name
@@ -242,7 +342,7 @@ main()
                 echo "Running $REC_TYPE Repair "
                 motr_trigger_repair "$REC_TYPE"
                 rc=$?
-        elif ["$TYPE" == "rebalance" ]; then
+        elif [ "$TYPE" == "rebalance" ]; then
                 echo "Running $REC_TYPE Rebalance "
                 motr_trigger_rebalance "$REC_TYPE"
                 rc=$?
@@ -278,6 +378,7 @@ usage()
         echo "./m0_ha_sim [OPTIONS]"
         echo "[OPTIONS]"
         echo "-t, --type        : Type of operation (drive/repair/rebalance/repreb)"
+	echo "-u, --utility     : Utility to be used for repair/rebalance (m0spiel / m0repair (Default))"
         echo "-o, --ops         : Sub operation of type (abort/pause/resume)"
         echo "-r, --recover-type: Type of recover (SNS (Default) / DIX)"
         echo "-i, --dev-id      : Device id of to failed/replaced device"
@@ -291,13 +392,14 @@ usage()
 if [ $# -eq 0 ]; then
         usage
 fi
-OPTS=`getopt -o t:o::r:i:d:s:vh --long type:,ops:,recover-type:,dev-id:,dev-path:,:state,read-verify,help -n 'parse-options' -- "$@"`
+OPTS=`getopt -o t:u:o::r:i:d:s:vh --long type:,ops:,recover-type:,dev-id:,dev-path:,:state,read-verify,help -n 'parse-options' -- "$@"`
 
 if [ $? != 0 ]; then echo "Failed parsing options." >&2; exit 1; fi
 eval set -- "$OPTS"
 while true; do
         case "$1" in
         -t | --type )   TYPE=$2; shift; shift;;
+        -u | --utility )   UTILITY=$2; shift; shift;;
         -o | --ops )   OPERATION=$2; shift; shift;;
         -r | --recover-type)  REC_TYPE=$2; shift; shift;;
         -i | --dev-id ) DEVICE_ID=$2; shift; shift;;


### PR DESCRIPTION
- The m0_ha_sim utility by default supports m0repair utility for
  SNS and DIX repair / rebalance. With this change, support for m0spiel
  utility is added for SNS repair / rebalance.
- Added new option -u to get the utility from user. m0repair is used by
  default.
- Fixed codacy issues.

Signed-off-by: Bhargav Dekivadiya <bhargav.dekivadiya@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

# Depends On
- PR : https://github.com/Seagate/cortx-motr/pull/1770