### PR TITLE
CORTX-29192: spiel sns repair ST failing at last step

### DIFF
--- a/motr/st/utils/spiel_sns_motr_repair.sh
+++ b/motr/st/utils/spiel_sns_motr_repair.sh
@@ -113,10 +113,10 @@ spiel_sns_repair_and_rebalance_test()
 	disk_state_get "$fail_device1" "$fail_device2" "$fail_device3" || return "$?"
 
         echo "Testing SNS rebalance abort with new disk failure..."
-	rebalance_abort 1 9
+	rebalance_abort 1 9 || return "$?"
 
 	echo "Testing SNS rebalance abort with repaired disk failure..."
-	rebalance_abort 1 1
+	rebalance_abort 1 1 || return "$?"
 	#######################################################################
 	#  End                                                                #
 	#######################################################################
@@ -217,9 +217,9 @@ rebalance_abort()
 	disk_state_set "repaired" "$fail_device1" || return "$?"
 	if [ "$fail_device1" -eq "$fail_device2" ]
 	then
-		test_repaired_device_failure "$fail_device1"
+		test_repaired_device_failure "$fail_device1" || return "$?"
 	else
-		test_new_device_failure "$fail_device1" "$fail_device2"
+		test_new_device_failure "$fail_device1" "$fail_device2" || return "$?"
 	fi
 }
 

--- a/spiel/st/m0t1fs_spiel_sns_common_inc.sh
+++ b/spiel/st/m0t1fs_spiel_sns_common_inc.sh
@@ -226,7 +226,7 @@ while (1):
     rc = spiel.sns_repair_status(fids['pool'], ppstatus)
     print ("sns repair status responded servers: " + str(rc))
     for i in range(0, rc):
-        print ("status of ", ppstatus[{}].sss_fid, " is: {}".format(i, ppstatus[i].sss_state))
+        print ("status of ppstatus[{}].sss_fid is: {}".format(i, ppstatus[i].sss_state))
         if (ppstatus[i].sss_state == 2) :
             print ("sns is still active on ", ppstatus[i].sss_fid)
             active = 1
@@ -300,7 +300,7 @@ while (1):
     rc = spiel.sns_rebalance_status(fids['pool'], ppstatus)
     print ("sns rebalance status responded servers: " + str(rc))
     for i in range(0, rc):
-        print ("status of ", ppstatus[{}].sss_fid, " is: {}".format(i, ppstatus[i].sss_state))
+        print ("status of ppstatus[{}].sss_fid is: {}".format(i, ppstatus[i].sss_state))
         if (ppstatus[i].sss_state == 2) :
             print ("sns is still active on ", ppstatus[i].sss_fid)
             active = 1


### PR DESCRIPTION
Problem: The ST 71spiel-sns-motr-repair was returning the END status as SUCCESS, even if the test failed.
This was a misleading behavior.

Solution: Added checks to return appropriate return values from function calls or test steps.
for more details please refer CORTX-29192.
Signed-off-by: Swapnil Chaudhary <swapnil.chaudhary@seagate.com>

