### PR TITLE
CORTX-31404: Changed log level of ha_event logs to capture in kubectl logs

### DIFF
--- a/ha/note.c
+++ b/ha/note.c
@@ -169,11 +169,19 @@ static void ha_state_accept(struct m0_confc         *confc,
 	m0_conf_cache_lock(cache);
 	for (i = 0; i < note->nv_nr; ++i) {
 		obj = m0_conf_cache_lookup(cache, &note->nv_note[i].no_id);
+		if (m0_fid_tget(&note->nv_note[i].no_id) == 'r') {
+		M0_LOG(M0_FATAL, "nv_note[%d]=(no_id="FID_F" no_state=%"PRIu32
+		       ") obj=%p obj->co_status=%d", i,
+		       FID_P(&note->nv_note[i].no_id),
+		       note->nv_note[i].no_state,
+		       obj, obj == NULL ? -1 : obj->co_status);
+		} else {
 		M0_LOG(M0_DEBUG, "nv_note[%d]=(no_id="FID_F" no_state=%"PRIu32
 		       ") obj=%p obj->co_status=%d", i,
 		       FID_P(&note->nv_note[i].no_id),
 		       note->nv_note[i].no_state,
 		       obj, obj == NULL ? -1 : obj->co_status);
+		}
 		if (obj != NULL && obj->co_status == M0_CS_READY) {
 			prev_ha_state = obj->co_ha_state;
 			obj->co_ha_state = note->nv_note[i].no_state;


### PR DESCRIPTION
Changed log level of event received logs from ha_state_accept() to FATAL so that it will reflect logs into kubectl logs of containers and will be persistent in case of trace file rotated. 
 
Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
