### PR TITLE
CORTX-31308: "btree-ut:lru_test" failing intermittently

### DIFF
--- a/btree/btree.c
+++ b/btree/btree.c
@@ -12314,10 +12314,12 @@ static void ut_lru_test(void)
 	 * be-allocator with chunk align parameter.
 	 *
 	 * 1. Allocate and fill up the btree with multiple records.
-	 * 2. Verify the size increase in memory.
+	 * 2. Verify the size increase in memory. If size increase in memory is
+	 *    negative then go to step 5 and restart the test (step 1).
 	 * 3. Use the m0_btree_lrulist_purge() to reduce the size by freeing up
 	 *    the unused nodes present in LRU list.
 	 * 4. Verify the reduction in size.
+	 * 5. Cleanup btree and allocated resources.
 	 */
 	M0_ENTRY();
 


### PR DESCRIPTION
Problem:
This issue was happening because we are collecting memory stats
using system api. There might be case when we write objects in that
timeframe some other process on the system might release memory and
hence we can see memory freed in our stats.

Solution:
If above case arises, cleanup the existing btree and records, then
restart the test, try upto 20 times restarting the test. If we
still get the issue, fail the test.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
