### PR TITLE
go:update module path so could work well with go modules

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,3 +1,3 @@
-module cortx-motr/bindings/go
+module github.com/Seagate/cortx-motr/bindings/go
 
 go 1.15

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,3 +1,3 @@
-module cortx-motr/bindings/go
+module github.com/kiwionly2/cortx-motr/bindings/go
 
 go 1.15

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/kiwionly2/cortx-motr/bindings/go
+module cortx-motr/bindings/go
 
 go 1.15

--- a/bindings/go/mcp/mcp.go
+++ b/bindings/go/mcp/mcp.go
@@ -28,7 +28,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "cortx-motr/bindings/go/mio"
+    "github/seagate/cortx-motr/bindings/go/mio"
 )
 
 func usage() {

--- a/bindings/go/mcp/mcp.go
+++ b/bindings/go/mcp/mcp.go
@@ -28,7 +28,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "github/seagate/cortx-motr/bindings/go/mio"
+    "github.com/Seagate/cortx-motr/bindings/go/mio"
 )
 
 func usage() {

--- a/bindings/go/mkv/mkv.go
+++ b/bindings/go/mkv/mkv.go
@@ -27,7 +27,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "cortx-motr/bindings/go/mio"
+    "github.com/seagate/cortx-motr/bindings/go/mio"
 )
 
 func usage() {

--- a/bindings/go/mkv/mkv.go
+++ b/bindings/go/mkv/mkv.go
@@ -27,7 +27,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "github.com/seagate/cortx-motr/bindings/go/mio"
+    "github.com/Seagate/cortx-motr/bindings/go/mio"
 )
 
 func usage() {


### PR DESCRIPTION
Update module path so could work well with go modules.

Signed-off-by: kiwionly2 <gheewooi.ong@seagate.com>

# Problem Statement
When run `got get github.com/Seagate/cortx-motr/bindings/go` , It complaint about the package name:

![image](https://user-images.githubusercontent.com/77140436/168956978-6a5775f4-0be0-4d22-8881-39bed6639ece.png)

The solution is to change `/cortx-motr/bindings/go` to `github.com/Seagate/cortx-motr/bindings/go` in module file.




# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
