### PR TITLE
Fix m0trace 'experimental' warnings on Rocky Linux

### DIFF
--- a/utils/trace/m0trace
+++ b/utils/trace/m0trace
@@ -35,6 +35,8 @@ use warnings;
 use autodie;
 use feature ':5.16';  # target minimum Perl version provided by the base distribution
 
+# Suppress warnings "given/when is experimental" in recent Perl versions:
+no if $] >= 5.018, warnings => qw( experimental::smartmatch );
 
 # check that all required external modules are available and display a hint to
 # the user about how they can be installed using default package management


### PR DESCRIPTION
Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- On Rocky Linux 8.4, m0trace shows warnings "when/given is experimental".  Rocky has more recent perl version, which is now showing such warnings.

# Design
- Tell Perl to suppress the warning.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
