### PR TITLE
CORTX-29815 m0spiel: Add support for new address format

### DIFF
--- a/spiel/st/spiel_multiple_confd.sh
+++ b/spiel/st/spiel_multiple_confd.sh
@@ -84,7 +84,7 @@ stop() {
 }
 
 _init() {
-    lnet_up
+    lnet_up "new"
     if [ "$XPRT" = "lnet" ]; then
         m0_modules_insert
     fi

--- a/utils/functions
+++ b/utils/functions
@@ -113,22 +113,38 @@ m0_modules_remove() {
 }
 
 lnet_up() {
+    local format=${1:-old}
+    local NID=$(m0_local_nid_get "$format")
+    XPRT=$(m0_default_xprt)
+
     if [ "$XPRT" = "lnet" ]; then
         modprobe lnet
         lctl network up >/dev/null
     fi
-    local LNET_NID=$(m0_local_nid_get)
 
-    ## LNet endpoint address format (see net/lnet/lnet.h):
-    ##     NID:PID:Portal:TMID
-    ##
-    ## The PID value of 12345 is used by Lustre in the kernel and is
-    ## the only value currently supported.
-    export M0T1FS_ENDPOINT="$LNET_NID:12345:34:1"
-    export M0D1_ENDPOINT="$LNET_NID:12345:34:1001"
-    export M0D2_ENDPOINT="$LNET_NID:12345:34:1002"
-    export M0D3_ENDPOINT="$LNET_NID:12345:34:1003"
-    export SPIEL_ENDPOINT="$LNET_NID:12345:34:2001"
+    if [[ "$XPRT" == "lnet" || "$format" == "old" ]]; then
+        ## LNet endpoint address format (see net/lnet/lnet.h):
+        ##     NID:PID:Portal:TMID
+        ##
+        ## The PID value of 12345 is used by Lustre in the kernel and is
+        ## the only value currently supported.
+        M0T1FS_EP=":12345:34:1"
+        M0D1_EP=":12345:34:1001"
+        M0D2_EP=":12345:34:1002"
+        M0D3_EP=":12345:34:1003"
+        SPIEL_EP=":12345:34:2001"
+    else
+        M0T1FS_EP="@3000"
+        M0D1_EP="@4001"
+        M0D2_EP="@4002"
+        M0D3_EP="@4003"
+        SPIEL_EP="@5001"
+    fi
+    export M0T1FS_ENDPOINT="$NID$M0T1FS_EP"
+    export M0D1_ENDPOINT="$NID$M0D1_EP"
+    export M0D2_ENDPOINT="$NID$M0D2_EP"
+    export M0D3_ENDPOINT="$NID$M0D3_EP"
+    export SPIEL_ENDPOINT="$NID$SPIEL_EP"
 }
 
 ## Adding function to identify the default available transport layer

--- a/utils/spiel/m0spiel
+++ b/utils/spiel/m0spiel
@@ -48,30 +48,29 @@ def get_motr_transport():
     return "libfab" if output else ''
 
 def address_get():
-    xprt = get_motr_transport()
-
-    if "libfab" in xprt :
+    if "libfab" in motr_xprt :
         conf = open("/etc/libfab.conf", "r")
         xprt = conf.read()
         iface_type = (xprt[xprt.find("=")+1:xprt.find("(")])
         iface = (xprt[xprt.find("(")+1:xprt.find(")")])
         ip_addr = get_ip_address(iface)
-        return ip_addr+"@"+iface_type
+        return "inet:"+iface_type+":"+ip_addr
     else:
-        try:
-            p = Popen(['lctl', 'list_nids'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-            output, err = p.communicate()
-        except OSError:
-            return ''
-    # When the tool is executing without sudo privileges (i. e. with "--help"
-    # option) then lctl output will be an empty string)
-    return output.split()[0] if output else ''
+        output = check_output("lctl list_nids", shell=True, encoding='ascii')
+        # When the tool is executing without sudo privileges (i. e. with "--help"
+        # option) then lctl output will be an empty string)
+        return output.split()[0] if output else ''
 
+motr_xprt = get_motr_transport()
 
 default_libmotr_path = '../../motr/.libs/libmotr.so'
 addr = address_get()
-default_ha_ep = addr + ':12345:34:1001'
-default_client_ep = addr + ':12345:34:200'
+if "libfab" in motr_xprt :
+    default_ha_ep = addr + '@4001'
+    default_client_ep = addr + '@4002'
+else:
+    default_ha_ep = addr + ':12345:34:1001'
+    default_client_ep = addr + ':12345:34:200'
 
 
 # Helper function to check the type of the function parameter. This is useful


### PR DESCRIPTION
# Problem Statement
- The m0spiel utility was using old address format for libfabric transport. 
- Also for lnet transport, there was failure in getting the IP address. Even command `m0spiel -h` also failed for lnet transport.

# Design
-  Added support for new address format for libfabric transport.
- Fixed issue in getting address for lnet transport.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
