### PR TITLE
CORTX-31497: Fix 52motr-singlenode-sanity system test for lnet transport

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/sanity/motr_sanity.sh
+++ b/scripts/install/opt/seagate/cortx/motr/sanity/motr_sanity.sh
@@ -152,7 +152,7 @@ node_sanity_check()
 		return 1
 	fi
 	if [ "$XPRT" = "lnet" ]; then
-		string=$(grep "$IP" "$conf" | cut -d '"' -f 2 | cut -d ':' -f 1)
+		string=$(grep "$IP" "$conf" | cut -d '"' -f 2 | cut -d ':' -f 1 | head -n 1)
 	else
 		string=$(grep "$IP" "$conf" | cut -d '"' -f 2 | cut -d '@' -f 1 | head -n 1)
 	fi

--- a/scripts/install/usr/libexec/cortx-motr/motr-service.functions
+++ b/scripts/install/usr/libexec/cortx-motr/motr-service.functions
@@ -367,7 +367,7 @@ m0_get_ep_of()
     local found=false
     local lnid=$(m0_get_lnet_nid $node)
 
-    if [ "$XPRT" = "lnet" ]; then
+    if [ "$xprt" = "lnet" ]; then
         local lpid=12345
         local confd_tid=1
         local mds_tid=201


### PR DESCRIPTION
# Problem Statement
- The failure was seen for 52motr-singlenode-sanity test on lnet transport.

# Design
-  The issue was in one of the condition check for transport.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
