### PR TITLE
CORTX-31531: Fix UT net-lnet for libfabric

### DIFF
--- a/ut/m0ut.c
+++ b/ut/m0ut.c
@@ -43,6 +43,7 @@
 #include "lib/memory.h"           /* m0_free0 */
 #include "lib/uuid.h"             /* m0_node_uuid_string_set */
 #include "lib/misc.h"             /* m0_performance_counters */
+#include "lib/string.h"           /* m0_streq */
 
 #define UT_SANDBOX "./ut-sandbox"
 
@@ -277,7 +278,8 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &m0_fom_stats_ut, true);
 	m0_ut_add(m, &m0_net_bulk_if_ut, true);
 	m0_ut_add(m, &m0_net_bulk_mem_ut, true);
-	m0_ut_add(m, &m0_net_lnet_ut, LNET_ENABLED);
+	m0_ut_add(m, &m0_net_lnet_ut, LNET_ENABLED &&
+				      (m0_streq(M0_DEFAULT_NETWORK, "LNET")));
 	m0_ut_add(m, &m0_net_misc_ut, true);
 	m0_ut_add(m, &m0_net_module_ut, true);
 	m0_ut_add(m, &m0_net_test_ut, true);


### PR DESCRIPTION
# Problem Statement
- The UT `net-lnet` uses m0tr.ko module. This gets inserted only for LNET transport. 
- In case of libfabric transport, this module is not inserted. Hence it fails.

# Design
-  The UT `net-lnet` is enabled only when default transport is LNET. Otherwise disabled it.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
