### PR TITLE
CORTX-30872 dix: add support of transient failures for GET

### DIFF
--- a/dix/req.c
+++ b/dix/req.c
@@ -1978,7 +1978,7 @@ static int dix__spare_target(struct m0_dix_rec_op         *rec_op,
 			return M0_ERR(rc);
 		spare = &rec_op->dgp_units[spare_offset + slot];
 		if (!spare->dpu_unavail) {
-			/* Found non-failed spare unit, exit the loop. */
+			/* Found an available spare unit, exit the loop. */
 			*spare_unit = spare;
 			*spare_slot = slot;
 			return M0_RC(0);

--- a/dix/req_internal.h
+++ b/dix/req_internal.h
@@ -130,10 +130,10 @@ struct m0_dix_pg_unit {
 	enum m0_pool_nd_state  dpu_pd_state;
 
 	/**
-	 * Indicates whether this parity group is unavailable, e.g. the target
-	 * for the unit has failed and not repaired yet.
+	 * Indicates whether this parity group unit is unavailable, e.g. the
+	 * target for the unit is offline or has failed and not repaired yet.
 	 */
-	bool                   dpu_failed;
+	bool                   dpu_unavail;
 	bool                   dpu_is_spare;
 	bool                   dpu_del_phase2;
 };


### PR DESCRIPTION
Problem:
Before merging of degraded DIX PUT support for transient
failures (PR https://github.com/Seagate/cortx-motr/pull/1545)
the degraded GET worked by a mistake: sending of requests
to offline targets + resend logic.
The PR mentioned above prevents sending of requests to
offline devices, so the offline unit is skipped. Other alive
targets are not selected due to dix_online_unit_choose()
function (limits the number of units to be selected to 1
to send a single request for DIX GET, allows to iterate
over parity units in case of server-side failures).
So if the first unit is offline then whole DIX operation
wails with -EIO immediately and no resend logic is triggered.
So need a proper way to handle transient failures for DIX GET.

Solution:
Mark a unit as unavailable (previously named "failed") if
corresponding device is OFFLINE, so that it is considered
by the dix_online_unit_choose() function.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>