### PR TITLE
Fix dtm recovery ut 2

### DIFF
--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -661,7 +661,8 @@ static int dtm0_rmsg_fom_tick(struct m0_fom *fom)
 	return M0_RC(result);
 }
 
-/** This fom is only being used in UTs. */
+/** This fom and this semaphore are only being used in UTs. */
+struct m0_semaphore dr_sema;
 static int dtm0_tmsg_fom_tick(struct m0_fom *fom)
 {
 	struct m0_dtm0_service *svc = m0_dtm0_fom2service(fom);
@@ -681,6 +682,7 @@ static int dtm0_tmsg_fom_tick(struct m0_fom *fom)
 		m0_be_queue_unlock(svc->dos_ut_queue);
 		m0_fom_phase_set(fom, M0_FOPH_SUCCESS);
 		result = M0_RC(M0_FSO_AGAIN);
+		m0_semaphore_up(&dr_sema);
 	}
 	return M0_RC(result);
 }

--- a/dtm0/ut/drlink.c
+++ b/dtm0/ut/drlink.c
@@ -44,6 +44,8 @@ enum {
 	DTM0_UT_DRLINK_SIMPLE_POST_NR = 0x100,
 };
 
+extern struct m0_semaphore dr_sema;
+
 void m0_dtm0_ut_drlink_simple(void)
 {
 	struct m0_ut_dtm0_helper *udh;
@@ -66,6 +68,8 @@ void m0_dtm0_ut_drlink_simple(void)
 
 	m0_ut_dtm0_helper_init(udh);
 	svc = udh->udh_client_dtm0_service;
+	rc = m0_semaphore_init(&dr_sema, 0);
+	M0_ASSERT(rc == 0);
 
 	M0_ALLOC_ARR(fid, DTM0_UT_DRLINK_SIMPLE_POST_NR);
 	M0_UT_ASSERT(fid != NULL);
@@ -131,8 +135,6 @@ void m0_dtm0_ut_drlink_simple(void)
 		M0_UT_ASSERT(found);
 	}
 	m0_be_op_fini(&op_out);
-	m0_be_queue_fini(svc->dos_ut_queue);
-	m0_free(svc->dos_ut_queue);
 	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i)
 		M0_UT_ASSERT(m0_fid_eq(&fid[i], &M0_FID0));
 	m0_free(fid);
@@ -142,6 +144,11 @@ void m0_dtm0_ut_drlink_simple(void)
 	}
 	m0_free(op);
 	m0_free(fop);
+	for (i = 0; i < DTM0_UT_DRLINK_SIMPLE_POST_NR; ++i)
+		m0_semaphore_down(&dr_sema);
+
+	m0_be_queue_fini(svc->dos_ut_queue);
+	m0_free(svc->dos_ut_queue);
 
 	m0_ut_dtm0_helper_fini(udh);
 	m0_free(udh);


### PR DESCRIPTION
# Problem Statement
m0_be_queue is going to m0_be_queue_fini() while there are still some records.

# Design
A semaphore is used to assure that the be queue records have been dequeued.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
