### PR TITLE
CORTX-31084: Race condition in libfab_poller() fi_trywait() call

### DIFF
--- a/net/libfab/libfab.c
+++ b/net/libfab/libfab.c
@@ -764,9 +764,11 @@ static void libfab_poller(struct m0_fab__tm *tm)
 	libfab_tm_event_post(tm, M0_NET_TM_STARTED);
 	while (tm->ftm_state != FAB_TM_SHUTDOWN) {
 		do {
+			m0_mutex_lock(&tm->ftm_fids.ftf_lock);
 			ret = fi_trywait(tm->ftm_fab->fab_fab,
 					 tm->ftm_fids.ftf_head,
 					 tm->ftm_fids.ftf_cnt);
+			m0_mutex_unlock(&tm->ftm_fids.ftf_lock);
 			/*
 			 * TBD : Add handling of other return values of
 			 * fi_trywait() if it returns something other than
@@ -1610,6 +1612,7 @@ static int libfab_tm_param_free(struct m0_fab__tm *tm)
 	close(tm->ftm_epfd);
 	m0_free(tm->ftm_fids.ftf_head);
 	m0_free(tm->ftm_fids.ftf_ctx);
+	m0_mutex_fini(&tm->ftm_fids.ftf_lock);
 	m0_free(tm->ftm_rem_iov);
 	m0_free(tm->ftm_loc_iov);
 
@@ -2476,17 +2479,21 @@ static int libfab_waitfd_bind(struct fid* fid, struct m0_fab__tm *tm, void *ctx)
 	rc = epoll_ctl(tm->ftm_epfd, EPOLL_CTL_ADD, fd, &ev);
 
 	if (rc == 0) {
+		m0_mutex_lock(&tmfid->ftf_lock);
 		if (tmfid->ftf_cnt >= (tmfid->ftf_arr_size - 1)) {
 			rc = libfab_fid_array_grow(tmfid,
 						   FAB_TM_FID_MALLOC_STEP);
-			if (rc != 0)
+			if (rc != 0) {
+				m0_mutex_unlock(&tmfid->ftf_lock);
 				return M0_ERR(rc);
+			}
 		}
 		tmfid->ftf_head[tmfid->ftf_cnt] = fid;
 		tmfid->ftf_ctx[tmfid->ftf_cnt]  = ptr;
 		ptr->evctx_pos = tmfid->ftf_cnt;
 		tmfid->ftf_cnt++;
 		M0_ASSERT(tmfid->ftf_cnt < tmfid->ftf_arr_size);
+		m0_mutex_unlock(&tmfid->ftf_lock);
 	}
 
 	return M0_RC(rc);
@@ -2512,6 +2519,7 @@ static int libfab_waitfd_unbind(struct fid* fid, struct m0_fab__tm *tm,
 
 	rc = epoll_ctl(tm->ftm_epfd, EPOLL_CTL_DEL, fd, &ev);
 	if (rc == 0) {
+		m0_mutex_lock(&tmfid->ftf_lock);
 		M0_LOG(M0_DEBUG, "DEL_FROM_EPOLL %s fid=%p fd=%d tm=%p pos=%d",
 		       ptr->evctx_dbg, fid, fd, tm, ptr->evctx_pos);
 		for (i = ptr->evctx_pos; i < tmfid->ftf_cnt - 1; i++) {
@@ -2523,6 +2531,7 @@ static int libfab_waitfd_unbind(struct fid* fid, struct m0_fab__tm *tm,
 		tmfid->ftf_head[tmfid->ftf_cnt] = 0;
 		tmfid->ftf_ctx[tmfid->ftf_cnt]  = 0;
 		ptr->evctx_pos = 0;
+		m0_mutex_unlock(&tmfid->ftf_lock);
 	}
 
 	return M0_RC(rc);
@@ -2934,6 +2943,7 @@ static int libfab_ma_init(struct m0_net_transfer_mc *ntm)
 		ftm->ftm_fids.ftf_cnt = 0;
 		M0_ALLOC_ARR(ftm->ftm_fids.ftf_head, FAB_TM_FID_MALLOC_STEP);
 		M0_ALLOC_ARR(ftm->ftm_fids.ftf_ctx, FAB_TM_FID_MALLOC_STEP);
+		m0_mutex_init(&ftm->ftm_fids.ftf_lock);
 		if (ftm->ftm_fids.ftf_head == NULL ||
 		    ftm->ftm_fids.ftf_ctx == NULL) {
 			m0_free(ftm->ftm_fids.ftf_head);

--- a/net/libfab/libfab_internal.h
+++ b/net/libfab/libfab_internal.h
@@ -391,6 +391,15 @@ struct m0_fab__ep {
  * to be monitored in epoll_wait().
  */
 struct m0_fab__tm_fids {
+	/**
+	 * Lock used to protect the transfer machine fids structure.
+	 * The fids and contexts of event queue, completion queue are
+	 * added/removed from ftf_head and ftf_ctx arrays during
+	 * endpoint creation/deletion which can happen in main or poller thread.
+	 * And the same arrays are used by fi_trywait().
+	 */
+	struct m0_mutex         ftf_lock;
+
 	/* Pointer to the head of the list (array in this case) */
 	struct fid            **ftf_head;
 


### PR DESCRIPTION
Problem:
libfab_poller() calls fi_trywait() without holding the tm lock.
A concurrent call to libfab_waitfd_unbind() can modify the fids array,
leading to NULL pointer dereference.

Solution:
Add m0_mutex to protect the transfer machine fids structure.

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
