### PR TITLE
Fix namei ops cancel dist

### DIFF
--- a/motr/client.c
+++ b/motr/client.c
@@ -841,6 +841,8 @@ M0_INTERNAL int m0_op_init(struct m0_op *op,
 	m0_mutex_init(&op->op_priv_lock);
 	m0_mutex_init(&op->op_pending_tx_lock);
 	spti_tlist_init(&op->op_pending_tx);
+	op->op_cancelling = false;
+	m0_semaphore_init(&op->op_sema, 0);
 
 	return M0_RC(0);
 }
@@ -859,6 +861,9 @@ void m0_op_fini(struct m0_op *op)
 					  M0_OS_FAILED)));
 	M0_PRE(op->op_size >= sizeof *oc);
 
+	if (op->op_cancelling)
+		m0_semaphore_down(&op->op_sema);
+
 	oc = bob_of(op, struct m0_op_common, oc_op, &oc_bobtype);
 	if (oc->oc_cb_fini != NULL)
 		oc->oc_cb_fini(oc);
@@ -876,6 +881,8 @@ void m0_op_fini(struct m0_op *op)
 	m0_sm_group_unlock(grp);
 	m0_sm_group_fini(grp);
 
+	op->op_cancelling = false;
+	m0_semaphore_fini(&op->op_sema);
 	/* Finalise op's bob */
 	m0_op_bob_fini(op);
 

--- a/motr/client.h
+++ b/motr/client.h
@@ -709,6 +709,17 @@ struct m0_op {
 	/* Operation's private data, can be used as arguments for callbacks.*/
 	void                          *op_datum;
 	uint64_t                       op_count;
+
+	/**
+	 * This flag is set when there is an onging cancel operation.
+	 * There is no refcount in this op. But the op cancelling AST
+	 * needs this op being valid. The op cancelling AST will
+	 * semaphore up when it is done. The m0_op_fini() checks this flag
+	 * and semaphore down on it if needed. This will make sure the op
+	 * is not freed before the op cancel is done.
+	 */
+	bool                           op_cancelling;
+	struct m0_semaphore            op_sema;
 	/**
 	 * Private field, to be used by internal implementation.
 	 */


### PR DESCRIPTION
# Problem Statement
The UT idx-dix:namei-ops-cancel-dist panics sometimes.
The problem is:
A Motr application wants to cancel an ongoing op by m0_op_cancel().
Then, this application waits for this op, and then calls m0_op_fini() and frees the op.
But the op cancel itself is asynchronous as an AST. At the time of the AST is scheduled to run,
the op itself may be already freed.

# Design
In order to maintain the call sequence of Motr application, a semaphore is introduced.
If the op cancel is still in progress, the m0_op_fini() will have to wait for this semaphore.
The semaphore will be up when the cancel AST is done.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
