### PR TITLE
client: do degraded read when -ENOENT is returned

### DIFF
--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -1573,22 +1573,22 @@ static int ioreq_dgmode_read(struct m0_op_io *ioo, bool rmw)
 	M0_ENTRY();
 	M0_PRE_EX(m0_op_io_invariant(ioo));
 
-        /*
-         * Return immediately if all devices are ONLINE and all requests
-         * return success.
-         *
-         * There exists some cases that a request returns -ENOENT error:
-         * (1) In case of read before write, due to CROW, COB will not be
-         *     present, resulting into -ENOENT error.
-         * (2) The unit to read is not created if ioservice crashed before
-         *     the corresponding cob is created.
-         * The -ENOENT error only means the corresponding cob doesn't exist
-         * and it doesn't mean the object to read doesn't exist as the object
-         * has to be opened before read. So in either of these cases,
-         * it is safe to let device_check() check if degraded read can proceed.
-         *
-         * Any other error will also fall to device_check().
-         */
+	/*
+	 * Return immediately if all devices are ONLINE and all requests
+	 * return success.
+	 *
+	 * There exists some cases that a request returns -ENOENT error:
+	 * (1) In case of read before write, due to CROW, COB will not be
+	 *     present, resulting into -ENOENT error.
+	 * (2) The unit to read is not created if ioservice crashed before
+	 *     the corresponding cob is created.
+	 * The -ENOENT error only means the corresponding cob doesn't exist
+	 * and it doesn't mean the object to read doesn't exist as the object
+	 * has to be opened before read. So in either of these cases,
+	 * it is safe to let device_check() check if degraded read can proceed.
+	 *
+	 * Any other error will also fall to device_check().
+	 */
 	xfer = &ioo->ioo_nwxfer;
 	if (xfer->nxr_rc == 0 && !ioo->ioo_dgmode_io_sent)
 		return M0_RC(xfer->nxr_rc);

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -1573,14 +1573,24 @@ static int ioreq_dgmode_read(struct m0_op_io *ioo, bool rmw)
 	M0_ENTRY();
 	M0_PRE_EX(m0_op_io_invariant(ioo));
 
-	/*
-	 * If all devices are ONLINE, all requests return success.
-	 * In case of read before write, due to CROW, COB will not be present,
-	 * resulting into ENOENT error.
-	 */
+        /*
+         * Return immediately if all devices are ONLINE and all requests
+         * return success.
+         *
+         * There exists some cases that a request returns -ENOENT error:
+         * (1) In case of read before write, due to CROW, COB will not be
+         *     present, resulting into -ENOENT error.
+         * (2) The unit to read is not created if ioservice crashed before
+         *     the corresponding cob is created.
+         * The -ENOENT error only means the corresponding cob doesn't exist
+         * and it doesn't mean the object to read doesn't exist as the object
+         * has to be opened before read. So in either of these cases,
+         * it is safe to let device_check() check if degraded read can proceed.
+         *
+         * Any other error will also fall to device_check().
+         */
 	xfer = &ioo->ioo_nwxfer;
-	if ((xfer->nxr_rc == 0 || xfer->nxr_rc == -ENOENT) &&
-	    !ioo->ioo_dgmode_io_sent)
+	if (xfer->nxr_rc == 0 && !ioo->ioo_dgmode_io_sent)
 		return M0_RC(xfer->nxr_rc);
 
 	/*


### PR DESCRIPTION
Problem:
There exists cases where an -ENOENT error is returned when
trying to read a data unit:
(1) In case of read before write, due to CROW, COB will not be
    present, resulting into -ENOENT error.
(2) The COB of the unit to read is not created if ioservice
    crashes before the COB creation.
For case 2, as current implementation returns -ENOENT immediately
from ioreq_dgmode_read() without triggering degraded read,
application gets -ENOENT error.

Solution:
As the -ENOENT error in the above cases only means the
corresponding COB doesn't exist and it doesn't mean the object to
read doesn't exist as the object has to be opened before read. So
in either of these cases, let device_check() decide if degraded
read can proceed.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
