### PR TITLE
Fixing m0d-ut:cs-rconfc-fatal

### DIFF
--- a/rm/st/wlock_helper.c
+++ b/rm/st/wlock_helper.c
@@ -186,8 +186,15 @@ static void _write_lock_put(struct wlock_ctx *wlx)
 M0_INTERNAL void rm_write_lock_put()
 {
 	_write_lock_put(&wlx);
-	wlock_ctx_destroy(&wlx);
+	/*
+	 * This gives other RM requests a chance to be handled and complete.
+	 * TODO: Even after some time, there might be some pending requests.
+	 * We need a better to handle this corner cases.
+	 */
+	m0_nanosleep(m0_time(3, 0), NULL);
+
 	wlock_ctx_disconnect(&wlx);
+	wlock_ctx_destroy(&wlx);
 	m0_free0(&wlx.wlc_rm_addr);
 	M0_LEAVE();
 }


### PR DESCRIPTION
Problem: rm_write_lock_put() releases the distributed lock, taken by
rm_write_lock_get(). It also finalises and frees "write lock
context" (struct wlock_ctx) that contains all the information necessary to
interact with resource manager. But it is possible that requests the revoke this
lock are processed concurrently (and, worse, they can arrive later).

This is a temporary fix. It adds some delay before finalising the write lock context.
Better solution is needed in future. But since this issue is in UT code, we will
use this fix now.

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
Similar problems in https://github.com/Seagate/cortx-motr/pull/1761

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
