### PR TITLE
CORTX-31470 remove facter package from motr

### DIFF
--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -162,7 +162,6 @@ Requires:       perl-autodie
 Requires:       perl-Try-Tiny
 Requires:       perl-Sereal
 Requires:       perl-MCE
-Requires:       facter
 %if %{rhel} < 8
 Requires:       python36-ply
 %else

--- a/scripts/provisioning/roles/motr-runtime/vars/RedHat.yml
+++ b/scripts/provisioning/roles/motr-runtime/vars/RedHat.yml
@@ -20,7 +20,6 @@
 ---
 motr_runtime_deps_pkgs:
   - attr
-  - facter
   - genders
   - libaio
   - libyaml


### PR DESCRIPTION
- removed facter reference from cortx-motr.spec.in file
- removed  facter reference from RedHat.yaml file 

Signed-off-by: Parikshit Dharmale <parikshit.dharmale@seagate.com>

# Problem Statement
- cortx-motr installs facter package, which is not used and needs to be removed 

# Design
-  Remove references of facter package 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Tested with custom build 6234, generated motr rpm does not have facter package 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
