### PR TITLE
Fix "Invalid entity fid detected" issue when boundary condition obj_id is passed …

### DIFF
--- a/motr/examples/example1.c
+++ b/motr/examples/example1.c
@@ -401,7 +401,7 @@ int main(int argc, char *argv[])
 		exit(-1);
 	}
 	obj_id.u_lo = atoll(argv[5]);
-	if (obj_id.u_lo < M0_ID_APP.u_lo) {
+	if (obj_id.u_lo <= M0_ID_APP.u_lo) {
 		printf("obj_id invalid. Please refer to M0_ID_APP "
 		       "in motr/client.c\n");
 		exit(-EINVAL);


### PR DESCRIPTION
…to Motr Object Application.

Signed-off-by: wb-droid <bo.b.wei@seagate.com>

# Problem Statement
- When obj_id of 1048576 is passed as input to the example below, the "Invalid entity fid detected" error is encountered. 
./example1 192.168.53.101@tcp:12345:34:1 192.168.53.101@tcp:12345:33:1000 0x7000000000000001:0 0x7200000000000001:64 1048576 
motr[04290]:  f0c0  ERROR  [client.c:360:entity_id_is_valid]  Invalid entity fid detected: <0:100000>.Entity id should larger than M0_ID_APP. 

-  The fix is to treat this boundary case as invalid input.
