### PR TITLE
CORTX-30433: Support to configure SKIP_LAYOUT and CROW for m0kv

### DIFF
--- a/motr/m0kv/cmd_main.c
+++ b/motr/m0kv/cmd_main.c
@@ -63,6 +63,8 @@ enum {
 static struct m0 instance;
 bool is_str;
 bool is_enf_meta;
+bool is_skip_layout;
+bool is_crow_disable;
 struct m0_fid dix_pool_ver;
 
 static int subsystem_id(char *name)
@@ -97,6 +99,10 @@ static void usage(void)
 		"-e  Enable M0_ENF_META flag and it is optional.\n"
 		"-v 7600000000000001:30 it is mandatory with -e for "
 		"PUT, GET, DEL and NEXT operations.\n"
+		"-L  Enable M0_OIF_SKIP_LAYOUT flag and it is optional.\n"
+		"-v 7600000000000001:30 it is mandatory with -L for "
+		"other operations except CREATE.\n"
+		"-C  Disable M0_OIF_CROW flag and it is optional.\n"
 		"Available subsystems and subsystem-specific commands are "
 		"listed below.\n");
 	for (i = 0; i < ARRAY_SIZE(subsystems); i++)
@@ -142,6 +148,10 @@ static int opts_get(struct params *par, int *argc, char ***argv)
 					&is_str),
 			M0_FLAGARG('e', "Enable M0_ENF_META flag",
 					&is_enf_meta),
+			M0_FLAGARG('L', "Enable M0_OIF_SKIP_LAYOUT flag",
+					&is_skip_layout),
+			M0_FLAGARG('C', "Disable M0_OIF_CROW flag",
+					&is_crow_disable),
 			M0_STRINGARG('v', "DIX pool version information",
 					LAMBDA(void, (const char *str) {
 						pv = (char *)str;
@@ -160,6 +170,12 @@ static int opts_get(struct params *par, int *argc, char ***argv)
 		common_args++;
 
 	if (is_enf_meta)
+		common_args++;
+
+	if (is_skip_layout)
+		common_args++;
+
+	if (is_crow_disable)
 		common_args++;
 
 	if (pv != NULL) {

--- a/motr/m0kv/index.h
+++ b/motr/m0kv/index.h
@@ -69,6 +69,8 @@ struct index_ctx
 
 extern bool is_str;
 extern bool is_enf_meta;
+extern bool is_skip_layout;
+extern bool is_crow_disable;
 extern struct m0_fid dix_pool_ver;
 
 int  index_execute(int argc, char** argv);

--- a/motr/m0kv/index_parser.c
+++ b/motr/m0kv/index_parser.c
@@ -480,13 +480,19 @@ void index_parser_print_command_help(void)
 		"\"Testing\" \n"
 		"\t\tNote: If key already exists put over-write the old value.\n"
 		"\t\t>m0kv [common args] -s index get \"1:5\" \"Department\" \n"
-		"\t\tNote: DIX pool version info on console if pass -e \n" 
-		"\t\t flag for index create.\n"
+		"\t\tNote: DIX pool version info on console if pass -e or -L"
+		"flag for index create.\n"
 		"\t\t>m0kv [common args] -e index create \"1:5\" \n"
-		"\t\tNote: Pass pool version info for PUT/GET/DEL/NEXT \n"
-		"\t\t operations if pass -e flag \n"
+		"\t\tNote: Pass pool version info for PUT/GET/DEL/NEXT "
+		"operations if pass -e flag \n"
 		"\t\t>m0kv [common args] -e -v 7600000000000001:30 -s index" 
-		" put \"1:5\" \"Department\" \"Testing\" \n" );
+		" put \"1:5\" \"Department\" \"Testing\" \n"
+		"\t\t>m0kv [common args] -L index create \"1:6\" \n"
+		"\t\tNote: Pass pool version info for other operations "
+		"if pass -L flag \n"
+		"\t\t>m0kv [common args] -L -v 7600000000000001:30 -s index"
+		" put \"1:6\" \"Department\" \"Testing\" \n"
+		"\t\t>m0kv [common args] -C index create \"1:6\" \n" );
 }
 
 #undef M0_TRACE_SUBSYSTEM


### PR DESCRIPTION
# Problem Statement
Support to configure SKIP_LAYOUT and CROW for m0kv

# Design
Added the "-L" flag to support M0_OIF_SKIP_LAYOUT. Pool version info
will be available on the console when run "m0kv index create" operation.
m0kv needs to pass the pool version info as an argument for all other
operations if the "-L" flag is added.
Added the "-C" flag to disable M0_OIF_CROW flag.

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
