### PR TITLE
CORTX-29888: Upgrade mini-provisioner interface (config) for rolling …

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -403,9 +403,13 @@ def add_entries_to_config_file(self, fname, kv_list):
             fp.write(f"{line}")
 
 def upgrade_phase_config_file(self, kv_list, flag):
+    MOTR_M0D_DATA_DIR = f"{self.local_path}/motr"
+    MOTR_LOCAL_SYSCONFIG_DIR = f"{MOTR_M0D_DATA_DIR}/sysconfig"
+    MOTR_M0D_CONF_FILE = f"{MOTR_LOCAL_SYSCONFIG_DIR}/{self.machine_id}/motr"
+
     lines = []
     # Get all lines of file in buffer
-    with open(f"{MOTR_SYS_CFG}", "r") as fp:
+    with open(f"{MOTR_M0D_CONF_FILE}", "r") as fp:
         for line in fp:
             lines.append(line)
     num_lines = len(lines)
@@ -438,7 +442,7 @@ def upgrade_phase_config_file(self, kv_list, flag):
     self.logger.info(f"After update, num_lines={num_lines}\n")
 
     # Write buffer to file
-    with open(f"{MOTR_SYS_CFG}", "w+") as fp:
+    with open(f"{MOTR_M0D_CONF_FILE}", "w+") as fp:
         for line in lines:
             fp.write(f"{line}")
 
@@ -1600,7 +1604,6 @@ def get_key_val_list_from_changed_entries(self, entries, key_val_list):
 # motr config files like /etc/sysconfig/motr and /etc/cortx/motr/sysconfig/<machine-id>/motr
 
 def upgrade_phase_copy_key_val_to_motr_config(self, key_val_list, flag):
-     print("")
      for i in key_val_list:
         key = i[0]
 
@@ -1657,16 +1660,3 @@ def motr_upgrade(self):
     entries_to_delete = Conf.get(self.changeset_index, 'deleted')
     if entries_to_delete is not None:
         add_del_update_keys_in_upgrade_phase(self, entries_to_delete, 'delete')
-
-    copy_motr_config_file(self)
-
-#Copy /etc/sysconfg/motr to /etc/cortx/motr/sysconfig/<machine-id>/
-def copy_motr_config_file(self):
-    validate_files([MOTR_SYS_CFG, self.local_path, self.log_path])
-    MOTR_M0D_DATA_DIR = f"{self.local_path}/motr"
-    MOTR_LOCAL_SYSCONFIG_DIR = f"{MOTR_M0D_DATA_DIR}/sysconfig"
-    MOTR_M0D_CONF_DIR = f"{MOTR_LOCAL_SYSCONFIG_DIR}/{self.machine_id}"
-    validate_files([MOTR_SYS_CFG, MOTR_M0D_CONF_DIR])
-    self.logger.info(f"Copying {MOTR_SYS_CFG} to {MOTR_M0D_CONF_DIR}\n")
-    cmd = f"cp {MOTR_SYS_CFG} {MOTR_M0D_CONF_DIR}"
-    execute_command(self, cmd)

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -1,4 +1,4 @@
-#!/usr/libexec/platform-python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -432,7 +432,7 @@ def upgrade_phase_sysconfig_file(self, kv_list, flag):
 
     # Write buffer to file
     # TODO: Consistency whould be maintained while writing to file.
-    # For example, if upgrade if crashed while updating the file then use the previous consistent copy.
+    # For example, if upgrade is crashed while updating the file then use the previous consistent copy.
     with open(f"{MOTR_M0D_CONF_FILE}", "w+") as fp:
         for line in lines:
             fp.write(f"{line}")
@@ -1566,7 +1566,7 @@ def start_service(self, service, idx):
     execute_command_console(self, cmd)
     return
 
-# Itertate recursiverly through dictionary and extract leaf <key, value>
+# Iterate recursively through dictionary and extract leaf <key, value>
 # For example,
 # Input: {'cortx': {'common': {'release': {'version': '2.0.0-788|2.0.0-790'}}, 'rgw': {'gc_max_objs': '32|123', 'init_timeout': '300|123'}}}
 # Output: [('version', '2.0.0-788|2.0.0-790'), ('gc_max_objs', '32|123'), ('init_timeout', '300|123')]

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -1578,7 +1578,7 @@ def start_service(self, service, idx):
 def recursive_iterate(key, val, list_op):
     if isinstance(val, dict):
         for k in val.keys():
-            ret = recursive_iterate(k, val[k], list_op)
+            recursive_iterate(k, val[k], list_op)
     else:
         if isinstance(val, list):
             for elem in val:
@@ -1592,9 +1592,6 @@ def update_kvs_to_motr_config(self, config_kvs, flag):
     if flag not in ['update', 'append', 'delete']:
         self.logger.error(f"flag={flag} not valid\n")
         return
-    MOTR_M0D_DATA_DIR = f"{self.local_path}/motr"
-    MOTR_LOCAL_SYSCONFIG_DIR = f"{MOTR_M0D_DATA_DIR}/sysconfig"
-    MOTR_M0D_CONF_DIR = f"{MOTR_LOCAL_SYSCONFIG_DIR}/{self.machine_id}"
     update_config_file_common(self, config_kvs, flag)
 
 # In upgrade phase, update the motr config file with changed

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -383,10 +383,10 @@ def validate_motr_rpm(self):
     self.logger.info(f"Checking for {MOTR_SYS_CFG}\n")
     validate_file(MOTR_SYS_CFG)
 
-#ToDo: 
+#TODO:
 #(key,val) might contain space so need to use trim before comparision.
 #Only motr sysconfig parameters need to be updated in this function.
-       
+
 def upgrade_phase_sysconfig_file(self, kv_list, flag):
     MOTR_LOCAL_SYSCONFIG_DIR = f"{self.local_path}/motr/sysconfig"
     MOTR_M0D_CONF_FILE = f"{MOTR_LOCAL_SYSCONFIG_DIR}/{self.machine_id}/motr"
@@ -418,7 +418,7 @@ def upgrade_phase_sysconfig_file(self, kv_list, flag):
             if flag == 'append':
                 self.logger.info(f"({k},{v}) not found in config. flag is {flag} so appending.\n")
                 lines.append(f"{k}={v}\n")
-            #ToDO: If user want to update the key which is not available then it should be error out.
+            #TODO: If user want to update the key which is not available then it should be error out.
             elif flag == 'update':
                 self.logger.info(f"({k},{v}) not found in config. so skipping {flag}.\n")
             elif flag == 'delete':
@@ -1636,14 +1636,14 @@ def add_del_update_keys_in_upgrade_phase(self, entries, flag):
 
 def motr_upgrade(self):
     # Update changed motr config parameters
-    # ToDO: update flag while calling add_del_update_keys_in_upgrade_phase should ne replaced by change.
+    # TODO: update flag while calling add_del_update_keys_in_upgrade_phase should ne replaced by change.
     changed_entries = Conf.get(self.changeset_index, 'changed')
     if changed_entries is not None:
         self.logger.info(f"changed_entries={changed_entries}\n")
         add_del_update_keys_in_upgrade_phase(self, changed_entries, 'update')
 
     # Add new motr config parameters.
-    # ToDO: append flag while calling add_del_update_keys_in_upgrade_phase should ne replaced by new/add.
+    # TODO: append flag while calling add_del_update_keys_in_upgrade_phase should ne replaced by new/add.
     new_entries = Conf.get(self.changeset_index, 'new')
     if new_entries is not None:
         self.logger.info(f"new_entries={new_entries}\n")

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -1,4 +1,4 @@
-#!/usr/libexec/platform-python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -35,13 +35,16 @@ MOTR_HARE_CONF_PATH = "/opt/seagate/cortx/motr/conf/motr_hare_keys.json"
 class Cmd:
     """Setup Command"""
     _index = "conf"
-
+    changeset_index = "changeset_conf"
     # Index for Hare-Motr keys required for intercomponent communication
     _index_motr_hare = "conf_motr_hare"
 
     def __init__(self, args: dict):
         self._url = args.config
-
+        if args.changeset not in [None, ""]:
+            self.changeset = args.changeset
+            Conf.load(self.changeset_index, self.changeset)
+            changeset_all_keys = Conf.get_keys(self.changeset_index)
         self._services = args.services
         self._idx = args.idx
         # URL for Hare-Motr keys required for intercomponent communication
@@ -113,6 +116,7 @@ class Cmd:
 
         parser1 = parser.add_parser(cls.name, help=f'setup {name}')
         parser1.add_argument('--config', type=str, help="Config URL")
+        parser1.add_argument('--changeset', type=str, help="Changeset URL for upgrade")    
         parser1.add_argument('args', nargs='*', default=[], help='args')
         parser1.add_argument('--debug', '-d', help='enable debug print',
                          action="store_true")
@@ -235,10 +239,21 @@ class UpgradeCmd(Cmd):
     name = "upgrade"
 
     def __init__(self, args):
-        super().__init__(args)
+        # args is of type Namespace.
+        # For example, args=Namespace(args=[], changeset=None,
+        #                             command=<class '__main__.UpgradeCmd'>,
+        #                             config='yaml:///etc/cortx/cluster.conf',
+        #                             debug=False, idx=None, services=None)
+        
+        # If changeset is not given or Null then set it to default value
+        if args.changeset in [None, ""]:
+            args.changeset = "yaml:///etc/cortx/changeset.conf"
 
+        super().__init__(args)
+        
     def process(self):
-        pass
+        self.logger.info(f"Processing {self.name} {self.url} changeset={self.changeset} {self._args}\n")
+        motr_upgrade(self)
 
 class BackupCmd(Cmd):
     """Backup Setup Cmd"""

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -116,7 +116,7 @@ class Cmd:
 
         parser1 = parser.add_parser(cls.name, help=f'setup {name}')
         parser1.add_argument('--config', type=str, help="Config URL")
-        parser1.add_argument('--changeset', type=str, help="Changeset URL for upgrade")    
+        parser1.add_argument('--changeset', type=str, help="Changeset URL for upgrade")
         parser1.add_argument('args', nargs='*', default=[], help='args')
         parser1.add_argument('--debug', '-d', help='enable debug print',
                          action="store_true")
@@ -244,13 +244,13 @@ class UpgradeCmd(Cmd):
         #                             command=<class '__main__.UpgradeCmd'>,
         #                             config='yaml:///etc/cortx/cluster.conf',
         #                             debug=False, idx=None, services=None)
-        
+
         # If changeset is not given or Null then set it to default value
         if args.changeset in [None, ""]:
             args.changeset = "yaml:///etc/cortx/changeset.conf"
 
         super().__init__(args)
-        
+
     def process(self):
         self.logger.info(f"Processing {self.name} {self.url} changeset={self.changeset} {self._args}\n")
         motr_upgrade(self)


### PR DESCRIPTION
…upgrade

Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
-  Upgrade mini-provisioner interface (config) for rolling

# Design
Config upgrade:

Each component provides a sample config file which is installed/copied as the main config for the first time. However when the CORTX component is upgraded, the main config exists and can not be overwritten. There are 3 possible scenarios that needs to be handled.

Add Keys - For this case, only new entries should be added to main config along with the default value.
Replace Keys - For this case, config entries need to merged / overwritten depending on the context and meaning of the config key.
Delete Keys - This case must be avoided. Config entry should exist and marked obsolete for at least 1-2 versions and then be deleted.
 

Design specifications:

https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/785448990/CORTX+Software+Upgrade
# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
1: Created build which contains changes of this PR#1840
    cortxcontrol: cortx-docker.colo.seagate.com/seagate/cortx-control:2.0.0-6690-custom-ci
    cortxdata: cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-6690-custom-ci
    cortxserver: cortx-docker.colo.seagate.com/seagate/cortx-rgw:2.0.0-6690-custom-ci
    cortxha: cortx-docker.colo.seagate.com/seagate/cortx-control:2.0.0-6690-custom-ci
    cortxclient: cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-6690-custom-ci
2: Deploy the singlenode setup with above build. It is up and running.
3: Now we want to upgrade cortx-data:2.0.0-6690-custom-ci to cortx-data:2.0.0-6698-custom-ci
3.1: For this, we entered the docker image of 6690 
docker run -it cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-6690-custom-ci /bin/bash

3.2: Edited following lines in file:/opt/seagate/cortx/RELEASE.INFO
VERSION: "2.0.0-6698"
COMPONENTS:
    - "cortx-motr-2.0.0-6698_gita7c53b28.el8.x86_64.rpm"

3.3: Save the docker image with new name
docker commit 704704d8cac0 cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-6698-custom-ci

4: Exit the docker image and update the solution.yaml as below
  images:
    cortxdata: cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-6698-custom-ci
5: Run upgrade command: 
Clone git clone https://github.com/seagate/cortx-k8s -b cortx-test
./upgrade-cortx-cloud.sh start -p data 

Note: Make sure to edit ./upgrade-cortx-cloud.sh  as below for local docker images
76 function fetch_solution_images() {
 77     printf "Using solution config file '%s'\n" "${SOLUTION_FILE}"
 78     # Fetch Upgrade Images from solution.yaml and validate them
 79     cortxcontrol_image=$(parse_solution 'solution.images.cortxcontrol' | cut -f2 -d'>')
 80     #validate_upgrade_images "${cortxcontrol_image}"
 81     cortxha_image=$(parse_solution 'solution.images.cortxha' | cut -f2 -d'>')
 82     #validate_upgrade_images "${cortxha_image}"
 83     cortxdata_image=$(parse_solution 'solution.images.cortxdata' | cut -f2 -d'>')
 84     cortxserver_image=$(parse_solution 'solution.images.cortxserver' | cut -f2 -d'>')
 85     #validate_upgrade_images "${cortxserver_image}"
 86 }
 

Output After upgrade. If you see pods are going in upgrade sequence

Every 2.0s: kubectl get pods                                                                                                                                     Tue Jun 14 09:16:00 2022

NAME                                                 READY   STATUS        RESTARTS   AGE
cortx-consul-client-jhwxb                            1/1     Running       0          141m
cortx-consul-server-0                                1/1     Running       0          141m
cortx-control-6bbfc4dcf9-7kwjq                       1/1     Running       0          141m
cortx-data-ssc-vm-g2-rhev4-3118-54ccdb45d6-cwmv8     0/4     Init:0/2      0          2s
cortx-data-ssc-vm-g2-rhev4-3118-845656b76b-4925q     4/4     Terminating   0          14m
cortx-ha-68b8b9c5c4-zmvjz                            3/3     Running       0          141m
cortx-kafka-0                                        1/1     Running       0          141m
cortx-server-ssc-vm-g2-rhev4-3118-655c959cd9-cdmr2   2/2     Running       0          141m
cortx-zookeeper-0                                    1/1     Running       0          1



Every 2.0s: kubectl get pods                                                                                                                                     Tue Jun 14 09:16:15 2022

NAME                                                 READY   STATUS        RESTARTS   AGE
cortx-consul-client-jhwxb                            1/1     Running       0          142m
cortx-consul-server-0                                1/1     Running       0          142m
cortx-control-6bbfc4dcf9-7kwjq                       1/1     Running       0          142m
cortx-data-ssc-vm-g2-rhev4-3118-54ccdb45d6-cwmv8     4/4     Running       0          17s
cortx-data-ssc-vm-g2-rhev4-3118-845656b76b-4925q     4/4     Terminating   0          14m
cortx-ha-68b8b9c5c4-zmvjz                            3/3     Running       0          141m
cortx-kafka-0                                        1/1     Running       0          142m
cortx-server-ssc-vm-g2-rhev4-3118-655c959cd9-cdmr2   2/2     Running       0          141m
cortx-zookeeper-0                                    1/1     Running       0          142m


[root@ssc-vm-g2-rhev4-3118 ~]# watch kubectl get pods
Every 2.0s: kubectl get pods                                                                                                                                     Tue Jun 14 09:16:50 2022

NAME                                                 READY   STATUS    RESTARTS   AGE
cortx-consul-client-jhwxb                            1/1     Running   0          142m
cortx-consul-server-0                                1/1     Running   0          142m
cortx-control-6bbfc4dcf9-7kwjq                       1/1     Running   0          142m
cortx-data-ssc-vm-g2-rhev4-3118-54ccdb45d6-cwmv8     4/4     Running   0          52s
cortx-ha-68b8b9c5c4-zmvjz                            3/3     Running   0          141m
cortx-kafka-0                                        1/1     Running   0          142m
cortx-server-ssc-vm-g2-rhev4-3118-655c959cd9-cdmr2   2/2     Running   0          141m
cortx-zookeeper-0                                    1/1     Running   0          142m




Upgrade Successful for cortx-data-ssc-vm-g2-rhev4-3118

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
