### PR TITLE
CORTX-30753: Codacy code cleanup(#1608)

### DIFF
--- a/addb2/st/addb2dump-plugin.sh
+++ b/addb2/st/addb2dump-plugin.sh
@@ -39,8 +39,8 @@ function generate_addb2_stob() {
 }
 
 function dump_addb2_stob() {
-    ADDB2_DUMP=`"${MOTR_SRC_DIR}"/utils/m0addb2dump -f -p "${PLUGIN_SO}" \
-    -- "${ADDB2_STOB}" | grep "measurement"`
+    ADDB2_DUMP=$("${MOTR_SRC_DIR}"/utils/m0addb2dump -f -p "${PLUGIN_SO}" \
+    -- "${ADDB2_STOB}" | grep "measurement")
 }
 
 function delete_ut_sandbox() {

--- a/console/st/console-st.sh
+++ b/console/st/console-st.sh
@@ -25,7 +25,7 @@ umask 0002
 ## CAUTION: This path will be removed by superuser.
 SANDBOX_DIR=${SANDBOX_DIR:-/var/motr/sandbox.console-st}
 
-M0_SRC_DIR=`readlink -f "$0"`
+M0_SRC_DIR=$(readlink -f "$0")
 M0_SRC_DIR=${M0_SRC_DIR%/*/*/*}
 
 . "$M0_SRC_DIR"/utils/functions # die, opcode, sandbox_init, report_and_exit
@@ -144,7 +144,7 @@ stop_server()
 check_reply()
 {
 	expected="$1"
-	actual=`awk '/replied/ {print $5}' "$OUTPUT_FILE"`
+	actual=$(awk '/replied/ {print $5}' "$OUTPUT_FILE")
 	[ -z "$actual" ] && die 'Reply not found'
 	[ "$actual" -eq "$expected" ] || die 'Invalid reply'
 }
@@ -189,7 +189,7 @@ run_st()
 ## main
 ## -------------------------------------------------------------------
 
-[ `id -u` -eq 0 ] || die 'Must be run by superuser'
+[ $(id -u) -eq 0 ] || die 'Must be run by superuser'
 
 sandbox_init
 start_server

--- a/dix/cm/st/m0t1fs_dix_repair.sh
+++ b/dix/cm/st/m0t1fs_dix_repair.sh
@@ -114,7 +114,7 @@ main()
 
 	sandbox_init
 
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
 	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."

--- a/fdmi/st/echo/echo_plugin_start.sh
+++ b/fdmi/st/echo/echo_plugin_start.sh
@@ -21,7 +21,7 @@
 
 #set -x
 
-ECHO_DIR=`dirname "$0"`
+ECHO_DIR=$(dirname "$0")
 SRC_DIR=$ECHO_DIR/../../..
 
 "$SRC_DIR"/m0t1fs/linux_kernel/st/st insmod

--- a/fdmi/st/fdmi_test.sh
+++ b/fdmi/st/fdmi_test.sh
@@ -19,7 +19,7 @@
 
 #set -x
 
-MOTR_SRC_ROOT=$PWD/`dirname "$0"`/../..
+MOTR_SRC_ROOT=$PWD/$(dirname "$0")/../..
 M0T1FS_TEST_DIR=$MOTR_SRC_ROOT/m0t1fs/linux_kernel/st
 ECHO_PLUGIN_DIR=$MOTR_SRC_ROOT/fdmi/st/echo
 
@@ -33,7 +33,7 @@ MOTR_SVCS_CNT=1
 
 unmount_and_stop()
 {
-	for i in `seq 1 "$MOTR_SVCS_CNT"` ; do
+	for i in $(seq 1 "$MOTR_SVCS_CNT") ; do
 		echo "Unmounting file system $i ..."
 		umount "$MOTR_M0T1FS_MOUNT_DIR"-"$i"
 	done
@@ -51,9 +51,9 @@ unmount_and_stop()
 
 fdmi_test_prepare()
 {
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 
-	for i in `seq 1 "$MOTR_SVCS_CNT"` ; do
+	for i in $(seq 1 "$MOTR_SVCS_CNT") ; do
 		MOTR_M0T1FS_TEST_DIR=/var/motr/systest-$$-$i
 
 		CONFD_EP=12345:3$i:100
@@ -98,7 +98,7 @@ fdmi_file_creation_test()
 	local SOURCE_TXT=/tmp/source.txt
 
 	for i in {a..z} {A..Z} ; do
-		for c in `seq 1 4095`;
+		for c in $(seq 1 4095);
 			do echo -n "$i" ;
 		done;
 		echo;
@@ -155,7 +155,7 @@ main()
 	fdmi_test_prepare
 	echo "Run plugin..."
 	#read
-	for i in `seq 1 "$MOTR_SVCS_CNT"`; do
+	for i in $(seq 1 "$MOTR_SVCS_CNT"); do
 		fdmi_file_creation_test 10 "$MOTR_M0T1FS_MOUNT_DIR"-"$i"
 	done
 	sleep 10


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
Warning fixed: "SC2006: Use $(...) notation instead of legacy backticked `...`".

Signed-off-by: alfhad <fahadshah2411@gmail.com>

# Problem Statement
We see 369 occurrence of pattern, "Use$(...) notation instead of legacy backticked ....".

# Design
Replaced the backticked with "$(...)"

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
