### PR TITLE
Pass rc to dix req and then to m0_op->op_rc.

### DIFF
--- a/cas/client.c
+++ b/cas/client.c
@@ -1355,6 +1355,8 @@ static void cas_rep_copy(const struct m0_cas_req *req,
 	M0_ASSERT(idx < m0_cas_req_nr(req));
 	rep->crr_rc = recv->cr_rec[idx].cr_rc;
 	rep->crr_hint = recv->cr_rec[idx].cr_hint;
+	M0_LOG(M0_DEBUG, "cas=%p rep=%p rep->crr_rc@%u = %d",
+			 req, rep, (uint32_t)idx, (int)rep->crr_rc);
 }
 
 M0_INTERNAL void m0_cas_index_create_rep(const struct m0_cas_req *req,

--- a/cas/service.c
+++ b/cas/service.c
@@ -2468,8 +2468,6 @@ static int cas_done(struct cas_fom *fom, struct m0_cas_op *op,
 	} else
 		m0_ctg_op_fini(&fom->cf_ctg_op);
 
-	++fom->cf_ipos;
-	++fom->cf_opos;
 	/*
 	 * Overwrite return code of put operation if key is already exist and
 	 * COF_CREATE is set or overwrite return code of del operation if key
@@ -2488,6 +2486,8 @@ static int cas_done(struct cas_fom *fom, struct m0_cas_op *op,
 	 */
 	fom->cf_out_key = M0_BUF_INIT0;
 	fom->cf_out_val = M0_BUF_INIT0;
+	++fom->cf_ipos;
+	++fom->cf_opos;
 
 	return rec_out->cr_rc;
 }

--- a/dix/meta.c
+++ b/dix/meta.c
@@ -315,7 +315,7 @@ M0_INTERNAL int m0_dix_meta_item_rc(const struct m0_dix_meta_req *req,
 				    uint64_t                      idx)
 {
 	M0_PRE(m0_dix_meta_generic_rc(req) == 0);
-	return m0_dix_item_rc(&req->dmr_req, idx);
+	return M0_RC(m0_dix_item_rc(&req->dmr_req, idx));
 }
 
 M0_INTERNAL int m0_dix_meta_req_nr(const struct m0_dix_meta_req *req)

--- a/motr/client.c
+++ b/motr/client.c
@@ -705,7 +705,7 @@ M0_INTERNAL void m0_op_launch_one(struct m0_op *op)
 	if (rc != 0) {
 		m0_sm_group_lock(&op->op_sm_group);
 		m0_sm_move(&op->op_sm, rc, M0_OS_FAILED);
-		op->op_rc = rc;
+		op->op_rc = M0_ERR(rc);
 		m0_sm_group_unlock(&op->op_sm_group);
 		return;
 	}

--- a/motr/cob.c
+++ b/motr/cob.c
@@ -526,7 +526,7 @@ static void cob_fail_op(struct m0_op *op, int rc)
 	}
 	m0_sm_group_unlock(en_grp);
 
-	op->op_rc = rc;
+	op->op_rc = M0_RC(rc);
 	m0_sm_group_lock(op_grp);
 	M0_ASSERT(M0_IN(op->op_sm.sm_state,
 		        (M0_OS_INITIALISED, M0_OS_LAUNCHED)));

--- a/motr/idx.c
+++ b/motr/idx.c
@@ -349,7 +349,7 @@ static void idx_op_fail(struct m0_op_idx *oi, int rc)
 	m0_sm_group_unlock(en_grp);
 
 	m0_sm_group_lock(op_grp);
-	op->op_rc = rc;
+	op->op_rc = M0_RC(rc);
 	m0_sm_move(&op->op_sm, 0, M0_OS_EXECUTED);
 	m0_op_executed(op);
 	m0_sm_move(&op->op_sm, 0, M0_OS_STABLE);
@@ -540,7 +540,7 @@ static void idx_op_cb_launch(struct m0_op_common *oc)
 	 *  = 1: the driver successes in launching the query asynchronously.
 	*/
 	rc = query(oi);
-	oi->oi_ar.ar_rc = rc;
+	oi->oi_ar.ar_rc = M0_RC(rc);
 	if (rc < 0) {
 		oi->oi_ar.ar_ast.sa_cb = &idx_op_ast_fail;
 		m0_sm_ast_post(oi->oi_sm_grp, &oi->oi_ar.ar_ast);
@@ -549,7 +549,7 @@ static void idx_op_cb_launch(struct m0_op_common *oc)
 		m0_sm_ast_post(oi->oi_sm_grp, &oi->oi_ar.ar_ast);
 	}
 
-	M0_LEAVE();
+	M0_LEAVE("rc=%d", rc);
 }
 
 int m0_idx_op(struct m0_idx       *idx,
@@ -608,7 +608,7 @@ M0_INTERNAL int m0_idx_op_namei(struct m0_entity *entity,
 	int                   rc;
 	struct m0_idx        *idx;
 
-	M0_ENTRY();
+	M0_ENTRY("opcode=%d", opcode);
 
 	M0_PRE(entity != NULL);
 	M0_PRE(op != NULL);

--- a/motr/obj.c
+++ b/motr/obj.c
@@ -747,7 +747,7 @@ static int entity_namei_op(struct m0_entity *entity,
 	int  rc;
 	bool pre_allocated = false;
 
-	M0_ENTRY();
+	M0_ENTRY("opcode=%d", opcode);
 
 	M0_PRE(entity != NULL);
 	M0_ASSERT(entity_invariant_full(entity));
@@ -804,7 +804,7 @@ int m0_entity_create(struct m0_fid *pool,
 {
 	struct m0_obj *obj;
 
-	M0_ENTRY();
+	M0_ENTRY("fid=" U128X_F, U128_P(&entity->en_id));
 	if (entity->en_flags & M0_ENF_META)
 		M0_LOG(M0_DEBUG, "M0_ENF_META FLAG is set from application");
 

--- a/motr/st/utils/m0kv_st.sh
+++ b/motr/st/utils/m0kv_st.sh
@@ -150,7 +150,7 @@ creates()
 	echo "Test:Create"
 	emsg="FAILED to create index by fid:${fid}"
 	${MOTRTOOL} ${drop} >/dev/null
-	${MOTRTOOL} ${create} >${out_file}
+	${MOTRTOOL} ${create} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	#check output: should be rc code 0
@@ -165,11 +165,16 @@ createm()
 	local rc=0
 	echo "Test:Create FIDS"
 	emsg="FAILED to create index by @fids:${fids_file}"
-	${MOTRTOOL} ${dropf} >/dev/null
-	${MOTRTOOL} ${create} >/dev/null
+	${MOTRTOOL} ${dropf}
+	${MOTRTOOL} ${create}
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${createf} >>${out_file}
+
+	rm -fv /var/motr/sandbox.m0kv-st/m0trace*
+	# This is going to create a list of index (fids from @fids:${fids_file})
+	# The first index was just already created. So, the first operation should
+	# fail with -EEXIST. We wiii check this failure code.
+	${MOTRTOOL} ${createf} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -187,7 +192,7 @@ drops()
 	${MOTRTOOL} ${create} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${drop} >${out_file}
+	${MOTRTOOL} ${drop} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -205,13 +210,13 @@ dropm()
 	${MOTRTOOL} ${createf} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${drop} >${out_file}
+	${MOTRTOOL} ${drop} | tee ${out_file}
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
 	grep -v "operation rc: 0" ${rc_file} >${erc_file}
 	[ -s "${erc_file}" ] && return 1
 	rm_logs
-	${MOTRTOOL} ${dropf} >${out_file}
+	${MOTRTOOL} ${dropf} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -228,7 +233,7 @@ list()
 	emsg="FAILED to get List"
 	${MOTRTOOL} ${dropf} >/dev/null
 	${MOTRTOOL} ${createf} >/dev/null
-	${MOTRTOOL} ${list3} >${out_file}
+	${MOTRTOOL} ${list3} | tee ${out_file}
 	grep "<" ${out_file} >${res_out_file}
 	[ $(cat ${res_out_file} | wc -l) == 3 ] || return 1
 	${MOTRTOOL} ${list} >${out_file}
@@ -245,13 +250,13 @@ lookup()
 	emsg="FAILED to check lookup functionality"
 	${MOTRTOOL} ${dropf} >/dev/null
 	${MOTRTOOL} ${create} >/dev/null
-	${MOTRTOOL} ${lookup} >${out_file}
+	${MOTRTOOL} ${lookup} | tee ${out_file}
 	grep "found rc" ${out_file} >${rc_file}
 	grep -v "found rc 0" ${rc_file} >${erc_file}
 	[ -s "${erc_file}" ] && return 1
 
 	${MOTRTOOL} ${drop} >/dev/null
-	${MOTRTOOL} ${lookup} >${out_file}
+	${MOTRTOOL} ${lookup} | tee ${out_file}
 	grep "found rc" ${out_file} >${rc_file}
 	grep -v "found rc -2" ${rc_file} >${erc_file}
 	[ -s "${erc_file}" ] && return 1
@@ -269,7 +274,7 @@ puts1()
 	${MOTRTOOL} ${create} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${put_fid_key} >${out_file}
+	${MOTRTOOL} ${put_fid_key} | tee ${out_file}
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
 	grep -v "operation rc: 0" ${rc_file} >${erc_file}
@@ -292,7 +297,7 @@ putsN_exist()
 	${MOTRTOOL} ${put_fid_key} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${put_fid_keys} >${out_file}
+	${MOTRTOOL} ${put_fid_keys} | tee ${out_file}
 	rc=$?
 	rm_logs
 	return $rc
@@ -303,7 +308,7 @@ bputsN_exist()
 	local rc=0
 	echo "Test:Put existing KEYS by one command"
 	emsg="FAILED to put existing @keys:${keys_file} @vals:${vals_file} into ${fid}"
-	${MOTRTOOL} ${dropf} ${create} ${put_fid_key} ${put_fid_keys} >${out_file}
+	${MOTRTOOL} ${dropf} ${create} ${put_fid_key} ${put_fid_keys} | tee ${out_file}
 	rc=$?
 	rm_logs
 	return $rc
@@ -320,7 +325,7 @@ putsN()
 	${MOTRTOOL} ${create} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${put_fid_keys} >${out_file}
+	${MOTRTOOL} ${put_fid_keys} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -341,7 +346,7 @@ putsNb()
 	${MOTRTOOL} ${create} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${put_fid_keys_bulk} >${out_file}
+	${MOTRTOOL} ${put_fid_keys_bulk} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -362,7 +367,7 @@ putmN()
 	${MOTRTOOL} ${createf} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${put_fids_keys} >${out_file}
+	${MOTRTOOL} ${put_fids_keys} | tee ${out_file}
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
 	grep -v "operation rc: 0" ${rc_file} >${erc_file}
@@ -385,7 +390,7 @@ gets1()
 	${MOTRTOOL} ${put_fid_key} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${get_fid_key} >${out_file}
+	${MOTRTOOL} ${get_fid_key} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -407,7 +412,7 @@ bgets1()
 	local rc=0
 	echo "Test:Get KEY by one command"
 	emsg="FAILED to get key:${key} from fid:${fid} by one command"
-	${MOTRTOOL} ${dropf} ${create} ${put_fid_key} ${get_fid_key} >${out_file}
+	${MOTRTOOL} ${dropf} ${create} ${put_fid_key} ${get_fid_key} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} > ${res_out_file}
@@ -429,7 +434,7 @@ getsN()
 	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${get_fid_keys} >${out_file}
+	${MOTRTOOL} ${get_fid_keys} | tee ${out_file}
 	grep -A 1 "KEY" ${out_file} > ${res_out_file}
 	local lines
 	let lines=$num*3-1
@@ -450,7 +455,7 @@ bgetsN()
 	local rc=0
 	echo "Test:Get KEYS by one command"
 	emsg="FAILED to get @keys:${keys_file} from fid:${fid} by one command"
-	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} ${get_fid_keys} >${out_file}
+	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} ${get_fid_keys} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} > ${res_out_file}
@@ -476,7 +481,7 @@ nextsN()
 	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${next} >${out_file}
+	${MOTRTOOL} ${next} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} > ${res_out_file}
@@ -495,7 +500,7 @@ bnextsN()
 	local rc=0
 	echo "Test:Get next keys by one command"
 	emsg="FAILED to get next keys from ${fid} start key ${key} by one command"
-	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} ${next} >${out_file}
+	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} ${next} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -A 1 "KEY" ${out_file} > ${res_out_file}
@@ -517,7 +522,7 @@ dels1()
 	${MOTRTOOL} ${dropf} ${create} ${put_fid_key} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} $del_fid_key >${out_file}
+	${MOTRTOOL} $del_fid_key | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -532,7 +537,7 @@ bdels1()
 	local rc=0
 	echo "Test:Del existing KEY by one command"
 	emsg="FAILED to del key:${key} from ${fid} by one command"
-	${MOTRTOOL} ${dropf} ${create} ${put_fid_key} $del_fid_key>${out_file}
+	${MOTRTOOL} ${dropf} ${create} ${put_fid_key} $del_fid_key | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -B 1 "del done:" ${out_file} >${rc_file}
@@ -550,7 +555,7 @@ delsN()
 	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${del_fid_keys} >${out_file}
+	${MOTRTOOL} ${del_fid_keys} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
@@ -565,7 +570,7 @@ bdelsN()
 	local rc=0
 	echo "Test:Del existing KEYS by one command"
 	emsg="FAILED to del keys:@${keys_file} from ${fid} by one command"
-	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} ${del_fid_keys} >${out_file}
+	${MOTRTOOL} ${dropf} ${create} ${put_fid_keys} ${del_fid_keys} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -B 1 "del done:" ${out_file} >${rc_file}
@@ -583,7 +588,7 @@ delmN()
 	${MOTRTOOL} ${dropf} ${createf} ${put_fids_keys} >/dev/null
 	rc=$?
 	[ $rc != 0 ] && return $rc
-	${MOTRTOOL} ${del_fids_keys} >${out_file}
+	${MOTRTOOL} ${del_fids_keys} | tee ${out_file}
 	[ $rc != 0 ] && return $rc
 	grep "operation rc:" ${out_file} >${rc_file}
 	grep -v "operation rc: 0" ${rc_file} >${erc_file}
@@ -597,7 +602,7 @@ bdelmN()
 	local rc=0
 	echo "Test:Del existing KEYS in several indices by one command"
 	emsg="FAILED to del keys:@${keys_file} from @${fid_file} by one command"
-	${MOTRTOOL} ${dropf} ${createf} ${put_fids_keys} ${del_fids_keys} >${out_file}
+	${MOTRTOOL} ${dropf} ${createf} ${put_fids_keys} ${del_fids_keys} | tee ${out_file}
 	rc=$?
 	[ $rc != 0 ] && return $rc
 	grep -B 1 "del done:" ${out_file} >${rc_file}

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -137,6 +137,8 @@ M0_INTERNAL void m0_sm_ast_post(struct m0_sm_group *grp, struct m0_sm_ast *ast)
 	M0_PRE(ast->sa_cb != NULL);
 	M0_PRE(ast->sa_next == NULL);
 
+	M0_LOG(M0_DEBUG, "grp=%p ast=%p cb=%p",
+		       grp, ast, ast->sa_cb);
 	do {
 		ast->sa_next = grp->s_forkq;
 		/*


### PR DESCRIPTION
In dixreq_clink_cb(), we need to pass the returned code from cas server to
dixreq_completed_post() -> and then -> dixreq_completed_ast() ->
idx_op_ast_fail() -> idx_op_fail() -> op->op_rc is updated there.

Other modification is just for debugging purpose.

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
