### PR TITLE
[DTM] Do not send REDO for transactions which happened after recovery started.

### DIFF
--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -567,6 +567,17 @@ M0_INTERNAL void m0_be_dtm0_log_iter_fini(struct m0_be_dtm0_log_iter *iter);
 M0_INTERNAL int m0_be_dtm0_log_iter_next(struct m0_be_dtm0_log_iter *iter,
 					 struct m0_dtm0_log_rec     *out);
 
+/**
+ * Get ID of the last transaction (or -ENOENT) from the log.
+ *
+ * @param out returned ID.
+ *
+ * @return 0 when the log is not empty and out parameter is properly filled.
+ * @return  -ENOENT when the log is empty.
+ */
+M0_INTERNAL int m0_be_dtm0_log_get_last_dtxid(struct m0_be_dtm0_log *log,
+					      struct m0_dtm0_tid    *out);
+
 /** @} */ /* end DTM0Internals */
 
 #endif /* __MOTR_BE_DTM0_LOG_H__ */

--- a/dtm0/recovery.c
+++ b/dtm0/recovery.c
@@ -1049,12 +1049,10 @@ recovery_machine_local_id(const struct m0_dtm0_recovery_machine *m)
 
 static int recovery_machine_log_iter_next(struct m0_dtm0_recovery_machine *m,
 					  struct m0_be_dtm0_log_iter *iter,
-					  const struct m0_fid *tgt_svc,
-					  const struct m0_fid *origin_svc,
 					  struct m0_dtm0_log_rec *record)
 {
 	M0_PRE(m->rm_ops->log_iter_next != NULL);
-	return m->rm_ops->log_iter_next(m, iter, tgt_svc, origin_svc, record);
+	return m->rm_ops->log_iter_next(m, iter, record);
 }
 
 static int recovery_machine_log_iter_init(struct m0_dtm0_recovery_machine *m,
@@ -1070,6 +1068,21 @@ static void recovery_machine_log_iter_fini(struct m0_dtm0_recovery_machine *m,
 {
 	M0_PRE(m->rm_ops->log_iter_fini != NULL);
 	m->rm_ops->log_iter_fini(m, iter);
+}
+
+static int recovery_machine_log_last_dtxid(struct m0_dtm0_recovery_machine *m,
+					   struct m0_dtm0_tid              *out)
+{
+	M0_PRE(m->rm_ops->log_last_dtxid != NULL);
+	return m->rm_ops->log_last_dtxid(m, out);
+}
+
+static int recovery_machine_dtxid_cmp(struct m0_dtm0_recovery_machine *m,
+				      struct m0_dtm0_tid              *left,
+				      struct m0_dtm0_tid              *right)
+{
+	M0_PRE(m->rm_ops->dtxid_cmp != NULL);
+	return m->rm_ops->dtxid_cmp(m, left, right);
 }
 
 static void recovery_machine_redo_post(struct m0_dtm0_recovery_machine *m,
@@ -1646,6 +1659,14 @@ static void eolq_await(struct m0_fom *fom, struct eolq_item *out)
 	*out = F(got) ? F(item) : (struct eolq_item) { .ei_type = EIT_END };
 }
 
+static bool participated(const struct m0_dtm0_log_rec *record,
+			 const struct m0_fid          *svc)
+{
+	return m0_exists(i, record->dlr_txd.dtd_ps.dtp_nr,
+			 m0_fid_eq(&record->dlr_txd.dtd_ps.dtp_pa[i].p_fid,
+				   svc));
+}
+
 /**
  * Restore missing transactions on remote participant.
  *
@@ -1665,7 +1686,26 @@ static void dtm0_restore(struct m0_fom        *fom,
 		      struct m0_fid       initiator;
 		      struct m0_be_op     reply_op;
 		      bool                next;
+		      struct m0_dtm0_tid  last_dtx_id;
+		      bool                last_dtx_met;
 		      );
+
+	/*
+	 * Remember the last DTX ID before this remote service went to
+	 * RECOVERING.  Then replay the log up to this transaction and stop. We
+	 * do it becase remote participant is accepting PUT operations even
+	 * during recovery, so no need to send REDOs for them.
+	 *
+	 * FIXME: Race condition scenario: client sent a lot of CAS reqs, then
+	 * one of participants restarted.  Some of the requests are still "in
+	 * queue to be executed" in this m0d, i.e.  don't yet have log record.
+	 * If restore is called at this moment (i.e. motr/HA were fast enough to
+	 * get to recovery), these "in queue" transactions won't be replayed.
+	 */
+	M0_SET0(&F(last_dtx_id));
+	rc = recovery_machine_log_last_dtxid(rf->rf_m, &F(last_dtx_id));
+	M0_ASSERT(M0_IN(rc, (0, -ENOENT)));
+	F(last_dtx_met) = (rc == -ENOENT);
 
 	recovery_machine_log_iter_init(rf->rf_m, &rf->rf_log_iter);
 
@@ -1677,11 +1717,40 @@ static void dtm0_restore(struct m0_fom        *fom,
 
 	do {
 		M0_SET0(&record);
-		rc = recovery_machine_log_iter_next(rf->rf_m, &rf->rf_log_iter,
-						    &rf->rf_tgt_svc, NULL,
-						    &record);
-		/* Any value except zero means that we should stop recovery. */
-		F(next) = rc == 0;
+		if (F(last_dtx_met)) {
+			/*
+			 * Last iteration reached the RECOVERING mark in the
+			 * log, don't need to send REDOs past this mark.
+			 */
+			F(next) = false;
+		} else {
+			do {
+				rc = recovery_machine_log_iter_next(
+						rf->rf_m, &rf->rf_log_iter,
+						&record);
+				/*
+				 * Any value except zero means that we should
+				 * stop recovery.
+				 *
+				 * XXX: handle cases when rc not in (0,
+				 * -ENOENT).
+				 */
+				F(next) = (rc == 0);
+				if (!F(next))
+					break;
+				rc = recovery_machine_dtxid_cmp(
+						rf->rf_m,
+						&record.dlr_txd.dtd_id,
+						&F(last_dtx_id));
+				F(last_dtx_met) = (rc == 0);
+				if (participated(&record, &rf->rf_tgt_svc))
+					break;
+				m0_dtm0_log_iter_rec_fini(&record);
+				if (F(last_dtx_met))
+					F(next) = false;
+			} while (!F(last_dtx_met));
+		}
+
 		redo = (struct dtm0_req_fop) {
 			.dtr_msg       = DTM_REDO,
 			.dtr_initiator = F(initiator),
@@ -1700,6 +1769,9 @@ static void dtm0_restore(struct m0_fom        *fom,
 		recovery_machine_redo_post(rf->rf_m, &rf->rf_base,
 					   &rf->rf_tgt_proc, &rf->rf_tgt_svc,
 					   &redo, &F(reply_op));
+
+		if (F(next))
+			m0_dtm0_log_iter_rec_fini(&record);
 
 		M0_LOG(M0_DEBUG, "out-redo: (m=%p) " REDO_F,
 		       rf->rf_m, REDO_P(&redo));
@@ -2049,40 +2121,15 @@ static void default_log_iter_fini(struct m0_dtm0_recovery_machine *m,
 	m0_be_dtm0_log_iter_fini(iter);
 }
 
-static bool participated(const struct m0_dtm0_log_rec *record,
-			 const struct m0_fid          *svc)
-{
-	return m0_exists(i, record->dlr_txd.dtd_ps.dtp_nr,
-			 m0_fid_eq(&record->dlr_txd.dtd_ps.dtp_pa[i].p_fid,
-				   svc));
-}
-
 static int default_log_iter_next(struct m0_dtm0_recovery_machine *m,
 				 struct m0_be_dtm0_log_iter      *iter,
-				 const struct m0_fid             *tgt_svc,
-				 const struct m0_fid             *origin_svc,
 				 struct m0_dtm0_log_rec          *record)
 {
 	struct m0_be_dtm0_log *log = m->rm_svc->dos_log;
 	int rc;
 
-	/* XXX: not supported yet */
-	M0_ASSERT(origin_svc == NULL);
-
 	m0_mutex_lock(&log->dl_lock);
-
-	/* Filter out records where tgt_svc is not a participant. */
-	do {
-		M0_SET0(record);
-		rc = m0_be_dtm0_log_iter_next(iter, record);
-		if (rc == 0) {
-			if (participated(record, tgt_svc))
-				break;
-			else
-				m0_dtm0_log_iter_rec_fini(record);
-		}
-	} while (rc == 0);
-
+	rc = m0_be_dtm0_log_iter_next(iter, record);
 	m0_mutex_unlock(&log->dl_lock);
 
 	/* XXX: error codes will be adjusted separately. */
@@ -2092,6 +2139,26 @@ static int default_log_iter_next(struct m0_dtm0_recovery_machine *m,
 	default:
 		return M0_ERR(rc);
 	}
+}
+
+static int default_log_last_dtxid(struct m0_dtm0_recovery_machine *m,
+				  struct m0_dtm0_tid              *out)
+{
+	struct m0_be_dtm0_log *log = m->rm_svc->dos_log;
+	int                    rc;
+
+	m0_mutex_lock(&log->dl_lock);
+	rc = m0_be_dtm0_log_get_last_dtxid(log, out);
+	m0_mutex_unlock(&log->dl_lock);
+
+	return rc;
+}
+
+static int default_dtxid_cmp(struct m0_dtm0_recovery_machine *m,
+			     struct m0_dtm0_tid              *left,
+			     struct m0_dtm0_tid              *right)
+{
+	return m0_dtm0_tid_cmp(m->rm_svc->dos_log->dl_cs, left, right);
 }
 
 /*
@@ -2183,6 +2250,9 @@ M0_INTERNAL const struct m0_dtm0_recovery_machine_ops
 	.log_iter_init = default_log_iter_init,
 	.log_iter_fini = default_log_iter_fini,
 	.log_iter_next = default_log_iter_next,
+
+	.log_last_dtxid = default_log_last_dtxid,
+	.dtxid_cmp      = default_dtxid_cmp,
 
 	.redo_post     = default_redo_post,
 	.ha_event_post = default_ha_event_post,

--- a/dtm0/recovery.h
+++ b/dtm0/recovery.h
@@ -36,6 +36,7 @@ struct m0_conf_process;
 struct dtm0_req_fop;
 struct m0_be_dtm0_log_iter;
 struct m0_dtm0_log_rec;
+struct m0_dtm0_tid;
 struct m0_be_op;
 struct m0_fom;
 
@@ -80,21 +81,28 @@ struct m0_dtm0_recovery_machine_ops {
 
 	/**
 	 * Get next log record (or -ENOENT) from the local DTM0 log.
-	 * @param[in] tgt_svc DTM0 service this REDO shall be sent to.
-	 * @param[in,opt] origin_svc DTM0 service to be selected. When
-	 *                           this parameter is set to non-NULL,
-	 *                           the iter is supposed to select only
-	 *                           the log records that were originated
-	 *                           on this particular service.
+	 *
+	 * Note, this returns a deep copy of a record, and caller is responsible
+	 * for freeing it properly -- call m0_dtm0_log_iter_rec_fini.
 	 */
 	int (*log_iter_next)(struct m0_dtm0_recovery_machine   *m,
 			     struct m0_be_dtm0_log_iter        *iter,
-			     const struct m0_fid               *tgt_svc,
-			     const struct m0_fid               *origin_svc,
 			     struct m0_dtm0_log_rec            *record);
 
 	void (*log_iter_fini)(struct m0_dtm0_recovery_machine *m,
 			      struct m0_be_dtm0_log_iter      *iter);
+
+	/**
+	 * Get ID of the last transaction (or -ENOENT) from the local DTM0 log.
+	 */
+	int (*log_last_dtxid)(struct m0_dtm0_recovery_machine *m,
+			      struct m0_dtm0_tid              *out);
+	/**
+	 * Compare two transaction IDs (-1 less/0 equal/1 greater).
+	 */
+	int (*dtxid_cmp)(struct m0_dtm0_recovery_machine *m,
+			 struct m0_dtm0_tid              *left,
+			 struct m0_dtm0_tid              *right);
 };
 
 

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -117,10 +117,11 @@ enum ut_client_persistence {
 	UT_CP_PERSISTENT_CLIENT,
 };
 
-struct m0_fid g_service_fids[UT_SIDE_NR];
+static struct m0_fid g_service_fids[UT_SIDE_NR];
 
 struct ut_remach {
-	bool                             use_real_log;
+	const struct m0_dtm0_recovery_machine_ops
+		                        *remach_ops;
 	enum ut_client_persistence       cp;
 
 	struct m0_ut_dtm0_helper         udh;
@@ -311,8 +312,6 @@ static void um_real_log_redo_post(struct m0_dtm0_recovery_machine *m,
 
 static int um_dummy_log_iter_next(struct m0_dtm0_recovery_machine *m,
 				  struct m0_be_dtm0_log_iter *iter,
-				  const struct m0_fid *tgt_svc,
-				  const struct m0_fid *origin_svc,
 				  struct m0_dtm0_log_rec *record)
 {
 	M0_SET0(record);
@@ -333,6 +332,14 @@ static void um_dummy_log_iter_fini(struct m0_dtm0_recovery_machine *m,
 	(void) m;
 	(void) iter;
 	/* nothing to do */
+}
+
+static int um_dummy_log_last_dtxid(struct m0_dtm0_recovery_machine *m,
+				   struct m0_dtm0_tid              *out)
+{
+	(void) m;
+	(void) out;
+	return -ENOENT;
 }
 
 void um_ha_event_post(struct m0_dtm0_recovery_machine *m,
@@ -376,10 +383,9 @@ static void ut_remach_ha_thinks(struct ut_remach        *um,
 }
 
 static const struct m0_dtm0_recovery_machine_ops*
-ut_remach_ops_get(struct ut_remach *um)
+ut_remach_ops_get_dummy_log(void)
 {
 	static struct m0_dtm0_recovery_machine_ops dummy_log_ops = {};
-	static struct m0_dtm0_recovery_machine_ops real_log_ops = {};
 	static bool initialized = false;
 
 	if (!initialized) {
@@ -389,10 +395,24 @@ ut_remach_ops_get(struct ut_remach *um)
 		dummy_log_ops.log_iter_next  = um_dummy_log_iter_next;
 		dummy_log_ops.log_iter_init  = um_dummy_log_iter_init;
 		dummy_log_ops.log_iter_fini  = um_dummy_log_iter_fini;
+		dummy_log_ops.log_last_dtxid = um_dummy_log_last_dtxid,
 
 		dummy_log_ops.redo_post      = um_dummy_log_redo_post;
 		dummy_log_ops.ha_event_post  = um_ha_event_post;
 
+		initialized = true;
+	}
+
+	return &dummy_log_ops;
+}
+
+static const struct m0_dtm0_recovery_machine_ops*
+ut_remach_ops_get_real_log(void)
+{
+	static struct m0_dtm0_recovery_machine_ops real_log_ops = {};
+	static bool initialized = false;
+
+	if (!initialized) {
 		/* Real log operations */
 		real_log_ops = m0_dtm0_recovery_machine_default_ops;
 
@@ -406,7 +426,14 @@ ut_remach_ops_get(struct ut_remach *um)
 		initialized = true;
 	}
 
-	return um->use_real_log ? &real_log_ops : &dummy_log_ops;
+	return &real_log_ops;
+}
+
+static const struct m0_dtm0_recovery_machine_ops*
+ut_remach_ops_get(struct ut_remach *um)
+{
+	M0_ASSERT(um->remach_ops != NULL);
+	return um->remach_ops;
 }
 
 static void ut_srv_remach_init(struct ut_remach *um)
@@ -514,10 +541,75 @@ static void ut_remach_init(struct ut_remach *um)
 	ut_cli_remach_init(um);
 }
 
+static void ut_remach_prune_plog(struct ut_remach *um, enum ut_sides side)
+{
+	struct m0_dtm0_recovery_machine *m = ut_remach_get(um, side);
+	struct m0_dtm0_service    *svc   = m->rm_svc;
+	struct m0_be_dtm0_log     *log   = svc->dos_log;
+	struct m0_be_tx           *tx    = NULL;
+	struct m0_be_seg          *seg   = log->dl_seg;
+	struct m0_be_tx_credit     cred  = {};
+	struct m0_be_ut_backend   *ut_be;
+	struct m0_be_dtm0_log_iter iter;
+	struct m0_dtm0_log_rec     record;
+	struct m0_dtm0_tid         last_dtx_id;
+	bool is_empty;
+	int rc;
+
+	if (!log->dl_is_persistent)
+		return;
+
+	m0_mutex_lock(&log->dl_lock);
+
+	M0_UT_ASSERT(svc->dos_generic.rs_reqh_ctx != NULL);
+	ut_be = &svc->dos_generic.rs_reqh_ctx->rc_be;
+
+	m0_be_dtm0_log_iter_init(&iter, log);
+
+	is_empty = true;
+	while (true) {
+		rc = m0_be_dtm0_log_iter_next(&iter, &record);
+		M0_UT_ASSERT(M0_IN(rc, (0, -ENOENT)));
+		if (rc == -ENOENT)
+			break;
+		M0_UT_ASSERT(rc == 0);
+
+		is_empty = false;
+		last_dtx_id = record.dlr_txd.dtd_id;
+		m0_be_dtm0_log_credit(M0_DTML_PRUNE, NULL, NULL, seg, &record,
+				      &cred);
+		m0_dtm0_log_iter_rec_fini(&record);
+	}
+
+	m0_be_dtm0_log_iter_fini(&iter);
+
+	if (!is_empty) {
+		M0_ALLOC_PTR(tx);
+		M0_UT_ASSERT(tx != NULL);
+		m0_be_ut_tx_init(tx, ut_be);
+		m0_be_tx_prep(tx, &cred);
+		rc = m0_be_tx_open_sync(tx);
+		M0_UT_ASSERT(rc == 0);
+
+		m0_be_dtm0_plog_prune(log, tx, &last_dtx_id);
+
+		m0_be_tx_close_sync(tx);
+		m0_be_tx_fini(tx);
+		m0_free(tx);
+
+		rc = m0_be_dtm0_log_get_last_dtxid(log, &last_dtx_id);
+		M0_ASSERT(rc == -ENOENT);
+	}
+
+	m0_mutex_unlock(&log->dl_lock);
+}
+
 static void ut_remach_fini(struct ut_remach *um)
 {
 	int i;
 
+	ut_remach_prune_plog(um, UT_SIDE_SRV);
+	ut_remach_prune_plog(um, UT_SIDE_CLI);
 	ut_cli_remach_fini(um);
 	ut_srv_remach_fini(um);
 	m0_ut_dtm0_helper_fini(&um->udh);
@@ -549,9 +641,9 @@ static void ut_remach_reset_srv(struct ut_remach *um)
 }
 
 static void ut_remach_log_gen_sync(struct ut_remach *um,
-				   enum ut_sides side,
-				   uint64_t ts_start,
-				   uint64_t records_nr)
+				   enum ut_sides     side,
+				   uint64_t          ts_start,
+				   uint64_t          records_nr)
 {
 	struct m0_dtm0_tx_desc           txd = {};
 	struct m0_buf                    payload = {};
@@ -625,6 +717,8 @@ static void log_subset_verify(struct ut_remach *um,
 		actual_records_nr++;
 	}
 
+	m0_be_dtm0_log_iter_fini(&a_iter);
+
 	M0_UT_ASSERT(ergo(expected_records_nr >= 0,
 			  expected_records_nr == actual_records_nr));
 
@@ -635,7 +729,10 @@ static void log_subset_verify(struct ut_remach *um,
 /* Case: Ensure the machine initialised properly. */
 static void remach_init_fini(void)
 {
-	struct ut_remach um = { .cp = UT_CP_PERSISTENT_CLIENT };
+	struct ut_remach um = {
+		.cp         = UT_CP_PERSISTENT_CLIENT,
+		.remach_ops = ut_remach_ops_get_dummy_log(),
+	};
 	ut_remach_init(&um);
 	ut_remach_fini(&um);
 }
@@ -643,7 +740,10 @@ static void remach_init_fini(void)
 /* Case: Ensure the machine is able to start/stop. */
 static void remach_start_stop(void)
 {
-	struct ut_remach um = { .cp = UT_CP_PERSISTENT_CLIENT };
+	struct ut_remach um = {
+		.cp         = UT_CP_PERSISTENT_CLIENT,
+		.remach_ops = ut_remach_ops_get_dummy_log(),
+	};
 	ut_remach_init(&um);
 	ut_remach_start(&um);
 	ut_remach_stop(&um);
@@ -668,6 +768,19 @@ static void ut_remach_boot(struct ut_remach *um)
 	ut_remach_init(um);
 	ut_remach_start(um);
 
+	/* Assert that DTM log is empty (make sure there is no left overs from
+	 * other unit tests that ran before us). */
+	for (i = 0; i < UT_SIDE_NR; ++i) {
+		struct m0_be_dtm0_log *log = ut_remach_svc_get(um, i)->dos_log;
+		struct m0_dtm0_tid     last_dtx_id;
+		int                    rc;
+
+		m0_mutex_lock(&log->dl_lock);
+		rc = m0_be_dtm0_log_get_last_dtxid(log, &last_dtx_id);
+		m0_mutex_unlock(&log->dl_lock);
+		M0_ASSERT(rc == -ENOENT);
+	}
+
 	for (i = 0; i < ARRAY_SIZE(starting); ++i)
 		ut_remach_ha_thinks(um, starting + i);
 
@@ -689,7 +802,10 @@ static void ut_remach_shutdown(struct ut_remach *um)
 /* Use-case: gracefull boot and shutdown of 2-node cluster. */
 static void remach_boot_cluster(enum ut_client_persistence cp)
 {
-	struct ut_remach um = { .cp = cp };
+	struct ut_remach um = {
+		.cp         = cp,
+		.remach_ops = ut_remach_ops_get_dummy_log(),
+	};
 
 	ut_remach_boot(&um);
 	ut_remach_shutdown(&um);
@@ -708,7 +824,10 @@ static void remach_boot_cluster_cs(void)
 /* Use-case: re-boot an ONLINE node. */
 static void remach_reboot_server(void)
 {
-	struct ut_remach um = { .cp = UT_CP_PERSISTENT_CLIENT };
+	struct ut_remach um = {
+		.cp         = UT_CP_PERSISTENT_CLIENT,
+		.remach_ops = ut_remach_ops_get_dummy_log(),
+	};
 
 	ut_remach_boot(&um);
 
@@ -730,7 +849,10 @@ static void remach_reboot_server(void)
 /* Use-case: reboot a node when it started to recover. */
 static void remach_reboot_twice(void)
 {
-	struct ut_remach um = { .cp = UT_CP_PERSISTENT_CLIENT };
+	struct ut_remach um = {
+		.cp         = UT_CP_PERSISTENT_CLIENT,
+		.remach_ops = ut_remach_ops_get_dummy_log(),
+	};
 
 	ut_remach_boot(&um);
 
@@ -768,8 +890,8 @@ static void remach_reboot_twice(void)
 static void remach_boot_real_log(void)
 {
 	struct ut_remach um = {
-		.cp = UT_CP_PERSISTENT_CLIENT,
-		.use_real_log = true
+		.cp         = UT_CP_PERSISTENT_CLIENT,
+		.remach_ops = ut_remach_ops_get_real_log(),
 	};
 	ut_remach_boot(&um);
 	ut_remach_shutdown(&um);
@@ -779,8 +901,8 @@ static void remach_boot_real_log(void)
 static void remach_real_log_replay(void)
 {
 	struct ut_remach um = {
-		.cp = UT_CP_PERSISTENT_CLIENT,
-		.use_real_log = true
+		.cp         = UT_CP_PERSISTENT_CLIENT,
+		.remach_ops = ut_remach_ops_get_real_log(),
 	};
 	/* cafe bell */
 	const uint64_t since = 0xCAFEBELL;
@@ -797,6 +919,7 @@ static void remach_real_log_replay(void)
 	ut_remach_ha_thinks(&um, &HA_THOUGHT(UT_SIDE_SRV, M0_NC_TRANSIENT));
 	ut_remach_ha_tells(&um, &HA_THOUGHT(UT_SIDE_CLI, M0_NC_ONLINE),
 			   UT_SIDE_SRV);
+
 	ut_remach_ha_thinks(&um, &HA_THOUGHT(UT_SIDE_SRV,
 					     M0_NC_DTM_RECOVERING));
 	m0_be_op_wait(um.recovered + UT_SIDE_SRV);
@@ -806,23 +929,102 @@ static void remach_real_log_replay(void)
 	ut_remach_shutdown(&um);
 }
 
+static uint64_t last_dtxid_dts_phys;
+static bool     last_dtxid_log_empty;
+
+static int um_dummy_last_dtxid(struct m0_dtm0_recovery_machine *m,
+			       struct m0_dtm0_tid              *out)
+{
+	static int call_counter = -1;
+
+	call_counter = (call_counter + 1) % 3;
+	if (call_counter < 2)
+		return -ENOENT;
+	if (last_dtxid_log_empty)
+		return -ENOENT;
+	out->dti_fid = *ut_remach_fid_get(UT_SIDE_CLI);
+	out->dti_ts.dts_phys = last_dtxid_dts_phys;
+	return 0;
+}
+
+/*
+ * Use-case: operations happen while node is recovering -- they must not be
+ * replayed.
+ */
+static void remach_recovering_marker(const int      recovering_mark_index,
+				     const uint64_t records_nr)
+{
+	struct m0_dtm0_recovery_machine_ops ops = *ut_remach_ops_get_real_log();
+	struct ut_remach um = {
+		.cp         = UT_CP_PERSISTENT_CLIENT,
+		.remach_ops = &ops,
+	};
+	/* cafe bell */
+	const uint64_t since = 0xCAFEBELL;
+
+	ops.log_last_dtxid = um_dummy_last_dtxid;
+	last_dtxid_log_empty = (recovering_mark_index == 0);
+	last_dtxid_dts_phys = since + recovering_mark_index - 1;
+
+	ut_remach_boot(&um);
+
+	m0_be_op_reset(um.recovered + UT_SIDE_SRV);
+	m0_be_op_active(um.recovered + UT_SIDE_SRV);
+	ut_remach_reset_srv(&um);
+
+	ut_remach_ha_thinks(&um, &HA_THOUGHT(UT_SIDE_SRV, M0_NC_TRANSIENT));
+	ut_remach_ha_tells(&um, &HA_THOUGHT(UT_SIDE_CLI, M0_NC_ONLINE),
+			   UT_SIDE_SRV);
+
+	ut_remach_log_gen_sync(&um, UT_SIDE_CLI, since, records_nr);
+
+	ut_remach_ha_thinks(&um, &HA_THOUGHT(UT_SIDE_SRV,
+					     M0_NC_DTM_RECOVERING));
+
+	m0_be_op_wait(um.recovered + UT_SIDE_SRV);
+	log_subset_verify(&um, recovering_mark_index, UT_SIDE_SRV, UT_SIDE_CLI);
+	ut_remach_ha_thinks(&um, &HA_THOUGHT(UT_SIDE_SRV, M0_NC_ONLINE));
+
+	ut_remach_shutdown(&um);
+}
+
+/*
+ * Use-case: operations happen while node is recovering -- they must not be
+ * replayed.  Empty log when recovery starts.
+ */
+static void remach_rec_mark_empty(void)
+{
+	remach_recovering_marker(0, 10);
+}
+
+/*
+ * Use-case: operations happen while node is recovering -- they must not be
+ * replayed.  Non-empty log when recovery starts.
+ */
+static void remach_rec_mark_nonempty(void)
+{
+	remach_recovering_marker(5, 10);
+}
+
 extern void m0_dtm0_ut_drlink_simple(void);
 extern void m0_dtm0_ut_domain_init_fini(void);
 
 struct m0_ut_suite dtm0_ut = {
 	.ts_name = "dtm0-ut",
 	.ts_tests = {
-		{ "xcode",                  cas_xcode_test        },
-		{ "drlink-simple",         &m0_dtm0_ut_drlink_simple },
-		{ "domain_init-fini",      &m0_dtm0_ut_domain_init_fini },
-		{ "remach-init-fini",       remach_init_fini      },
-		{ "remach-start-stop",      remach_start_stop     },
-		{ "remach-boot-cluster-ss", remach_boot_cluster_ss },
-		{ "remach-boot-cluster-cs", remach_boot_cluster_cs },
-		{ "remach-reboot-server",   remach_reboot_server  },
-		{ "remach-reboot-twice",    remach_reboot_twice   },
-		{ "remach-boot-real-log",   remach_boot_real_log  },
-		{ "remach-real-log-replay", remach_real_log_replay  },
+		{ "xcode",                    cas_xcode_test              },
+		{ "drlink-simple",           &m0_dtm0_ut_drlink_simple    },
+		{ "domain_init-fini",        &m0_dtm0_ut_domain_init_fini },
+		{ "remach-init-fini",         remach_init_fini            },
+		{ "remach-start-stop",        remach_start_stop           },
+		{ "remach-boot-cluster-ss",   remach_boot_cluster_ss      },
+		{ "remach-boot-cluster-cs",   remach_boot_cluster_cs      },
+		{ "remach-reboot-server",     remach_reboot_server        },
+		{ "remach-reboot-twice",      remach_reboot_twice         },
+		{ "remach-boot-real-log",     remach_boot_real_log        },
+		{ "remach-real-log-replay",   remach_real_log_replay      },
+		{ "remach-rec-mark-empty",    remach_rec_mark_empty       },
+		{ "remach-rec-mark-nonempty", remach_rec_mark_nonempty    },
 		{ NULL, NULL },
 	}
 };


### PR DESCRIPTION
Remember last entry in the log at the start of recovery, and stop
recovery when reaching that point.  All new transactions added after
will not be replayed.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
