### PR TITLE
CORTX-30753: Codacy code cleanup(#1608)

### DIFF
--- a/m0t1fs/linux_kernel/st/m0t1fs_cc_io_with_sns_repair.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_cc_io_with_sns_repair.sh
@@ -19,11 +19,11 @@
 #
 
 
-. `dirname "$0"`/common.sh
-. `dirname "$0"`/m0t1fs_common_inc.sh
-. `dirname "$0"`/m0t1fs_client_inc.sh
-. `dirname "$0"`/m0t1fs_server_inc.sh
-. `dirname "$0"`/m0t1fs_sns_common_inc.sh
+. $(dirname "$0")/common.sh
+. $(dirname "$0")/m0t1fs_common_inc.sh
+. $(dirname "$0")/m0t1fs_client_inc.sh
+. $(dirname "$0")/m0t1fs_server_inc.sh
+. $(dirname "$0")/m0t1fs_sns_common_inc.sh
 
 ###################################################
 # SNS repair is only supported in COPYTOOL mode,
@@ -357,7 +357,7 @@ sns_repair_cc_delete_test()
 	fi
 
 	ps aux | grep "$MOTR_M0T1FS_MOUNT_DIR" | grep -v "grep"
-	rm_count=`ps aux | grep "$MOTR_M0T1FS_MOUNT_DIR" | grep -v "grep" -c`
+	rm_count=$(ps aux | grep "$MOTR_M0T1FS_MOUNT_DIR" | grep -v "grep" -c)
 	echo "rm_count : $rm_count"
 	if [ "$rm_count" -ne 0 ]; then
 		echo "Error: $rm_count rm jobs still running...."
@@ -430,7 +430,7 @@ sns_rebalance_cc_delete_test()
 	fi
 
 	ps aux | grep "$MOTR_M0T1FS_MOUNT_DIR"| grep -v "grep"
-	rm_count=`ps aux | grep "$MOTR_M0T1FS_MOUNT_DIR"| grep -v "grep" -c`
+	rm_count=$(ps aux | grep "$MOTR_M0T1FS_MOUNT_DIR"| grep -v "grep" -c)
 	echo "rm_count : $rm_count"
 	if [ "$rm_count" -ne 0 ]; then
 		"Error: $rm_count rm jobs still running...."
@@ -466,7 +466,7 @@ main()
 {
 	local rc=0
 
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
 
 	sandbox_init

--- a/m0t1fs/linux_kernel/st/m0t1fs_client.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_client.sh
@@ -21,7 +21,7 @@
 
 usage()
 {
-	echo "Usage: `basename $0` server_nid"
+	echo "Usage: $(basename $0) server_nid"
 	echo "Please provide the server nid you want to use."
 	echo "e.g. 192.168.172.130@tcp"
 }
@@ -40,9 +40,9 @@ fi
 
 server_nid=$1
 
-. `dirname $0`/common.sh
-. `dirname $0`/m0t1fs_common_inc.sh
-. `dirname $0`/m0t1fs_client_inc.sh
+. $(dirname $0)/common.sh
+. $(dirname $0)/m0t1fs_common_inc.sh
+. $(dirname $0)/m0t1fs_client_inc.sh
 
 main()
 {

--- a/m0t1fs/linux_kernel/st/m0t1fs_client_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_client_inc.sh
@@ -277,7 +277,7 @@ file_creation_test()
 	local BS=$((4 * $NR_DATA * 2))K
 
 	for i in {a..z} {A..Z}; do
-		for c in `seq 1 4095`;
+		for c in $(seq 1 4095);
 			do echo -n $i ;
 		done;
 		echo;
@@ -621,19 +621,19 @@ m0t1fs_large_dir()
 	echo "Test: larde_dir: mode=$1 fsname_prefix=$2..."
 	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR "$mode" || rc=1
 	mount | grep m0t1fs                                 || rc=1
-	for i in `seq 1 $count`; do
+	for i in $(seq 1 $count); do
 		touch $MOTR_M0T1FS_MOUNT_DIR/$fsname_prex$i || rc=1
 		stat  $MOTR_M0T1FS_MOUNT_DIR/$fsname_prex$i -c "%n: %a %s" || rc=1
 	done
 
-	local dirs=`/bin/ls $MOTR_M0T1FS_MOUNT_DIR -U`
-	local dirs_count=`echo $dirs | wc -w`
+	local dirs=$(/bin/ls $MOTR_M0T1FS_MOUNT_DIR -U)
+	local dirs_count=$(echo $dirs | wc -w)
 	echo "readdir count: result $dirs_count, expected $count"
 	if [ ! $dirs_count -eq $count ] ; then
 		rc=1
 	fi
-	for i in `seq 1 $count`; do
-		local match=`echo $dirs | grep -c "\<$fsname_prex$i\>"`
+	for i in $(seq 1 $count); do
+		local match=$(echo $dirs | grep -c "\<$fsname_prex$i\>")
 		if [ ! $match -eq 1 ] ; then
 			echo "match $fsname_prex$i failed: $match"
 			rc=1
@@ -683,7 +683,7 @@ m0t1fs_oostore_mode_basic()
 	echo "Test: oostore_mode_basic..."
 
 	for i in {a..z} {A..Z} ; do
-		for c in `seq 1 4095`;
+		for c in $(seq 1 4095);
 			do echo -n $i ;
 		done;
 		echo;
@@ -748,7 +748,7 @@ m0t1fs_parallel_io_test()
 		setfattr -n writesize -v $BS $MOTR_M0T1FS_MOUNT_DIR/$i || rc=1
 	done
 	echo "Spawn parallel dd's"
-	for i in `seq 1 4`
+	for i in $(seq 1 4)
 	do
 		fid="0:100"$i"000"
 		dd if=/dev/zero of=$MOTR_M0T1FS_MOUNT_DIR/$fid \
@@ -756,7 +756,7 @@ m0t1fs_parallel_io_test()
 		dd_pid[$i]=$!
 	done
 	echo "Wait for IO to complete"
-	for i in `seq 1 4`
+	for i in $(seq 1 4)
 	do
 		echo ${dd_pid[$i]}
 		wait ${dd_pid[$i]}
@@ -803,20 +803,20 @@ m0t1fs_test_MOTR_2099()
 	mount_m0t1fs $MOTR_M0T1FS_MOUNT_DIR || rc=1
 
 	df $MOTR_M0T1FS_MOUNT_DIR
-	used_before=`df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1`
+	used_before=$(df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1)
 	for i in 0:00{0..9}{0..1}; do
 		# This is to create 20 files, 200MB each, 8GB in total.
 		m0t1fs_file=$MOTR_M0T1FS_MOUNT_DIR/${i}
 		touch_file $m0t1fs_file 8192 && run "dd if=/dev/zero of=$m0t1fs_file bs=200M count=1" || rc=1
 	done
 	df $MOTR_M0T1FS_MOUNT_DIR
-	used_after=`df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1`
+	used_after=$(df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1)
 	for i in 0:00{0..9}{0..1}; do
 		m0t1fs_file=$MOTR_M0T1FS_MOUNT_DIR/${i}
 		rm -f $m0t1fs_file
 	done
 	df $MOTR_M0T1FS_MOUNT_DIR
-	used_delete=`df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1`
+	used_delete=$(df $MOTR_M0T1FS_MOUNT_DIR --output=used | tail -n 1)
 	echo "used_before used_after used_delete $used_before $used_after $used_delete"
 	if [ $used_before -ne $used_delete ] ; then
 		echo "balloc space leak? After deletion, used blocks are not the same as before."

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -18,7 +18,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-M0_SRC_DIR=`readlink -f ${BASH_SOURCE[0]}`
+M0_SRC_DIR=$(readlink -f ${BASH_SOURCE[0]})
 M0_SRC_DIR=${M0_SRC_DIR%/*/*/*/*}
 
 . $M0_SRC_DIR/utils/functions  # sandbox_init, report_and_exit
@@ -27,8 +27,8 @@ M0_SRC_DIR=${M0_SRC_DIR%/*/*/*/*}
 ## XXX TODO: Replace `MOTR_M0T1FS_TEST_DIR' with `SANDBOX_DIR' everywhere
 ## and delete the former.
 MOTR_M0T1FS_TEST_DIR=$SANDBOX_DIR
-MOTR_TEST_LOGFILE=$SANDBOX_DIR/motr_`date +"%Y-%m-%d_%T"`.log
-MOTR_M0T1FS_MOUNT_DIR=/tmp/test_m0t1fs_`date +"%d-%m-%Y_%T"`
+MOTR_TEST_LOGFILE=$SANDBOX_DIR/motr_$(date +"%Y-%m-%d_%T").log
+MOTR_M0T1FS_MOUNT_DIR=/tmp/test_m0t1fs_$(date +"%d-%m-%Y_%T")
 
 MOTR_MODULE=m0tr
 
@@ -240,7 +240,7 @@ unprepare()
 
 export PROF_OPT='0x7000000000000001:0'
 
-. `dirname ${BASH_SOURCE[0]}`/common_service_fids_inc.sh
+. $(dirname ${BASH_SOURCE[0]})/common_service_fids_inc.sh
 
 # On cent OS 7 loop device is created during losetup, so no need to call
 # create_loop_device().
@@ -712,7 +712,7 @@ service_eps_get()
 	local service_eps
 	if [ "$XPRT" = "lnet" ]
 	then
-		lnet_nid=`sudo lctl list_nids | head -1`
+		lnet_nid=$(sudo lctl list_nids | head -1)
 	else
 		lnet_nid=$(m0_local_nid_get)
 	fi
@@ -783,7 +783,7 @@ fid: !fid [0,0]
 process: ^r|0.0
 service: ^s|0.0
 data:'
-	ha_msg_nvec=`echo "$ha_msg_nvec" | sed 's/^/  /g'`
+	ha_msg_nvec=$(echo "$ha_msg_nvec" | sed 's/^/  /g')
 	ha_msg_yaml+="$ha_msg_nvec"
 
 	# Convert a yaml message to its xcode representation
@@ -799,7 +799,7 @@ data:'
 	for ep in "${remote_eps[@]}"; do
 		cmd="$cmd_xcode | $M0_SRC_DIR/utils/m0ham -v -s $local_ep $ep"
 		echo "$cmd"
-		local xcode=`eval "$cmd"`
+		local xcode=$(eval "$cmd")
 		if [ $? -ne 0 ]; then
 			echo "m0ham failed to send a message"
 			return 1
@@ -831,7 +831,7 @@ ignore_same_state: false
 notes:'
 	for fid in "${fids[@]}"; do
 		# Convert fid to m0hagen's format
-		fid=`echo "$fid" | tr : .`
+		fid=$(echo "$fid" | tr : .)
 		yaml="$yaml
   - {fid: $fid, state: $state}"
 	done
@@ -871,7 +871,7 @@ ignore_same_state: false
 fids:'
 	for fid in "${fids[@]}"; do
 		# Convert fid to m0hagen's format
-		fid=`echo "$fid" | tr : .`
+		fid=$(echo "$fid" | tr : .)
 		yaml="$yaml
   - $fid"
 	done

--- a/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_dgmode_io.sh
@@ -21,12 +21,12 @@
 
 #set -x
 
-. `dirname $0`/common.sh
-. `dirname $0`/m0t1fs_common_inc.sh
-. `dirname $0`/m0t1fs_client_inc.sh
-. `dirname $0`/m0t1fs_server_inc.sh
-. `dirname $0`/m0t1fs_sns_common_inc.sh
-. `dirname $0`/m0t1fs_io_config_params.sh
+. $(dirname $0)/common.sh
+. $(dirname $0)/m0t1fs_common_inc.sh
+. $(dirname $0)/m0t1fs_client_inc.sh
+. $(dirname $0)/m0t1fs_server_inc.sh
+. $(dirname $0)/m0t1fs_sns_common_inc.sh
+. $(dirname $0)/m0t1fs_io_config_params.sh
 
 N=3
 K=3
@@ -887,7 +887,7 @@ main()
 	echo 'oostore test.'
 	echo '*********************************************************'
 
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	fmio_sandbox="$MOTR_M0T1FS_TEST_DIR/sandbox"
 	rc=0
 

--- a/m0t1fs/linux_kernel/st/m0t1fs_failure_after_sns_repair_quiesce.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_failure_after_sns_repair_quiesce.sh
@@ -19,11 +19,11 @@
 #
 
 
-. `dirname $0`/common.sh
-. `dirname $0`/m0t1fs_common_inc.sh
-. `dirname $0`/m0t1fs_client_inc.sh
-. `dirname $0`/m0t1fs_server_inc.sh
-. `dirname $0`/m0t1fs_sns_common_inc.sh
+. $(dirname $0)/common.sh
+. $(dirname $0)/m0t1fs_common_inc.sh
+. $(dirname $0)/m0t1fs_client_inc.sh
+. $(dirname $0)/m0t1fs_server_inc.sh
+. $(dirname $0)/m0t1fs_sns_common_inc.sh
 
 ###################################################
 # SNS repair is only supported in COPYTOOL mode,
@@ -145,7 +145,7 @@ main()
 
 	sandbox_init
 
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
 	motr_service start $multiple_pools $stride $N $K $S $P || {
 		echo "Failed to start Motr Service."

--- a/m0t1fs/linux_kernel/st/m0t1fs_fsync_test.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_fsync_test.sh
@@ -35,7 +35,7 @@ main()
 {
 	sandbox_init
 
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	echo "About to start Motr service"
 	local multiple_pools=0
 	motr_service start $multiple_pools

--- a/m0t1fs/linux_kernel/st/m0t1fs_fwait_test.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_fwait_test.sh
@@ -22,15 +22,15 @@
 # Tests the fwait feature on Motr.
 #
 
-. `dirname $0`/common.sh
-. `dirname $0`/m0t1fs_common_inc.sh
-. `dirname $0`/m0t1fs_client_inc.sh
-. `dirname $0`/m0t1fs_server_inc.sh
-. `dirname $0`/m0t1fs_sns_common_inc.sh
+. $(dirname $0)/common.sh
+. $(dirname $0)/m0t1fs_common_inc.sh
+. $(dirname $0)/m0t1fs_client_inc.sh
+. $(dirname $0)/m0t1fs_server_inc.sh
+. $(dirname $0)/m0t1fs_sns_common_inc.sh
 
 fwait_test()
 {
-	`dirname $0`/m0t1fs_fwait_test_helper $MOTR_M0T1FS_MOUNT_DIR
+	$(dirname $0)/m0t1fs_fwait_test_helper $MOTR_M0T1FS_MOUNT_DIR
 	return $?
 }
 
@@ -38,7 +38,7 @@ main()
 {
 	sandbox_init
 
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	echo "About to start Motr service"
 	local multiple_pools=0
 	motr_service start $multiple_pools

--- a/m0t1fs/linux_kernel/st/m0t1fs_multi_clients.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_multi_clients.sh
@@ -19,14 +19,14 @@
 #
 
 
-. `dirname $0`/common.sh
-. `dirname $0`/m0t1fs_common_inc.sh
-. `dirname $0`/m0t1fs_client_inc.sh
-. `dirname $0`/m0t1fs_server_inc.sh
+. $(dirname $0)/common.sh
+. $(dirname $0)/m0t1fs_common_inc.sh
+. $(dirname $0)/m0t1fs_client_inc.sh
+. $(dirname $0)/m0t1fs_server_inc.sh
 
 multi_clients()
 {
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
 
 	motr_service start $multiple_pools

--- a/m0t1fs/linux_kernel/st/m0t1fs_pool_version_assignment.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_pool_version_assignment.sh
@@ -19,10 +19,10 @@
 #
 
 
-. `dirname $0`/common.sh
-. `dirname $0`/m0t1fs_common_inc.sh
-. `dirname $0`/m0t1fs_client_inc.sh
-. `dirname $0`/m0t1fs_server_inc.sh
+. $(dirname $0)/common.sh
+. $(dirname $0)/m0t1fs_common_inc.sh
+. $(dirname $0)/m0t1fs_client_inc.sh
+. $(dirname $0)/m0t1fs_server_inc.sh
 
 multiple_pools=1
 
@@ -35,7 +35,7 @@ start_stop_m0d()
 	then
 		# Stop m0d
 		echo -n "Stopping m0d on controller ep $IOS_PVER2_EP "
-		m0d_pid=`pgrep -fn m0d.+$IOS_PVER2_EP`
+		m0d_pid=$(pgrep -fn m0d.+$IOS_PVER2_EP)
 		kill -TERM $m0d_pid >/dev/null 2>&1
 		# Wait util $m0d_pid is terminated
 		while ps -p $m0d_pid -o s= >/dev/null; do
@@ -95,7 +95,7 @@ pool_version_assignment()
         local disk2_from_pver_actual_0="^k|1:2"
         local disk3_from_pver_actual_0="^k|1:3"
         local disk1_from_pver_actual_1="^k|10:1"
-        local lnet_nid=`sudo lctl list_nids | head -1`
+        local lnet_nid=$(sudo lctl list_nids | head -1)
         local console_ep="$lnet_nid:$POOL_MACHINE_CLI_EP"
 	local client_endpoint="$lnet_nid:12345:33:1"
         local eplist=()
@@ -464,7 +464,7 @@ pool_version_assignment()
 
 m0t1fs_pool_version_assignment()
 {
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 
 	local unit=16 # Kbytes
 	local N=2


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
Warning fixed: "SC2006: Use $(...) notation instead of legacy backticked `...`"

Signed-off-by: alfhad <fahadshah2411@gmail.com>

# Problem Statement
We see 369 occurrence of pattern, "Use$(...) notation instead of legacy backticked ....".

# Design
Replaced the backticked with "$(...)"

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
