### PR TITLE
CORTX-31966: Add a flag to disable RMW for an IO operation

### DIFF
--- a/motr/client.h
+++ b/motr/client.h
@@ -582,7 +582,18 @@ enum m0_op_obj_flags {
 	 * Write, alloc and free operations wait for the transaction to become
 	 * persistent before returning.
 	 */
-	M0_OOF_SYNC = 1 << 1
+	M0_OOF_SYNC = 1 << 1,
+	/**
+	 * If this flags is set during m0_obj_op() that means that IO operation
+	 * won't trigger RMW.
+	 * XXX: This flag is not to be used if the IO operation starts
+	 * from a parity group which is partially spanned as in that
+	 * case the parity needs to be re-calculated and updated by
+	 * considering the new data units, but M0_OOF_NO_RMW disables
+	 * rmw code path entirely. This will cause the parity units
+	 * to become stale and invalid.
+	 */
+	M0_OOF_NO_RMW =  1 << 2
 } M0_XCA_ENUM;
 
 /**
@@ -631,14 +642,9 @@ enum m0_entity_type {
 	 */
 	M0_ENF_META = 1 << 0,
 	/**
-	 * If this flags is set during entity_create() that means application
-	 * do not support update operation. This flag is not in use yet.
-	 */
-	M0_ENF_NO_RMW =  1 << 1,
-	/**
 	 * This flag is to enable data integrity.
 	 */
- 	M0_ENF_DI = 1 << 2
+ 	M0_ENF_DI = 1 << 1
  } M0_XCA_ENUM;
 
 /**

--- a/motr/client.h
+++ b/motr/client.h
@@ -642,9 +642,14 @@ enum m0_entity_type {
 	 */
 	M0_ENF_META = 1 << 0,
 	/**
+	 * If this flags is set during entity_create() that means application
+	 * do not support update operation. This flag is not in use yet.
+	 */
+	M0_ENF_NO_RMW = 1 << 1,
+	/**
 	 * This flag is to enable data integrity.
 	 */
- 	M0_ENF_DI = 1 << 1
+ 	M0_ENF_DI = 1 << 2
  } M0_XCA_ENUM;
 
 /**

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -479,7 +479,8 @@ static void ioreq_iosm_handle_executed(struct m0_sm_group *grp,
 	 */
 	M0_LOG(M0_DEBUG, "map=%" PRIu64 " map_nr=%"PRIu64,
 	       ioo->ioo_map_idx, ioo->ioo_iomap_nr);
-	rmw = ioo->ioo_map_idx != ioo->ioo_iomap_nr;
+	rmw = ioo->ioo_map_idx != ioo->ioo_iomap_nr &&
+	      !(ioo->ioo_flags & M0_OOF_NO_RMW);
 	if (ioreq_sm_state(ioo) == IRS_TRUNCATE_COMPLETE)
 		goto done;
 	if (!rmw) {


### PR DESCRIPTION
Added a flag M0_OOF_NO_RMW which can be used during m0_obj_op()
to disable rmw for that IO operation.
This comes with a caveat that the IO operation should not start
from a partially spanned parity group.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
