### PR TITLE
Fix assertion during shutdown in m0_pools_service_ctx_destroy.

### DIFF
--- a/pool/pool.c
+++ b/pool/pool.c
@@ -864,7 +864,7 @@ static void service_ctxs_destroy(struct m0_pools_common *pc)
 			rc = m0_reqh_service_disconnect_wait(ctx);
 			M0_ASSERT_INFO(M0_IN(rc, (0, -ECANCELED, -ETIMEDOUT,
 						  -EINVAL, -EHOSTUNREACH,
-						  -ECONNREFUSED, -EIO)),
+						  -ECONNREFUSED, -EIO, -EPERM)),
 				       "rc=%d", rc);
 		}
 		m0_reqh_service_ctx_destroy(ctx);


### PR DESCRIPTION
Problem: when running a repeated bootstrap/shutdown of the cluster (bootstrap till all m0d are online, followed by immediate shutdown, no delays anywhere; repeated in the loop), the following assertion is triggered time to time (saw it twice, one time on 6th iteration, another time at 27th iteration).

```
(gdb) bt
0  0x00007fed6452338f in raise () from /lib64/libc.so.6
1  0x00007fed6450ddc5 in abort () from /lib64/libc.so.6
2  0x00007fed66709150 in m0_arch_panic (c=0x7fed66d1ab00 <__pctx.23240>, ap=0x7ffd24f6ecb8) at lib/user_space/uassert.c:131
3  0x00007fed666e9498 in m0_panic (ctx=0x7fed66d1ab00 <__pctx.23240>) at lib/assert.c:52
4  0x00007fed667b4d41 in service_ctxs_destroy (pc=0x7ffd24f6ef20) at pool/pool.c:865
5  0x00007fed667b7c4e in m0_pools_service_ctx_destroy (pc=0x7ffd24f6ef20) at pool/pool.c:1624
6  0x00007fed66725f05 in cs_level_leave (module=0x7ffd24f7d9b8) at motr/setup.c:2881
7  0x00007fed6677e928 in m0_module_fini (module=0x7ffd24f7d9b8, level=-1) at module/module.c:154
8  0x00007fed667265c5 in m0_cs_fini (cctx=0x7ffd24f6ef20) at motr/setup.c:3031
9  0x0000000000401627 in main (argc=28, argv=0x7ffd24f7ec28) at motr/m0d.c:260
```

The immediate reason for crash -- m0_reqh_service_disconnect_wait returns EPERM, which is not listed among other error codes in the assertion which follows the call.

Solution: after brainstorming with NikitaD and IvanA, decision was that it is enough to simply add EPERM into the list.


# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
