### PR TITLE
CORTX-31617: fix data recovering on degraded read

### DIFF
--- a/lib/vec.c
+++ b/lib/vec.c
@@ -560,6 +560,14 @@ M0_INTERNAL void m0_indexvec_free(struct m0_indexvec *ivec)
 }
 M0_EXPORTED(m0_indexvec_free);
 
+M0_INTERNAL m0_bindex_t m0_indexvec_end(const struct m0_indexvec *ivec)
+{
+	uint32_t i = ivec->iv_vec.v_nr - 1;
+
+	return ivec->iv_index[i] + ivec->iv_vec.v_count[i];
+}
+M0_EXPORTED(m0_indexvec_end);
+
 M0_INTERNAL void m0_bufvec_cursor_init(struct m0_bufvec_cursor *cur,
 				       const struct m0_bufvec *bvec)
 {

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -315,6 +315,11 @@ M0_INTERNAL void m0_indexvec_free(struct m0_indexvec *ivec);
  */
 M0_INTERNAL uint32_t m0_indexvec_pack(struct m0_indexvec *ivec);
 
+/**
+ * Returns the end index (exclusive) of the given ivec.
+ */
+M0_INTERNAL m0_bindex_t m0_indexvec_end(const struct m0_indexvec *ivec);
+
 /** Cursor to traverse a bufvec */
 struct m0_bufvec_cursor {
 	/** Vector cursor used to track position in the vector

--- a/motr/client.h
+++ b/motr/client.h
@@ -582,7 +582,29 @@ enum m0_op_obj_flags {
 	 * Write, alloc and free operations wait for the transaction to become
 	 * persistent before returning.
 	 */
-	M0_OOF_SYNC = 1 << 1
+	M0_OOF_SYNC = 1 << 1,
+	/**
+	 * Last unit(s) of the object. User must specify this flag when reading
+	 * or writing last unit(s) of the object to indicate where the object
+	 * ends. Otherwise, in degraded read mode, libmotr may try to read all
+	 * the missing units of the last parity group, including those which
+	 * are beyond the object end, and may end up with too many errors to be
+	 * able to recover the data. Or, on writing, it may trigger needless
+	 * RMW and result with the wrong parity data after reading the stale
+	 * data units of the existing old object.
+	 *
+	 * Note: this flag is needed, because Motr does not know the size of
+	 * objects it stores. (But the user does know, for example, by storing
+	 * objects' metadata in KV-store.)
+	 */
+	M0_OOF_LAST = 1 << 2,
+	/**
+	 * Use this flag to indicate that the provided extents at indexvec
+	 * for the I/O operation fully span the parity groups, and that RMW
+	 * (read-modify-write) should not happen. Motr will check it, and
+	 * return -EINVAL if it is not so.
+	 */
+	M0_OOF_FULL = 1 << 3,
 } M0_XCA_ENUM;
 
 /**
@@ -632,7 +654,10 @@ enum m0_entity_type {
 	M0_ENF_META = 1 << 0,
 	/**
 	 * If this flags is set during entity_create() that means application
-	 * do not support update operation. This flag is not in use yet.
+	 * do not support update operation.
+	 * XXX: This flag is not in use and will be deleted soon, so please
+	 *      remove it from your code. If you need to avoid RMW when writing
+	 *      the non-full last parity group, use M0_OOF_LAST flag instead.
 	 */
 	M0_ENF_NO_RMW =  1 << 1,
 	/**
@@ -1452,8 +1477,9 @@ void m0_obj_idx_init(struct m0_idx       *idx,
  *                       (m0_vec_count(&ext->iv_vec) >> obj->ob_attr.oa_bshift)
  * @pre ergo(M0_IN(opcode, (M0_OC_ALLOC, M0_OC_FREE)),
  *           data == NULL && attr == NULL && mask == 0)
- * @pre ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_HOLE)))
- * @pre ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC)))
+ * @pre ergo(opcode == M0_OC_READ, !(flags & ~(M0_OOF_HOLE|M0_OOF_LAST)))
+ * @pre ergo(opcode != M0_OC_READ,
+ *           !(flags & ~(M0_OOF_SYNC|M0_OOF_LAST|M0_OOF_FULL)))
  *
  * @post ergo(*op != NULL, *op->op_code == opcode &&
  *            *op->op_sm.sm_state == M0_OS_INITIALISED)

--- a/motr/io.c
+++ b/motr/io.c
@@ -734,8 +734,10 @@ int m0_obj_op(struct m0_obj       *obj,
 		  opcode == M0_OC_FREE ? "free" : "");
 	M0_PRE(obj != NULL);
 	M0_PRE(op != NULL);
-	M0_PRE(ergo(opcode == M0_OC_READ, M0_IN(flags, (0, M0_OOF_HOLE))));
-	M0_PRE(ergo(opcode != M0_OC_READ, M0_IN(flags, (0, M0_OOF_SYNC))));
+	M0_PRE(ergo(opcode == M0_OC_READ,
+		    !(flags & ~(M0_OOF_HOLE|M0_OOF_LAST))));
+	M0_PRE(ergo(opcode != M0_OC_READ,
+		    !(flags & ~(M0_OOF_SYNC|M0_OOF_LAST|M0_OOF_FULL))));
 	if (M0_FI_ENABLED("fail_op"))
 		return M0_ERR(-EINVAL);
 

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -1079,14 +1079,10 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 		/*
 		 * Use NOHOLE by default (i.e. return error for missing
 		 * units instead of zeros), unless we are in read-verify
-		 * mode or in the degraded-read mode. Otherwise, in case of
-		 * partially spanned parity groups (last groups, usually),
-		 * we will get a lot of bogus errors when all data units
-		 * of the group are read.
+		 * mode.
 		 *
-		 * Note: parity units are always present in the groups, even
-		 * in the partially spanned ones. So we always use NOHOLE
-		 * for them. Otherwise, the user may get corrupted data.
+		 * Note: parity units are always present in the groups,
+		 * so we always use NOHOLE for them.
 		 */
 		instance = m0__op_instance(&ioo->ioo_oo.oo_oc.oc_op);
 		if (ioreq_sm_state(ioo) == IRS_READING && !read_in_write &&
@@ -1096,7 +1092,7 @@ static int target_ioreq_iofops_prepare(struct target_ioreq *ti,
 			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
 
 		if (ioreq_sm_state(ioo) == IRS_DEGRADED_READING &&
-		    !read_in_write && filter == PA_PARITY)
+		    !read_in_write)
 			rw_fop->crw_flags |= M0_IO_FLAG_NOHOLE;
 
 		/* Assign the checksum buffer for traget */

--- a/motr/io_req.c
+++ b/motr/io_req.c
@@ -888,7 +888,7 @@ static int ioreq_iomaps_prepare(struct m0_op_io *ioo)
 	play = pdlayout_get(ioo);
 
 	M0_LOG(M0_DEBUG, "ioo=%p spanned_groups=%"PRIu64
-			 " [N,K,us]=[%d,%d,%" PRIu64 "]",
+			 " [N,K,usz]=[%d,%d,%" PRIu64 "]",
 			 ioo, ioo->ioo_iomap_nr, layout_n(play),
 			 layout_k(play), layout_unit_size(play));
 

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -540,6 +540,9 @@ int m0_read(struct m0_container *container,
 		prepare_ext_vecs(&ext, &attr, bcount,
 				 block_size, &last_index);
 
+		if (block_count == bcount)
+			flags |= M0_OOF_LAST;
+
 		rc = read_data_from_object(&obj, &ext, &data, NULL, flags);
 		if (rc != 0) {
 			fprintf(stderr, "Reading from object failed!\n");

--- a/rpc/frmops.c
+++ b/rpc/frmops.c
@@ -476,7 +476,7 @@ static void item_done(struct m0_rpc_packet *p, struct m0_rpc_item *item, int rc)
 	if (item->ri_error != 0 &&
 	    item->ri_sm.sm_state != M0_RPC_ITEM_FAILED) {
 		M0_LOG(M0_ERROR, " item: %p dest_ep=%s ri_session=%p ri_nr_sent_max=%"PRIu64
-		       "ri_deadline=%" PRIu64 " ri_nr_sent=%u", item,
+		       " ri_deadline=%" PRIu64 " ri_nr_sent=%u", item,
 		       item->ri_session == NULL ? "NOT AVAILABLE" :
 		       m0_rpc_item_remote_ep_addr(item), item->ri_session,
 		       item->ri_nr_sent_max, item->ri_deadline, item->ri_nr_sent);


### PR DESCRIPTION
Currently, in degraded read mode we read all data units of the
parity group without M0_IO_FLAG_NOHOLE flag (we get zeros from
servers for the missing units instead of errors). So if unit is
missing not because there is no user data (last parity group),
but because of previous degraded write - we will provide wrong
input for the recovery function and return garbage to the user.

Solution: 1) read data units with M0_IO_FLAG_NOHOLE flag in de-
graded mode; 2) introduce M0_OOF_LAST flag for the user to
specify for the last read unit(s) of the object, and don't try
to read the missing units beyond the object size.

Also, check M0_OOF_LAST flag to avoid RMW on writing the last
units of non-fully-spanned parity group, and avoid calculating the
wrong parity when overwriting the existing object of bigger size.

Also, introduce M0_OOF_FULL flag so that Motr apps could make
sure that the extents they provided fully span the parity groups
and that RMW will not happen.

Closes #1817.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
