### PR TITLE
CORTX-31985: Increase the receive rpc queue lenth to 64 for 36 node cluster

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -59,6 +59,7 @@ TEMP_FID_FILE = "/opt/seagate/cortx/motr/conf/service_fid.yaml"
 CMD_RETRY_COUNT = 5
 MEM_THRESHOLD = 4*1024*1024*1024
 CVG_COUNT_KEY = "num_cvg"
+MOTR_M0D_MIN_RPC_RECVQ_LEN = 64
 
 class MotrError(Exception):
     """ Generic Exception with error code and output """
@@ -439,7 +440,8 @@ def update_copy_motr_config_file(self):
                    ("MOTR_M0D_DATA_DIR", f"{MOTR_M0D_DATA_DIR}"),
                    ("MOTR_M0D_CONF_XC", f"{MOTR_M0D_CONF_XC}"),
                    ("MOTR_M0D_ADDB_STOB_DIR", f"{MOTR_M0D_ADDB_STOB_DIR}"),
-                   ("MOTR_M0D_TRACE_DIR", f"{MOTR_M0D_TRACE_DIR}")]
+                   ("MOTR_M0D_TRACE_DIR", f"{MOTR_M0D_TRACE_DIR}"),
+                   ("MOTR_M0D_MIN_RPC_RECVQ_LEN", f"{MOTR_M0D_MIN_RPC_RECVQ_LEN}")]
 
     update_config_file(self, f"{MOTR_SYS_CFG}", config_kvs)
 

--- a/spiel/cmd.c
+++ b/spiel/cmd.c
@@ -2371,6 +2371,20 @@ M0_INTERNAL int m0_spiel__fs_stats_fetch(struct m0_spiel_core *spc,
 			m0_free(proc);
 			continue;
 		}
+		M0_LOG(M0_ALWAYS, "FID="FID_F" "
+				  "FS-STAT: fsx.fx_free_seg=%llu, fsx.fx_total_seg=%llu, "
+				  "fx_free_disk=%llu, fx_avail_disk=%llu, "
+				  "fx_total_disk=%llu, fx_svc_total=%llu, "
+				  "fx_svc_replied=%llu",
+				  FID_P(&proc->spi_fid),
+				  (unsigned long long)fsx.fx_free_seg,
+				  (unsigned long long)fsx.fx_total_seg,
+				  (unsigned long long)fsx.fx_free_disk,
+				  (unsigned long long)fsx.fx_avail_disk,
+				  (unsigned long long)fsx.fx_total_disk,
+				  (unsigned long long)fsx.fx_svc_total,
+				  (unsigned long long)fsx.fx_svc_replied);
+				  
 		fsx.fx_svc_total += proc->spi_svc_count;
 	} m0_tl_endfor;
 	m0_tl_for(spiel_proc_items, &fsx.fx_items, proc) {

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -1946,6 +1946,7 @@ static int stob_ad_write_prepare(struct m0_stob_io        *io,
 		todo -= got;
 		++bfrags;
 		if (todo > 0) {
+			M0_ASSERT(bfrags < BALLOC_FRAGS_MAX);
 			if (bfrags >= BALLOC_FRAGS_MAX) {
 				rc = M0_ERR(-ENOSPC);
 				break;


### PR DESCRIPTION
# Problem Statement
- For cluster scaling to 36 nodes, increate the receive rpc queue length

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
