### PR TITLE
CORTX-31180 cas: fix sdev ID if it does not match local sdev

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -312,7 +312,7 @@ struct cas_service {
 	struct m0_reqh_service  c_service;
 	struct m0_be_domain    *c_be_domain;
 
-	/*
+	/**
 	 * sdev used by an instance of CAS service. This should be just one,
 	 * but current unit tests use more than one count and to make
 	 * sure those continue to run we skip the sdev replacement if more than
@@ -603,7 +603,7 @@ static int cas_service_get_sdev_id(struct cas_service *cas_svc)
 			cas_svc->c_sdev_id = sdev->sd_dev_idx;
 			found = true;
 		} else {
-			/*
+			/**
 			 * Several devices attached to a single CAS service are
 			 * possible if we are run in ut. In this case we
 			 * do not replace the device ID and leave the ut alone.

--- a/dix/fid_convert.c
+++ b/dix/fid_convert.c
@@ -35,6 +35,15 @@
  * @{
  */
 
+/* Set device id in a DIX fid. */
+M0_INTERNAL void m0_dix_fid__device_id_set(struct m0_fid *fid,
+					   uint32_t       dev_id)
+{
+	M0_PRE(fid != NULL && (dev_id <= M0_DIX_FID_DEVICE_ID_MAX));
+	fid->f_container = (fid->f_container & ~M0_DIX_FID_DEVICE_ID_MASK) |
+			   (((uint64_t)dev_id) << M0_DIX_FID_DEVICE_ID_OFFSET);
+}
+
 /* extract bits [32, 56) from fid->f_container */
 M0_INTERNAL uint32_t m0_dix_fid__device_id_extract(const struct m0_fid *fid)
 {

--- a/dix/fid_convert.h
+++ b/dix/fid_convert.h
@@ -78,6 +78,8 @@ M0_INTERNAL bool m0_dix_fid_validate_cctg(const struct m0_fid *cctg_fid);
 
 M0_INTERNAL uint32_t m0_dix_fid__device_id_extract(const struct m0_fid *fid);
 
+M0_INTERNAL void m0_dix_fid__device_id_set(struct m0_fid *fid,
+					   uint32_t       dev_id);
 /** @} end of dix group */
 #endif /* __MOTR_DIX_FID_CONVERT_H__ */
 


### PR DESCRIPTION
Problem:
REDO messages sent by the DTX participants contain CAS operation
with a component catalogue FID containing device ID that is local
for each participant.
Handling of the REDO message resulting in a processing of CAS
operation. During processing of any CAS operation we didn't check
that device encoded into component catalogue FID is served by
the target CAS service using conf cache (rely on the client).
But in case of REDO device ID is incorrect, that results into
a new component catalogue creation using CROW mechanism that is
incorrect.

Solution:
Check the device ID of the incoming request and fix it if it does
not match the device that is attached to the CAS service that is
handling the request.

Assumption: CAS service has a single attached device that is the
right configuration currently. For some unit tests (DIX client UTs)
we have a configuration with a several attached devices to emulate
several CAS services. In that case the device ID fixing logic is
disabled.

Issues:
For the recovering process the state of attached device is OFFLINE,
but we need to handle REDO messages that result into processing of
CAS operation. Device state is checked in this case and now we need
to treat OFFLINE device as ok for operation that is logically
incorrect. Probably need to add a special device state that will
be exposing RECOVERING state.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>