### PR TITLE
Check that conf is initialized before accessing it

### DIFF
--- a/dtm0/domain.c
+++ b/dtm0/domain.c
@@ -243,6 +243,8 @@ M0_INTERNAL bool
 m0_dtm0_domain_is_recoverable(struct m0_dtm0_domain *dod,
 			      struct m0_reqh        *reqh)
 {
+	struct m0_confc * confc;
+
 	(void)dod;
 	/*
 	 * XXX:
@@ -253,10 +255,10 @@ m0_dtm0_domain_is_recoverable(struct m0_dtm0_domain *dod,
 	 */
 	if (ENABLE_DTM0)
 		return false;
-	else
-		M0_LOG(M0_DEBUG, "Recovery machine is not here yet.");
 
-	return m0_reqh2confc(reqh) != NULL && has_in_conf(reqh);
+	M0_LOG(M0_DEBUG, "Recovery machine is not here yet.");
+	confc = m0_reqh2confc(reqh);
+	return confc != NULL && m0_confc_is_inited(confc) && has_in_conf(reqh);
 }
 
 #undef M0_TRACE_SUBSYSTEM


### PR DESCRIPTION
Check that conf is initialized before accessing it (fix regression after merging domain/recovered, see #1744).

Problem: client-ut fails:

```
$ sudo ./utils/m0run -- m0ut -t client-ut
START Iteration: 1 out of 1
client-ut
  m0_client_init  motr[648725]:  6ba0  FATAL  [lib/assert.c:50:m0_panic]  panic: (confc->cc_root != ((void *)0)) at m0_confc_root_open() (conf/helpers.c:226)  [git: 2.0.0-794-16-g4bdd8326-dirty] /var/motr/m0ut/m0trace.648725.2022-06-10-03:33:52
Motr panic: (confc->cc_root != ((void *)0)) at m0_confc_root_open() conf/helpers.c:226 (errno: 0) (last failed: none) [git: 2.0.0-794-16-g4bdd8326-dirty] pid: 648725  /var/motr/m0ut/m0trace.648725.2022-06-10-03:33:52
```

```
(gdb) bt
#0  0x00007fffe9ba837f in raise () from /lib64/libc.so.6
#1  0x00007fffe9b92db5 in abort () from /lib64/libc.so.6
#2  0x00007fffebd8d2de in m0_arch_panic (c=0x7fffec2c12e0 <__pctx.14974>, ap=0x7fffffffdb18) at lib/user_space/uassert.c:131
#3  0x00007fffebd6d626 in m0_panic (ctx=0x7fffec2c12e0 <__pctx.14974>) at lib/assert.c:52
#4  0x00007fffebc91476 in m0_confc_root_open (confc=0x87f5f8, root=0x7fffffffdcc8) at conf/helpers.c:226
#5  0x00007fffebcefc2c in has_in_conf (reqh=0x87e6b8) at dtm0/domain.c:233
#6  0x00007fffebcefcdb in m0_dtm0_domain_is_recoverable (dod=0x887b88, reqh=0x87e6b8) at dtm0/domain.c:259
#7  0x00007fffed5b6baa in m0_client_init (m0c_p=0x7fffffffde20, conf=0x7ffff209be20 <default_config>, init_m0=false) at /root/cortx-motr/motr/client_init.c:1674
#8  0x00007fffed5ae4b3 in do_init (instance=0x7fffffffde20) at /root/cortx-motr/motr/ut/client.h:55
#9  0x00007fffed5b7931 in ut_test_m0_client_init () at motr/ut/client.c:255
#10 0x00007fffed6a917f in run_test (test=0x707908 <ut_suite+4488>, max_name_len=43) at ut/ut.c:390
#11 0x00007fffed6a9468 in run_suite (suite=0x706780 <ut_suite>, max_name_len=43) at ut/ut.c:459
#12 0x00007fffed6a9706 in tests_run_all (m=0x7ffff7dc0220 <ut>) at ut/ut.c:513
#13 0x00007fffed6a9764 in m0_ut_run () at ut/ut.c:539
#14 0x0000000000404b13 in main (argc=3, argv=0x7fffffffe598) at ut/m0ut.c:533
```

Solution: check that conf is initialized before accessing it.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
