### PR TITLE
CORTX-30435: Support to configure SKIP_LAYOUT and CROW for m0crate

### DIFF
--- a/motr/m0crate/crate_client.h
+++ b/motr/m0crate/crate_client.h
@@ -56,6 +56,8 @@ struct crate_conf {
 	int log_level;
 	uint64_t addb_size;
 	bool is_enf_meta;
+	bool is_skip_layout;
+	bool is_crow_disable;
 };
 
 enum m0_operation_type {

--- a/motr/m0crate/crate_index.c
+++ b/motr/m0crate/crate_index.c
@@ -27,6 +27,8 @@
 #include "motr/m0crate/logger.h"
 #include "motr/m0crate/crate_client.h"
 #include "motr/m0crate/crate_client_utils.h"
+#include "lib/misc.h"
+#include "motr/client_internal.h"
 
 struct m0_fid dix_pool_ver;
 extern struct crate_conf *conf;
@@ -976,6 +978,24 @@ static int cr_idx_w_find_rnd_k(struct cr_idx_w *w,
 	return M0_RC(rc);
 }
 
+void set_idx_flags(struct m0_op *op)
+{
+	struct m0_op_common *oc;
+	struct m0_op_idx    *oi;
+
+	oc = M0_AMB(oc, op, oc_op);
+	oi = M0_AMB(oi, oc, oi_oc);
+
+	if (conf->is_skip_layout)
+		oi->oi_flags |= M0_OIF_SKIP_LAYOUT;
+
+	if (conf->is_crow_disable)
+		oi->oi_flags &= ~M0_OIF_CROW;
+	else
+		oi->oi_flags |= M0_OIF_CROW;
+
+}
+
 static int cr_execute_query(struct m0_fid *id,
 			     struct kv_pair *p,
 			     enum cr_opcode opcode)
@@ -1011,6 +1031,8 @@ static int cr_execute_query(struct m0_fid *id,
 		      strerror(-rc));
 		goto end;
 	}
+
+	set_idx_flags(ops[0]);
 
 	m0_op_launch(ops, 1);
 
@@ -1368,6 +1390,7 @@ static M0_UNUSED int delete_index(struct m0_uint128 id)
 	return M0_RC(rc);
 }
 
+
 static int create_index(struct m0_uint128 id)
 {
 	int            rc;
@@ -1380,11 +1403,16 @@ static int create_index(struct m0_uint128 id)
 	/* Set an index creation operation. */
 	m0_idx_init(&idx, crate_uber_realm(), &id);
 
+	if (conf->is_skip_layout)
+		conf->is_enf_meta = true;
+
 	if (conf->is_enf_meta)
 		idx.in_entity.en_flags |= M0_ENF_META;
 
 	rc = m0_entity_create(NULL, &idx.in_entity, &ops[0]);
 	if (rc == 0) {
+		set_idx_flags(ops[0]);
+
 		/* Launch and wait for op to complete */
 		m0_op_launch(ops, 1);
 		rc = m0_op_wait(ops[0], M0_BITS(M0_OS_FAILED,

--- a/motr/m0crate/parser.c
+++ b/motr/m0crate/parser.c
@@ -56,6 +56,8 @@ enum config_key_val {
 	ADDB_INIT,
 	ADDB_SIZE,
 	IS_ENF_META,
+	IS_SKIP_LAYOUT,
+	IS_CROW_DISABLE,
 	LOG_LEVEL,
 	/*
 	 * All parameters below are workload-specific,
@@ -159,6 +161,8 @@ struct key_lookup_table lookuptable[] = {
 	{"MODE", MODE},
 	{"MAX_NR_OPS", MAX_NR_OPS},
 	{"IS_ENF_META", IS_ENF_META},
+	{"IS_SKIP_LAYOUT", IS_SKIP_LAYOUT},
+	{"IS_CROW_DISABLE", IS_CROW_DISABLE},
 	{"NR_ROUNDS", NR_ROUNDS},
 };
 
@@ -598,6 +602,12 @@ int copy_value(struct workload *load, int max_workload, int *index,
 			break;
 		case IS_ENF_META:
 			conf->is_enf_meta = atoi(value);
+			break;
+		case IS_SKIP_LAYOUT:
+			conf->is_skip_layout = atoi(value);
+			break;
+		case IS_CROW_DISABLE:
+			conf->is_crow_disable = atoi(value);
 			break;
 		default:
 			break;

--- a/motr/st/utils/m0crate_st_workloads.yaml
+++ b/motr/st/utils/m0crate_st_workloads.yaml
@@ -33,6 +33,10 @@ MOTR_CONFIG:
    IS_ENF_META: 0                # Pool version info will be stored by client and pass
                                  # the pool version for PUT/GET/DEL/NEXT operations if
                                  # IS_ENF_META enabled.
+   IS_SKIP_LAYOUT: 0             # It will be enable M0_OIF_SKIP_LAYOUT flag if
+                                 # IS_SKIP_LAYOUT is 1
+   IS_CROW_DISABLE: 0            # M0_OIF_CROW flag will be disable if IS_CROW_DISABLE
+                                 # is 1
 
 WORKLOAD_SPEC:                   # Workload specification section
    WORKLOAD:                     # First Workload


### PR DESCRIPTION
Added IS_SKIP_LAYOUT to enable M0_OIF_SKIP_LAYOUT. It will enable
single Tx support.
Added IS_CROW_DISABLE to disable MO_OIF_CROW.

Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>
