### PR TITLE
Use 'extern' instead of 'M0_EXTERN' for m0_dtm0_recovery_machine_default_ops

### DIFF
--- a/dtm0/recovery.h
+++ b/dtm0/recovery.h
@@ -103,7 +103,7 @@ struct m0_dtm0_recovery_machine {
 	struct m0_sm                               rm_sm;
 };
 
-M0_EXTERN const struct m0_dtm0_recovery_machine_ops
+extern const struct m0_dtm0_recovery_machine_ops
 			m0_dtm0_recovery_machine_default_ops;
 
 M0_INTERNAL int m0_drm_domain_init(void);


### PR DESCRIPTION
M0_EXTERN was causing errors in altogether mode.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
