### PR TITLE
CORTX-31180 dtm0/cas: fix sdev ID for incoming REDO messages

### DIFF
--- a/cas/cas.h
+++ b/cas/cas.h
@@ -471,6 +471,9 @@ M0_INTERNAL int m0_cas_fom_spawn(
 	struct m0_fop           *cas_fop,
 	void                   (*on_fom_complete)(struct m0_fom_thralldom *,
 						  struct m0_fom           *));
+M0_INTERNAL uint32_t m0_cas_svc_device_id_get(
+	const struct m0_reqh_service_type *stype,
+	const struct m0_reqh              *reqh);
 #else
 #define m0_cas_svc_init()
 #define m0_cas_svc_fini()

--- a/dix/fid_convert.c
+++ b/dix/fid_convert.c
@@ -35,6 +35,15 @@
  * @{
  */
 
+/* Set device id in a DIX fid. */
+M0_INTERNAL void m0_dix_fid__device_id_set(struct m0_fid *fid,
+					   uint32_t       dev_id)
+{
+	M0_PRE(fid != NULL && (dev_id <= M0_DIX_FID_DEVICE_ID_MAX));
+	fid->f_container = (fid->f_container & ~M0_DIX_FID_DEVICE_ID_MASK) |
+			   (((uint64_t)dev_id) << M0_DIX_FID_DEVICE_ID_OFFSET);
+}
+
 /* extract bits [32, 56) from fid->f_container */
 M0_INTERNAL uint32_t m0_dix_fid__device_id_extract(const struct m0_fid *fid)
 {

--- a/dix/fid_convert.h
+++ b/dix/fid_convert.h
@@ -78,6 +78,8 @@ M0_INTERNAL bool m0_dix_fid_validate_cctg(const struct m0_fid *cctg_fid);
 
 M0_INTERNAL uint32_t m0_dix_fid__device_id_extract(const struct m0_fid *fid);
 
+M0_INTERNAL void m0_dix_fid__device_id_set(struct m0_fid *fid,
+					   uint32_t       dev_id);
 /** @} end of dix group */
 #endif /* __MOTR_DIX_FID_CONVERT_H__ */
 

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -1118,7 +1118,7 @@ static void dtm0_ut_cas_op_prepare(const struct m0_fid    *cfid,
 	}
 }
 
-static void dtm0_ut_send_redo(const struct m0_fid *ifid,
+static void dtm0_ut_send_redo(const struct m0_fid *ifid, uint32_t sdev_id,
 			      uint64_t *key, uint64_t *val)
 {
 	int                     rc;
@@ -1142,8 +1142,6 @@ static void dtm0_ut_send_redo(const struct m0_fid *ifid,
 	 * Ivan Alekhin.
 	 */
 	struct m0_fom           zero_fom_to_be_deleted = {};
-	/* Extreme hack to convert index fid to component catalogue fid. */
-	uint32_t                sdev_idx = 10;
 
 	m0_dtm0_clk_src_init(&dcs, M0_DTM0_CS_PHYS);
 	m0_dtm0_clk_src_now(&dcs, &now);
@@ -1162,7 +1160,7 @@ static void dtm0_ut_send_redo(const struct m0_fid *ifid,
 		.dti_fid = cli_dtm0_fid
 	};
 
-	m0_dix_fid_convert_dix2cctg(ifid, &cctg_fid, sdev_idx);
+	m0_dix_fid_convert_dix2cctg(ifid, &cctg_fid, sdev_id);
 
 	dtm0_ut_cas_op_prepare(&cctg_fid, &cas_op, &cas_rec, key, val, &txr);
 
@@ -1216,7 +1214,7 @@ static void dtm0_ut_read_and_check(uint64_t key, uint64_t val)
 	m0_free0(&rcs);
 }
 
-static void st_dtm0_r(void)
+static void st_dtm0_r_common(uint32_t sdev_id)
 {
 	m0_time_t rem;
 	uint64_t  key = 111;
@@ -1227,7 +1225,7 @@ static void st_dtm0_r(void)
 
 	idx_setup();
 	exec_one_by_one(1, M0_IC_PUT);
-	dtm0_ut_send_redo(&duc.duc_ifid, &key, &val);
+	dtm0_ut_send_redo(&duc.duc_ifid, sdev_id, &key, &val);
 
 	/* XXX dirty hack, but now we don't have completion notification */
 	rem = 2ULL * M0_TIME_ONE_SECOND;
@@ -1236,6 +1234,27 @@ static void st_dtm0_r(void)
 
 	dtm0_ut_read_and_check(key, val);
 	idx_teardown();
+}
+
+static void st_dtm0_r(void)
+{
+	/* CAS sdev id from the configuration. */
+	uint32_t sdev_id = 10;
+	st_dtm0_r_common(sdev_id);
+}
+
+static void st_dtm0_r_wrong_sdev(void)
+{
+	/*
+	 * Random CAS sdev id, should be fixed by REDO handler.
+	 * In a real system participants will send the REDO messages
+	 * with their own CAS devices IDs during recovery, so the REDO
+	 * handler of the process to be recovered needs to get the CAS
+	 * device ID attached to a local CAS service and set it in an
+	 * operation CAS ID.
+	 */
+	uint32_t sdev_id = 12345;
+	st_dtm0_r_common(sdev_id);
 }
 
 struct m0_ut_suite ut_suite_mt_idx_dix = {
@@ -1252,6 +1271,7 @@ struct m0_ut_suite ut_suite_mt_idx_dix = {
 		{ "dtm0_e_then_s",  st_dtm0_e_then_s, "Ivan"     },
 		{ "dtm0_c",         st_dtm0_c,        "Ivan"     },
 		{ "dtm0_r",         st_dtm0_r,        "Sergey"   },
+		{ "dtm0_r_wrong_sdev", st_dtm0_r_wrong_sdev, "Sergey" },
 		{ NULL, NULL }
 	}
 };


### PR DESCRIPTION
Problem:
REDO messages sent by the DTX participants contain CAS operation
with a component catalogue FID containing device ID that is local
for each participant.
Handling of the REDO message resulting in a processing of CAS
operation. During processing of any CAS operation we didn't check
that device encoded into component catalogue FID is served by
the target CAS service using conf cache (rely on the client).
But in case of REDO device ID is incorrect, that results into
a new component catalogue creation using CROW mechanism that is
incorrect.

Solution:
Find attached device in conf and store it inside of CAS service
structure when CAS service starts.
When the REDO message arrives the REDO message handler related to
CAS service gets device id attached to a local CAS service and
sets it as a part of operation CAS id.

Assumption:
CAS service has a single attached device that is the standard
configuration currently. For some unit tests (DIX client UTs)
we have a configuration with a several attached devices to emulate
several CAS services. In that case the device ID stored in a CAS
service structure is set to a special invalid value.

Issues:
For the recovering process the state of attached device is OFFLINE,
but we need to handle REDO messages that result into processing of
CAS operation. Device state is checked in this case and now we need
to treat OFFLINE device as ok for operation that is logically
incorrect. Probably need to add a special device state that will
be exposing RECOVERING state.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>