### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/spiel/st/spiel_multiple_confd.sh
+++ b/spiel/st/spiel_multiple_confd.sh
@@ -96,7 +96,7 @@ _fini() {
     if [[ "$(is_lnet_available)" == "true" ]]; then
         m0_modules_remove
     fi
-    cd $M0_SRC_DIR/utils/spiel
+    cd "$M0_SRC_DIR"/utils/spiel
     cat $INSTALLED_FILES | xargs rm -rf
     rm -rf build/ $INSTALLED_FILES
 }
@@ -156,7 +156,7 @@ confd_mkfs_start() {
     -w 3 -f ${!fid}"
 
     echo "--- $(date) ---" >>"$path"/m0d.log
-    cd $path
+    cd "$path"
 
     echo "$M0_SRC_DIR"/utils/mkfs/m0mkfs $OPTS
     "$M0_SRC_DIR"/utils/mkfs/m0mkfs $OPTS >>"$path"/mkfs.log ||
@@ -173,11 +173,11 @@ confd_start() {
     -m $MAX_RPC_MSG_SIZE -q $TM_MIN_RECV_QUEUE_LEN -c $CONF_FILE\
     -w 3 -f ${!fid}"
 
-    echo "--- `date` ---" >>$path/m0d.log
-    cd $path
+    echo "--- `date` ---" >>"$path"/m0d.log
+    cd "$path"
 
     echo "$M0_SRC_DIR"/motr/m0d $OPTS
-    $M0_SRC_DIR/motr/m0d $OPTS >>$path/m0d.log 2>&1 &
+    "$M0_SRC_DIR"/motr/m0d $OPTS >>"$path"/m0d.log 2>&1 &
     local PID=$!
     sleep 10
     kill -0 $PID 2>/dev/null ||


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Signed-off-by: alfhad <fahadshah2411@gmail.com>

# Problem Statement
We see 1688 occurrence of pattern, "Double quote to prevent globing and words splitting".

# Design
We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
