### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/st/m0d-signal-test.sh
+++ b/st/m0d-signal-test.sh
@@ -29,9 +29,9 @@ SANDBOX_DIR=${SANDBOX_DIR:-/var/motr/sandbox.signal-st}
 M0_SRC_DIR=`readlink -f $0`
 M0_SRC_DIR=${M0_SRC_DIR%/*/*}
 
-. $M0_SRC_DIR/utils/functions # report_and_exit
+. "$M0_SRC_DIR"/utils/functions # report_and_exit
 
-cd $M0_SRC_DIR
+cd "$M0_SRC_DIR"
 
 scripts/install-motr-service -u
 scripts/install-motr-service -l
@@ -62,7 +62,7 @@ test_for_signal()
     done
 
     echo "Sending $sig to ios1"
-    systemctl -s $sig --kill-who=main kill motr-server@ios1
+    systemctl -s "$sig" --kill-who=main kill motr-server@ios1
 
     if [[ $sig == SIGUSR1 ]] ; then
         sleep 5
@@ -112,7 +112,7 @@ rc2=$?
 
 rc=$((rc1 + rc2))
 if [ $rc -eq 0 ]; then
-    rm -r $SANDBOX_DIR
+    rm -r "$SANDBOX_DIR"
 fi
 
 report_and_exit m0d-signal $rc


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Signed-off-by: alfhad <fahadshah2411@gmail.com>

# Problem Statement
We see 1688 occurrence of pattern, "Double quote to prevent globing and words splitting".

# Design
We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
