### PR TITLE
Changes in BE allocator to support no-clear mode during allocation.

### DIFF
--- a/be/linux_kernel/stubs.c
+++ b/be/linux_kernel/stubs.c
@@ -61,12 +61,33 @@ M0_INTERNAL void m0_be_alloc_aligned(struct m0_be_allocator *a,
 	m0_be_alloc(a, tx, op, ptr, size);
 }
 
+M0_INTERNAL void m0_be_alloc_aligned_no_clear(struct m0_be_allocator *a,
+					      struct m0_be_tx *tx,
+					      struct m0_be_op *op,
+					      void **ptr,
+					      m0_bcount_t size,
+					      unsigned shift,
+					      uint64_t zonemask,
+					      bool chunk_align)
+{
+	m0_be_alloc_aligned(a, tx, op, ptr, size, shift, zonemask, chunk_align);
+}
+
 M0_INTERNAL void m0_be_allocator_credit(struct m0_be_allocator *a,
 					enum m0_be_allocator_op optype,
 					m0_bcount_t size,
 					unsigned shift,
 					struct m0_be_tx_credit *accum)
 {
+}
+
+M0_INTERNAL void m0_be_allocator_credit_no_clear(struct m0_be_allocator *a,
+						 enum m0_be_allocator_op optype,
+						 m0_bcount_t             size,
+						 unsigned                shift,
+						 struct m0_be_tx_credit *accum)
+{
+	m0_be_allocator_credit(a, optype, size, shift, accum);
 }
 
 M0_INTERNAL void m0_be_free(struct m0_be_allocator *a,

--- a/be/ut/main.c
+++ b/be/ut/main.c
@@ -138,6 +138,7 @@ extern void m0_be_ut_alloc_init_fini(void);
 extern void m0_be_ut_alloc_create_destroy(void);
 extern void m0_be_ut_alloc_multiple(void);
 extern void m0_be_ut_alloc_concurrent(void);
+extern void m0_be_ut_alloc_verify(void);
 extern void m0_be_ut_alloc_oom(void);
 extern void m0_be_ut_alloc_info(void);
 extern void m0_be_ut_alloc_spare(void);
@@ -261,6 +262,7 @@ struct m0_ut_suite be_ut = {
 		{ "alloc-info",              m0_be_ut_alloc_info              },
 		{ "alloc-spare",             m0_be_ut_alloc_spare             },
                 { "alloc-align",             m0_be_ut_alloc_align             },
+                { "alloc-verify",            m0_be_ut_alloc_verify            },
 		{ "obj",                     m0_be_ut_obj_test                },
 		{ "actrec",                  m0_be_ut_actrec_test             },
 #endif /* __KERNEL__ */


### PR DESCRIPTION
# Problem Statement
- Current BE allocator will clear memory contents when m0_alloc*() routines are
called. This is not always desirable since the Tx credits requirements increase
because the cleared memory needs to be captured in the transaction.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed


This commit contains:
1) Changes to skip memory clearing during allocation.
2) Revised credit needs when no-clear version of the allocation is called.
3) UT to verify memory allocation contents.
4) Btree changes to use he no-clear memory routines.

Signed-off-by: Shashank Parulekar <Shashank.Parulekar@seagate.com>

