### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/spiel/st/m0t1fs_spiel_sns_common_inc.sh
+++ b/spiel/st/m0t1fs_spiel_sns_common_inc.sh
@@ -91,8 +91,8 @@ verify()
 {
 	echo "verifying ..."
 	for ((i=0; i < ${#files[*]}; i++)) ; do
-		local_read $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
-		read_and_verify ${files[$i]} $((${unit_size[$i]} * 1024)) ${file_size[$i]} || return $?
+		local_read $((${unit_size[$i]} * 1024)) "${file_size[$i]}" || return $?
+		read_and_verify "${files[$i]}" $((${unit_size[$i]} * 1024)) "${file_size[$i]}" || return $?
 	done
 
 	echo "file verification sucess"
@@ -143,7 +143,7 @@ spiel_prepare()
 
 spiel_cleanup()
 {
-	cd $M0_SRC_DIR/utils/spiel
+	cd "$M0_SRC_DIR"/utils/spiel
 	cat $PYTHON_STUFF | xargs rm -rf
 	rm -rf build/ $PYTHON_STUFF
 	cd -
@@ -166,8 +166,8 @@ EOF
 
 spiel_sns_repair_abort()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 $SPIEL_FIDS_LIST
 
 $SPIEL_RCONF_START
@@ -181,8 +181,8 @@ EOF
 
 spiel_sns_repair_quiesce()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 $SPIEL_FIDS_LIST
 
 $SPIEL_RCONF_START
@@ -196,8 +196,8 @@ EOF
 
 spiel_sns_repair_continue()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 $SPIEL_FIDS_LIST
 
 $SPIEL_RCONF_START
@@ -211,8 +211,8 @@ EOF
 
 spiel_wait_for_sns_repair()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 import time
 $SPIEL_FIDS_LIST
 
@@ -240,8 +240,8 @@ EOF
 
 spiel_sns_rebalance_start()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 $SPIEL_FIDS_LIST
 
 $SPIEL_RCONF_START
@@ -255,8 +255,8 @@ EOF
 
 spiel_sns_rebalance_quiesce()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 $SPIEL_FIDS_LIST
 
 $SPIEL_RCONF_START
@@ -270,8 +270,8 @@ EOF
 
 spiel_sns_rebalance_continue()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 $SPIEL_FIDS_LIST
 
 $SPIEL_RCONF_START
@@ -285,8 +285,8 @@ EOF
 
 spiel_wait_for_sns_rebalance()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 import time
 $SPIEL_FIDS_LIST
 
@@ -314,8 +314,8 @@ EOF
 
 spiel_sns_rebalance_abort()
 {
-echo $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS
-    $M0_SRC_DIR/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
+echo "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS
+    "$M0_SRC_DIR"/utils/spiel/m0spiel $SPIEL_OPTS <<EOF
 $SPIEL_FIDS_LIST
 
 $SPIEL_RCONF_START


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Signed-off-by: alfhad <fahadshah2411@gmail.com>

# Problem Statement
We see 1688 occurrence of pattern, "Double quote to prevent globing and words splitting".

# Design
We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
