### PR TITLE
Fix dix STs for btree.

### DIFF
--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -1142,7 +1142,7 @@ static bool ctg_op_cb(struct m0_clink *clink)
 	if (opc == CO_PUT &&
 	    ctg_op->co_flags & COF_CREATE &&
 	    rc == -EEXIST)
-		ctg_op->co_rc = 0;
+		rc = 0;
 
 	ctg_op->co_rc = M0_RC(rc);
 	m0_chan_broadcast_lock(&ctg_op->co_channel);


### PR DESCRIPTION
Fix issue due to rc getting overwritten in ctg_op_cb().

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
