### PR TITLE
CORTX-32415: halink does not disconnect on M0_NC_TRANSIENT for process

### DIFF
--- a/ha/halon/interface.c
+++ b/ha/halon/interface.c
@@ -318,7 +318,8 @@ halon_interface_process_failure_check(struct m0_halon_interface_internal *hii,
 				       FID_F, FID_P(&note->no_id));
 				continue;
 			}
-			if (note->no_state == M0_NC_FAILED) {
+			if (note->no_state == M0_NC_FAILED ||
+			    note->no_state == M0_NC_TRANSIENT) {
 				if (just_added) {
 					M0_LOG(M0_DEBUG,
 					       "Ignoring M0_NC_FAILED as "


### PR DESCRIPTION
Hare broadcasts OFFLINE (M0_NC_TRANSIENT) for process on restarts, it is
expected that corresponding Hare to motr process halinks must disconnect,
but they don't unlike on notifying M0_NC_FAILED.

Solution:
Allow disconnecting halink on M0_NC_TRANSIENT process state as well.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
