### PR TITLE
CORTX-32368: Increase FQDN length to 255 characters in motr for kubernetes

### DIFF
--- a/net/ip.h
+++ b/net/ip.h
@@ -25,7 +25,7 @@
 #ifndef __MOTR_NET_IP_H__
 #define __MOTR_NET_IP_H__
 
-#define M0_NET_IP_STRLEN_MAX  150
+#define M0_NET_IP_STRLEN_MAX  255
 #define M0_NET_IP_PORTLEN_MAX 6
 #define M0_NET_IP_PORT_MAX    65536
 


### PR DESCRIPTION
# Problem Statement
- Increase FQDN length to 255 characters in motr for kubernetes.

Motr currently defines network names to a maximum length of 150 characters via `#define M0_NET_IP_STRLEN_MAX 150` , however this will cause issues in more dynamic Kubernetes environments as it is a relatively low character count when deploying large and robust CORTX clusters on Kubernetes.

In following with the https://www.ietf.org/rfc/rfc1035.txt spec and [base Kubernetes Object Naming characteristics](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names), this should be updated to be 253 characters or less.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
