### PR TITLE
CORTX-32426:Motr mini provisioner log file  contain only recent start…

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -61,7 +61,7 @@ class Cmd:
         self._url_motr_hare = f"json://{self._motr_hare_conf}"
         self.log_path_motr = f"{self.log_path}/motr/{self.machine_id}"
 
-        # Check if local and log path exists, return if not exists
+        # Check if local and log path exist, return if not exist
         validate_files([self.local_path, self.log_path])
 
         create_dirs(self, [self.local_path_motr, self.log_path_motr])

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_setup
@@ -67,7 +67,7 @@ class Cmd:
         create_dirs(self, [self.local_path_motr, self.log_path_motr])
         self.logfile =  f"{self.log_path_motr}/mini_provisioner"
         self.logger = config_logger(self)
-
+        self.logger.info(f"Logger configured for phase={self.name}\n")
         # Default setup size is small
         set_setup_size(self, self._services)
 


### PR DESCRIPTION


# Problem Statement
- Motr mini prov log file (/etc/cortx/log/motr/<machine-id>/mini_provisioner)
do not contain logs of previous restarts

# Design
Keep on appending the logs  to same log file after each motr restart

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
1: Logs after deployment is in attached file 'mini_provisioner' till line num 591 
2: If we restart one ioservice then logs after restart is appended to the same file and restart logs are seen from line num 592.
[mini_provisioner.zip](https://github.com/Seagate/cortx-motr/files/8977276/mini_provisioner.zip)


# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
