### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/spiel/st/m0t1fs_spiel_dix_repair_quiesce.sh
+++ b/spiel/st/m0t1fs_spiel_dix_repair_quiesce.sh
@@ -21,7 +21,7 @@
 M0_SRC_DIR=`readlink -f $0`
 M0_SRC_DIR=${M0_SRC_DIR%/*/*/*}
 
-. $M0_SRC_DIR/spiel/st/m0t1fs_spiel_dix_common_inc.sh
+. "$M0_SRC_DIR"/spiel/st/m0t1fs_spiel_dix_common_inc.sh
 
 spiel_dix_repair_quiesce_test()
 {
@@ -109,7 +109,7 @@ main()
 
 	NODE_UUID=`uuidgen`
 	local multiple_pools=0
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		return 1
 	}


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Signed-off-by: alfhad <fahadshah2411@gmail.com>

# Problem Statement
We see 1688 occurrence of pattern, "Double quote to prevent globing and words splitting".

# Design
We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
