### PR TITLE
CORTX-32040 : GITHUB ISSUE-./scripts/install-build-deps fails

### DIFF
--- a/scripts/install-build-deps
+++ b/scripts/install-build-deps
@@ -187,9 +187,21 @@ if ! $use_ansible ; then
    exit 0
 elif ! which ansible &>/dev/null ; then
     case $(distro_type) in
-        redhat) yum -y install epel-release
+        redhat) rc=0
+                yum -y install epel-release
                 yum -y install epel-release # Update it
-                yum -y install ansible ;;
+                yum -y install ansible || rc=$?
+                if [[ rc -ne 0 ]]; then
+                        EPEL_REPO_NAME=$(rpm -qa | grep epel)
+                        rpm -e "$EPEL_REPO_NAME"
+                        source /etc/os-release
+                        ARCH="$(uname -m)"
+                        yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/"$VERSION_ID"/Everything/"$ARCH"/
+                        mv /etc/yum.repos.d/archives.fedoraproject.org_pub_archive_epel_"$VERSION_ID"_Everything_"$ARCH"_.repo /etc/yum.repos.d/epel.repo
+                        yum -y install epel-release
+                        yum -y install ansible
+                fi
+                ;;
         debian) apt install ansible ;;
     esac
 fi


### PR DESCRIPTION
Problem : On Rocky Linux version 8.4 ./scripts/install-build-deps
          is failing for ansible with the error "nothing provides
          (ansible-core >= 2.12.2 with ansible-core < 2.13)
          needed by ansible-5.4.0-2.el8.noarch" also if we ignore
          the ansible then it is failing with the error "nothing
          provides libLLVM-13.so()(64bit) needed by
          castxml-0.4.5-2.el8.x86_64".

Solution : New yum repo is added via yum-config-manager. If the
           installation of ansible is failed, it will install
           epel repo and ansible again after fetching from the
           newley added repo.

Signed-off-by: Bhargav Dekivadiya <bhargav.dekivadiya@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
