### PR TITLE
CORTX-32368 : Motr needs to support Kubernetes Pod FQDNs that are longer than 150 characters.

### DIFF
--- a/motr/setup.h
+++ b/motr/setup.h
@@ -470,7 +470,11 @@ struct m0_motr {
 };
 
 enum {
-	CS_MAX_EP_ADDR_LEN = 86 /* "lnet:" + M0_NET_LNET_XEP_ADDR_LEN */
+	/**
+	 * Increased to 300 to support long fqdn names of the type
+	 * <xprt>:<family>:<proto>:<fqdn/ip>@<port>
+	 * For eg - libfab:inet:tcp:cortx-data-0.cortx-data-headless.reallylongnamespace.svc.cluster.local@22002 */
+	CS_MAX_EP_ADDR_LEN = 300
 };
 M0_BASSERT(CS_MAX_EP_ADDR_LEN >= sizeof "lnet:" + M0_NET_LNET_XEP_ADDR_LEN);
 


### PR DESCRIPTION
Increase ep length in motr/setup.h to support very long fqdn names.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
