### PR TITLE
CORTX-30106: Changed data type of return value for read to ssize_t from size_t

### DIFF
--- a/spiel/ut/spiel_conf_ut.c
+++ b/spiel/ut/spiel_conf_ut.c
@@ -159,7 +159,7 @@ static int spiel_copy_file(const char *source, const char* dest)
 	char buf[1024];
 	int in_fd;
 	int out_fd;
-	size_t result;
+	ssize_t result;
 	int rc = 0;
 
 	in_fd = open(source, O_RDONLY);


### PR DESCRIPTION
Signed-off-by: Papan Kumar Singh <papan.kumarsingh@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
