### PR TITLE
Start FDMI source dock timer fom only when FDMI filters are defined.

### DIFF
--- a/fdmi/source_dock_internal.h
+++ b/fdmi/source_dock_internal.h
@@ -92,7 +92,6 @@ struct fdmi_rr_fom {
 struct fdmi_sd_timer_fom {
 	struct m0_fom           fstf_fom;
 	struct m0_fom_timeout   fstf_timeout;
-	struct m0_sm_ast        fstf_wakeup_ast;
 	struct m0_semaphore     fstf_shutdown;
 };
 


### PR DESCRIPTION
Also, we don't do wakeup the timer fom when stopping FDMI service. It will finalizes
itself when timeout arrives. This is to avoid race conditions if there are
two ways to wake up a fom.

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
```
cas-service [Nikita]
  init-fini [Nikita]                              0.29 sec   74 MiB
  init-fail [Leonid]                              0.30 sec   81 MiB
  re-init [Egor]                                  2.03 sec    6 MiB
  re-start [Nikita] 
---jenkins metadata---
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.testnode0.m0reportbug-traces.partial.tar.xz]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.testnode0.m0reportbug-data.partial.tar.xz]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.stdout.log]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.memory-info.log]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.messages.testnode0.log]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.stderr.log]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.stacktrace.testnode0.log]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.memorytrace.testnode0.log]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.testnode0.m0reportbug-cores.partial.tar.xz]]
[[ATTACHMENT|/storage/fsroots/motr-remote-controller-smc13-m11/workspace/Cortx-PR-Build/Motr/junit/01motr-single-node.00userspace-tests/00userspace-tests.mount-info.log]]
<measurement><name>Time</name><value>606</value></measurement>
Standard Error
----- run_ut -----
motr[102931]:  6b10  FATAL  [lib/assert.c:50:m0_panic]  panic: ((loc->fl_wail_nr) != 0) at m0_fom_ready() (fop/fom.c:436)  [git: sage-base-1.0-942-g5a50834-dirty] /var/motr/m0ut/m0trace.102931.2022-06-29-08:51:11
Motr panic: ((loc->fl_wail_nr) != 0) at m0_fom_ready() fop/fom.c:436 (errno: 0) (last failed: none) [git: sage-base-1.0-942-g5a50834-dirty] pid: 102931  /var/motr/m0ut/m0trace.102931.2022-06-29-08:51:11
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_arch_backtrace+0x20)[0x7ff0e5660b40]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_arch_panic+0xe6)[0x7ff0e5660cf6]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(+0x3a2c34)[0x7ff0e564ec34]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(+0x37397b)[0x7ff0e561f97b]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_sm_asts_run+0xb7)[0x7ff0e56f4fe7]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(+0x374ff7)[0x7ff0e5620ff7]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(m0_thread_trampoline+0x5e)[0x7ff0e565607e]
/root/motr/motr_test_github_workdir/workdir/src/motr/.libs/libmotr.so.2(+0x3b59dd)[0x7ff0e56619dd]
/lib64/libpthread.so.0(+0x7e65)[0x7ff0e4d95e65]
/lib64/libc.so.6(clone+0x6d)[0x7ff0e371b88d]
/root/motr/motr_test_github_workdir/workdir/src/utils/m0run: line 433: 102931 Aborted                 (core dumped) $(srcdir_path_of $binary) "$@"
```

# Design
- Start the FDMI source dock timer fom only when FDMI filters are defined.
- Don't call m0_fom_wakeup() when the FDMI service is stopping. The FDMI source dock timer fom will be woken up by the timer. If we explicitly call m0_fom_wakeup(), there might be race condition: the fom is being woken up by two threads, and they are not synchronized. 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
