### PR TITLE
be/tool: Do not check the value of streq agains 0

### DIFF
--- a/be/tool/main.c
+++ b/be/tool/main.c
@@ -154,11 +154,11 @@ static void scan_btree(struct m0_be_domain *dom, bool print_btree)
 					  objtype->b0_name, suffix,
 					  objtype, seg );
 
-			if (m0_streq(objtype->b0_name, "M0_BE:COB") == 0) {
+			if (m0_streq(objtype->b0_name, "M0_BE:COB")) {
 				cdom = *(struct m0_cob_domain**)opt.b_addr;
 				track_cob_btrees(cdom, print_btree);
 			}
-			else if (m0_streq(objtype->b0_name, "M0_BE:AD") == 0) {
+			else if (m0_streq(objtype->b0_name, "M0_BE:AD")) {
 				rec = (struct stob_ad_0type_rec *)opt.b_addr;
 				track_ad_btrees(rec, print_btree);
 			}
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
 
 	if (argc == 3 && m0_streq(argv[1], "st") &&
 	    (m0_streq(argv[2], "mkfs") || m0_streq(argv[2], "run"))) {
-		if (m0_streq(argv[2], "mkfs") == 0)
+		if (m0_streq(argv[2], "mkfs"))
 			rc = m0_betool_st_mkfs();
 		else
 			rc = m0_betool_st_run();


### PR DESCRIPTION
# Motivation and context

Sometime ago I tried to use m0betool to dump the contents of BE stobs. It did not work out really well. Then, after a quick round of debugging with gdb, I realized that this is just because "m0_streq(expr) == 0" pattern was used there. This PR contains a patch that addresses it.

# Testing

No testing was done, no tests were added in the patch. From what I've heard, we do not have system tests for the tool. Therefore, there is no way to test it except doing manual tests.

# Integration

It looks like the corresponding code is not in-use (otherwise, the bug would have been discovered already). So that, it does not look like the patch could break anything that is in-use.

<details>
  <summary>Click here to see the pull request template </summary>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
</details>