### PR TITLE
CORTX-32856 fom: don't long hung foms of DTM requests

### DIFF
--- a/fop/fom.c
+++ b/fop/fom.c
@@ -349,6 +349,10 @@ static bool hung_fom_notify(const struct m0_fom *fom)
 	if (M0_IN(fom->fo_type->ft_id, (M0_BE_TX_GROUP_OPCODE,
 					M0_ADDB_FOP_OPCODE,
 					M0_HA_LINK_OUTGOING_OPCODE,
+					M0_DTM0_REQ_OPCODE,
+					M0_DTM0_REDO_OPCODE,
+					M0_DTM0_RLINK_OPCODE,
+					M0_DTM0_RECOVERY_FOM_OPCODE,
 					M0_FDMI_SOURCE_DOCK_OPCODE)))
 	    return true;
 


### PR DESCRIPTION
Problem:
 As livenesss of DTM foms is longer they are logged as hung foms,
 which causes logs getting filled, due to which containers are evicted
 due to disk full.

Solution:
 Don't post the hung fom logs for DTM requests.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
