### PR TITLE
CORTX-33161 client: fix panic of RGW server

### DIFF
--- a/dtm0/recovery.c
+++ b/dtm0/recovery.c
@@ -1739,8 +1739,9 @@ static void remote_recovery_fom_coro(struct m0_fom *fom)
 
 		switch (F(state)) {
 		case M0_NC_DTM_RECOVERING:
-			F(action) = rf->rf_is_volatile ? heq_await :
-							 dtm0_restore;
+			F(action) = rf->rf_is_volatile ||
+				    recovery_fom_local(rf->rf_m)->rf_is_volatile ?
+				    	heq_await : dtm0_restore;
 			break;
 		case M0_NC_FAILED:
 			if (ALL2ALL)

--- a/dtm0/ut/main.c
+++ b/dtm0/ut/main.c
@@ -496,7 +496,7 @@ static void ut_remach_init(struct ut_remach *um)
 
 	m0_fi_enable("m0_dtm0_in_ut", "ut");
 	m0_fi_enable("is_manual_ss_enabled", "ut");
-	m0_fi_enable("m0_dtm0_is_expecting_redo_from_client", "ut");
+	/* m0_fi_enable("m0_dtm0_is_expecting_redo_from_client", "ut"); */
 	if (um->cp == UT_CP_PERSISTENT_CLIENT)
 		m0_fi_enable("is_svc_volatile", "always_false");
 
@@ -523,7 +523,7 @@ static void ut_remach_fini(struct ut_remach *um)
 	m0_ut_dtm0_helper_fini(&um->udh);
 	if (um->cp == UT_CP_PERSISTENT_CLIENT)
 		m0_fi_disable("is_svc_volatile", "always_false");
-	m0_fi_disable("m0_dtm0_is_expecting_redo_from_client", "ut");
+	/* m0_fi_disable("m0_dtm0_is_expecting_redo_from_client", "ut"); */
 	m0_fi_disable("is_manual_ss_enabled", "ut");
 	m0_fi_disable("m0_dtm0_in_ut", "ut");
 	for (i = 0; i < ARRAY_SIZE(um->recovered); ++i) {


### PR DESCRIPTION
Problem:
Following panic occured in RGW server,
0x00007fe42959810d in m0_panic (ctx=ctx@entry=0x7fe429a58da0 <signal_panic>) at lib/assert.c:52
0x00007fe4295a975c in sigsegv (sig=11) at lib/user_space/ucookie.c:52
<signal handler called>
0x00007fe42959ff6c in m0_tlist_next (d=d@entry=0x7fe4299c55a0 <lrec_tl>, list=0x55dc7fe1f6a0, obj=0x0) at lib/tlist.c:283
0x00007fe4294eb492 in lrec_tlist_next (amb=<optimized out>, list=<optimized out>) at be/dtm0_log.c:43
m0_be_dtm0_log_iter_next (iter=iter@entry=0x55dc84dccd38, out=out@entry=0x7fe41cc47ef0) at be/dtm0_log.c:689
0x00007fe429553704 in default_log_iter_next (m=<optimized out>, iter=<optimized out>, tgt_svc=<optimized out>,
origin_svc=<optimized out>, record=0x7fe41cc47ef0) at dtm0/recovery.c:2077
0x00007fe42955448e in recovery_machine_log_iter_next (origin_svc=0x0, record=0x7fe41cc47ef0, tgt_svc=0x55dc84dccd58,
iter=0x55dc84dccd38, m=<optimized out>) at dtm0/recovery.c:1057
dtm0_restore (fom=0x55dc84dcc000, out=<optimized out>, eoq=<optimized out>) at dtm0/recovery.c:1680
0x00007fe429551d81 in remote_recovery_fom_coro (fom=fom@entry=0x55dc84dcc000) at dtm0/recovery.c:1759
0x00007fe4295541ae in recovery_fom_coro (fom=fom@entry=0x55dc84dcc000) at dtm0/recovery.c:1947
0x00007fe4295542af in recovery_fom_tick (fom=0x55dc84dcc000) at dtm0/recovery.c:1954
0x00007fe4295689b4 in fom_exec (fom=0x55dc84dcc000) at fop/fom.c:804
loc_handler_thread (th=0x55dc7f10cb40) at fop/fom.c:944

Solution:
RGW servers or clients are volatile, they should not try to read
from persistent logs. Thus check is added to avoid reading of
persistent logs for clients.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
