### PR TITLE
DTM/recovery: Do not send REDO for transactions which happened after recovery started

### DIFF
--- a/be/dtm0_log.h
+++ b/be/dtm0_log.h
@@ -567,6 +567,17 @@ M0_INTERNAL void m0_be_dtm0_log_iter_fini(struct m0_be_dtm0_log_iter *iter);
 M0_INTERNAL int m0_be_dtm0_log_iter_next(struct m0_be_dtm0_log_iter *iter,
 					 struct m0_dtm0_log_rec     *out);
 
+/**
+ * Get ID of the last transaction (or -ENOENT) from the log.
+ *
+ * @param out returned ID.
+ *
+ * @return 0 when the log is not empty and out parameter is properly filled.
+ * @return  -ENOENT when the log is empty.
+ */
+M0_INTERNAL int m0_be_dtm0_log_get_last_dtxid(struct m0_be_dtm0_log *log,
+					      struct m0_dtm0_tid    *out);
+
 /** @} */ /* end DTM0Internals */
 
 #endif /* __MOTR_BE_DTM0_LOG_H__ */

--- a/dtm0/recovery.h
+++ b/dtm0/recovery.h
@@ -36,6 +36,7 @@ struct m0_conf_process;
 struct dtm0_req_fop;
 struct m0_be_dtm0_log_iter;
 struct m0_dtm0_log_rec;
+struct m0_dtm0_tid;
 struct m0_be_op;
 struct m0_fom;
 
@@ -80,21 +81,28 @@ struct m0_dtm0_recovery_machine_ops {
 
 	/**
 	 * Get next log record (or -ENOENT) from the local DTM0 log.
-	 * @param[in] tgt_svc DTM0 service this REDO shall be sent to.
-	 * @param[in,opt] origin_svc DTM0 service to be selected. When
-	 *                           this parameter is set to non-NULL,
-	 *                           the iter is supposed to select only
-	 *                           the log records that were originated
-	 *                           on this particular service.
+	 *
+	 * Note, this returns a deep copy of a record, and caller is responsible
+	 * for freeing it properly -- call m0_dtm0_log_iter_rec_fini.
 	 */
 	int (*log_iter_next)(struct m0_dtm0_recovery_machine   *m,
 			     struct m0_be_dtm0_log_iter        *iter,
-			     const struct m0_fid               *tgt_svc,
-			     const struct m0_fid               *origin_svc,
 			     struct m0_dtm0_log_rec            *record);
 
 	void (*log_iter_fini)(struct m0_dtm0_recovery_machine *m,
 			      struct m0_be_dtm0_log_iter      *iter);
+
+	/**
+	 * Get ID of the last transaction (or -ENOENT) from the local DTM0 log.
+	 */
+	int (*log_last_dtxid)(struct m0_dtm0_recovery_machine *m,
+			      struct m0_dtm0_tid              *out);
+	/**
+	 * Compare two transaction IDs (-1 less/0 equal/1 greater).
+	 */
+	int (*dtxid_cmp)(struct m0_dtm0_recovery_machine *m,
+			 struct m0_dtm0_tid              *left,
+			 struct m0_dtm0_tid              *right);
 };
 
 


### PR DESCRIPTION
Re-opens the same fix as in PR #1846.

Problem: under load, with continuous S3 IO, recovery will never end -- new entries will be continuously added to the end of the log, and recovery machine will keep replaying them forever.

Solution: Remember last entry in the log at the start of recovery, and stop recovery when reaching that point.  All new transactions added after will not be replayed.

Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
