### PR TITLE
[DTM] Add Client eviction

### DIFF
--- a/be/dtm0_log.c
+++ b/be/dtm0_log.c
@@ -698,6 +698,9 @@ M0_INTERNAL int m0_be_dtm0_log_iter_next(struct m0_be_dtm0_log_iter *iter,
 			return M0_ERR(rc);
 	}
 
+	if (rec)
+		M0_LOG(M0_DEBUG, "next record dtxid: " DTID0_F,
+		       DTID0_P(&rec->dlr_txd.dtd_id));
 	return M0_RC(rec != NULL ? 0 : -ENOENT);
 }
 
@@ -730,6 +733,7 @@ M0_INTERNAL int m0_be_dtm0_log_get_last_dtxid(struct m0_be_dtm0_log *log,
 
 	if (rec != NULL) {
 		*out = rec->dlr_txd.dtd_id;
+		M0_LOG(M0_DEBUG, "tail entry dtxid: " DTID0_F, DTID0_P(out));
 		rc = 0;
 	} else
 		rc = -ENOENT;

--- a/dtm0/fop.h
+++ b/dtm0/fop.h
@@ -69,11 +69,13 @@ struct dtm0_req_fop {
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 
-#define REDO_F "redo={ txid=" DTID0_F ", ini=" FID_F ", is_eol=%d }"
+#define REDO_F "redo={ txid=" DTID0_F ", ini=" FID_F ", is_eol=%d " \
+	       "is_eviction=%d }"
 #define REDO_P(_redo)                       \
 	DTID0_P(&(_redo)->dtr_txr.dtd_id),  \
 	FID_P(&(_redo)->dtr_initiator),      \
-	!!((_redo)->dtr_flags & M0_BITS(M0_DMF_EOL))
+	!!((_redo)->dtr_flags & M0_BITS(M0_DMF_EOL)), \
+	!!((_redo)->dtr_flags & M0_BITS(M0_DMF_EVICTION))
 
 struct dtm0_rep_fop {
 	/** Status code of dtm operation. */

--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -522,6 +522,9 @@ function recovery_phase()
 
     client_wait
 
+    _info "Sleeping 5 sec to prevent victim catching client eviction REDOs"
+    sleep 5
+
     # TODO: Run ctgcmp to ensure mykey3 does not exist in the victim's storage.
 
     _info "Resurrect the victim: $svc_name"

--- a/dtm0/recovery.h
+++ b/dtm0/recovery.h
@@ -63,7 +63,6 @@ struct m0_dtm0_recovery_machine_ops {
 	 */
 	void (*redo_post)(struct m0_dtm0_recovery_machine *m,
 			  struct m0_fom                   *fom,
-			  const struct m0_fid             *tgt_proc,
 			  const struct m0_fid             *tgt_svc,
 			  struct dtm0_req_fop             *redo,
 			  struct m0_be_op                 *op);
@@ -103,6 +102,12 @@ struct m0_dtm0_recovery_machine_ops {
 	int (*dtxid_cmp)(struct m0_dtm0_recovery_machine *m,
 			 struct m0_dtm0_tid              *left,
 			 struct m0_dtm0_tid              *right);
+
+	/**
+	 * Callback for the moment when eviction is completed.
+	 */
+	void (*evicted)(struct m0_dtm0_recovery_machine *m,
+			const struct m0_fid             *tgt_svc);
 };
 
 

--- a/dtm0/tx_desc.c
+++ b/dtm0/tx_desc.c
@@ -130,7 +130,7 @@ M0_INTERNAL void m0_dtm0_tx_desc_apply(struct m0_dtm0_tx_desc *tgt,
 	struct m0_dtm0_tx_pa *tgt_pa;
 	struct m0_dtm0_tx_pa *upd_pa;
 
-	M0_ENTRY();
+	M0_ENTRY("updating dtxid " DTID0_F, DTID0_P(&tgt->dtd_id));
 
 	M0_PRE(m0_dtm0_tx_desc__invariant(tgt));
 	M0_PRE(m0_dtm0_tx_desc__invariant(upd));
@@ -143,9 +143,10 @@ M0_INTERNAL void m0_dtm0_tx_desc_apply(struct m0_dtm0_tx_desc *tgt,
 	for (i = 0; i < upd->dtd_ps.dtp_nr; ++i) {
 		tgt_pa = &tgt->dtd_ps.dtp_pa[i];
 		upd_pa = &upd->dtd_ps.dtp_pa[i];
-
+		M0_LOG(M0_DEBUG, "tgt state %" PRIu32 ", upd state %" PRIu32,
+		       tgt_pa->p_state, upd_pa->p_state);
 		tgt_pa->p_state = max_check(tgt_pa->p_state,
-					     upd_pa->p_state);
+					    upd_pa->p_state);
 	}
 
 	M0_LEAVE();


### PR DESCRIPTION
Note: PR #1967 must be merged first.

Problem: When client is terminated, all volatile state is lost.  If the failure happened in the middle of a distributed transaction, some of CAS requests may be 'lost', not sent to participants.  In this case, some participants are updated to new value, and some are not.  There is currently no mechanism to heal this inconsistency.

Solution: In this case, participants who _did_ get CAS requests from this client, must re-send them to all remaining participants who did not yet report Pmsg on these transactions.  So when we recieve an HA event that a client is offline (failed or transient), we send REDOs for all non-all-P transcactions coming from that client.  This process is called "client eviction".

Additional unrelated change done as part of this PR:

* Remove unneeded locks in m0_ut_remach_heq_post

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
