### PR TITLE
CORTX-33577: fix panic in degraded mode read

### DIFF
--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -1928,8 +1928,14 @@ out:
 		 *    The units needed for recvoery are ready.
 		 */
 		M0_ASSERT(ioreq_sm_state(ioo) == IRS_DEGRADED_READING);
-		M0_ASSERT(op->op_code == M0_OC_READ &&
-			  instance->m0c_config->mc_is_read_verify);
+		if (op->op_code == M0_OC_READ &&
+		    instance->m0c_config->mc_is_read_verify) {
+			M0_LOG(M0_DEBUG, "As per design in Read verify mode");
+		} else {
+			M0_LOG(M0_ERROR, "More than K targets are offline");
+			rc = -EIO;
+		}
+
 		ioreq_sm_state_set_locked(ioo, IRS_READ_COMPLETE);
 	} else if (rc == 0)
 		xfer->nxr_state = NXS_INFLIGHT;

--- a/motr/io_nw_xfer.c
+++ b/motr/io_nw_xfer.c
@@ -1925,7 +1925,7 @@ out:
 		 *    In 'parity verify' mode, a whole parity group, including
 		 *    data and parity units are all read from ioservices.
 		 *    If some units failed to read, no need to read extra unit.
-		 *    The units needed for recvoery are ready.
+		 *    The units needed for recovery are ready.
 		 */
 		M0_ASSERT(ioreq_sm_state(ioo) == IRS_DEGRADED_READING);
 		if (op->op_code == M0_OC_READ &&


### PR DESCRIPTION
It might be possible that in degraded mode we may land up in a situation
where there are more than K failures and read_verify_is not true. In this
case, ideally, we should return proper error code (-EIO) instead of assert.

# Problem
It might be possible that in degraded mode we may land up in a situation
where there are more than K failures and read_verify_is not true.

# Design 
In this case, ideally, we should return proper error code (-EIO) instead of assert.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
