### PR TITLE
DTM0: detect ctgdump failures in all2all script

### DIFF
--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -392,7 +392,9 @@ function ctgdump()
     mkdir -p $out_dir
 
     _info "$cmd $cmd_args"
-    $cmd $cmd_args | sort > "$out_file"
+    (set -o pipefail
+     $cmd $cmd_args | sort > "$out_file"
+    )
 }
 
 function ctg_eq()
@@ -423,7 +425,10 @@ function check_ctg_consistency()
     rm -fR "$CTGDUMP_DIR"
 
     for i in $(seq 0 $((${#M0D_FIDS_HEX[@]}-1))); do
-        ctgdump $i
+        if ! ctgdump $i; then
+            _err "ctgdump failed, terminating."
+            exit 1
+        fi
     done
 
     for i in ${targets[@]}; do


### PR DESCRIPTION
Earlier, ctgdump failures were ignored, and certain issues were not detected in integration test.  For example -- recent b-tree changes broke ctgdump (it crashes with core dumps), but all2all did not "notice" these crashes and reported success.

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
