### PR TITLE
CORTX-33586: ctgdump is crashing after new btree merge

### DIFF
--- a/be/extmap.c
+++ b/be/extmap.c
@@ -349,10 +349,9 @@ m0_be_emap_init(struct m0_be_emap *map, struct m0_be_seg *db)
 {
 	struct m0_btree_op         b_op = {};
 	int                        rc;
-	struct m0_btree_rec_key_op keycmp;
+	struct m0_btree_rec_key_op keycmp = { .rko_keycmp = be_emap_cmp };
 	be_emap_init(map, db);
 
-	keycmp.rko_keycmp = be_emap_cmp;
 	M0_ALLOC_PTR(map->em_mapping);
 	if (map->em_mapping == NULL)
 		M0_ASSERT(0);
@@ -388,7 +387,7 @@ M0_INTERNAL void m0_be_emap_create(struct m0_be_emap   *map,
 	struct m0_btree_op         b_op = {};
 	struct m0_fid              fid;
 	int                        rc;
-	struct m0_btree_rec_key_op keycmp;
+	struct m0_btree_rec_key_op keycmp = { .rko_keycmp = be_emap_cmp };
 	M0_PRE(map->em_seg != NULL);
 
 	m0_be_op_active(op);
@@ -402,7 +401,7 @@ M0_INTERNAL void m0_be_emap_create(struct m0_be_emap   *map,
 		.ksize = sizeof(struct m0_be_emap_key),
 		.vsize = -1,
 	};
-	keycmp.rko_keycmp = be_emap_cmp;
+
 	fid = M0_FID_TINIT('b', M0_BT_EMAP_EM_MAPPING, bfid->f_key);
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
 				      m0_btree_create(&map->em_mp_node,

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -441,10 +441,12 @@ static void ctg_fini(struct m0_cas_ctg *ctg)
 	M0_ENTRY("ctg=%p", ctg);
 
 	ctg->cc_inited = false;
-	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
-				      m0_btree_close(ctg->cc_tree, &b_op));
-	M0_ASSERT(rc == 0);
-	m0_free0(&ctg->cc_tree);
+	if (ctg->cc_tree != NULL) {
+		rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op,
+					   m0_btree_close(ctg->cc_tree, &b_op));
+		M0_ASSERT(rc == 0);
+		m0_free0(&ctg->cc_tree);
+	}
 	m0_long_lock_fini(m0_ctg_lock(ctg));
 	m0_chan_fini_lock(&ctg->cc_chan.bch_chan);
 	m0_mutex_fini(&ctg->cc_chan_guard.bm_u.mutex);
@@ -505,6 +507,7 @@ int m0_ctg_create(struct m0_be_seg *seg, struct m0_be_tx *tx,
 						      &b_op, ctg->cc_tree,
 						      seg, fid, tx, &key_cmp));
 	if (rc != 0) {
+		m0_free0(&ctg->cc_tree);
 		ctg_fini(ctg);
 		M0_BE_FREE_PTR_SYNC(ctg, seg, tx);
 	}
@@ -523,6 +526,7 @@ static void ctg_destroy(struct m0_cas_ctg *ctg, struct m0_be_tx *tx)
 	rc = M0_BTREE_OP_SYNC_WITH_RC(&b_op, m0_btree_destroy(ctg->cc_tree,
 							      &b_op, tx));
 	M0_ASSERT(rc == 0);
+	m0_free0(&ctg->cc_tree);
 	ctg_fini(ctg);
 	M0_BE_FREE_PTR_SYNC(ctg, cas_seg(tx->t_engine->eng_domain), tx);
 }
@@ -2468,15 +2472,12 @@ M0_INTERNAL int ctg_index_btree_dump(struct m0_motr *motr_ctx,
                                      struct m0_cas_ctg *ctg,
 				     bool dump_in_hex)
 {
-	struct m0_be_seg       *seg =
-				  cas_seg(&motr_ctx->cc_reqh_ctx.rc_be.but_dom);
 	struct m0_buf           key;
 	struct m0_buf           val;
 	struct m0_btree_cursor  cursor;
 	int                     rc;
 
-	ctg_init(ctg, seg);
-	ctg_open(ctg, seg);
+	ctg_open(ctg, cas_seg(&motr_ctx->cc_reqh_ctx.rc_be.but_dom));
 
 	m0_btree_cursor_init(&cursor, ctg->cc_tree);
 	for (rc = m0_btree_cursor_first(&cursor); rc == 0;

--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -436,7 +436,7 @@ static void ctg_open(struct m0_cas_ctg *ctg, struct m0_be_seg *seg)
 static void ctg_fini(struct m0_cas_ctg *ctg)
 {
 	struct m0_btree_op b_op = {};
-	int                rc   = 0;
+	int                rc;
 
 	M0_ENTRY("ctg=%p", ctg);
 


### PR DESCRIPTION
Issue:
- ctg_open() is responsible for allocating tree pointer and
  opening the btree. This was missing before accessing the
  catalogue tree in the ctgdump().

Fix:
- Added ctg_open() call before accessing tree pointer.
- Added m0_btree_close() to close tree in ctg_fini().

Signed-off-by: Kanchan Chaudhari <kanchan.chaudhari@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
