### PR TITLE
dtm0/it: fix all2all CDF according to new changes in hare

### DIFF
--- a/dtm0/it/all2all/cdf.yaml
+++ b/dtm0/it/all2all/cdf.yaml
@@ -7,18 +7,22 @@ nodes:
       - runs_confd: true
         io_disks:
           data: []
+          log: []
       - io_disks:
           data:
             - path: /dev/loop0
             - path: /dev/loop1
+          log: []
       - io_disks:
           data:
             - path: /dev/loop2
             - path: /dev/loop3
+          log: []
       - io_disks:
           data:
             - path: /dev/loop4
             - path: /dev/loop5
+          log: []
     m0_clients:
         - name: motr_client
           instances: 1


### PR DESCRIPTION
Problem:
The log device support has been added for hare CDF
 * https://github.com/Seagate/cortx-hare/pull/2136

that leads to CDF format errors during cluster bootstrap
in all2all DTM0 integration test.

Solution:
Add missing log sections for confd and m0d into CDF.
In case of DTM0 integration test that sections contains an
empty devices list.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>