### PR TITLE
CORTX-33021 : [F-58E]: Avoid redundant logs, improve log relevance: Motr

### DIFF
--- a/lib/memory.c
+++ b/lib/memory.c
@@ -146,8 +146,6 @@ void m0_free(void *data)
 	if (data != NULL) {
 		size_t size = m0_arch_alloc_size(data);
 
-		M0_LOG(M0_DEBUG, "%p", data);
-
 		if (DEV_MODE) {
 			m0_atomic64_sub(&allocated, size);
 			m0_atomic64_add(&cumulative_free, size);

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -127,7 +127,6 @@ void *m0_alloc(size_t size)
 {
 	void *area;
 
-	M0_ENTRY("size=%zi", size);
 	if (M0_FI_ENABLED("fail_allocation"))
 		return NULL;
 	area = m0_arch_alloc(size);
@@ -138,7 +137,6 @@ void *m0_alloc(size_t size)
 		M0_LOG(M0_ERROR, "Failed to allocate %zi bytes.", size);
 		m0_backtrace();
 	}
-	M0_LEAVE("ptr=%p size=%zi", area, size);
 	return area;
 }
 M0_EXPORTED(m0_alloc);

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -127,6 +127,8 @@ void *m0_alloc(size_t size)
 {
 	void *area;
 
+        /* 9% of logs in m0trace log file is due to M0_ENTRY  and M0_LEAVE */
+	//M0_ENTRY("size=%zi", size);
 	if (M0_FI_ENABLED("fail_allocation"))
 		return NULL;
 	area = m0_arch_alloc(size);
@@ -137,6 +139,7 @@ void *m0_alloc(size_t size)
 		M0_LOG(M0_ERROR, "Failed to allocate %zi bytes.", size);
 		m0_backtrace();
 	}
+	//M0_LEAVE("ptr=%p size=%zi", area, size);
 	return area;
 }
 M0_EXPORTED(m0_alloc);
@@ -145,6 +148,9 @@ void m0_free(void *data)
 {
 	if (data != NULL) {
 		size_t size = m0_arch_alloc_size(data);
+
+                /* 5% of logs in m0trace log file is m0_free */
+		//M0_LOG(M0_DEBUG, "%p", data);
 
 		if (DEV_MODE) {
 			m0_atomic64_sub(&allocated, size);


### PR DESCRIPTION
Removed  M0_ENTRY and M0_LEAVE from m0_alloc

Signed-off-by: Papan Kumar Singh <papan.kumarsingh@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
