### PR TITLE
CORTX-32897: Support default parameters for pre-merge job

### DIFF
--- a/scripts/install/usr/libexec/cortx-motr/motr-cleanup
+++ b/scripts/install/usr/libexec/cortx-motr/motr-cleanup
@@ -43,7 +43,7 @@ for s in m0d@* m0t1fs@* motr-client motr-kernel motr-mkfs motr-mkfs@* motr-serve
 	motr_services="$motr_services $s.service"
 done
 
-systemctl list-units --all $motr_services
+systemctl list-units --all $motr_services | tee
 
 m0_log 'Stopping motr-kernel with all dependencies ...'
 systemctl stop motr-kernel || m0_exit 'Failed to stop motr-kernel.'
@@ -51,7 +51,7 @@ systemctl stop motr-kernel || m0_exit 'Failed to stop motr-kernel.'
 m0_log 'Stopping all Motr services ...'
 systemctl stop $motr_services || m0_exit 'Failed to stop Motr services.'
 
-systemctl list-units --all $motr_services
+systemctl list-units --all $motr_services | tee
 
 for s in $(systemctl list-units --failed $motr_services | awk '/failed/ {if ($4 == "failed") print $2}'); do
 	m0_log "Resetting failed state for $s."


### PR DESCRIPTION
Since Motr-Hare-Single-Node-Cluster-Deployment-On-Rocky-Linux
will be used as a pre merge job we need to remove the parameters
that it accepts and run the job on dedicated machines.

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
Cannot give parameters to pre merge job Motr-Hare-Single-Node-Cluster-Deployment-On-Rocky-Linux.

# Design
Modified the job to run on dedicated machines.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
