### PR TITLE
CORTX-33605: Support DTM0 recovery for CAS DEL operations

### DIFF
--- a/cas/cas.h
+++ b/cas/cas.h
@@ -405,10 +405,10 @@ struct m0_cas_op {
  * The structure to be passed in DTM0 log as a payload
  */
 struct m0_cas_dtm0_log_payload  {
-   /**  CAS op */
-	struct m0_cas_op  cdg_cas_op;
+        /**  CAS op */
+	struct m0_cas_op cdg_cas_op;
 	/** CAS operation code */
-	uint32_t          cdg_cas_opcode;
+	uint32_t         cdg_cas_opcode;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 /**

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -406,7 +406,7 @@ struct m0_cas_op {
 struct m0_cas_dtm0_log_payload  {
 	/** CAS op */
 	struct m0_cas_op cdg_cas_op;
-	/** CAS operation code */
+	/** CAS rpc fop/item opcode */
 	uint32_t         cdg_cas_opcode;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -366,6 +366,7 @@ enum m0_cas_type {
 	CT_MEM
 } M0_XCA_ENUM;
 
+
 /**
  * CAS-GET, CAS-PUT, CAS-DEL and CAS-CUR fops.
  *
@@ -398,6 +399,16 @@ struct m0_cas_op {
 	 * Transaction descriptor associated with CAS operation.
 	 */
 	struct m0_dtm0_tx_desc cg_txd;
+} M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
+
+/**
+ * The structure to be passed in DTM0 log as a payload
+ */
+struct m0_cas_dtm0_log_payload  {
+   /**  CAS op */
+	struct m0_cas_op  cdg_cas_op;
+	/** CAS operation code */
+	uint32_t          cdg_cas_opcode;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);
 
 /**

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -404,8 +404,8 @@ struct m0_cas_op {
  * The structure to be passed in DTM0 log as a payload
  */
 struct m0_cas_dtm0_log_payload  {
-        /**  CAS op */
-	struct           m0_cas_op cdg_cas_op;
+	/** CAS op */
+	struct m0_cas_op cdg_cas_op;
 	/** CAS operation code */
 	uint32_t         cdg_cas_opcode;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);

--- a/cas/cas.h
+++ b/cas/cas.h
@@ -366,7 +366,6 @@ enum m0_cas_type {
 	CT_MEM
 } M0_XCA_ENUM;
 
-
 /**
  * CAS-GET, CAS-PUT, CAS-DEL and CAS-CUR fops.
  *
@@ -406,7 +405,7 @@ struct m0_cas_op {
  */
 struct m0_cas_dtm0_log_payload  {
         /**  CAS op */
-	struct m0_cas_op cdg_cas_op;
+	struct           m0_cas_op cdg_cas_op;
 	/** CAS operation code */
 	uint32_t         cdg_cas_opcode;
 } M0_XCA_RECORD M0_XCA_DOMAIN(rpc);

--- a/cas/service.c
+++ b/cas/service.c
@@ -1135,7 +1135,7 @@ static int cas_dtm0_logrec_add(struct m0_fom *fom0,
 	}
 	dtm_payload.cdg_cas_op = *cas_op(fom0);
 	dtm_payload.cdg_cas_opcode = m0_fop_opcode(fom0->fo_fop);
-	if(dtm_payload.cdg_cas_opcode == M0_CAS_DEL_FOP_OPCODE) {
+	if (dtm_payload.cdg_cas_opcode == M0_CAS_DEL_FOP_OPCODE) {
 		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.ab_type = M0_RPC_AT_EMPTY;
 		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.u.ab_buf = M0_BUF_INIT0;
 	}
@@ -1939,11 +1939,11 @@ static int cas_id_check(const struct m0_cas_id *cid, const struct cas_fom *fom)
 			if (svc->c_sdev_id != INVALID_CAS_SDEV_ID &&
 			    svc->c_sdev_id != device_id &&
 			    cas_type(&fom->cf_fom) != CT_META) {
-				return M0_ERR_INFO(-EPROTO, 
+				return M0_ERR_INFO(-EPROTO,
 						   "Incorrect device ID (%d) "
 						   "found in component "
 						   "catalogue FID. Valid device"
-						   " ID should be %d", 
+						   " ID should be %d",
 						   device_id, svc->c_sdev_id);
 			}
 		}

--- a/cas/service.c
+++ b/cas/service.c
@@ -1136,10 +1136,12 @@ static int cas_dtm0_logrec_add(struct m0_fom *fom0,
 	dtm_payload.cdg_cas_op = *cas_op(fom0);
 	dtm_payload.cdg_cas_opcode = m0_fop_opcode(fom0->fo_fop);
 	if (dtm_payload.cdg_cas_opcode == M0_CAS_DEL_FOP_OPCODE) {
-		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.ab_type = M0_RPC_AT_EMPTY;
-		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.u.ab_buf = M0_BUF_INIT0;
+		struct m0_cas_rec *rec = dtm_payload.cdg_cas_op.cg_rec.cr_rec;
+		rec->cr_val.ab_type = M0_RPC_AT_EMPTY;
+		rec->cr_val.u.ab_buf = M0_BUF_INIT0;
 	}
-	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_dtm0_log_payload_xc, &dtm_payload),
+	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_dtm0_log_payload_xc,
+						   &dtm_payload),
 				     &buf.b_addr, &buf.b_nob) ?:
 		m0_dtm0_logrec_update(dtms->dos_log, &fom0->fo_tx.tx_betx, msg,
 				      &buf);

--- a/cas/service.c
+++ b/cas/service.c
@@ -1132,8 +1132,12 @@ static int cas_dtm0_logrec_add(struct m0_fom *fom0,
 			break;
 		}
 	}
-	memcpy(&dtm_payload.cdg_cas_op, cas_op(fom0), sizeof(dtm_payload.cdg_cas_op));
+	dtm_payload.cdg_cas_op = *cas_op(fom0);
 	dtm_payload.cdg_cas_opcode = m0_fop_opcode(fom0->fo_fop);
+	if(dtm_payload.cdg_cas_opcode == M0_CAS_DEL_FOP_OPCODE) {
+		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.ab_type = M0_RPC_AT_EMPTY;
+		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.u.ab_buf = M0_BUF_INIT0;
+	}
 	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_dtm0_log_payload_xc, &dtm_payload),
 				     &buf.b_addr, &buf.b_nob) ?:
 		m0_dtm0_logrec_update(dtms->dos_log, &fom0->fo_tx.tx_betx, msg,

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -648,7 +648,7 @@ static int dtm0_rmsg_fom_tick(struct m0_fom *fom)
 				    M0_CONF_HA_PROCESS_DTM_RECOVERED);
 		*/
 		rc = dtm0_cas_fop_prepare(dfom->dtf_fom.fo_service->rs_reqh,
-					  req,  &cas_fop);
+					  req, &cas_fop);
 		if (rc == 0) {
 			rc = dtm0_cas_fom_spawn(dfom, cas_fop,
 						&dtm0_cas_done_cb);

--- a/dtm0/fop.c
+++ b/dtm0/fop.c
@@ -61,7 +61,6 @@ static void dtm0_fom_fini(struct m0_fom *fom);
 static size_t dtm0_fom_locality(const struct m0_fom *fom);
 static int dtm0_cas_fop_prepare(struct m0_reqh      *reqh,
 				struct dtm0_req_fop *req,
-				struct m0_fop_type  *cas_fopt,
 				struct m0_fop      **cas_fop_out);
 static int dtm0_cas_fom_spawn(
 	struct dtm0_fom *dfom,
@@ -568,28 +567,35 @@ static void dtm0_cas_sdev_id_set(
 
 static int dtm0_cas_fop_prepare(struct m0_reqh      *reqh,
 				struct dtm0_req_fop *req,
-				struct m0_fop_type  *cas_fopt,
 				struct m0_fop      **cas_fop_out)
 {
-	int               rc;
-	struct m0_cas_op *cas_op;
-	struct m0_fop    *cas_fop;
-
+	int                             rc;
+	struct m0_cas_op               *cas_op;
+	struct m0_fop                  *cas_fop;
+	struct m0_cas_dtm0_log_payload *dtm_payload;
+	struct m0_fop_type             *cas_fopt = NULL;
 	M0_ENTRY();
 
 	*cas_fop_out = NULL;
 
-	M0_ALLOC_PTR(cas_op);
+	M0_ALLOC_PTR(dtm_payload);
 	M0_ALLOC_PTR(cas_fop);
 
-	if (cas_op == NULL || cas_fop == NULL) {
+	if (dtm_payload == NULL || cas_fop == NULL) {
 		rc = -ENOMEM;
 	} else {
 		rc = m0_xcode_obj_dec_from_buf(
-			&M0_XCODE_OBJ(m0_cas_op_xc, cas_op),
+			&M0_XCODE_OBJ(m0_cas_dtm0_log_payload_xc, dtm_payload),
 			req->dtr_payload.b_addr,
 			req->dtr_payload.b_nob);
 		if (rc == 0) {
+			cas_op = &dtm_payload->cdg_cas_op;
+			if (dtm_payload->cdg_cas_opcode == M0_CAS_PUT_FOP_OPCODE)
+				 cas_fopt = &cas_put_fopt;
+			else if(dtm_payload->cdg_cas_opcode == M0_CAS_DEL_FOP_OPCODE)
+				 cas_fopt = &cas_del_fopt;
+			M0_ASSERT(cas_fopt != NULL);
+
 			dtm0_cas_sdev_id_set(
 				reqh, cas_fopt->ft_fom_type.ft_rstype, cas_op);
 			m0_fop_init(cas_fop, cas_fopt, cas_op,
@@ -601,7 +607,7 @@ static int dtm0_cas_fop_prepare(struct m0_reqh      *reqh,
 	if (rc == 0) {
 		*cas_fop_out = cas_fop;
 	} else {
-		m0_free(cas_op);
+		m0_free(dtm_payload);
 		m0_free(cas_fop);
 	}
 
@@ -642,7 +648,7 @@ static int dtm0_rmsg_fom_tick(struct m0_fom *fom)
 				    M0_CONF_HA_PROCESS_DTM_RECOVERED);
 		*/
 		rc = dtm0_cas_fop_prepare(dfom->dtf_fom.fo_service->rs_reqh,
-					  req, &cas_put_fopt, &cas_fop);
+					  req,  &cas_fop);
 		if (rc == 0) {
 			rc = dtm0_cas_fom_spawn(dfom, cas_fop,
 						&dtm0_cas_done_cb);

--- a/motr/ut/idx_dix.c
+++ b/motr/ut/idx_dix.c
@@ -29,6 +29,7 @@
 #include "ut/ut.h"
 #include "ut/misc.h"                /* M0_UT_CONF_PROFILE */
 #include "rpc/rpclib.h"             /* m0_rpc_server_ctx */
+#include "rpc/rpc_opcodes.h"
 #include "fid/fid.h"
 #include "motr/client.h"
 #include "motr/client_internal.h"
@@ -314,7 +315,7 @@ static void ut_dix_namei_ops(bool dist, uint32_t flags)
 	int                  rc;
 	struct m0_op_common *oc;
 	struct m0_op_idx    *oi;
-	
+
 	idx_dix_ut_init();
 	m0_container_init(&realm, NULL, &M0_UBER_REALM, ut_m0c);
 	general_ifid_fill(&ifid, dist);
@@ -1119,20 +1120,21 @@ static void dtm0_ut_cas_op_prepare(const struct m0_fid    *cfid,
 }
 
 static void dtm0_ut_send_redo(const struct m0_fid *ifid, uint32_t sdev_id,
-			      uint64_t *key, uint64_t *val)
+			      uint64_t *key, uint64_t *val, uint32_t opcode)
 {
-	int                     rc;
-	struct dtm0_req_fop     req = { .dtr_msg = DTM_REDO };
-	struct m0_dtm0_tx_desc  txr = {};
-	struct m0_dtm0_clk_src  dcs;
-	struct m0_dtm0_ts       now;
-	struct m0_dtm0_service *dtm0 = ut_m0c->m0c_dtms;
-	struct m0_buf           payload;
-	struct m0_cas_op        cas_op = {};
-	struct m0_cas_rec       cas_rec = {};
-	struct m0_fid           srv_dtm0_fid;
-	struct m0_fid           srv_proc_fid;
-	struct m0_fid           cctg_fid;
+	int                            rc;
+	struct dtm0_req_fop            req = { .dtr_msg = DTM_REDO };
+	struct m0_dtm0_tx_desc         txr = {};
+	struct m0_dtm0_clk_src         dcs;
+	struct m0_dtm0_ts              now;
+	struct m0_dtm0_service        *dtm0 = ut_m0c->m0c_dtms;
+	struct m0_buf                  payload;
+	struct m0_cas_op               cas_op = {};
+	struct m0_cas_rec              cas_rec = {};
+	struct m0_fid                  srv_dtm0_fid;
+	struct m0_fid                  srv_proc_fid;
+	struct m0_fid                  cctg_fid;
+	struct m0_cas_dtm0_log_payload dtm_payload;
 	/*
 	 * FIXME: this zeroed fom is added by DTM0 team mates' request
 	 * to make the merge easier as there is a massive parallel work.
@@ -1163,8 +1165,16 @@ static void dtm0_ut_send_redo(const struct m0_fid *ifid, uint32_t sdev_id,
 	m0_dix_fid_convert_dix2cctg(ifid, &cctg_fid, sdev_id);
 
 	dtm0_ut_cas_op_prepare(&cctg_fid, &cas_op, &cas_rec, key, val, &txr);
-
-	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_op_xc, &cas_op),
+	dtm_payload.cdg_cas_op = cas_op;
+	dtm_payload.cdg_cas_opcode = opcode;
+	if (opcode == M0_CAS_DEL_FOP_OPCODE) {
+		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.ab_type =
+								M0_RPC_AT_EMPTY;
+		dtm_payload.cdg_cas_op.cg_rec.cr_rec->cr_val.u.ab_buf =
+								M0_BUF_INIT0;
+	}
+	rc = m0_xcode_obj_enc_to_buf(&M0_XCODE_OBJ(m0_cas_dtm0_log_payload_xc,
+						   &dtm_payload),
 				     &payload.b_addr, &payload.b_nob);
 	M0_UT_ASSERT(rc == 0);
 
@@ -1183,7 +1193,7 @@ static void dtm0_ut_send_redo(const struct m0_fid *ifid, uint32_t sdev_id,
 	M0_UT_ASSERT(rc == 0);
 }
 
-static void dtm0_ut_read_and_check(uint64_t key, uint64_t val)
+static void dtm0_ut_read_and_check(uint64_t key, uint64_t val, uint32_t opcode)
 {
 	struct m0_idx      *idx = &duc.duc_idx;
 	struct m0_op       *op = NULL;
@@ -1202,11 +1212,16 @@ static void dtm0_ut_read_and_check(uint64_t key, uint64_t val)
 	m0_op_launch(&op, 1);
 	rc = m0_op_wait(op, M0_BITS(M0_OS_STABLE), WAIT_TIMEOUT);
 	M0_UT_ASSERT(rc == 0);
-	M0_UT_ASSERT(rcs[0] == 0);
-	M0_UT_ASSERT(vals.ov_vec.v_nr == 1);
-	M0_UT_ASSERT(vals.ov_vec.v_count[0] == sizeof(val));
-	M0_UT_ASSERT(vals.ov_buf[0] != NULL);
-	M0_UT_ASSERT(*(uint64_t *)vals.ov_buf[0] == val);
+	if (opcode == M0_CAS_PUT_FOP_OPCODE) {
+		M0_UT_ASSERT(rcs[0] == 0);
+		M0_UT_ASSERT(vals.ov_vec.v_nr == 1);
+		M0_UT_ASSERT(vals.ov_vec.v_count[0] == sizeof(val));
+		M0_UT_ASSERT(vals.ov_buf[0] != NULL);
+		M0_UT_ASSERT(*(uint64_t *)vals.ov_buf[0] == val);
+	}
+	else if (opcode == M0_CAS_DEL_FOP_OPCODE) {
+		 M0_UT_ASSERT(rcs[0] == -ENOENT);
+	}
 	m0_bufvec_free(&keys);
 	m0_bufvec_free(&vals);
 	m0_op_fini(op);
@@ -1276,15 +1291,34 @@ static void st_dtm0_r_common(uint32_t sdev_id)
 		return;
 
 	idx_setup();
+	/** PUT redo */
 	exec_one_by_one(1, M0_IC_PUT);
-	dtm0_ut_send_redo(&duc.duc_ifid, sdev_id, &key, &val);
+	dtm0_ut_send_redo(&duc.duc_ifid, sdev_id, &key, &val,
+			  M0_CAS_PUT_FOP_OPCODE);
 
 	/* XXX dirty hack, but now we don't have completion notification */
 	rem = 2ULL * M0_TIME_ONE_SECOND;
         while (rem != 0)
                 m0_nanosleep(rem, &rem);
 
-	dtm0_ut_read_and_check(key, val);
+	dtm0_ut_read_and_check(key, val, M0_CAS_PUT_FOP_OPCODE);
+
+	idx_teardown();
+
+	/** Delete Redo */
+	idx_setup();
+	exec_one_by_one(1, M0_IC_PUT);
+	exec_one_by_one(1, M0_IC_DEL);
+
+	dtm0_ut_send_redo(&duc.duc_ifid, sdev_id, &key, &val,
+			  M0_CAS_DEL_FOP_OPCODE);
+
+	/* XXX dirty hack, but now we don't have completion notification */
+	rem = 2ULL * M0_TIME_ONE_SECOND;
+        while (rem != 0)
+                m0_nanosleep(rem, &rem);
+
+	dtm0_ut_read_and_check(key, val, M0_CAS_DEL_FOP_OPCODE);
 	idx_teardown();
 }
 


### PR DESCRIPTION
# Problem Statement
- Currently each DTM0 log record contains m0_cas_op as a payload, but m0_cas_op structure does not contain operation type. 
-  So that each REDO packet is treated as CAS PUT by default. In order to recover CAS DEL we need to distinguish the CAS 
-  operation type on the REDO receiver side during recovery process.

# Design
-  introduce a new structure that contains operation type (RPC opcode can be used) and m0_cas_op. This structure is serialized using XCODE and stored in DTM0 log as a payload. During recovery process this payload is sent as a part of REDO packet. The REDO receiver should de-serialize this payload

# Coding
   Checklist for Author
-  [ x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit Tests are added
- [x] Validated with all2all_del with motr-hare 
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
