### PR TITLE
dtm0/it: execute index operations in a single transaction

### DIFF
--- a/dtm0/it/all2all/all2all
+++ b/dtm0/it/all2all/all2all
@@ -346,7 +346,7 @@ function m0kv_async()
     args=$(python3 -c "import yaml; \
         conf = yaml.load(open('$M0CRATE_CFG'), Loader=yaml.FullLoader); \
         m = conf['MOTR_CONFIG']; \
-        print('-l %s -h %s -p %s -f %s' % (m['MOTR_LOCAL_ADDR'], m['MOTR_HA_ADDR'], m['PROF'], m['PROCESS_FID']));")
+        print('-L -C -l %s -h %s -p %s -f %s' % (m['MOTR_LOCAL_ADDR'], m['MOTR_HA_ADDR'], m['PROF'], m['PROCESS_FID']));")
 
     _info "m0kv $args $@"
     ${MOTR_UTILS_DIR}/m0kv $args $@ &
@@ -361,9 +361,15 @@ function m0kv()
 
 function m0kv_run_sync()
 {
-    m0kv index create "${DINDEX}"
-    m0kv -s index put "${DINDEX}" mykey myvalue
-    m0kv -s index get "${DINDEX}" mykey
+    local m0kv_tmp_out="/tmp/m0kv_tmp_out"
+    local pool_version=
+
+    m0kv -e index create "${DINDEX}" | tee "${m0kv_tmp_out}"
+    pool_version=$(cat "${m0kv_tmp_out}" | grep "pool" | awk '{ print $4; }')
+    rm -f "${m0kv_tmp_out}"
+
+    m0kv -v "${pool_version}" -s index put "${DINDEX}" mykey myvalue
+    m0kv -v "${pool_version}" -s index get "${DINDEX}" mykey
     m0kv index drop "${DINDEX}"
 }
 
@@ -489,18 +495,22 @@ function recovery_phase()
     local redo_pattern="m0_dtm0_recovery_machine_redo_post   > in-redo"
     local dtx_done_pattern="dtx_done                             >"
     local m0kv_wait_file="/tmp/m0kv_wait"
+    local m0kv_tmp_out="/tmp/m0kv_tmp_out"
+    local pool_version=
 
     _info "Phase recovery:recovery"
     local svc_name="m0d@0x720000000000000${M0D_FIDS_HEX[VICTIM]}.service"
 
     _info "Create an index"
-    m0kv index create "${DINDEX}"
+    m0kv -e index create "${DINDEX}" | tee "${m0kv_tmp_out}"
+    pool_version=$(cat "${m0kv_tmp_out}" | grep "pool" | awk '{ print $4; }')
+    rm -f "${m0kv_tmp_out}"
 
     _info "Populate the index"
-    m0kv -s index put "${DINDEX}" mykey1 myvalue1
+    m0kv -v "${pool_version}" -s index put "${DINDEX}" mykey1 myvalue1
 
     _info "PUT one key, hang on"
-    m0kv_async -s index put "${DINDEX}" mykey2 myvalue2 \
+    m0kv_async -v "${pool_version}" -s index put "${DINDEX}" mykey2 myvalue2 \
         wait "${m0kv_wait_file}" put "${DINDEX}" mykey3 myvalue3
 
     _info "Wait until mykey2 reached the persistent storage on at least one node."


### PR DESCRIPTION
This is the experimental change in all2all DTM0 integration test
that uses a combination of flags M0_ENF_META and M0_OIF_SKIP_LAYOUT
to execute index operations in a single transaction.

Problem:
Currently DTM0 is only applicable for ordinary DIX operations like
key/value PUT and DEL since these operations are executed in a
single local transaction. In case of index create/delete operations
we have two local transactions for layout operation and component
catalogues creation (with and without CROW). Since DTX is not applicable
for multiple local transactions we can not cover index operations with
DTM0 and recover such operations during DTM0 recovery process.

Solution:
Recently two flags of interest were introduced: M0_ENF_META and
M0_OIF_SKIP_LAYOUT. A combination of these two flags with disabled
CROW allows to skip layout operations and use a pool version for
the further ordinary operations stored after index create is executed.
That means we have a single local transaction to create component
catalogues only and DTX for index operations can be used in this case.
Recently the changes were introduced that allow to set these flags
from the command line for m0kv. Since m0kv is used as a client for
all2all DTM0 integration test now we can test these flags to ensure
that index operation is done in a single transaction and following
ordinary key/value operations work. So this is the first step to
start working on DTX support for index operations.

Changes:
In comparison to original all2all the changes in calling of m0kv are:
 * specify -L (enable M0_OIF_SKIP_LAYOUT) and -C (disable M0_OIF_CROW)
   options for all m0kv calls (index and ordinary operations)
 * specify -e (enable M0_ENF_META) m0kv option for index create operation,
   the pool version is printed out in this case and stored into bash variable
 * specify m0kv option -v <pool_version> that was stored after index create
   for key/value PUT operations

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>