### PR TITLE
CORTX-33661 : Analyse and fix memory leaks for cob module using cob-ut and cob-foms-ut

### DIFF
--- a/cob/cob.c
+++ b/cob/cob.c
@@ -2171,7 +2171,6 @@ M0_INTERNAL int m0_cob_delete(struct m0_cob *cob, struct m0_be_tx *tx)
 		cob_table_delete(cob->co_dom->cd_fileattr_omg, tx, &key);
 	}
 out:
-	m0_cob_put(cob);
 	return M0_RC(rc);
 }
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -2171,6 +2171,7 @@ M0_INTERNAL int m0_cob_delete(struct m0_cob *cob, struct m0_be_tx *tx)
 		cob_table_delete(cob->co_dom->cd_fileattr_omg, tx, &key);
 	}
 out:
+	m0_cob_put(cob);
 	return M0_RC(rc);
 }
 

--- a/cob/cob.c
+++ b/cob/cob.c
@@ -1702,6 +1702,7 @@ M0_INTERNAL int m0_cob_locate(struct m0_cob_domain *dom,
 		return M0_RC(rc);
 	}
 
+	/* The result cob must be released by calling m0_cob_put(). */
 	*out = cob;
 	return M0_RC(rc);
 }

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -709,7 +709,7 @@ M0_INTERNAL int m0_cob_lookup(struct m0_cob_domain *dom,
  * a record; i.e. the filename. This also lookups for all attributes,
  * that is, fab, omg, etc., according to @need flags.
  * 
- * Note : If this function returns success, the result cob must be released
+ * Note : If this function returns success, the returned cob must be released
  *        by calling m0_cob_put().
  *
  * @param dom   cob domain to use

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -708,12 +708,14 @@ M0_INTERNAL int m0_cob_lookup(struct m0_cob_domain *dom,
  * Create a new cob and populate it with the contents of the
  * a record; i.e. the filename. This also lookups for all attributes,
  * that is, fab, omg, etc., according to @need flags.
+ * 
+ * Note : If this function returns success, the result cob must be released
+ *        by calling m0_cob_put().
  *
  * @param dom   cob domain to use
  * @param oikey oikey (fid) to lookup
  * @param flags flags specifying what parts of cob to populate
  * @param out   resulting cob is store here
- * @param tx    db transaction to be used
  *
  * @see m0_cob_lookup
  */

--- a/cob/ut/cob.c
+++ b/cob/ut/cob.c
@@ -103,6 +103,7 @@ static void test_mkfs(void)
 	rc = _locate(M0_MDSERVICE_SLASH_FID.f_container,
 	             M0_MDSERVICE_SLASH_FID.f_key); /* slash */
 	M0_UT_ASSERT(rc == 0);
+	m0_cob_put(cob);
 	rc = _locate(M0_COB_ROOT_FID.f_container,
 	             M0_COB_ROOT_FID.f_key); /* root */
 	M0_UT_ASSERT(rc != 0);

--- a/ioservice/cob_foms.c
+++ b/ioservice/cob_foms.c
@@ -1156,7 +1156,7 @@ static int cd_cob_delete(struct m0_fom            *fom,
 	if (rc != 0)
 		M0_ERR_INFO(rc, "Bytecount decrement unsuccesfull");
 
-	rc = m0_cob_delete(cob, m0_fom_tx(fom));
+	rc = m0_cob_delete_put(cob, m0_fom_tx(fom));
 	if (rc == 0)
 		M0_LOG(M0_DEBUG, "Cob deleted successfully.");
 

--- a/ioservice/cob_foms.c
+++ b/ioservice/cob_foms.c
@@ -480,7 +480,7 @@ static int cob_setattr_fom_tick(struct m0_fom *fom)
 static bool cob_pool_version_mismatch(const struct m0_fom *fom)
 {
 	int                       rc;
-	struct m0_cob            *cob;
+	struct m0_cob            *cob = NULL;
 	struct m0_fop_cob_common *common;
 
 	common = m0_cobfop_common_get(fom->fo_fop);
@@ -489,8 +489,12 @@ static bool cob_pool_version_mismatch(const struct m0_fom *fom)
 		M0_LOG(M0_DEBUG, "cob pver"FID_F", common pver"FID_F,
 				FID_P(&cob->co_nsrec.cnr_pver),
 				FID_P(&common->c_body.b_pver));
-		return !m0_fid_eq(&cob->co_nsrec.cnr_pver,
-				  &common->c_body.b_pver);
+		if (!m0_fid_eq(&cob->co_nsrec.cnr_pver, &common->c_body.b_pver))
+			return true;
+		else {
+			m0_cob_put(cob);
+			return false;
+		}
 	}
 	return false;
 }

--- a/ioservice/cob_foms.c
+++ b/ioservice/cob_foms.c
@@ -482,6 +482,7 @@ static bool cob_pool_version_mismatch(const struct m0_fom *fom)
 	int                       rc;
 	struct m0_cob            *cob = NULL;
 	struct m0_fop_cob_common *common;
+	bool                      ret;
 
 	common = m0_cobfop_common_get(fom->fo_fop);
 	rc = cob_locate(fom, &cob);
@@ -489,12 +490,10 @@ static bool cob_pool_version_mismatch(const struct m0_fom *fom)
 		M0_LOG(M0_DEBUG, "cob pver"FID_F", common pver"FID_F,
 				FID_P(&cob->co_nsrec.cnr_pver),
 				FID_P(&common->c_body.b_pver));
-		if (!m0_fid_eq(&cob->co_nsrec.cnr_pver, &common->c_body.b_pver))
-			return true;
-		else {
-			m0_cob_put(cob);
-			return false;
-		}
+		ret = !m0_fid_eq(&cob->co_nsrec.cnr_pver,
+				 &common->c_body.b_pver);
+		m0_cob_put(cob);
+		return ret;
 	}
 	return false;
 }

--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1861,7 +1861,6 @@ static int io_launch(struct m0_fom *fom)
 	} m0_tl_endfor;
 
 	m0_cob_put(container_of(file, struct m0_cob, co_file));
-	m0_cob_put(fom_obj->fcrw_cob);
 
 	M0_LOG(M0_DEBUG, "total  fom: %" PRIi64 ", expect: %"PRIi64,
 	       fom_obj->fcrw_fom_start_time,

--- a/ioservice/io_foms.c
+++ b/ioservice/io_foms.c
@@ -1861,6 +1861,7 @@ static int io_launch(struct m0_fom *fom)
 	} m0_tl_endfor;
 
 	m0_cob_put(container_of(file, struct m0_cob, co_file));
+	m0_cob_put(fom_obj->fcrw_cob);
 
 	M0_LOG(M0_DEBUG, "total  fom: %" PRIi64 ", expect: %"PRIi64,
 	       fom_obj->fcrw_fom_start_time,
@@ -2357,6 +2358,7 @@ static int m0_io_fom_cob_rw_tick(struct m0_fom *fom)
 					      m0_fom_tx(fom));
 			if (bc_rc != 0)
 				M0_ERR_INFO(bc_rc, "Failed to update cob_size");
+			m0_cob_put(cob);
 		}
 	}
 	/* Set operation status in reply fop if FOM ends.*/

--- a/ioservice/ut/bulkio_ut.c
+++ b/ioservice/ut/bulkio_ut.c
@@ -1117,6 +1117,7 @@ static int bulkio_stob_create_fom_tick(struct m0_fom *fom)
 	m0_cob_oikey_make(&oikey, &cc.fco_cfid, 0);
 	rc = m0_cob_locate(ios->rios_cdom, &oikey, 0, &cob);
 	M0_UT_ASSERT(rc == 0);
+	m0_cob_put(cob);
 
 	wrep = m0_fop_data(fom->fo_rep_fop);
 	wrep->c_rep.rwr_rc = 0;

--- a/ioservice/ut/cob_foms.c
+++ b/ioservice/ut/cob_foms.c
@@ -795,7 +795,7 @@ static void cc_stob_create_test()
 /*
  * Test function to check COB record in the database.
  */
-static void cob_verify(struct m0_fom *fom, const bool exists)
+static void cob_verify(struct m0_fom *fom, const bool exists, bool to_free)
 {
 	int		      rc;
 	struct m0_cob_domain *cobdom;
@@ -828,6 +828,9 @@ static void cob_verify(struct m0_fom *fom, const bool exists)
 		M0_UT_ASSERT(rc == -ENOENT);
         if (rc != 0)
 	        m0_free(nskey);
+
+	if (to_free)
+		m0_cob_put(test_cob);
 }
 
 static void md_cob_fop_create_delete_test(bool create_p,
@@ -864,6 +867,7 @@ static void md_cob_create_delete()
 	md_cob_fop_create_delete_test(true, &CONF_PVER_FID, 0);
 	/* Create the same mdcob again. */
 	md_cob_fop_create_delete_test(true, &CONF_PVER_FID, -EEXIST);
+	md_cob_fop_create_delete_test(false, &CONF_PVER_FID, 0);
 	/* Create the same mdcob with different pool version. */
 	md_cob_fop_create_delete_test(true, &CONF_PVER_FID1, 0);
 	/* Delete the mdcob. */
@@ -922,7 +926,7 @@ static void cc_cob_create_test()
 	/*
 	 * Test-case 1 - Verify COB creation
 	 */
-	cob_verify(fom, true);
+	cob_verify(fom, true, false);
 
 	/*
 	 * Test-case 2 - Test failure case. Try to create the
@@ -978,7 +982,7 @@ static void cc_fom_state_test(void)
 	M0_UT_ASSERT(rc == M0_FSO_AGAIN);
 	M0_UT_ASSERT(m0_fom_phase(cfom) == M0_FOPH_SUCCESS);
 
-	cob_verify(cfom, true);
+	cob_verify(cfom, true, true);
 
 	/*
 	 * Now create delete fom. Use FOM functions to delete cob-data.
@@ -1217,7 +1221,7 @@ static void cd_cob_delete_test()
 	/*
 	 * Make sure that there no entry in the database.
 	 */
-	cob_verify(cfom, false);
+	cob_verify(cfom, false, false);
 
 	/*
 	 * Test-case 2: Delete cob again. The test should fail.

--- a/ioservice/ut/cob_foms.c
+++ b/ioservice/ut/cob_foms.c
@@ -925,6 +925,8 @@ static void cc_cob_create_test()
 
 	/*
 	 * Test-case 1 - Verify COB creation
+	 * The test_cob is not released here, because it is used later in this
+	 * test to do cob_delete.
 	 */
 	cob_verify(fom, true, false);
 

--- a/sns/cm/storage.c
+++ b/sns/cm/storage.c
@@ -197,13 +197,17 @@ static int cob_stob_check(struct m0_cm_cp *cp)
 	struct m0_sns_cm_file_ctx *fctx;
 	struct m0_fid             *pver;
 	struct m0_cob             *cob;
+	int                        ret;
 
 	fctx = ag2snsag(cp->c_ag)->sag_fctx;
 	pver = &fctx->sf_attr.ca_pver;
 	m0_fid_convert_stob2cob(&cp2snscp(cp)->sc_stob_id, &fid);
 
-	return m0_io_cob_stob_create(&cp->c_fom, m0_sns_cm_cp2cdom(cp), &fid,
-				     pver, fctx->sf_attr.ca_lid, true, &cob);
+	ret = m0_io_cob_stob_create(&cp->c_fom, m0_sns_cm_cp2cdom(cp), &fid,
+				    pver, fctx->sf_attr.ca_lid, true, &cob);
+	if(cob != NULL)
+		m0_cob_put(cob);
+	return ret;
 }
 
 static int cp_stob_release_exts(struct m0_stob *stob,
@@ -366,6 +370,7 @@ M0_INTERNAL int m0_sns_cm_cp_io_wait(struct m0_cm_cp *cp)
 		if (rc == 0) {
 			io_size = max64u(cob->co_nsrec.cnr_size, io_size);
 			rc = m0_cob_size_update(cob, io_size, betx);
+			m0_cob_put(cob);
 		}
 	}
 	if (rc == 0) {

--- a/sns/cm/storage.c
+++ b/sns/cm/storage.c
@@ -196,7 +196,7 @@ static int cob_stob_check(struct m0_cm_cp *cp)
 	struct m0_fid              fid;
 	struct m0_sns_cm_file_ctx *fctx;
 	struct m0_fid             *pver;
-	struct m0_cob             *cob;
+	struct m0_cob             *cob = NULL;
 	int                        ret;
 
 	fctx = ag2snsag(cp->c_ag)->sag_fctx;
@@ -205,7 +205,7 @@ static int cob_stob_check(struct m0_cm_cp *cp)
 
 	ret = m0_io_cob_stob_create(&cp->c_fom, m0_sns_cm_cp2cdom(cp), &fid,
 				    pver, fctx->sf_attr.ca_lid, true, &cob);
-	if(cob != NULL)
+	if (cob != NULL)
 		m0_cob_put(cob);
 	return ret;
 }


### PR DESCRIPTION
Fix memory leaks for m0_cob_alloc in cob-ut,cob-foms-ut,bulk-client-ut and bulk-server-ut.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
