### PR TITLE
CORTX-33701: Fix memory leak related to m0_cob_bc_entries_dump()

### DIFF
--- a/cob/cob.c
+++ b/cob/cob.c
@@ -469,8 +469,8 @@ M0_INTERNAL void m0_cob_bc_iterator_fini(struct m0_cob_bc_iterator *it)
 }
 
 M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
-				       struct m0_buf       **out_keys,
-				       struct m0_buf       **out_recs,
+				       struct m0_buf        *out_keys,
+				       struct m0_buf        *out_recs,
 				       uint32_t             *out_count)
 {
 	struct m0_cob_bc_iterator it;
@@ -482,8 +482,8 @@ M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
 
 	M0_ENTRY();
 
-	M0_PRE(*out_keys == NULL);
-	M0_PRE(*out_recs == NULL);
+	M0_PRE(out_keys != NULL);
+	M0_PRE(out_recs != NULL);
 
 	if (cdom->cd_bytecount == NULL)
 		return M0_ERR(-ENOENT);
@@ -499,33 +499,23 @@ M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
 
 	M0_LOG(M0_DEBUG, "Found %" PRIu32 " entries in btree", *out_count);
 
-	M0_ALLOC_PTR(*out_keys);
-	if (*out_keys == NULL)
-		return M0_ERR(-ENOMEM);
-	M0_ALLOC_PTR(*out_recs);
-	if (*out_recs == NULL) {
-		m0_free(*out_keys);
-		return M0_ERR(-ENOMEM);
-	}
-
-	rc = m0_buf_alloc(*out_keys, sizeof(struct m0_cob_bckey) *
+	rc = m0_buf_alloc(out_keys, sizeof(struct m0_cob_bckey) *
 			 (*out_count));
 	if (rc != 0) {
-		m0_free(*out_keys);
-		m0_free(*out_recs);
+		m0_btree_cursor_fini(&it.ci_cursor);
 		return M0_ERR(rc);
 	}
-	rc = m0_buf_alloc(*out_recs, sizeof(struct m0_cob_bcrec) *
+	
+	rc = m0_buf_alloc(out_recs, sizeof(struct m0_cob_bcrec) *
 			 (*out_count));
 	if (rc != 0) {
-		m0_buf_free(*out_keys);
-		m0_free(*out_keys);
-		m0_free(*out_recs);
+		m0_buf_free(out_keys);
+		m0_btree_cursor_fini(&it.ci_cursor);
 		return M0_ERR(rc);
 	}
 
-	key_cursor = (struct m0_cob_bckey *)(*out_keys)->b_addr;
-	rec_cursor = (struct m0_cob_bcrec *)(*out_recs)->b_addr;
+	key_cursor = (struct m0_cob_bckey *)out_keys->b_addr;
+	rec_cursor = (struct m0_cob_bcrec *)out_recs->b_addr;
 
 	rc = m0_btree_cursor_first(&it.ci_cursor);
 

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -979,8 +979,11 @@ M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
  *
  * Similar logic applies to record buffer.
  *
- * @pre   out_keys == NULL
- * @pre   out_recs == NULL
+ * Memory for *out_keys and *out_recs is allocated inside the function and
+ * must be freed by the caller.
+ *
+ * @pre  *out_keys == NULL
+ * @pre  *out_recs == NULL
  *
  * @param cdom      cob domain where the bytecount btree resides.
  * @param out_keys  out parameter buffer which gets populated by keys.

--- a/cob/cob.h
+++ b/cob/cob.h
@@ -979,11 +979,8 @@ M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
  *
  * Similar logic applies to record buffer.
  *
- * Memory for *out_keys and *out_recs is allocated inside the function and
- * must be freed by the caller.
- *
- * @pre  *out_keys == NULL
- * @pre  *out_recs == NULL
+ * @pre out_keys != NULL
+ * @pre out_recs != NULL
  *
  * @param cdom      cob domain where the bytecount btree resides.
  * @param out_keys  out parameter buffer which gets populated by keys.
@@ -994,8 +991,8 @@ M0_INTERNAL int m0_cob_bc_iterator_get(struct m0_cob_bc_iterator *it);
  * @retval -errno   Other error.
  */
 M0_INTERNAL int m0_cob_bc_entries_dump(struct m0_cob_domain *cdom,
-				       struct m0_buf       **out_keys,
-				       struct m0_buf       **out_recs,
+				       struct m0_buf        *out_keys,
+				       struct m0_buf        *out_recs,
 				       uint32_t             *out_count);
 
 /**

--- a/cob/ut/bytecount.c
+++ b/cob/ut/bytecount.c
@@ -149,8 +149,8 @@ void test_entries_dump(void)
 	uint32_t             count;
 	struct m0_cob_bckey  dump_keys[KEY_VAL_NR];
 	struct m0_cob_bcrec  dump_recs[KEY_VAL_NR];
-	struct m0_buf       *keys = NULL;
-	struct m0_buf       *recs = NULL;
+	struct m0_buf        keys;
+	struct m0_buf        recs;
 	struct m0_fid        temp_fid;
 	struct m0_cob_bckey *kcurr;
 	struct m0_cob_bcrec *rcurr;
@@ -159,8 +159,8 @@ void test_entries_dump(void)
 	M0_UT_ASSERT(rc == 0);
 	M0_UT_ASSERT(count == KEY_VAL_NR);
 
-	kcurr = (struct m0_cob_bckey *)keys->b_addr;
-	rcurr = (struct m0_cob_bcrec *)recs->b_addr;
+	kcurr = (struct m0_cob_bckey *)keys.b_addr;
+	rcurr = (struct m0_cob_bcrec *)recs.b_addr;
 
 	for (i =0; i < count; i++) {
 		memcpy(&dump_keys[i], kcurr, sizeof(struct m0_cob_bckey));

--- a/sss/process_foms.c
+++ b/sss/process_foms.c
@@ -385,8 +385,8 @@ static int ss_bytecount_stats_ingest(struct m0_cob_domain *cdom,
 				     struct m0_ss_process_rep *rep)
 {
 	int                  rc;
-	struct m0_buf       *key_buf = NULL;
-	struct m0_buf       *rec_buf = NULL;
+	struct m0_buf        key_buf = {};
+	struct m0_buf        rec_buf = {};
 
 	/* DUMMY values */
 	if (M0_FI_ENABLED("dummy_bytecount_data")) {
@@ -406,10 +406,8 @@ static int ss_bytecount_stats_ingest(struct m0_cob_domain *cdom,
 
 	rc = m0_cob_bc_entries_dump(cdom, &key_buf, &rec_buf, &rep->sspr_kv_count);
 	if (rc == 0) {
-		m0_buf_init(&rep->sspr_bckey, key_buf->b_addr, key_buf->b_nob);
-		m0_buf_init(&rep->sspr_bcrec, rec_buf->b_addr, rec_buf->b_nob);
-		m0_free(key_buf);
-		m0_free(rec_buf);
+		m0_buf_init(&rep->sspr_bckey, key_buf.b_addr, key_buf.b_nob);
+		m0_buf_init(&rep->sspr_bcrec, rec_buf.b_addr, rec_buf.b_nob);
 	}
 
 	return rc;

--- a/sss/process_foms.c
+++ b/sss/process_foms.c
@@ -408,6 +408,8 @@ static int ss_bytecount_stats_ingest(struct m0_cob_domain *cdom,
 	if (rc == 0) {
 		m0_buf_init(&rep->sspr_bckey, key_buf->b_addr, key_buf->b_nob);
 		m0_buf_init(&rep->sspr_bcrec, rec_buf->b_addr, rec_buf->b_nob);
+		m0_free(key_buf);
+		m0_free(rec_buf);
 	}
 
 	return rc;


### PR DESCRIPTION
Problem:
out_keys and out_recs are supposed to be freed by the caller of m0_cob_bc_entries_dump().
These were not being freed, which caused a memory leak every time bytecount was fetched.

Solution:
Changed the approach in m0_cob_bc_entries_dump() to take buffer pointers,
so the caller can just send pointer to structures in the stack and skip allocating on the heap.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
