### PR TITLE
CORTX-33706: Motr halon interface buffer size setting is truncating the end points

### DIFF
--- a/ha/halon/interface.c
+++ b/ha/halon/interface.c
@@ -77,11 +77,6 @@
 #include "ha/note.h"            /* M0_HA_NVEC_SET */
 
 
-enum {
-	HALON_INTERFACE_EP_BUF        = 0x40,
-	HALON_INTERFACE_NVEC_SIZE_MAX = 0x1000,
-};
-
 struct m0_halon_interface_cfg {
 	const char      *hic_build_git_rev_id;
 	const char      *hic_build_configure_opts;

--- a/ha/halon/interface.h
+++ b/ha/halon/interface.h
@@ -269,6 +269,12 @@
  */
 
 #include "lib/types.h"          /* bool */
+#include "net/ip.h"
+
+enum {
+        HALON_INTERFACE_EP_BUF        = M0_NET_IP_STRLEN_MAX,
+        HALON_INTERFACE_NVEC_SIZE_MAX = 0x1000,
+};
 
 struct m0_rpc_machine;
 struct m0_reqh;


### PR DESCRIPTION
Problem:
   motr halon interface code assumes a size of 0x40 for the EP_BUF

Solution:
   The size of the EP_BUF so used should ideally come from libfabric #define (M0_NET_IP_STRLEN_MAX)

Signed-off-by: Deepak Nayak <deepak.nayak@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
