### PR TITLE
cas/service: forbid operating on sdevs in OFFLINE state

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -1910,7 +1910,6 @@ static int cas_device_check(const struct cas_fom   *fom,
 			pm = &pver->pv_mach;
 			rc = cas_sdev_state(pm, device_id, &state);
 			if (rc == 0 && !M0_IN(state, (M0_PNDS_ONLINE,
-						      M0_PNDS_OFFLINE,
 						      M0_PNDS_SNS_REBALANCING)))
 				rc = M0_ERR(-EBADFD);
 		} else


### PR DESCRIPTION
Problem:
Some time ago Hare was not updating devices state during
DTM0 recovery and they were still in OFFLINE state. In order
to process incoming REDO msgs and unblock working on DTM0
recovery we allowed operating on CAS OFFLINE devices, that
was a temporary workaround.
But logically it's not correct to operate with OFFLINE devices.

Solution:
Now Hare updates the state of devices that belong to the
recovering process. So that we can remove OFFLINE CAS device
state from allowed states for operating.

Signed-off-by: Sergey Shilov <sergey.shilov@seagate.com>