### PR TITLE
CORTX-30751- fixing double quote issue under sns_repair_motr_quiesce.sh

### DIFF
--- a/motr/st/utils/sns_repair_motr_quiesce.sh
+++ b/motr/st/utils/sns_repair_motr_quiesce.sh
@@ -113,7 +113,7 @@ main()
 
 	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		return 1
 	}

--- a/net/test/demo/demo-list-nids.sh
+++ b/net/test/demo/demo-list-nids.sh
@@ -25,7 +25,7 @@ SSH="ssh"
 main()
 {
 	while read addr; do
-		ssh_get_nids $addr | awk "{print \"$addr \" \$0}"
+		ssh_get_nids "$addr" | awk "{print \"$addr \" \$0}"
 	done
 }
 


### PR DESCRIPTION
Signed-off-by: Zoheb Khan <zoheb.khan@seagate.com>

# Problem Statement
- fixing double quote issue under file sns_repair_motr_quiesce.sh

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
