### PR TITLE
CORTX-33735: Gdb extensions throwing error

### DIFF
--- a/scripts/gdb/gdb-extensions.py
+++ b/scripts/gdb/gdb-extensions.py
@@ -166,7 +166,7 @@ Total: 2
 		print "Total: %d" % total
 
 	@staticmethod
-	def get_head(self, argv):
+	def get_head(argv):
 		ok    = True
 		head  = 0
 		vhead = gdb.parse_and_eval(argv[0])
@@ -187,7 +187,7 @@ Total: 2
 		return vhead, head, ok
 
 	@staticmethod
-	def get_offset(self, argv):
+	def get_offset(argv):
 		argc     = len(argv)
 		offset   = 0
 		elm_type = None


### PR DESCRIPTION
Problem :
while fixing a codacy warning we made some of the method
static to overcome the warning due to which gdb
extensions was throwing error.

Solution:
Removed the self parameter, as static functions do not need them 

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
Gdb extension throwing error

# Design
Removed the self parameter, as static functions do not need them 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
