### PR TITLE
add link to motr rust api

### DIFF
--- a/doc/motr-developer-guide.md
+++ b/doc/motr-developer-guide.md
@@ -76,6 +76,8 @@ as the last argument to the object program. In the object example, we will only 
     *   [m0crate](/motr/m0crate/)
 *   CORTX Motr Go bindings:
     *   [bindings/go/](/bindings/go)
+*   CORTX Motr Rust API:
+    *   https://github.com/mengwanguc/rust_motr
 *   CORTX Motr HSM utility and library:
     *   [hsm/](/hsm/)
 *   CORTX Motr Python wrapper:


### PR DESCRIPTION
Add a link to motr rust API.

Signed-off-by: Meng Wang <mengwanguc@gmail.com>


-----
[View rendered doc/motr-developer-guide.md](https://github.com/mengwanguc/cortx-motr/blob/patch-16/doc/motr-developer-guide.md)