### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/net/test/st/st-ping.sh
+++ b/net/test/st/st-ping.sh
@@ -21,11 +21,11 @@
 
 CWD=$(cd "$( dirname "$0")" && pwd)
 
-source $CWD/st-config.sh
+source "$CWD"/st-config.sh
 TEST_TYPE="ping"
 MSG_NR=1048576
 MSG_SIZE=4k
 CONCURRENCY_CLIENT=8
 CONCURRENCY_SERVER=16
 
-source $CWD/run-1x1.sh
+source "$CWD"/run-1x1.sh

--- a/rpc/ub/plot.sh
+++ b/rpc/ub/plot.sh
@@ -103,7 +103,7 @@ set: rpc-ub
 	         run: [      1]  14.69  14.69  14.69  0.00% 1.469e+01/6.806e-02
 
 EOF
-    } | awk -v OPTS="$OPTS" '
+    } | awk -v OPTS=$OPTS '
 $2 == OPTS        { p = 1; next }
 p                 { print }
 p && $1 == "run:" { exit }
@@ -116,7 +116,7 @@ get_val() {
     local KEY="$1"
     local OPTS="$2"
 
-    echo "$OPTS" | tr , \\n | sed -n "s/^$KEY=//p"
+    echo $OPTS | tr , \\n | sed -n "s/^$KEY=//p"
 }
 
 ### Generate CSV file.
@@ -136,7 +136,7 @@ gen_csv() {
 	local OPTS="${VAR_OPT}=${x},${COMMON_OPTS}"
 	echo "----------[ $OPTS ]----------"
 
-	rpc-ub -o "$OPTS" | tee "$TMP"
+	rpc-ub -o $OPTS | tee "$TMP"
 	[ "${PIPESTATUS[0]}" -eq 0 ] || exit "${PIPESTATUS[0]}"
 
 	local NR_CONNS=$(get_val nr_conns $OPTS)

--- a/rpc/ub/plot.sh
+++ b/rpc/ub/plot.sh
@@ -201,7 +201,7 @@ nr_conns=96,nr_msgs=100  msg_len  64 128 256 512
 EOF
 } | while read -a ARGS; do
     CSV=$((++i)).csv
-    gen_csv $CSV "$TMP" "${ARGS[@]}"
+    gen_csv $CSV "$TMP" ${ARGS[@]}
     gen_script "${ARGS[0]}" $CSV "${ARGS[1]}" >"$TMP"
     gnuplot "$TMP"
 done

--- a/rpc/ub/plot.sh
+++ b/rpc/ub/plot.sh
@@ -103,7 +103,7 @@ set: rpc-ub
 	         run: [      1]  14.69  14.69  14.69  0.00% 1.469e+01/6.806e-02
 
 EOF
-    } | awk -v OPTS=$OPTS '
+    } | awk -v OPTS="$OPTS" '
 $2 == OPTS        { p = 1; next }
 p                 { print }
 p && $1 == "run:" { exit }
@@ -128,7 +128,7 @@ gen_csv() {
     local VAR_OPT="$1"; shift
     local VALUES="$*"
 
-    local NR_MSGS=$(get_val nr_msgs $COMMON_OPTS)
+    local NR_MSGS=$(get_val nr_msgs "$COMMON_OPTS")
 
     echo "# $VAR_OPT time msg/s MB/s" >"$OUT"
 
@@ -136,11 +136,11 @@ gen_csv() {
 	local OPTS="${VAR_OPT}=${x},${COMMON_OPTS}"
 	echo "----------[ $OPTS ]----------"
 
-	rpc-ub -o $OPTS | tee "$TMP"
-	[ ${PIPESTATUS[0]} -eq 0 ] || exit ${PIPESTATUS[0]}
+	rpc-ub -o "$OPTS" | tee "$TMP"
+	[ "${PIPESTATUS[0]}" -eq 0 ] || exit "${PIPESTATUS[0]}"
 
-	local NR_CONNS=$(get_val nr_conns $OPTS)
-	local MSG_LEN=$(get_val msg_len $OPTS)
+	local NR_CONNS=$(get_val nr_conns "$OPTS")
+	local MSG_LEN=$(get_val msg_len "$OPTS")
 	awk -v X="$x" -v NR_MSGS=$((NR_CONNS * NR_MSGS)) -v MSG_LEN="$MSG_LEN" \
 	    -v PROG="${0##*/}" '
 function die(msg) {
@@ -201,7 +201,7 @@ nr_conns=96,nr_msgs=100  msg_len  64 128 256 512
 EOF
 } | while read -a ARGS; do
     CSV=$((++i)).csv
-    gen_csv $CSV $TMP ${ARGS[@]}
-    gen_script ${ARGS[0]} $CSV ${ARGS[1]} >$TMP
-    gnuplot $TMP
+    gen_csv $CSV "$TMP" "${ARGS[@]}"
+    gen_script "${ARGS[0]}" $CSV "${ARGS[1]}" >"$TMP"
+    gnuplot "$TMP"
 done

--- a/rpc/ub/plot.sh
+++ b/rpc/ub/plot.sh
@@ -128,7 +128,7 @@ gen_csv() {
     local VAR_OPT="$1"; shift
     local VALUES="$*"
 
-    local NR_MSGS=$(get_val nr_msgs "$COMMON_OPTS")
+    local NR_MSGS=$(get_val nr_msgs $COMMON_OPTS)
 
     echo "# $VAR_OPT time msg/s MB/s" >"$OUT"
 
@@ -139,8 +139,8 @@ gen_csv() {
 	rpc-ub -o "$OPTS" | tee "$TMP"
 	[ "${PIPESTATUS[0]}" -eq 0 ] || exit "${PIPESTATUS[0]}"
 
-	local NR_CONNS=$(get_val nr_conns "$OPTS")
-	local MSG_LEN=$(get_val msg_len "$OPTS")
+	local NR_CONNS=$(get_val nr_conns $OPTS)
+	local MSG_LEN=$(get_val msg_len $OPTS)
 	awk -v X="$x" -v NR_MSGS=$((NR_CONNS * NR_MSGS)) -v MSG_LEN="$MSG_LEN" \
 	    -v PROG="${0##*/}" '
 function die(msg) {


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Co-authored-by: Pradeep Kumbhre <pradeep.kumbhre@seagate.com>
Signed-off-by: Zoheb Khan <zoheb.khan@seagate.com>

# Problem Statement
- We see 1688 occurrence of pattern, "Double quote to prevent globing and word splitting".

# Design
-  We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
