### PR TITLE
CORTX-33595: Motr should support separate log device for deployment

### DIFF
--- a/scripts/install/usr/libexec/cortx-motr/motr-server
+++ b/scripts/install/usr/libexec/cortx-motr/motr-server
@@ -149,6 +149,8 @@ m0_server()
     local be_seg0_path=
     local be_seg_path=
     local be_seg_size=
+    local log_device_path=
+    local log_device_size=
 
     # @todo
     # These BE segment devices needs to pass through Motr configuration
@@ -162,6 +164,13 @@ m0_server()
         be_seg_path=" -B $MOTR_BE_SEG_PATH "
         if [[ -n "$MOTR_M0D_IOS_BESEG_SIZE" ]]; then
             be_seg_size=" -z $MOTR_M0D_IOS_BESEG_SIZE"
+        fi
+    fi
+
+    if [[ -n "$MOTR_LOG_PATH" && -b $MOTR_LOG_PATH ]]; then
+        log_device_path=" -L $MOTR_LOG_PATH "
+        if [[ -n "$MOTR_LOG_SIZE" ]]; then
+            log_device_size=" -V $MOTR_LOG_SIZE "
         fi
     fi
 
@@ -270,6 +279,7 @@ m0_server()
                     -A linuxstob:${addbstob_dir}addb-stobs \
                     -f $proc_fid $stob_type $stob_path $MOTR_M0D_OPTS \
                        $be_seg0_path $be_seg_path $be_seg_size \
+                       $log_device_path $log_device_size \
                        $stob_opts $cmd_opts $addb_opts $conf_opts \
                        $MOTR_M0D_EXTRA_OPTS
 }


### PR DESCRIPTION
# Problem Statement
- Motr should support separate log device for deployment

# Design
1: In dev environment, Hare provides the LOG device and LOG device size in /etc/sysconfig/m0d-0x7200000000000001\:0x2
as below
...................XX......................
[root@ssc-vm-g4-rhev4-1201 cortx-motr-1]# cat  /etc/sysconfig/m0d-0x7200000000000001\:0x2
MOTR_M0D_EP='inet:tcp:10.230.244.166@21003'
MOTR_HA_EP='inet:tcp:10.230.244.166@22001'
MOTR_PROCESS_FID='0x7200000000000001:0x2'
MOTR_BE_SEG_PATH='/dev/loop9'
MOTR_NODE_UUID='fdc5d3d6-11dc-11ed-af73-566fcce40abf'
MOTR_LOG_PATH='/dev/loop8'
MOTR_LOG_SIZE='1073741824'

...................XX...........................
2: Motr then uses these MOTR_LOG_PATH, MOTR_LOG_SIZE in motr-server while calling mkfs, m0d commands for ios services
Ex: 
1: For confd, don't use   MOTR_LOG_PATH, MOTR_LOG_SIZE
 
 1.1: cmd = '/root/cortx-motr-1/utils/mkfs/m0mkfs -e libfab:inet:tcp:10.230.244.166@21002  -A linuxstob:addb-stobs                     -f <0x7200000000000001:0x1> -T linux -S stobs  -D db  -m 524288  -q 16   -C 307200 -E 32 -J 64 -t 0 -X 209715200 -P 314572800 -O 524288000 -w 8 -c /etc/motr/confd.xc -H inet:tcp:10.230.244.166@22001 -U                                                                            -F -u fdc5d3d6-11dc-11ed-af73-566fcce40abf  -z 8589934592  -r 134217728 
 
 1.2: cmd = /root/cortx-motr-1/motr/m0d -e libfab:inet:tcp:10.230.244.166@21002  -A linuxstob:addb-stobs    -f <0x7200000000000001:0x1> -T linux -S stobs  -D db  -m 524288  -q 16   -C 307200 -E 32 -J 64 -t 0 -X 209715200 -P 314572800 -O 524288000 -w 8 -c /etc/motr/confd.xc -H inet:tcp:10.230.244.166@22001 -U                                                                           -r 134217728

2: For ios, use MOTR_LOG_PATH, MOTR_LOG_SIZE

2.1: cmd = '/root/cortx-motr-1/utils/mkfs/m0mkfs -e libfab:inet:tcp:10.230.244.166@21003                     -A linuxstob:addb-stobs                     -f <0x7200000000000001:0x2> -T ad -S stobs  -D db  -m 524288  -q 16   -C 307200 -E 32 -J 64 -t 0 -X 209715200 -P 314572800 -O 524288000 -w 8 -H inet:tcp:10.230.244.166@22001 -U                          -B /dev/loop9                           **-L /dev/loop8   -V 1073741824**                          -F -u fdc5d3d6-11dc-11ed-af73-566fcce40abf   -r 134217728

2.2: cmd = '/root/cortx-motr-1/motr/m0d -e libfab:inet:tcp:10.230.244.166@21003                     -A linuxstob:addb-stobs                     -f <0x7200000000000001:0x2> -T ad -S stobs  -D db  -m 524288  -q 16   -C 307200 -E 32 -J 64 -t 0 -X 209715200 -P 314572800 -O 524288000 -w 8 -H inet:tcp:10.230.244.166@22001 -U     -B /dev/loop9   **-L /dev/loop8   -V 1073741824**                            -r 134217728
........................................................................................................................................
# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
1: CDF file
........................CDF Start...........................................................
# Cluster Description File (CDF).
# See `cfgen --help-schema` for the format description.

nodes:
  - hostname: ssc-vm-g4-rhev4-1201.colo.seagate.com      # [user@]hostname
    node_group: ssc-vm-g4-rhev4-1201.colo.seagate.com
    data_iface: eth0        # name of data network interface
    data_iface_ip_addr: null
    transport_type: libfab
    m0_servers:
      - runs_confd: true
        io_disks:
          data: []
          log: []
          meta_data: null
      - runs_confd: null
        io_disks:
          data:
            - path: /dev/loop0
            - path: /dev/loop1
            - path: /dev/loop2
            - path: /dev/loop3
            - path: /dev/loop4
            - path: /dev/loop5
            - path: /dev/loop6
            - path: /dev/loop7
          log:
            - path: /dev/loop8
          meta_data: /dev/loop9
    m0_clients:
      - name: m0_client_other  # name of the motr client
        instances: 2   # Number of instances, this host will run
create_aux: false # optional; supported values: "false" (default), "true"
pools:
  - name: the pool
    type: sns  # optional; supported values: "sns" (default), "dix", "md"
    disk_refs:
      - { path: /dev/loop0, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
      - { path: /dev/loop1, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
      - { path: /dev/loop2, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
      - { path: /dev/loop3, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
      - { path: /dev/loop4, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
      - { path: /dev/loop5, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
      - { path: /dev/loop6, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
      - { path: /dev/loop7, node: ssc-vm-g4-rhev4-1201.colo.seagate.com }
    data_units: 1
    parity_units: 0
    spare_units: 0
........................CDF End...........................................................
2:  Tested with hctl bootstrap with CDF file
    hctl bootstrap --mkfs ~/CDF_1aug.yaml
....................................................................................................................
# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
