### PR TITLE
Fix possible race during ctg_state_update

### DIFF
--- a/cas/ctg_store.c
+++ b/cas/ctg_store.c
@@ -1033,12 +1033,13 @@ static uint64_t ctg_state_update(struct m0_be_tx *tx, uint64_t size,
 		ctg_state_counter_sub(rec_size, size);
 	}
 	m0_format_footer_update(ctg_store.cs_state);
-	m0_mutex_unlock(&ctg_store.cs_state_mutex);
 
 	M0_LOG(M0_DEBUG, "ctg_state_update: rec_nr %"PRIx64 " rec_size %"PRIx64,
 	       ctg_store.cs_state->cs_rec_nr,
 	       ctg_store.cs_state->cs_rec_size);
 	M0_BE_TX_CAPTURE_PTR(seg, tx, ctg_store.cs_state);
+	m0_mutex_unlock(&ctg_store.cs_state_mutex);
+
 	return *recs_nr;
 }
 


### PR DESCRIPTION
Signed-off-by: Mehul Joshi <mehul.joshi@seagate.com>

# Problem Statement
- There is a potential for a race condition in ctg_state_update() as ctg_store.cs_state_mutex is released before
   the change to ctg_store.cs_state is captured in the tx.

# Design
-  Move the statement unlocking the mutex to the line after the capture.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- This is a potential fix identified based on visual inspection. As such there is no known scenario where this issue is hit or can be tested.

# Review Checklist 
  Checklist for Author
- [x] PR is self reviewed
- [x] Check if the description is clear and explained

