### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/net/test/test.sh
+++ b/net/test/test.sh
@@ -45,7 +45,7 @@ tailseek=$(( $(stat -c %s "$log") + 1 ))
 
 # currently, kernel UT runs as part of loading m0ut module
 modload
-insmod $MODMAIN $*
+insmod $MODMAIN "$*"
 rmmod $MODMAIN
 modunload
 

--- a/rpc/ub/plot.sh
+++ b/rpc/ub/plot.sh
@@ -128,7 +128,7 @@ gen_csv() {
     local VAR_OPT="$1"; shift
     local VALUES="$*"
 
-    local NR_MSGS=$(get_val nr_msgs "$COMMON_OPTS")
+    local NR_MSGS=$(get_val nr_msgs $COMMON_OPTS)
 
     echo "# $VAR_OPT time msg/s MB/s" >"$OUT"
 

--- a/rpc/ub/plot.sh
+++ b/rpc/ub/plot.sh
@@ -103,7 +103,7 @@ set: rpc-ub
 	         run: [      1]  14.69  14.69  14.69  0.00% 1.469e+01/6.806e-02
 
 EOF
-    } | awk -v OPTS="$OPTS" '
+    } | awk -v OPTS=$OPTS '
 $2 == OPTS        { p = 1; next }
 p                 { print }
 p && $1 == "run:" { exit }

--- a/rpc/ub/plot.sh
+++ b/rpc/ub/plot.sh
@@ -103,7 +103,7 @@ set: rpc-ub
 	         run: [      1]  14.69  14.69  14.69  0.00% 1.469e+01/6.806e-02
 
 EOF
-    } | awk -v OPTS=$OPTS '
+    } | awk -v OPTS="$OPTS" '
 $2 == OPTS        { p = 1; next }
 p                 { print }
 p && $1 == "run:" { exit }
@@ -128,7 +128,7 @@ gen_csv() {
     local VAR_OPT="$1"; shift
     local VALUES="$*"
 
-    local NR_MSGS=$(get_val nr_msgs $COMMON_OPTS)
+    local NR_MSGS=$(get_val nr_msgs "$COMMON_OPTS")
 
     echo "# $VAR_OPT time msg/s MB/s" >"$OUT"
 


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed : "Double quote to prevent globing and words splitting".

Co-authored-by: Pradeep Kumbhre [pradeep.kumbhre@seagate.com](mailto:pradeep.kumbhre@seagate.com)
Signed-off-by: Zoheb Khan [zoheb.khan@seagate.com](mailto:zoheb.khan@seagate.com)

# Problem Statement
- We see 1688 occurrence of pattern, "Double quote to prevent globing and word splitting".

# Design
-  We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
