### PR TITLE
CORTX-32172: Fixes ADDB client logs to bundled it in rgw support bundle

### DIFF
--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -27,6 +27,7 @@
 #include "lib/arith.h"                /* M0_CNT_INC */
 #include "lib/mutex.h"                /* m0_mutex_lock */
 #include "lib/time.h"                 /* m0_nanosleep */
+#include "lib/string.h"               /* getenv() */
 #include "addb2/global.h"
 #include "addb2/sys.h"
 #include "fid/fid.h"                  /* m0_fid */
@@ -1528,7 +1529,6 @@ M0_INTERNAL int m0_client_global_init(void)
 }
 
 #define NOT_EMPTY(x) (x != NULL && *x != '\0')
-
 static struct m0 m0_client_motr_instance;
 int m0_client_init(struct m0_client **m0c_p,
 		   struct m0_config *conf, bool init_m0)
@@ -1678,16 +1678,37 @@ int m0_client_init(struct m0_client **m0c_p,
 	}
 
 	if (conf->mc_is_addb_init) {
-		char buf[64];
+		char        buf[256];
+		/* uint64 max character size */
+		enum { MAX_PID_IN_CHAR_SIZE = 20 };
+		const char *addb_stob_location = NULL;
 		/* Default client addb record file size set to 128M */
 		m0_bcount_t size = DEFAULT_CLIENT_ADDB2_RECORD_SIZE;
+
 		if (conf->mc_addb_size != 0) {
 			if (conf->mc_addb_size > MAX_ADDB2_RECORD_SIZE)
 				M0_LOG(M0_WARN, "ADDB size is more than recommended");
 			size = conf->mc_addb_size;
 			M0_LOG(M0_DEBUG, "ADDB size = %" PRIu64 "", size);
 		}
-		sprintf(buf, "linuxstob:./addb_%d", (int)m0_pid());
+#ifndef __KERNEL__
+		addb_stob_location = getenv("M0_CLIENT_ADDB_DIR");
+#endif
+		/* checking for buf size overflow */
+		if (addb_stob_location != NULL && sizeof(&addb_stob_location) >=
+		   sizeof(buf) - (sizeof("linuxstob:/addb_") +
+		   MAX_PID_IN_CHAR_SIZE))
+		{
+			M0_LOG(M0_WARN, "ADDB location is more than defined "
+			                "size .. ignoring it.");
+			addb_stob_location = NULL;
+		}
+		if (addb_stob_location == NULL)
+			addb_stob_location = ".";
+
+		snprintf(buf, 255, "linuxstob:%s/addb_%d",
+		         addb_stob_location, (int)m0_pid());
+		M0_LOG(M0_DEBUG, "addb_files directory=%s\n", addb_stob_location);
 		M0_LOG(M0_DEBUG, "addb size=%llu\n", (unsigned long long)size);
 		rc = m0_reqh_addb2_init(&m0c->m0c_reqh, buf,
 					0xaddbf11e, true, true, size);


### PR DESCRIPTION
Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>

# Problem Statement
The addb client logs in rgw container is generating in wrong directory (rgw_debug). This "rgw_debug" directories meant for rgw crash files only. Our expectation, addb client logs should be resides in "addb_files-0x7200000000000001:0x13" directory.

# Design
-  It's required to set an environment for `M0_CLIENT_ADDB_DIR` on cortx-rgw-integration repository in `src/rgw/setup/rgw.py` at config stage.
-  In cortx-motr, `motr>client_init.c` will make use of `M0_CLIENT_ADDB_DIR` environment variable to store addb client log. 

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
