### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/motr/st/utils/sns_repair_motr_shutdown.sh
+++ b/motr/st/utils/sns_repair_motr_shutdown.sh
@@ -73,7 +73,7 @@ main()
 
 	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		return 1
 	}

--- a/motr/st/utils/spiel_sns_motr_repair.sh
+++ b/motr/st/utils/spiel_sns_motr_repair.sh
@@ -233,7 +233,7 @@ main()
 
 	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
-	motr_service start $multiple_pools "$stride" $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		return 1
 	}

--- a/motr/st/utils/spiel_sns_motr_repair.sh
+++ b/motr/st/utils/spiel_sns_motr_repair.sh
@@ -233,7 +233,7 @@ main()
 
 	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" $N $K $S $P || {
 		echo "Failed to start Motr Service."
 		return 1
 	}

--- a/motr/st/utils/spiel_sns_motr_repair_quiesce.sh
+++ b/motr/st/utils/spiel_sns_motr_repair_quiesce.sh
@@ -122,7 +122,7 @@ main()
 
 	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
-	motr_service start $multiple_pools "$stride" $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		return 1
 	}

--- a/motr/st/utils/spiel_sns_motr_repair_quiesce.sh
+++ b/motr/st/utils/spiel_sns_motr_repair_quiesce.sh
@@ -122,7 +122,7 @@ main()
 
 	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" $N $K $S $P || {
 		echo "Failed to start Motr Service."
 		return 1
 	}


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed: "Double quote to prevent globing and words splitting".

Signed-off-by: Zoheb Khan <zoheb.khan@seagate.com>

# Problem Statement
- We see 1688 occurrences of the pattern, "Double quote to prevent globing and word splitting".

# Design
-  We are putting the variable references in double quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
