### PR TITLE
CORTX-33725: Add lock for m0_rpc_bulk buffer(rbulk)

### DIFF
--- a/motr/io_req_fop.c
+++ b/motr/io_req_fop.c
@@ -756,6 +756,7 @@ M0_INTERNAL int ioreq_fop_dgmode_read(struct ioreq_fop *irfop)
 	               ioo_nwxfer, &ioo_bobtype);
 	rbulk = &irfop->irf_iofop.if_rbulk;
 
+	m0_mutex_lock(&rbulk->rb_mutex);
 	m0_tl_for (rpcbulk, &rbulk->rb_buflist, rbuf) {
 
 		index  = rbuf->bb_zerovec.z_index;
@@ -787,6 +788,7 @@ M0_INTERNAL int ioreq_fop_dgmode_read(struct ioreq_fop *irfop)
 				return M0_ERR(rc);
 		}
 	} m0_tl_endfor;
+	m0_mutex_unlock(&rbulk->rb_mutex);
 	return M0_RC(0);
 }
 

--- a/motr/io_req_fop.c
+++ b/motr/io_req_fop.c
@@ -784,8 +784,10 @@ M0_INTERNAL int ioreq_fop_dgmode_read(struct ioreq_fop *irfop)
 			rc = map->pi_ops->pi_dgmode_process(map,
 					irfop->irf_tioreq, &index[seg - cnt],
 					cnt);
-			if (rc != 0)
+			if (rc != 0) {
+				m0_mutex_unlock(&rbulk->rb_mutex);
 				return M0_ERR(rc);
+			}
 		}
 	} m0_tl_endfor;
 	m0_mutex_unlock(&rbulk->rb_mutex);


### PR DESCRIPTION
rbulk buffer was not protected under lock in ioreq_fop_dgmode_read().
Added lock which was missing earlier.

Signed-off-by: Yatin Mahajan <yatin.mahajan@seagate.com>

# Problem Statement
rbulk buffer was not protected under lock in ioreq_fop_dgmode_read() due to which panic was observed.

# Design
Added lock which was missing earlier.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
