### PR TITLE
CORTX-33927: Deployment failure due to wrong traversing of consul conf store

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -518,7 +518,6 @@ def motr_tune_memory_config(self):
 
     # Get number of services.
     # Ex: num_of_services will be 2 since in motr services will be confd, ios
-    # But in /etc/cortx/cluster.conf io is represented by ios. So first get the service names right
     num_of_services = get_value(self, 'cortx>motr>limits>num_services', str)
 
     # collect the memory and cpu limits.

--- a/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
+++ b/scripts/install/opt/seagate/cortx/motr/bin/motr_mini_prov.py
@@ -516,14 +516,20 @@ def motr_tune_memory_config(self):
         self.logger.debug(f"FILE not found  {MOTR_M0D_CONF_FILE_PATH}\n")
         return
 
+    # Get number of services.
+    # Ex: num_of_services will be 2 since in motr services will be confd, ios
+    # But in /etc/cortx/cluster.conf io is represented by ios. So first get the service names right
+    num_of_services = get_value(self, 'cortx>motr>limits>num_services', str)
+
     # collect the memory and cpu limits.
-    services_limits = Conf.get(self._index, 'cortx>motr>limits')['services']
-    for arr_elem in services_limits:
-        if arr_elem['name'] == "ios":
-            mem_min = arr_elem['memory']['min']
-            mem_max = arr_elem['memory']['max']
-            cpu_min = arr_elem['cpu']['min']
-            cpu_max = arr_elem['cpu']['max']
+    for i in range(num_of_services):
+        service_name = get_value(self, f'cortx>motr>limits>services[{i}]>name', str)
+        if service_name == "ios":
+            mem_min = get_value(self, f'cortx>motr>limits>services[{i}]>memory>min', str)
+            mem_max = get_value(self, f'cortx>motr>limits>services[{i}]>memory>max', str)
+            cpu_min = get_value(self, f'cortx>motr>limits>services[{i}]>cpu>min', str)
+            cpu_max = get_value(self, f'cortx>motr>limits>services[{i}]>cpu>max', str)
+            break
 
     self.logger.debug(f"Avaiable memory  {mem_min} {mem_max}\n")
     self.logger.debug(f"Avaiable CPU     {cpu_min} {cpu_max}\n")


### PR DESCRIPTION
# Problem Statement
- Deployment failure due to wrong traversing of consul conf store

# Design
Change the code so that only iterations of strings are valid and not any other structures like dictionary, list etc.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
Tested with k8s branch https://github.com/keithpine/cortx-k8s/tree/CORTX-33054_consul-confstore-url
Status after deployment:

`[root@ssc-vm-g2-rhev4-3118 ~]# kubectl get pods -n default
NAME                            READY   STATUS    RESTARTS   AGE
cortx-client-0                  2/2     Running   0          61m
cortx-consul-client-n5m6f       1/1     Running   0          61m
cortx-consul-server-0           1/1     Running   0          61m
cortx-control-dd4d9b489-tv244   1/1     Running   0          61m
cortx-data-g0-0                 3/3     Running   0          61m
cortx-data-g1-0                 3/3     Running   0          61m
cortx-ha-5b84c64ff5-xqj9s       3/3     Running   0          61m
cortx-kafka-0                   1/1     Running   0          61m
cortx-server-0                  2/2     Running   0          61m
cortx-zookeeper-0               1/1     Running   0          61m
`
# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
