### PR TITLE
fixes to build cortx debian packages on ubuntu jammy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1094,6 +1094,12 @@ AS_IF([test x$enable_coverage = xyes],
       ]
 )
 
+AX_CHECK_COMPILE_FLAG([-Wno-array-bounds],
+  [M0_CFLAGS="-Wno-array-bounds $M0_CFLAGS"])
+
+AX_CHECK_COMPILE_FLAG([-Wno-return-local-addr],
+  [M0_CFLAGS="-Wno-return-local-addr $M0_CFLAGS"])
+
 AS_IF([test x$enable_mcheck = xyes],
       [M0_LDFLAGS="-lmcheck $M0_LDFLAGS"]
 )
@@ -1118,7 +1124,7 @@ M0_CPPFLAGS_DIST=$(echo "$M0_CPPFLAGS" | grep -Po -e '-D\S+|-I/usr\S+|-inc\S+' |
 # __attribute__, such as __attribute__((gccxml(...))). It's important because we
 # use -Werror, which turns warnings into errors, but we still need to be able to
 # use gccxml attributes.
-M0_CFLAGS="-pipe -Wall -Werror -Wno-attributes -fno-strict-aliasing $M0_CFLAGS"
+M0_CFLAGS="-pipe -Wall -Werror -Wno-deprecated-declarations -Wno-attributes -fno-strict-aliasing $M0_CFLAGS"
 
 # Prevents gcc from introducing common symbols in object files. These symbols
 # are avoided because they break the compilation toolchain that Parallel

--- a/cortx-motr.spec.in
+++ b/cortx-motr.spec.in
@@ -83,6 +83,7 @@ Provides:       motr-modules = %{version}-%{release}
 
 BuildRequires:  automake
 BuildRequires:  autoconf
+BuildRequires:  autoconf-archive
 BuildRequires:  libtool
 BuildRequires:  make
 BuildRequires:  gcc

--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Build-Depends: automake,
                libio-all-perl,
                libfile-slurp-perl,
                libyaml-libyaml-perl,
-               python2-dev,
+               python2-dev | python3-dev,
                python3-ply
  
 Package: cortx-motr

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Maintainer: Andriy Tkachuk <andriy.tkachuk@seagate.com>
 Standards-Version: 4.4.0
 Build-Depends: automake,
                autoconf,
+               autoconf-archive,
                binutils-dev,
                libtool,
                make (>= 4.1),

--- a/debian/cortx-motr-dev.install
+++ b/debian/cortx-motr-dev.install
@@ -239,6 +239,8 @@ usr/include/motr/fop/fom_simple.h
 usr/include/motr/fop/fop.h
 usr/include/motr/fop/fop_item_type.h
 usr/include/motr/fop/ut/iterator_test_xc.h
+usr/include/motr/fop/wire.h
+usr/include/motr/fop/wire_xc.h
 usr/include/motr/format/format.h
 usr/include/motr/format/format_xc.h
 usr/include/motr/graph/graph.h
@@ -473,6 +475,7 @@ usr/include/motr/rpc/ub/fops_xc.h
 usr/include/motr/rpc/ut/at/at_ut_xc.h
 usr/include/motr/rpc/ut/fops_xc.h
 usr/include/motr/sm/sm.h
+usr/include/motr/sm/op.h
 usr/include/motr/sns/cm/ag.h
 usr/include/motr/sns/cm/cm.h
 usr/include/motr/sns/cm/cm_utils.h

--- a/debian/cortx-motr.install
+++ b/debian/cortx-motr.install
@@ -30,11 +30,11 @@ usr/lib/*/cortx-motr/motr-server
 usr/lib/*/cortx-motr/motr-dixinit
 usr/lib/udev/rules.d/99-motr.rules
 usr/sbin/m0gendisks
-usr/sbin/m0beck
+# usr/sbin/m0beck
 usr/sbin/m0protocol
 usr/sbin/m0ham
 usr/sbin/m0console
-usr/sbin/m0genfacts
+# usr/sbin/m0genfacts
 usr/sbin/m0kv
 usr/sbin/m0composite
 usr/sbin/m0betool

--- a/debian/cortx-motr.install
+++ b/debian/cortx-motr.install
@@ -12,8 +12,8 @@ usr/lib/systemd/system/motr.service
 usr/lib/systemd/system/motr-singlenode.service
 usr/lib/systemd/system/motr-cleanup.service
 usr/lib/systemd/system/motr-server@.service
-usr/lib/python2.7/site-packages/motr-1.0-py2.7.egg-info
-usr/lib/python2.7/site-packages/motr.so
+usr/lib/python*/site-packages/motr-1.0-py*.egg-info
+usr/lib/python*/site-packages/motr.*so
 usr/lib/*/libmotr.so*
 usr/lib/*/libmotr-helpers.so*
 usr/lib/*/libm0isc.so*

--- a/debian/cortx-motr.install
+++ b/debian/cortx-motr.install
@@ -99,7 +99,6 @@ opt/seagate/cortx/motr/common/m0_utils_common.sh
 opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
 opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
 opt/seagate/cortx/motr/common/cortx_util_funcs.sh
-opt/seagate/cortx/motr/common/core-traces
 opt/seagate/cortx/motr/bin/motr_mini_prov.py
 opt/seagate/cortx/motr/bin/motr_setup
 opt/seagate/cortx/motr/sanity/cortx_srvc_sanity.sh

--- a/stob/ut/domain.c
+++ b/stob/ut/domain.c
@@ -100,7 +100,8 @@ void m0_stob_ut_stob_domain_perf_null(void)
 }
 
 extern void m0_stob_ut_ad_init(struct m0_be_ut_backend *ut_be,
-			       struct m0_be_ut_seg     *ut_seg);
+			       struct m0_be_ut_seg     *ut_seg,
+			       bool use_small_credits);
 extern void m0_stob_ut_ad_fini(struct m0_be_ut_backend *ut_be,
 			       struct m0_be_ut_seg     *ut_seg);
 
@@ -112,7 +113,7 @@ void m0_stob_ut_stob_domain_ad(void)
 	char                    *cfg;
 	char                    *init_cfg;
 
-	m0_stob_ut_ad_init(&ut_be, &ut_seg);
+	m0_stob_ut_ad_init(&ut_be, &ut_seg, false);
 	stob = m0_ut_stob_linux_get();
 	M0_UT_ASSERT(stob != NULL);
 	m0_stob_ad_cfg_make(&cfg, ut_seg.bus_seg, m0_stob_id_get(stob), 0);

--- a/stob/ut/stob.c
+++ b/stob/ut/stob.c
@@ -271,7 +271,8 @@ void m0_stob_ut_stob_perf_null(void)
 }
 
 extern void m0_stob_ut_ad_init(struct m0_be_ut_backend *ut_be,
-			       struct m0_be_ut_seg     *ut_seg);
+			       struct m0_be_ut_seg     *ut_seg,
+			       bool use_small_credits);
 extern void m0_stob_ut_ad_fini(struct m0_be_ut_backend *ut_be,
 			       struct m0_be_ut_seg     *ut_seg);
 
@@ -283,7 +284,7 @@ void m0_stob_ut_stob_ad(void)
 	char                    *dom_cfg;
 	char                    *dom_init_cfg;
 
-	m0_stob_ut_ad_init(&ut_be, &ut_seg);
+	m0_stob_ut_ad_init(&ut_be, &ut_seg, false);
 	stob = m0_ut_stob_linux_get();
 	M0_UT_ASSERT(stob != NULL);
 


### PR DESCRIPTION
# Problem Statement
- Problem statement

we fail to build cortx-motr debian packages using the recipe in `debian` directory on ubuntu jammy

# Design

- be compatible with python3
- silence warnings from GCC-11
- correct the inconsistent function signatures
- do not package missing files 

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
