### PR TITLE
CORTX-33702: Codacy cleanup of markdown files

### DIFF
--- a/doc/FOPFOM-Programming-Guide.md
+++ b/doc/FOPFOM-Programming-Guide.md
@@ -38,7 +38,7 @@ A .ff file should be compiled using ff2c compiler.
 After writing FOPs and creating .ff file for a particular module, we need to make an entry for the same in the module's Makefile.am file. This would automatically invoke ff2c on the .ff files and create corresponding “C” format structures.
 
 ** A FOP, containing native data types in file fom_io_xc.ff:**  
-```  
+```C  
 record {
         u64 f_seq;
         u64 f_oid

--- a/doc/HLD-OF-Motr-LNet-Transport.md
+++ b/doc/HLD-OF-Motr-LNet-Transport.md
@@ -140,7 +140,7 @@ See Support for multiple message delivery in a single network buffer.
 
 The design provides an API for the higher level application to associate the internal threads used by a transfer machine with a set of processors. In particular the API guarantees that buffer and transfer machine callbacks will be made only on the processors specified.
 
-```
+```C
 #include “lib/processor.h”
 
 ...

--- a/doc/HLD-of-Catalogue-Service.md
+++ b/doc/HLD-of-Catalogue-Service.md
@@ -147,7 +147,7 @@ Deathrow catalogue contains all large catalogues which are in the process of bei
 
 GET	cfid, input: array of {key	rc, output: array of {exists, val}
 
-```
+```C
 cat = catalogue_get(req.cfid);
 
 foreach key in req.input {

--- a/doc/Motr-Epochs-HLD.md
+++ b/doc/Motr-Epochs-HLD.md
@@ -74,7 +74,7 @@ EpochTransitionRequest { service :: ServiceId
                        , targetEpoch  :: EpochId }
 ```
 HA services that wrap Motr services must be able to accept the following additional messages:
-```
+```Text
 EpochTransition { targetEpoch            :: EpochId
 
                 , epochTransitionPayload :: a }  

--- a/doc/Motr-Lnet-Transport.md
+++ b/doc/Motr-Lnet-Transport.md
@@ -140,7 +140,7 @@ See Support for multiple message delivery in a single network buffer.
 
 The design provides an API for the higher level application to associate the internal threads used by a transfer machine with a set of processors. In particular the API guarantees that buffer and transfer machine callbacks will be made only on the processors specified.
 
-```
+```C
 #include “lib/processor.h”
 
 ...

--- a/doc/Seagate-FDMI-HLD.md
+++ b/doc/Seagate-FDMI-HLD.md
@@ -121,7 +121,7 @@ the data to plug-in instance.
 
 Successful data processing results in returning acknowledge along with confirmation allowing data release, if required.  
 
-### 1.9.3 De-initialization  
+### 1.9.3 De-initialization ###
 ![image](./images/Image4_sequenceDiagram.PNG)    
 
 Plug-in initiates de-initialization by calling local FDMI. The latter deregisters plug-in’s filter set with filtered service. After

--- a/doc/motr-kv-app.md
+++ b/doc/motr-kv-app.md
@@ -17,10 +17,10 @@ Init the m0\_idx struct with m0\_idx\_init().
 
 Init the index create operation with m0\_entity\_create().
 
-```
+`
 An ID is needed for this index. In this example, ID is configured from command line.
 Developers are responsible to generate an unique ID for their indices.
-```
+`
 
 Launch the operation with m0\_op\_launch().
 

--- a/doc/motr-object-app.md
+++ b/doc/motr-object-app.md
@@ -31,7 +31,7 @@ Motr applications. Please refer to source code "lib/"
 
 Define necessary variables (global or in main() function)
 
-```
+```C
     static struct m0_client         *m0_instance = NULL;
     static struct m0_container       motr_container;
     static struct m0_config          motr_conf;
@@ -40,7 +40,7 @@ Define necessary variables (global or in main() function)
 
 Get configuration arguments from command line
 
-```
+```C
 
 #include "motr/client.h"
 

--- a/scripts/provisioning/README.md
+++ b/scripts/provisioning/README.md
@@ -333,7 +333,7 @@ which is more convenient:
     ```
 
 The `m0vg` helper script is a wrapper around _Vagrant_ and _Ansible_ commands
-that can be *symlinked* somewhere into the `PATH` and be called from any
+that can be **symlinked** somewhere into the `PATH` and be called from any
 directory. Check out `m0vg --help` for more info.
 
 It will spawn a VM and configure it using _Ansible_ "playbook"
@@ -354,7 +354,9 @@ below for the list of other useful _Vagrant_ commands.
 
 If a cluster-like environment is needed, more machines can be provisioned:
 
-    ./scripts/m0vg up cmu /ssu/ /client/
+```sh
+./scripts/m0vg up cmu /ssu/ /client/
+```
 
 The additional parameters are also explained in the _Vagrant basics_ section
 below.


### PR DESCRIPTION
Signed-off-by: Rohan Dhodare <rohan.v.dhodare@seagate.com>

# Problem Statement
- Codacy warnings in below given files:
  - [fenced-code-flag]
    - doc/FOPFOM-Programming-Guide.md
    - doc/HLD-OF-Motr-LNet-Transport.md
    - doc/HLD-of-Catalogue-Service.md
    - doc/Motr-Epochs-HLD.md
    - doc/Motr-Lnet-Transport.md
    - doc/motr-kv-app.md
    - doc/motr-object-app.md

  - [emphasis-marker]
    - scripts/provisioning/README.md
   
  - [code-block-style]
    - doc/Running_Motr_Across_a_Cluster.md
    - scripts/provisioning/README.md
   
  - [heading-style]
    - doc/Seagate-FDMI-HLD.md


# Design
- [fenced-code-flag] -> added name of programming language after  3 backquotes ```
- [emphasis-marker] -> added * before and after the word to be emphasised
- [code-block-style] -> added 3 backquote ```
- [heading-style] -> used atx-closed formatting for headings

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


-----
[View rendered doc/FOPFOM-Programming-Guide.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/FOPFOM-Programming-Guide.md)
[View rendered doc/HLD-OF-Motr-LNet-Transport.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/HLD-OF-Motr-LNet-Transport.md)
[View rendered doc/HLD-of-Catalogue-Service.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/HLD-of-Catalogue-Service.md)
[View rendered doc/Motr-Epochs-HLD.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/Motr-Epochs-HLD.md)
[View rendered doc/Motr-Lnet-Transport.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/Motr-Lnet-Transport.md)
[View rendered doc/Running_Motr_Across_a_Cluster.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/Running_Motr_Across_a_Cluster.md)
[View rendered doc/Seagate-FDMI-HLD.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/Seagate-FDMI-HLD.md)
[View rendered doc/motr-kv-app.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/motr-kv-app.md)
[View rendered doc/motr-object-app.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/doc/motr-object-app.md)
[View rendered scripts/provisioning/README.md](https://github.com/RohanDhodare/cortx-motr/blob/CORTX-33702/scripts/provisioning/README.md)