### PR TITLE
Test Motr key-value application

### DIFF
--- a/doc/motr-kv-app.md
+++ b/doc/motr-kv-app.md
@@ -89,7 +89,10 @@ Run the application with the following command parameters.
 
 ```
 ./example2 192.168.53.101@tcp:12345:34:1 192.168.53.101@tcp:12345:33:1000 0x7000000000000001:0 0x7200000000000001:64 1234567         
-rc=0 op_rc=0                                                                                                  index create rc:0                                                                                                     rc=0 op_rc=0                                                                                                  PUT 0: key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA val=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+rc=0 op_rc=0                                                                                                  
+index create rc:0                                                                                                     
+rc=0 op_rc=0                                                                                                 
+PUT 0: key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA val=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ...
 app completed: 0 
 ```

--- a/doc/motr-kv-app.md
+++ b/doc/motr-kv-app.md
@@ -72,6 +72,11 @@ The steps to delete an existing index: function index\_delete().
 *   Retrieve the result.
 *   Finalize and free the operation with m0\_op\_fini() and m0\_op\_free().
 
+## Troubleshoot
+
+To find the application's 2nd parameter (LOCAL_ADDR), look for the running motr's Client_addr. 
+
 # Tested by
 
+*   Aug 16, 2022: Bo Wei (bo.b.wei@seagate.com) tested using CentOS 7.9.
 *   Sep 28, 2021: Liana Valdes Rodriguez (liana.valdes@seagate.com / lvald108@fiu.edu) tested using CentOS Linux release 7.8.2003 x86_64

--- a/doc/motr-kv-app.md
+++ b/doc/motr-kv-app.md
@@ -76,6 +76,24 @@ The steps to delete an existing index: function index\_delete().
 
 To find the application's 2nd parameter (LOCAL_ADDR), look for the running motr's Client_addr. 
 
+For example, for the motr instance below,
+
+```
+HA_addr    : 192.168.53.101@tcp:12345:34:1                                                                               
+Client_addr: 192.168.53.101@tcp:12345:33:1000                                                                            
+Profile_fid: 0x7000000000000001:0                                                                                     
+Process_fid: 0x7200000000000001:64    
+```
+
+Run the application with the following command parameters.
+
+```
+./example2 192.168.53.101@tcp:12345:34:1 192.168.53.101@tcp:12345:33:1000 0x7000000000000001:0 0x7200000000000001:64 1234567         
+rc=0 op_rc=0                                                                                                  index create rc:0                                                                                                     rc=0 op_rc=0                                                                                                  PUT 0: key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA val=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+...
+app completed: 0 
+```
+
 # Tested by
 
 *   Aug 16, 2022: Bo Wei (bo.b.wei@seagate.com) tested using CentOS 7.9.


### PR DESCRIPTION
Test Motr key-value application. Add instruction on the application's 2nd parameter (LOCAL_ADDR). 

-----
[View rendered doc/motr-kv-app.md](https://github.com/wb-droid/cortx-motr/blob/main/doc/motr-kv-app.md)