### PR TITLE
CORTX-33057: Error handing for asserts.

### DIFF
--- a/motr/setup.c
+++ b/motr/setup.c
@@ -1672,7 +1672,12 @@ static int cs_storage_setup(struct m0_motr *cctx)
 		}
 	}
 
-	M0_ASSERT(rctx->rc_mdstore.md_dom != NULL);
+	if (rctx->rc_mdstore.md_dom == NULL) {
+		rc = -ENOENT;
+		M0_ERR_INFO(rc, "Cob domain not found for root cob");
+		goto cleanup_addb2;
+	}
+
 	/* Init mdstore and root cob as it should be created by mkfs. */
 	rc = m0_mdstore_init(&rctx->rc_mdstore, rctx->rc_beseg, true);
 	if (rc != 0) {


### PR DESCRIPTION
motr/setup.c: M0_ASSERT(rctx->rc_mdstore.md_dom != NULL);
This Assert was changed to check for NULL md_dom and return -ENOENT
if check failed instead of raising a panic.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
