### PR TITLE
CORTX-33972: DI : 43motr-sync-replication ST, be-ut, io-nw-xfer-ut fix

### DIFF
--- a/be/ut/extmap.c
+++ b/be/ut/extmap.c
@@ -33,7 +33,7 @@
 #include "be/ut/helper.h"
 #include "be/extmap.h"
 
-#define EXTMAP_UT_UNIT_SIZE 10
+#define EXTMAP_UT_UNIT_SIZE 16
 #define EXTMAP_UT_CS_SIZE   16
 
 static struct m0_be_ut_backend be_ut_emap_backend;
@@ -550,8 +550,8 @@ static void test_paste_checksum_validation(void)
 	M0_UT_ASSERT(seg->ee_ext.e_end   == M0_BINDEX_MAX + 1);
 
 	idx = 0;
-	e.e_start = 50;
-	e.e_end   = 100;
+	e.e_start = m0_round_up(50, EXTMAP_UT_UNIT_SIZE);
+	e.e_end   = m0_round_up(100, EXTMAP_UT_UNIT_SIZE);
 	es[idx] = e_temp[idx] = e;
 	e_val[idx] = 12;
 
@@ -601,8 +601,8 @@ static void test_paste_checksum_validation(void)
 	 * New segment paste operation 1
 	 */
 	idx = 1;
-	e.e_start = 100;
-	e.e_end   = 150;
+	e.e_start = m0_round_up(100, EXTMAP_UT_UNIT_SIZE);
+	e.e_end   = m0_round_up(150, EXTMAP_UT_UNIT_SIZE);
 	es[idx] = e_temp[idx] = e;
 	e_val[idx] = 11;
 
@@ -660,8 +660,8 @@ static void test_paste_checksum_validation(void)
 	 * New segment overwrite paste operation
 	 */
 	idx = 2;
-	e.e_start = 80;
-	e.e_end   = 130;
+	e.e_start = m0_round_up(80, EXTMAP_UT_UNIT_SIZE);
+	e.e_end   = m0_round_up(130, EXTMAP_UT_UNIT_SIZE);
 	es[idx] = e_temp[idx] = e;
 	e_val[idx] = 13;
 

--- a/motr/st/utils/motr_sync_replication_st.sh
+++ b/motr/st/utils/motr_sync_replication_st.sh
@@ -34,10 +34,7 @@ m0t1fs_dir="$motr_st_util_dir/../../../m0t1fs/linux_kernel/st"
 . $motr_st_util_dir/motr_local_conf.sh
 . $motr_st_util_dir/motr_st_inc.sh
 
-# TODO : N will be reverted to 1 after addressing the code fix in DI checksum
-# computation in read path, for the specific case of N=1, K=2, 2 disc failure
-# degraded read.
-N=2
+N=1
 K=2
 S=2
 P=15

--- a/motr/ut/io_nw_xfer.c
+++ b/motr/ut/io_nw_xfer.c
@@ -272,6 +272,8 @@ static void ut_test_target_ioreq_seg_add(void)
 	m0_bufvec_alloc(&ti->ti_auxbufvec, 1, unit_size);
 	M0_SET0(&ioo->ioo_attr);
 	M0_ALLOC_ARR(ti->ti_pageattrs, 1);
+	m0_indexvec_alloc(&ti->ti_goff_ivec, 1);
+	ti->ti_goff_ivec.iv_vec.v_nr = 0;
 
 	target_ioreq_seg_add(ti, src, tgt, 111, 1, map);
 	M0_UT_ASSERT(ti->ti_ivec.iv_vec.v_nr == 1);
@@ -287,6 +289,7 @@ static void ut_test_target_ioreq_seg_add(void)
 	m0_bufvec_free(&ti->ti_bufvec);
 	m0_bufvec_free(&ti->ti_auxbufvec);
 	m0_indexvec_free(&ti->ti_ivec);
+	m0_indexvec_free(&ti->ti_goff_ivec);
 
 	ut_dummy_pargrp_iomap_delete(map, instance);
 	m0_free(tgt);


### PR DESCRIPTION
*43motr-sync-replication
*be-ut failure in emap
*io-nw-xfer-ut failure in target_ioreq_seg_add

Signed-off-by: Rajat Patil <rajat.r.patil@seagate.com>
Co-authored-by: Vidyadhar Pinglikar <vidyadhar.pinglikar@seagate.com>

# Problem Statement
- 43motr-sync-replication ST fails.
- be-ut failure in emap and io-nw-xfer-ut failure in target_ioreq_seg_add fails.

# Design
- 43motr-sync-replication fixed for N < K by shifting goff by (K-N)*offset.
- be-ut failure in emap is fixed by changing EXTMAP_UT_UNIT_SIZE to 16 from 10 as it should be in range of power 2.
- io-nw-xfer-ut is fixed by allocating ti_goff_ivec.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
