### PR TITLE
st: fix failure of rpc cancel ST

### DIFF
--- a/motr/st/utils/motr_rpc_cancel_test.sh
+++ b/motr/st/utils/motr_rpc_cancel_test.sh
@@ -297,7 +297,7 @@ motr_cancel_during_unlink()
 	pid=$!
 
 	echo "Wait for few seconds to generate enough fops "
-	sleep 15
+	sleep 5
 
 	echo "Sending cancle fop"
 	motr_cancel_session_fop

--- a/motr/st/utils/motr_rpc_cancel_test.sh
+++ b/motr/st/utils/motr_rpc_cancel_test.sh
@@ -238,7 +238,7 @@ motr_cancel_during_create()
 	pid=$!
 
 	echo "Wait for few seconds to generate enough fops "
-	sleep 3
+	sleep 1
 
 	echo "Sending cancle fop"
 	motr_cancel_session_fop

--- a/scripts/m0
+++ b/scripts/m0
@@ -44,6 +44,8 @@ M0_SRC_DIR="${M0_SRC_DIR%/*/*}"
 
 SUDO="${SUDO-sudo -E}"  # the absence of ':' is important
 
+check_and_restart_lnet
+
 # Check which library is used for reed-solomon encode and decode
 _check_rs_library() {
     is_isal=`whereis libisal | cut -d ':' -f 1 --complement`


### PR DESCRIPTION
Problem:
RPC cancel ST is failing due to m0ham utility is failing to send
the HA message to client(m0touch).

Solution:
Currently wait of 3 seconds is there between start of m0touch with
n create operations and m0ham message to do the cancel operation.
Reduced it to 1 second so that m0touch will be there when m0ham is
started.

Signed-off-by: Madhavrao Vemuri <madhav.vemuri@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
