### PR TITLE
cortx-34068: Fix m0_utils_common to point to correct path of m0hagen

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/common/m0_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_utils_common.sh
@@ -28,7 +28,7 @@ XPRT=""
 
 M0_REPAIR_UTILS=/usr/sbin/m0repair
 M0_HAM_UTILS=/usr/sbin/m0ham
-M0_HAGEN_UTILS=/usr/sbin/m0hagen
+M0_HAGEN_UTILS=/usr/bin/m0hagen
 MOTR_COPY=/usr/bin/m0cp
 MOTR_CAT=/usr/bin/m0cat
 


### PR DESCRIPTION
Signed-off-by: Mehul Joshi <mehul.joshi@seagate.com>

# Problem Statement
- m0_ha_sim fails to locate m0hagen command while running

# Design
-  Correct the location/path pointing to m0hagen in motr/common/m0_utils_common.sh 

# Coding
 -  [X] Coding conventions are followed and code is consistent

# Testing 
- [ ] Ran m0_ha_sim with the changes and validated the change

# Impact Analysis
- [X] Side effects on other features (deployment/upgrade): None
- [X] Dependencies on other component(s): None

# Review Checklist 
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide: NA
