### PR TITLE
CORTX-33803: Run UT's Individually

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -19,8 +19,1268 @@
 
 ---
 Tests:
-  - id       : 00userspace-tests
-    script   : 'm0 run-ut'
+  - id       : 00userspace-tests_libm0-ut
+    script   : 'm0 run-ut -t libm0-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_addb2-base
+    script   : 'm0 run-ut -t addb2-base'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_addb2-consumer
+    script   : 'm0 run-ut -t addb2-consumer'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_addb2-histogram
+    script   : 'm0 run-ut -t addb2-histogram'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_addb2-net
+    script   : 'm0 run-ut -t addb2-net'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_addb2-storage
+    script   : 'm0 run-ut -t addb2-storage'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_addb2-sys
+    script   : 'm0 run-ut -t addb2-sys'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_di-ut
+    script   : 'm0 run-ut -t di-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_balloc-ut
+    script   : 'm0 run-ut -t balloc-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_be-ut
+    script   : 'm0 run-ut -t be-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_buffer_pool_ut
+    script   : 'm0 run-ut -t buffer_pool_ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_bulk-client-ut
+    script   : 'm0 run-ut -t bulk-client-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_bulk-server-ut
+    script   : 'm0 run-ut -t bulk-server-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_bytecount-ut
+    script   : 'm0 run-ut -t bytecount-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dtm0-ut
+    script   : 'm0 run-ut -t dtm0-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_btree-ut
+    script   : 'm0 run-ut -t btree-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_capa-ut
+    script   : 'm0 run-ut -t capa-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_cas-client
+    script   : 'm0 run-ut -t cas-client'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_cas-service
+    script   : 'm0 run-ut -t cas-service'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_client-ut
+    script   : 'm0 run-ut -t client-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_obj-ut
+    script   : 'm0 run-ut -t obj-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_io-ut
+    script   : 'm0 run-ut -t io-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_io-nw-xfer-ut
+    script   : 'm0 run-ut -t io-nw-xfer-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_io-pargrp-ut
+    script   : 'm0 run-ut -t io-pargrp-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_io-req-ut
+    script   : 'm0 run-ut -t io-req-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_io-req-fop-ut
+    script   : 'm0 run-ut -t io-req-fop-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_sync-ut
+    script   : 'm0 run-ut -t sync-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_idx-ut
+    script   : 'm0 run-ut -t idx-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_idx-dix
+    script   : 'm0 run-ut -t idx-dix'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_idx-dix-mt
+    script   : 'm0 run-ut -t idx-dix-mt'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_layout-ut
+    script   : 'm0 run-ut -t layout-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_helpers-ufid-ut
+    script   : 'm0 run-ut -t helpers-ufid-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_cm-cp-ut
+    script   : 'm0 run-ut -t cm-cp-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_cm-ut
+    script   : 'm0 run-ut -t cm-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_cob-ut
+    script   : 'm0 run-ut -t cob-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_cob-foms-ut
+    script   : 'm0 run-ut -t cob-foms-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_conf-ut
+    script   : 'm0 run-ut -t conf-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_conf-load-ut
+    script   : 'm0 run-ut -t conf-load-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_conf-pvers-ut
+    script   : 'm0 run-ut -t conf-pvers-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_confc-ut
+    script   : 'm0 run-ut -t confc-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_conf-glob-ut
+    script   : 'm0 run-ut -t conf-glob-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_conf-diter-ut
+    script   : 'm0 run-ut -t conf-diter-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_confstr-ut
+    script   : 'm0 run-ut -t confstr-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_conf-validation-ut
+    script   : 'm0 run-ut -t conf-validation-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_conf-walk-ut
+    script   : 'm0 run-ut -t conf-walk-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rconfc-ut
+    script   : 'm0 run-ut -t rconfc-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-connection-ut
+    script   : 'm0 run-ut -t rpc-connection-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dix-client-ut
+    script   : 'm0 run-ut -t dix-client-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dix-cm-iter
+    script   : 'm0 run-ut -t dix-cm-iter'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dtm-nucleus-ut
+    script   : 'm0 run-ut -t dtm-nucleus-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dtm-transmit-ut
+    script   : 'm0 run-ut -t dtm-transmit-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dtm-dtx-ut
+    script   : 'm0 run-ut -t dtm-dtx-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dtm0-clk-src-ut
+    script   : 'm0 run-ut -t dtm0-clk-src-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_dtm0-log-ut
+    script   : 'm0 run-ut -t dtm0-log-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_failure_domains_tree-ut
+    script   : 'm0 run-ut -t failure_domains_tree-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_failure_domains-ut
+    script   : 'm0 run-ut -t failure_domains-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fis-ut
+    script   : 'm0 run-ut -t fis-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fdmi-filterc-ut
+    script   : 'm0 run-ut -t fdmi-filterc-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fdmi-pd-ut
+    script   : 'm0 run-ut -t fdmi-pd-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fdmi-sd-ut
+    script   : 'm0 run-ut -t fdmi-sd-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fdmi-fol-ut
+    script   : 'm0 run-ut -t fdmi-fol-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fdmi-fol-fini-ut
+    script   : 'm0 run-ut -t fdmi-fol-fini-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fdmi-filter-eval-ut
+    script   : 'm0 run-ut -t fdmi-filter-eval-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fit-ut
+    script   : 'm0 run-ut -t fit-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fol-ut
+    script   : 'm0 run-ut -t fol-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fom-timedwait-ut
+    script   : 'm0 run-ut -t fom-timedwait-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-formation-ut
+    script   : 'm0 run-ut -t rpc-formation-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_ha-ut
+    script   : 'm0 run-ut -t ha-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_ha-state-ut
+    script   : 'm0 run-ut -t ha-state-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_ios-bufferpool-ut
+    script   : 'm0 run-ut -t ios-bufferpool-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_isc-api-ut
+    script   : 'm0 run-ut -t isc-api-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_isc-service-ut
+    script   : 'm0 run-ut -t isc-service-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-item-ut
+    script   : 'm0 run-ut -t rpc-item-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-item-source-ut
+    script   : 'm0 run-ut -t rpc-item-source-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_layout-ut
+    script   : 'm0 run-ut -t layout-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_layout-access-plan-ut
+    script   : 'm0 run-ut -t layout-access-plan-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-link-ut
+    script   : 'm0 run-ut -t rpc-link-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fop-lock-ut
+    script   : 'm0 run-ut -t fop-lock-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_fom-stats-ut
+    script   : 'm0 run-ut -t fom-stats-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_net-bulk-if
+    script   : 'm0 run-ut -t net-bulk-if'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_net-bulk-mem
+    script   : 'm0 run-ut -t net-bulk-mem'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_net-lnet
+    script   : 'm0 run-ut -t net-lnet'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_libfab-ut
+    script   : 'm0 run-ut -t libfab-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_net-misc-ut
+    script   : 'm0 run-ut -t net-misc-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_net-module
+    script   : 'm0 run-ut -t net-module'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_net-test
+    script   : 'm0 run-ut -t net-test'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_net-prov-ut
+    script   : 'm0 run-ut -t net-prov-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_m0d-ut
+    script   : 'm0 run-ut -t m0d-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_mdservice-ut
+    script   : 'm0 run-ut -t mdservice-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_module-ut
+    script   : 'm0 run-ut -t module-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_ms-fom-ut
+    script   : 'm0 run-ut -t ms-fom-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-packet-encdec-ut
+    script   : 'm0 run-ut -t rpc-packet-encdec-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_parity_math-ut
+    script   : 'm0 run-ut -t parity_math-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_parity_math_ssse3-ut
+    script   : 'm0 run-ut -t parity_math_ssse3-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_poolmach-ut
+    script   : 'm0 run-ut -t poolmach-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_reqh-ut
+    script   : 'm0 run-ut -t reqh-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_reqh-fop-allow-ut
+    script   : 'm0 run-ut -t reqh-fop-allow-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_reqh-service-ut
+    script   : 'm0 run-ut -t reqh-service-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_reqh-service-ctx-ut
+    script   : 'm0 run-ut -t reqh-service-ctx-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rm-ut
+    script   : 'm0 run-ut -t rm-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rm-rcredits-ut
+    script   : 'm0 run-ut -t rm-rcredits-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rm-rwlock-ut
+    script   : 'm0 run-ut -t rm-rwlock-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-at
+    script   : 'm0 run-ut -t rpc-at'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-machine-ut
+    script   : 'm0 run-ut -t rpc-machine-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-rcv-session-ut
+    script   : 'm0 run-ut -t rpc-rcv-session-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-lib-ut
+    script   : 'm0 run-ut -t rpc-lib-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-conn-pool-ut
+    script   : 'm0 run-ut -t rpc-conn-pool-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_rpc-session-ut
+    script   : 'm0 run-ut -t rpc-session-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_sm-ut
+    script   : 'm0 run-ut -t sm-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_snscm_xform-ut
+    script   : 'm0 run-ut -t snscm_xform-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_snscm_storage-ut
+    script   : 'm0 run-ut -t snscm_storage-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_sns-cm-repair-ut
+    script   : 'm0 run-ut -t sns-cm-repair-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_snscm_net-ut
+    script   : 'm0 run-ut -t snscm_net-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_sns-file-lock-ut
+    script   : 'm0 run-ut -t sns-file-lock-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_spiel-ut
+    script   : 'm0 run-ut -t spiel-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_spiel-ci-ut
+    script   : 'm0 run-ut -t spiel-ci-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_sss-ut
+    script   : 'm0 run-ut -t sss-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_stats-ut
+    script   : 'm0 run-ut -t stats-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_spiel-conf-ut
+    script   : 'm0 run-ut -t spiel-conf-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_stob-ut
+    script   : 'm0 run-ut -t stob-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_storage-dev-ut
+    script   : 'm0 run-ut -t storage-dev-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_udb-ut
+    script   : 'm0 run-ut -t udb-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_xcode_bufvec_fop-ut
+    script   : 'm0 run-ut -t xcode_bufvec_fop-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_ff2c-ut
+    script   : 'm0 run-ut -t ff2c-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_xcode-ut
+    script   : 'm0 run-ut -t xcode-ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_pi_ut
+    script   : 'm0 run-ut -t pi_ut'
+    dir      : src/scripts
+    executor : Xperior::Executor::MotrTest
+    #executor : Xperior::Executor::Skip
+    sandbox  : /var/motr/m0ut
+    groupname: 01motr-single-node
+    polltime : 15
+    timeout  : 2400
+
+  - id       : 00userspace-tests_libconsole-ut
+    script   : 'm0 run-ut -t libconsole-ut'
     dir      : src/scripts
     executor : Xperior::Executor::MotrTest
     #executor : Xperior::Executor::Skip


### PR DESCRIPTION
Since UT's are being run as a group when one of the UT fails
the regression Job in motr does not run the rest of the UT's.
Hence we want to run the UT's individually.

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
If one of the UT fails the rest are not executed.

# Design
Run the UT's individually instead of running them as a group.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
