### PR TITLE
CORTX-33834: Fixed rpc/conn.c m0_rpc_conn_ha_timer_start() memory leak

### DIFF
--- a/rpc/conn.c
+++ b/rpc/conn.c
@@ -1433,7 +1433,8 @@ M0_INTERNAL int m0_rpc_conn_ha_timer_start(struct m0_rpc_conn *conn)
 		return M0_RC(0); /* there's no point to arm the timer */
 	if (m0_sm_timer_is_armed(&conn->c_ha_timer))
 		return M0_RC(0); /* Already started */
-	else if (conn->c_ha_timer.tr_timer.t_state != M0_TIMER_UNINIT)
+	else if (M0_IN(conn->c_ha_timer.tr_timer.t_state,
+			(M0_TIMER_STOPPED, M0_TIMER_INITED)))
 		m0_sm_timer_fini(&conn->c_ha_timer);
 	if (conn->c_rpc_machine->rm_stopping)
 		return M0_RC(0);
@@ -1453,8 +1454,10 @@ M0_INTERNAL void m0_rpc_conn_ha_timer_stop(struct m0_rpc_conn *conn)
 	if (m0_sm_timer_is_armed(&conn->c_ha_timer)) {
 		M0_LOG(M0_DEBUG, "Cancelling HA timer; rpc conn=%p", conn);
 		m0_sm_timer_cancel(&conn->c_ha_timer);
-		m0_sm_timer_fini(&conn->c_ha_timer);
 	}
+	else if (M0_IN(conn->c_ha_timer.tr_timer.t_state,
+			(M0_TIMER_STOPPED, M0_TIMER_INITED)))
+		m0_sm_timer_fini(&conn->c_ha_timer);
 }
 
 /**

--- a/rpc/conn.c
+++ b/rpc/conn.c
@@ -1433,7 +1433,7 @@ M0_INTERNAL int m0_rpc_conn_ha_timer_start(struct m0_rpc_conn *conn)
 		return M0_RC(0); /* there's no point to arm the timer */
 	if (m0_sm_timer_is_armed(&conn->c_ha_timer))
 		return M0_RC(0); /* Already started */
-	else
+	else if (conn->c_ha_timer.tr_timer.t_state != M0_TIMER_UNINIT)
 		m0_sm_timer_fini(&conn->c_ha_timer);
 	if (conn->c_rpc_machine->rm_stopping)
 		return M0_RC(0);
@@ -1448,10 +1448,12 @@ M0_INTERNAL int m0_rpc_conn_ha_timer_start(struct m0_rpc_conn *conn)
 
 M0_INTERNAL void m0_rpc_conn_ha_timer_stop(struct m0_rpc_conn *conn)
 {
+	M0_ENTRY("conn %p", conn);
 	M0_PRE(m0_rpc_machine_is_locked(conn->c_rpc_machine));
 	if (m0_sm_timer_is_armed(&conn->c_ha_timer)) {
 		M0_LOG(M0_DEBUG, "Cancelling HA timer; rpc conn=%p", conn);
 		m0_sm_timer_cancel(&conn->c_ha_timer);
+		m0_sm_timer_fini(&conn->c_ha_timer);
 	}
 }
 

--- a/rpc/conn.c
+++ b/rpc/conn.c
@@ -1454,8 +1454,7 @@ M0_INTERNAL void m0_rpc_conn_ha_timer_stop(struct m0_rpc_conn *conn)
 	if (m0_sm_timer_is_armed(&conn->c_ha_timer)) {
 		M0_LOG(M0_DEBUG, "Cancelling HA timer; rpc conn=%p", conn);
 		m0_sm_timer_cancel(&conn->c_ha_timer);
-	}
-	else if (M0_IN(conn->c_ha_timer.tr_timer.t_state,
+	} else if (M0_IN(conn->c_ha_timer.tr_timer.t_state,
 			(M0_TIMER_STOPPED, M0_TIMER_INITED)))
 		m0_sm_timer_fini(&conn->c_ha_timer);
 }


### PR DESCRIPTION
Problem: Prior to this patch, m0_rpc_conn_ha_timer_start() was responsible for initializing
and finalizing the timer m0_rpc_conn::c_ha_timer. The old timer would be finalized
and freed and then the new timer would be allocated and initialized. This led to a memory leak because
one instance of c_ha_timer was always left.

Solution: m0_rpc_conn_ha_timer_stop() now finalizes the RPC timer c_ha_timer and
m0_rpc_conn_ha_timer_start() is modified to finalize only the timer which is not already finalized.

Signed-off-by: Abhishek Saha <abhishek.saha@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
