### PR TITLE
CORTX-30074: Add support to m0_ha_sim for sns direct rebalance

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
@@ -82,6 +82,68 @@ $SPIEL_RCONF_STOP
 EOF
 }
 
+spiel_sns_dtrebalance_start()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+rc = spiel.sns_dtrebalance_start(fids['pool'])
+print ("sns dtrebalance start rc: " + str(rc))
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_wait_for_sns_dtrebalance()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+import time
+$SPIEL_FIDS_LIST
+
+$SPIEL_RCONF_START
+
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+active = 0
+while (1):
+    active = 0
+    nr = spiel.sns_dtrebalance_status(fids['pool'], ppstatus)
+    print ("sns dtrebalance status responded servers: " + str(nr))
+    for i in range(0, nr):
+        print ("status of ", ppstatus[{}].sss_fid, " is: {}".format(i, ppstatus[i].sss_state))
+        if (ppstatus[i].sss_state == 2) :
+            print ("sns is still active on ", ppstatus[i].sss_fid)
+            active = 1
+    if (active == 0):
+        break;
+    time.sleep(3)
+
+$SPIEL_RCONF_STOP
+EOF
+}
+
+spiel_sns_dtrebalance_status()
+{
+echo "$M0_SPIEL_UTILS $SPIEL_OPTS"
+    eval "$M0_SPIEL_UTILS $SPIEL_OPTS" <<EOF
+$SPIEL_FIDS_LIST
+$SPIEL_RCONF_START
+one_status = SpielSnsStatus()
+ppstatus = pointer(one_status)
+nr = spiel.sns_dtrebalance_status(fids['pool'], ppstatus)
+print ("sns dtrebalance status responded servers: " + str(nr))
+for i in range(0, nr):
+        print("status of ", ppstatus[i].sss_fid, " is: ", ppstatus[i].sss_state)
+        if (ppstatus[i].sss_state == 2) :
+                print("sns dtrebalance is still active on ", ppstatus[i].sss_fid)
+$SPIEL_RCONF_STOP
+EOF
+}
+
 spiel_sns_rebalance_start()
 {
 echo "$M0_SPIEL_UTILS $SPIEL_OPTS"

--- a/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
+++ b/scripts/install/opt/seagate/cortx/motr/libexec/m0_ha_sim
@@ -112,6 +112,61 @@ _sns_rebalance_status()
         return $rc
 }
 
+
+_sns_dtrebalance_start()
+{
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_sns_dtrebalance_start
+        else
+                # sns_repair # Using m0repair
+                echo "unsupported utility $UTILITY; use m0spiel"
+                return rc=1
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "SNS dtrebalance start failed with rc = $rc."
+        fi
+        return $rc
+}
+
+_sns_dtrebalance_wait()
+{
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_wait_for_sns_dtrebalance
+        else
+                # wait_for_sns_repair_or_rebalance "dtrebalance"
+                echo "unsupported utility $UTILITY; use m0spiel"
+                return rc=1
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "Wait for SNS dtrebalance failed with rc = $rc."
+        fi
+        return $rc
+}
+
+_sns_dtrebalance_status()
+{
+        local rc
+        if [ "$UTILITY" == "m0spiel" ]; then
+                spiel_sns_dtrebalance_status
+        else
+                # sns_repair_or_rebalance_status "dtrebalance"
+                echo "unsupported utility $UTILITY; use m0spiel"
+                return rc=1
+        fi
+        rc=$?
+        if [ $rc != 0 ]
+        then
+                echo "SNS repair status failed with rc = $rc."
+        fi
+        return $rc
+}
+
 _dix_repair_start()
 {
 	local rc
@@ -270,6 +325,37 @@ _motr_trigger_sns_repair()
        return $?
 }
 
+_motr_trigger_sns_dtrebalance()
+{
+        local rc=0
+        local fail_device=$DEVICE_ID
+
+        echo "Starting SNS direct rebalance ..."
+
+        echo "Disk state get"
+        disk_state_get "$fail_device"
+        if [ "$state_recv" != "failed" ]; then
+                echo "Device state doesn't seem in  "failed""
+                return 1
+        fi
+
+        disk_state_set "repair" "$fail_device" || return $?
+        echo "trigger sns direct rebalance"
+        _sns_dtrebalance_start || return $?
+
+        echo "wait for sns direct rebalance"
+        _sns_dtrebalance_wait || return $?
+
+        echo "query sns direct rebalance status"
+        _sns_dtrebalance_status || return $?
+
+        disk_state_set "online" "$fail_device" || return $?
+
+        echo "SNS Direct rebalance done."
+
+        return $?
+}
+
 _motr_trigger_dix_rebalance()
 {
         local rc=0
@@ -339,6 +425,16 @@ motr_trigger_repair()
                 _motr_trigger_dix_repair || return 1
         else
                 _motr_trigger_sns_repair || return 1
+        fi
+}
+
+motr_trigger_dtrebalance()
+{
+        if [ "$REC_TYPE" == "DIX" ]; then
+                # _motr_trigger_dix_repair || return 1
+                return 1
+        else
+                _motr_trigger_sns_dtrebalance || return 1
         fi
 }
 
@@ -447,6 +543,10 @@ main()
         elif [ "$TYPE" == "rebalance" ]; then
                 echo "Running $REC_TYPE Rebalance "
                 motr_trigger_rebalance
+                rc=$?
+        elif [ "$TYPE" == "dtrebalance" ]; then
+                echo "Running $REC_TYPE Direct Rebalance "
+                motr_trigger_dtrebalance
                 rc=$?
         elif [ "$TYPE" == "repreb" ]; then
                 echo "Running $REC_TYPE Repair and Rebalance "

--- a/utils/spiel/m0spiel
+++ b/utils/spiel/m0spiel
@@ -546,6 +546,27 @@ class SpielWrapper:
                                                     byref(ppstatus))
 
     @require(fid=Fid)
+    def sns_dtrebalance_start(self, fid):
+        return self.motr.m0_spiel_sns_dtrebalance_start(self.spiel, byref(fid))
+
+    @require(fid=Fid)
+    def sns_dtrebalance_abort(self, fid):
+        return self.motr.m0_spiel_sns_dtrebalance_abort(self.spiel, byref(fid))
+
+    @require(fid=Fid)
+    def sns_dtrebalance_quiesce(self, fid):
+        return self.motr.m0_spiel_sns_dtrebalance_quiesce(self.spiel, byref(fid))
+
+    @require(fid=Fid)
+    def sns_dtrebalance_continue(self, fid):
+        return self.motr.m0_spiel_sns_dtrebalance_continue(self.spiel, byref(fid))
+
+    @require(fid=Fid, ppstatus=POINTER(SpielSnsStatus))
+    def sns_dtrebalance_status(self, fid, ppstatus):
+        return self.motr.m0_spiel_sns_dtrebalance_status(self.spiel, byref(fid),
+                                                         byref(ppstatus))
+
+    @require(fid=Fid)
     def dix_repair_start(self, fid):
         return self.motr.m0_spiel_dix_repair_start(self.spiel, byref(fid))
 


### PR DESCRIPTION
This commit adds changes in m0_ha_sim to invoke sns direct rebalance
using m0spiel utility.

Signed-off-by: Mehul Joshi <mehul.joshi@seagate.com>

# Problem Statement
- Add support to m0_ha_sim utility for executing sns direct rebalance using m0spiel utility

# Design
-  There was no need to redesign anything. This change plugs in support for sns direct rebalance to existing m0_ha_sim utility.

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 

Tested direct rebalance with m0_ha_sim and spiel using following steps:
1) Mark device as failed.
/opt/seagate/cortx/motr/libexec/m0_ha_sim -t drive -i 12 -s failed -u m0spiel
2) Check status of device is displayed correctly as failed.
/opt/seagate/cortx/motr/libexec/m0_ha_sim -t drive -i 12 -u m0spiel
3) run dtrebalance operation using m0_ha_sim and m0spiel
/opt/seagate/cortx/motr/libexec/m0_ha_sim -t dtrebalance -i 12 -s failed -u m0spiel
4) Check status of device is displayed correctly as online.
/opt/seagate/cortx/motr/libexec/m0_ha_sim -t drive -i 12 -u m0spiel

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

