### PR TITLE
CORTX-26280_Removal_of_redundant_log

### DIFF
--- a/cas/service.c
+++ b/cas/service.c
@@ -1449,7 +1449,7 @@ static int cas_fom_tick(struct m0_fom *fom0)
 				     fom->cf_ikv_nr);
 			m0_fom_phase_set(fom0, M0_FOPH_INIT);
 		} else
-			m0_fom_phase_move(fom0, M0_ERR(rc), M0_FOPH_FAILURE);
+			m0_fom_phase_move(fom0, M0_RC(rc), M0_FOPH_FAILURE);
 		break;
 	case CAS_START:
 		if (is_meta) {


### PR DESCRIPTION
CORTX-26280_Removal_of_redundant_log
Problem:
While doing IO's, the mini provisioner log is getting flooded with error messages.
This message can be ignored.
Solution:
Instead of M0_ERR, we are using M0_RC to reduce the flooding of log message.
# Coding
   Checklist for Author
-  [Y ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ Y] JIRA number/GitHub Issue added to PR
- [ Y] PR is self reviewed
- [ Y] Jira and state/status is updated and JIRA is updated with PR link
- [ Y] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
