### PR TITLE
CORTX-33803: Run UT's excluding failed tests

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -20,7 +20,7 @@
 ---
 Tests:
   - id       : 00userspace-tests
-    script   : 'm0 run-ut'
+    script   : 'm0 run-ut -x mdservice-ut'
     dir      : src/scripts
     executor : Xperior::Executor::MotrTest
     #executor : Xperior::Executor::Skip


### PR DESCRIPTION
Since UT's are being run as a group when one of the UT fails
the regression Job in motr does not run the rest of the UT's.
Hence we want to exclude the failing UT's.

Signed-off-by: Rinku Kothiya <rinku.kothiya@seagate.com>

# Problem Statement
If one of the UT fails the rest are not executed.

# Design
Exclude the failing UT's while running the test.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
