### PR TITLE
CORTX-33899 : Delayed Motr service start makes cortx-rgw container restart

### DIFF
--- a/motr/client_init.c
+++ b/motr/client_init.c
@@ -1239,13 +1239,13 @@ static int initlift_layouts(struct m0_sm *mach)
 }
 
 #define MAX_CLIENT_INIT_RETRIES 1000
-int retry_count = 0;
 static int initlift_idx_service(struct m0_sm *mach)
 {
 	int                               rc = 0;
 	struct m0_client                 *m0c;
 	struct m0_idx_service            *service;
 	struct m0_idx_service_ctx        *ctx;
+	static int 			 retry_count = 0;
 
 	M0_ENTRY();
 	M0_PRE(mach != NULL);
@@ -1275,7 +1275,7 @@ static int initlift_idx_service(struct m0_sm *mach)
 			 * PODs. Ref: Jira ID Cortx-33899
 			 */
 			if (retry_count < MAX_CLIENT_INIT_RETRIES
-			    && (rc == -EIO || rc == -EPROTO)) {
+			    && M0_IN(rc, (-EIO, -EPROTO))) {
 				retry_count += 1;
 				M0_LOG(M0_ERROR, "client init \
 				       failed with %d. Retrying.", rc);


### PR DESCRIPTION
Issue: During startup, if data PODs are delayed, then server PODs are
restarting with error "Couldn't init storage provider"

Root Cause: During startup, radosgw calling m0_client_init() api to
initialize motr client. This api initializes different components in
order, one of which is IL_IDX_SERVICE. Initialization of this service is
failing with -EIO OR -EPROTO, as data PODs are not yet up.

Solution: During startup, if PODs are started in out of order, then
server POD should not crash. Added a retry mechanism in initialization
of IL_IDX_SERVICE.

Signed-off-by: Naga Kishore Kommuri <nagakishore.kommuri@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
