### PR TITLE
CORTX-34151 dtm0: add redo log only if dtm is enabled

### DIFF
--- a/cas/cas.c
+++ b/cas/cas.c
@@ -289,7 +289,7 @@ M0_INTERNAL bool m0_crv_is_none(const struct m0_crv *crv)
 M0_INTERNAL bool m0_cas_fop_is_redoable(struct m0_fop *fop)
 {
 	struct m0_fop_type *cas_fopt = &cas_put_fopt;
-	return fop->f_type == cas_fopt;
+	return ENABLE_DTM0 && fop->f_type == cas_fopt;
 }
 
 M0_INTERNAL int m0_cas_fop2redo(const struct m0_fop *fop,

--- a/cas/cas.c
+++ b/cas/cas.c
@@ -289,11 +289,7 @@ M0_INTERNAL bool m0_crv_is_none(const struct m0_crv *crv)
 M0_INTERNAL bool m0_cas_fop_is_redoable(struct m0_fop *fop)
 {
 	struct m0_fop_type *cas_fopt = &cas_put_fopt;
-	/*
-	 * TODO: disable only for required operation
-	 * for ex: enable redo only for delete operation.
-	 */
-	return ENABLE_DTM0 && fop->f_type == cas_fopt;
+	return fop->f_type == cas_fopt;
 }
 
 M0_INTERNAL int m0_cas_fop2redo(const struct m0_fop *fop,

--- a/cas/cas.c
+++ b/cas/cas.c
@@ -289,6 +289,10 @@ M0_INTERNAL bool m0_crv_is_none(const struct m0_crv *crv)
 M0_INTERNAL bool m0_cas_fop_is_redoable(struct m0_fop *fop)
 {
 	struct m0_fop_type *cas_fopt = &cas_put_fopt;
+	/*
+	 * TODO: disable only for required operation
+	 * for ex: enable redo only for delete operation.
+	 */
 	return ENABLE_DTM0 && fop->f_type == cas_fopt;
 }
 

--- a/cas/service.c
+++ b/cas/service.c
@@ -2334,9 +2334,13 @@ static int cas_dtm0_prep(struct cas_fom *fom)
 
 	M0_ASSERT(fom->cf_redo == NULL);
 
-	/* Try to update "new" dtm0 log. */
-	if (m0_cas_fop_is_redoable(fom0->fo_fop) &&
+	/*
+	 * TODO: disable only for required operation
+	 * for ex: enable redo only for delete operation.
+	 */
+	if (ENABLE_DTM0 && m0_cas_fop_is_redoable(fom0->fo_fop) &&
 	    cas_type(fom0) == CT_BTREE) {
+		/* Try to update "new" dtm0 log. */
 		/* See cas_redo_free0. */
 		rc = cas_redo_alloc(fom0, &fom->cf_redo);
 		if (rc != 0)


### PR DESCRIPTION
Signed-off-by: Yeshpal Jain <yeshpal.jain@seagate.com>

# Problem Statement
- With build#935, it was observed that the memory was consumed higher than previous build and after 40+ hours of long run IO,OOM was observed,
one of the suspect for this was dtm log pruner initial changes which was recently added, to narrow down the issue, the log pruner is enabled only if DTM is enabled.

# Design
-  Enabled log pruner only if there if dtm is enabled.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
