### PR TITLE
CORTX-34154: motr logs are not in compressed format

### DIFF
--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -157,10 +157,12 @@ main() {
     done
 
     # Helps in debugging, If m0reportbug fails due to huge size
-    echo "du -sh $LIVE_CORE_DIR" >&2
-    du_output=`du -sh "$LIVE_CORE_DIR" 2>&1`
-    du_size=`echo $du_output | awk '{print $1}'`
-    echo "The size of $LIVE_CORE_DIR is : $du_size"
+    if [ -d "$LIVE_CORE_DIR" ]; then
+	echo "du -sh $LIVE_CORE_DIR" >&2
+	du_output=`du -sh "$LIVE_CORE_DIR" 2>&1`
+	du_size=`echo $du_output | awk '{print $1}'`
+	echo "The size of $LIVE_CORE_DIR is : $du_size"
+    fi
 
     # Create directory and put only latest files created into it.
     TEMP_WORKSPACE="$LIVE_CORE_DIR/tmpspace/"

--- a/utils/m0reportbug
+++ b/utils/m0reportbug
@@ -159,7 +159,7 @@ main() {
     # Helps in debugging, If m0reportbug fails due to huge size
     echo "du -sh $LIVE_CORE_DIR" >&2
     du_output=`du -sh "$LIVE_CORE_DIR" 2>&1`
-    echo "$du_output" >&2
+    du_size=`echo $du_output | awk '{print $1}'`
     echo "The size of $LIVE_CORE_DIR is : $du_size"
 
     # Create directory and put only latest files created into it.


### PR DESCRIPTION
# Problem Statement
- Support bundle was not collecting the motr logs correctly.
- Earlier the logs were collected in tar format(The logs were compressed using tar utility)
Example: 
[root@cortx-data-g0-0 motr]# ls
motr_SBag9s2g08_7ba8990a85d38508ca9bac4ff516d3ea_motr.tar.gz
- The issue was caused due to EOS-24059.

# Design
Modified the m0reportbug script to correctly print the size of disk usage of the specified directory

# Coding
   Checklist for Author
-  [Y ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ Y] JIRA number/GitHub Issue added to PR
- [ Y] PR is self reviewed
- [ Y] Jira and state/status is updated and JIRA is updated with PR link
- [ Y] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
