### PR TITLE
CORTX-33051 : DI:Modify RMW ST to run with and without -G(Generate DI) option

### DIFF
--- a/motr/st/utils/motr_rmw_st.sh
+++ b/motr/st/utils/motr_rmw_st.sh
@@ -241,7 +241,7 @@ test_rmw()
 			create_files $update_count
 
 			write_and_update $LID $update_count true
-			write_and_update $LID $update_count false -G
+			write_and_update $LID $update_count true -G
 
 			echo "diff"
 			diff $src_file'2' $dest_file'_'$LID || {

--- a/motr/st/utils/motr_rmw_st.sh
+++ b/motr/st/utils/motr_rmw_st.sh
@@ -120,9 +120,10 @@ write_and_update()
 {
 	local LID=$1
 	local update_count=$2
+	local di_flag=$4
 
 	echo "m0cp"
-	$motr_st_util_dir/m0cp -G $MOTR_PARAMS -o $object_id $src_file \
+	$motr_st_util_dir/m0cp $di_flag $MOTR_PARAMS -o $object_id $src_file \
                                 -s $block_size -c $block_count -L $LID || {
 		error_handling $? "Failed to copy object"
 		break
@@ -144,7 +145,7 @@ write_and_update()
 		break
 	}
 	echo "m0cat"
-	$motr_st_util_dir/m0cat -G $MOTR_PARAMS -o $object_id -s $block_size \
+	$motr_st_util_dir/m0cat $di_flag $MOTR_PARAMS -o $object_id -s $block_size \
                                   -c $block_count -L $LID \
                                   $dest_file'_'$LID || {
 		error_handling $? "Failed to read object"
@@ -222,6 +223,7 @@ test_rmw()
 			create_files $update_count
 
 			write_and_update $LID $update_count false
+			write_and_update $LID $update_count false -G
 
 			echo "diff"
 			diff $src_file'2' $dest_file'_'$LID || {
@@ -239,6 +241,7 @@ test_rmw()
 			create_files $update_count
 
 			write_and_update $LID $update_count true
+			write_and_update $LID $update_count false -G
 
 			echo "diff"
 			diff $src_file'2' $dest_file'_'$LID || {


### PR DESCRIPTION
Signed-off-by: Rajat Patil <rajat.r.patil@seagate.com>

# Problem Statement
- Modify 45motr-rmw ST to run with and without -G(Generate DI) option.

# Design
-  Modified RMW ST to run with and without -G option.
-  Made changes in 45motr-rmw ST to test all scenarios with and without generating DI.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
