### PR TITLE
CORTX-34165 : Disable libfab-ut if libfabric is not present.

### DIFF
--- a/ut/m0ut.c
+++ b/ut/m0ut.c
@@ -184,12 +184,6 @@ extern struct m0_ut_suite btree_ut;
 #define LNET_ENABLED (false)
 #endif
 
-#if defined(USE_LIBFAB)
-#define LIBFAB_ENABLED (true)
-#else
-#define LIBFAB_ENABLED (false)
-#endif
-
 static void tests_add(struct m0_ut_module *m)
 {
 	/*
@@ -287,7 +281,7 @@ static void tests_add(struct m0_ut_module *m)
 	m0_ut_add(m, &m0_net_bulk_if_ut, true);
 	m0_ut_add(m, &m0_net_bulk_mem_ut, true);
 	m0_ut_add(m, &m0_net_lnet_ut, LNET_ENABLED);
-	m0_ut_add(m, &m0_net_libfab_ut, LIBFAB_ENABLED);
+	m0_ut_add(m, &m0_net_libfab_ut, USE_LIBFAB);
 	m0_ut_add(m, &m0_net_misc_ut, true);
 	m0_ut_add(m, &m0_net_module_ut, true);
 	m0_ut_add(m, &m0_net_test_ut, true);


### PR DESCRIPTION
Disable libfab-ut if libfabric is not present.

Signed-off-by: Upendra Patwardhan <upendra.patwardhan@seagate.com>

# Problem Statement
- libfab-ut was getting executed even if the default transport was defined as lnet.

# Design
-  Disable libfab-ut when libfabric is not present. Only enable libfab-ut when libfabric is the default network transport.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
