### PR TITLE
CORTX-32405: Fixed the Codacy Warnings in be/tool/beck.c

### DIFF
--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -558,6 +558,8 @@ static void sig_handler(int num)
 	printf("Caught Signal %d \n", num);
 	signaled = true;
 }
+static int b_stob_path_length = 0;
+static int b_dom_path_length  = 0;
 
 int main(int argc, char **argv)
 {
@@ -616,10 +618,12 @@ int main(int argc, char **argv)
 		   M0_STRINGARG('a', "stob domain path",
 			   LAMBDA(void, (const char *s) {
 				   beck_builder.b_stob_path = s;
+				   b_stob_path_length = sizeof(s);
 				   })),
 		   M0_STRINGARG('d', "segment stob domain path path",
 			LAMBDA(void, (const char *s) {
-				beck_builder.b_dom_path = s;
+				   beck_builder.b_dom_path = s;
+				   b_dom_path_length = sizeof(s);
 			})),
 		   M0_FLAGARG('m', "MMAP BE segment file. Useful for "
 			      "developer debugging.", &mmap_be_segment));
@@ -1958,7 +1962,7 @@ static int ad_dom_init(struct builder *b)
 	if (disable_directio)
 		str_cfg_init = "directio=false";
 
-	stob_location = m0_alloc(strlen(b->b_stob_path) + 20);
+	stob_location = m0_alloc(strnlen(b->b_stob_path,b_stob_path_length) + 20);
 	if (stob_location == NULL)
 		return M0_ERR(-ENOMEM);
 
@@ -2041,7 +2045,7 @@ static int builder_init(struct builder *b)
 			      .rhia_fid     = &fid);
 	if (result != 0)
 		return M0_ERR(result);
-	ub->but_stob_domain_location = m0_alloc(strlen(b->b_dom_path) + 20);
+	ub->but_stob_domain_location = m0_alloc(strnlen(b->b_dom_path,b_dom_path_length) + 20);
 	if (ub->but_stob_domain_location == NULL)
 		return M0_ERR(-ENOMEM); /* No cleanup, fatal anyway. */
 	sprintf(ub->but_stob_domain_location, "linuxstob:%s%s",

--- a/be/tool/beck.c
+++ b/be/tool/beck.c
@@ -618,12 +618,12 @@ int main(int argc, char **argv)
 		   M0_STRINGARG('a', "stob domain path",
 			   LAMBDA(void, (const char *s) {
 				   beck_builder.b_stob_path = s;
-				   b_stob_path_length = sizeof(s);
+				   b_stob_path_length = sizeof(*s);
 				   })),
 		   M0_STRINGARG('d', "segment stob domain path path",
 			LAMBDA(void, (const char *s) {
 				   beck_builder.b_dom_path = s;
-				   b_dom_path_length = sizeof(s);
+				   b_dom_path_length = sizeof(*s);
 			})),
 		   M0_FLAGARG('m', "MMAP BE segment file. Useful for "
 			      "developer debugging.", &mmap_be_segment));


### PR DESCRIPTION
Signed-off-by: Rohan Dhodare <rohan.v.dhodare@seagate.com>

# Problem Statement
- The file consists of following warning:
   - Does not handle strings that are not \0-terminated; if given one it may perform an over-read (it could cause a crash if unprotected) (CWE-126).
   - Easily used incorrectly; doesn't always \0-terminate or check for invalid pointers [MS-banned] (CWE-120).

# Design
-  [CWE-126]: Fixed by replacing strlen with strnlen.


# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
