### PR TITLE
improve the disk full testing (73motr-io-small-disks)

### DIFF
--- a/balloc/balloc.c
+++ b/balloc/balloc.c
@@ -3026,8 +3026,7 @@ static int balloc_alloc(struct m0_ad_balloc *ballroom, struct m0_dtx *tx,
 			 (unsigned long long)freeblocks,
 			 (unsigned long long)motr->cb_sb.bsb_freeblocks);
 
-
-	return M0_RC(rc);
+	return rc != 0 ? M0_ERR(rc) : M0_RC(rc);
 }
 
 /**

--- a/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
@@ -82,7 +82,7 @@ IOS5_CMD=""       #IOS5 process commandline to spawn it again on Controller even
 
 IOS4_CMD=""
 
-export IOS_DISK_SEEK_BLOCK_COUNT=1M
+export IOS_DISK_SEEK_BLOCK_COUNT=1048576 #1024 * 1024
 
 # list of md server end points tmid in [800, 899)
 MDSEP=(

--- a/m0t1fs/linux_kernel/st/m0t1fs_server_inc.sh
+++ b/m0t1fs/linux_kernel/st/m0t1fs_server_inc.sh
@@ -39,7 +39,8 @@ conf_ios_device_setup()
 	eval "$id_count_out"=$(( $_id_count + 1 ))
 
 	#dev conf obj
-	local ddev_obj="{0x64| (($ddev_id), $(($_DDEV_ID - 1)), 4, 1, 4096, 596000000000, 3, 4, \"/dev/loop$_DDEV_ID\")}"
+	local ddev_size=$((1024 * 1024 * (IOS_DISK_SEEK_BLOCK_COUNT + 1)))
+	local ddev_obj="{0x64| (($ddev_id), $(($_DDEV_ID - 1)), 4, 1, 4096, $ddev_size, 3, 4, \"/dev/loop$_DDEV_ID\")}"
 	#disk conf obj
         local ddisk_obj="{0x6b| (($ddisk_id), $ddev_id, [1: $PVERID])}"
 	if (($NR_DISK_FIDS == 0))

--- a/motr/setup.c
+++ b/motr/setup.c
@@ -884,9 +884,12 @@ static int cs_storage_devs_init(struct cs_stobs          *stob,
 						break;
 					}
 					M0_LOG(M0_DEBUG, "cid:0x%"PRIx64
-					       " -> sdev_fid:"FID_F" idx:0x%x",
+					       " -> sdev_fid:"FID_F" idx:0x%x"
+					       " size=%" PRIu64,
 					       cid, FID_P(&sdev_fid),
-					       conf_sdev->sd_dev_idx);
+					       conf_sdev->sd_dev_idx,
+					       conf_sdev->sd_size);
+					size = conf_sdev->sd_size;
 				} else
 					/* Every storage device need not have a
 					 * counterpart in configuration. */
@@ -897,6 +900,8 @@ static int cs_storage_devs_init(struct cs_stobs          *stob,
 					 * sizes reduced to 256 MB.
 					 */
 					size = 1024ULL *1024 * 256;
+				M0_LOG(M0_DEBUG, "cid=%"PRIu64 "path=%s size=%"
+						 PRIu64, cid, f_path, size);
 				rc = m0_storage_dev_new(devs, cid, f_path, size,
 							conf_sdev, force, &dev);
 				if (rc == 0) {

--- a/stob/ad.c
+++ b/stob/ad.c
@@ -278,8 +278,13 @@ static int stob_ad_domain_cfg_create_parse(const char *str_cfg_create,
 		rc = -ENOMEM;
 
 	if (rc == 0) {
-		if (cfg->adg_container_size == 0)
+		if (cfg->adg_container_size == 0) {
+			M0_LOG(M0_WARN, "The default container size %" PRId64
+					" is used for this device, but it may "
+					"differ from the actual size.",
+					BALLOC_DEF_CONTAINER_SIZE);
 			cfg->adg_container_size = BALLOC_DEF_CONTAINER_SIZE;
+		}
 		cfg->adg_bshift     = BALLOC_DEF_BLOCK_SHIFT;
 		/*
 		 * Big number of groups slows balloc initialisation. Therefore,

--- a/stob/ioq.c
+++ b/stob/ioq.c
@@ -439,8 +439,10 @@ static void ioq_io_error(struct m0_stob_ioq *ioq, struct ioq_qev *qev)
 	uint64_t              tag;
 
 	M0_ENTRY();
-	M0_LOG(M0_WARN, "IO error: stob_id=" STOB_ID_F " conf_sdev=" FID_F,
-	       STOB_ID_P(&lstob->sl_stob.so_id), FID_P(&lstob->sl_conf_sdev));
+	M0_LOG(M0_WARN, "IO error: stob_id=" STOB_ID_F " conf_sdev=" FID_F
+			" opcode=%d rc=%d",
+			STOB_ID_P(&lstob->sl_stob.so_id),
+			FID_P(&lstob->sl_conf_sdev), io->si_opcode, io->si_rc);
 
 	if (m0_get()->i_ha == NULL || m0_get()->i_ha_link == NULL) {
 		/*


### PR DESCRIPTION
- Prepare actual disk size to conf.
- Retrieve the actual disk size from conf.
- Write to objects until disk full.
- Report error when error happens in balloc, e.g. -ENOSPC.

Signed-off-by: Hua Huang <hua.huang@seagate.com>

# Problem Statement
- Actual "disk size" is not passed to balloc. So, the disk full code path in balloc is not covered in the testing.

# Design
Prepare the disk size when generating the conf. This size is passed to Motr and then passed to balloc
when doing initialization. So, when disk space is consumed more and more, and finally the balloc will
return -ENOSPC error. This error will be passed to upper layer and then to client.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
