### PR TITLE
CORTX-34094 Enable 10pver-assign ST

### DIFF
--- a/motr/st/utils/cat.c
+++ b/motr/st/utils/cat.c
@@ -77,6 +77,7 @@ static void cat_usage(FILE *file, char *prog_name)
 "  -z, --fill-zeros               Fill holes with zeros.\n"
 "  -G, --DI-generate              Flag to generate Data Integrity\n"
 "  -I, --DI-user-input            Flag to pass checksum by user\n"
+"  -g, --get-pver                 Print pool version of object read"
 "  -h, --help                     Shows this help text and exit.\n"
 , prog_name, WIDTH, ' ', WIDTH, ' ', WIDTH, ' ', WIDTH, ' ', WIDTH, ' ',
 WIDTH, ' ');
@@ -107,7 +108,7 @@ int main(int argc, char **argv)
 			  cat_param.cup_offset,
 			  cat_param.cup_blks_per_io, cat_param.cup_take_locks,
 			  cat_param.flags, &cat_param.cup_pver,
-			  cat_param.entity_flags);
+			  cat_param.entity_flags, cat_param.cup_print_pver);
 	if (rc < 0) {
 		fprintf(stderr, "m0_read failed! rc = %d\n", rc);
 	}

--- a/motr/st/utils/client.c
+++ b/motr/st/utils/client.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
 				     block_size, block_count, offset,
 				     blocks_per_io,
 				     params.cup_take_locks,
-				     0, NULL, params.entity_flags);
+				     0, NULL, params.entity_flags, false);
 		} else if (strcmp(arg, "write") == 0) {
 			GET_COMMON_ARG(arg, fname, saveptr, id,
 				       block_size, block_count,

--- a/motr/st/utils/helper.c
+++ b/motr/st/utils/helper.c
@@ -484,7 +484,8 @@ int m0_read(struct m0_container *container,
 	    struct m0_uint128 id, char *dest,
 	    uint32_t block_size, uint32_t block_count,
 	    uint64_t offset, int blks_per_io, bool take_locks,
-	    uint32_t flags, struct m0_fid *read_pver, uint32_t entity_flags)
+	    uint32_t flags, struct m0_fid *read_pver,
+	    uint32_t entity_flags, bool print_pver)
 {
 	int                           i;
 	int                           j;
@@ -539,6 +540,10 @@ int m0_read(struct m0_container *container,
 	if (entity_sm_state(&obj) != M0_ES_OPEN || rc != 0)
 		goto cleanup;
 
+	if (print_pver) {
+		M0_LOG(M0_ALWAYS, "Object pool version is = "FID_F,
+		FID_P(&obj.ob_attr.oa_pver));
+	}
 	last_index = offset;
 
 	if (blks_per_io == 0)
@@ -1019,11 +1024,12 @@ int m0_utility_args_init(int argc, char **argv,
 				{"fill-zeros",    no_argument,       NULL, 'z'},
 				{"DI-generate",   no_argument,       NULL, 'G'},
 				{"DI-user-input", no_argument,       NULL, 'I'},
+				{"print-pver",    no_argument,       NULL, 'g'},
 				{"help",          no_argument,       NULL, 'h'},
 				{0,               0,                 0,     0 }};
 
         while ((c = getopt_long(argc, argv,
-				":l:H:p:P:o:s:c:i:t:L:v:n:S:q:b:O:uerzhGI",
+				":l:H:p:P:o:s:c:i:t:L:v:n:S:q:b:O:uerzhGIg",
 				l_opts, &option_index)) != -1)
 	{
 		switch (c) {
@@ -1162,6 +1168,8 @@ int m0_utility_args_init(int argc, char **argv,
 			case 'G': params->entity_flags |= M0_ENF_GEN_DI;
 				  continue;
 			case 'I': params->entity_flags |= M0_ENF_DI;
+				  continue;
+			case 'g': params->cup_print_pver = true;
 				  continue;
 			case 'h': utility_usage(stderr, basename(argv[0]));
 				  exit(EXIT_FAILURE);

--- a/motr/st/utils/helper.h
+++ b/motr/st/utils/helper.h
@@ -76,6 +76,7 @@ struct m0_utility_param {
 	struct m0_fid     cup_pver;
 	uint32_t          flags;
 	uint32_t          entity_flags;
+	bool              cup_print_pver;
 };
 
 struct m0_copy_mt_args {
@@ -126,7 +127,7 @@ int m0_read(struct m0_container *container,
 	    struct m0_uint128 id, char *dest, uint32_t block_size,
 	    uint32_t block_count, uint64_t offset, int blks_per_io,
 	    bool take_locks, uint32_t flags, struct m0_fid *read_pver,
-	    uint32_t entity_flags);
+	    uint32_t entity_flags, bool print_pver);
 
 int m0_truncate(struct m0_container *container,
 		struct m0_uint128 id, uint32_t block_size,

--- a/motr/st/utils/motr_pver_assign_st.sh
+++ b/motr/st/utils/motr_pver_assign_st.sh
@@ -53,8 +53,6 @@ main()
 {
 	sandbox_init
 
-	NODE_UUID=`uuidgen`
-	motr_dgmode_sandbox="$MOTR_TEST_DIR/sandbox"
 	src_file="$MOTR_TEST_DIR/motr_source"
 	dest_file="$MOTR_TEST_DIR/motr_dest"
 	dest_file2="$MOTR_TEST_DIR/motr_dest2"
@@ -151,7 +149,7 @@ main()
         fi
 	fi
 
-    rm -f "$SANDBOX_DIR"/m0cat.log
+	rm -f "$SANDBOX_DIR"/m0cat.log
 
 	if [ "$pver_obj1" != "$pver_obj2" ]; then
 		echo "Pool version of obj1 and obj2 are different as expected."

--- a/motr/st/utils/motr_pver_assign_st.sh
+++ b/motr/st/utils/motr_pver_assign_st.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+
+#set -x
+
+motr_st_util_dir=$( cd "$(dirname "$0")" ; pwd -P )
+m0t1fs_dir="$motr_st_util_dir/../../../m0t1fs/linux_kernel/st"
+
+# Re-use as many m0t1fs system scripts as possible
+. "$m0t1fs_dir"/common.sh
+. "$m0t1fs_dir"/m0t1fs_common_inc.sh
+. "$m0t1fs_dir"/m0t1fs_client_inc.sh
+. "$m0t1fs_dir"/m0t1fs_server_inc.sh
+. "$m0t1fs_dir"/m0t1fs_sns_common_inc.sh
+
+. "$motr_st_util_dir"/motr_local_conf.sh
+. "$motr_st_util_dir"/motr_st_inc.sh
+
+N=6
+K=2
+S=0
+P=15
+stride=32
+BLOCKSIZE=""
+BLOCKCOUNT=""
+OBJ_ID1="1048577"
+OBJ_ID2="1048578"
+export MOTR_CLIENT_ONLY=1
+
+MOTR_TEST_DIR=$SANDBOX_DIR
+MOTR_TEST_LOGFILE=$SANDBOX_DIR/motr_`date +"%Y-%m-%d_%T"`.log
+MOTR_TRACE_DIR=$SANDBOX_DIR/motr
+
+main()
+{
+	sandbox_init
+
+	NODE_UUID=`uuidgen`
+	motr_dgmode_sandbox="$MOTR_TEST_DIR/sandbox"
+	src_file="$MOTR_TEST_DIR/motr_source"
+	dest_file="$MOTR_TEST_DIR/motr_dest"
+	dest_file2="$MOTR_TEST_DIR/motr_dest2"
+	rc=0
+
+	BLOCKSIZE=16384 #4096
+	BLOCKCOUNT=8
+	echo "dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of=$src_file"
+	dd if=/dev/urandom bs=$BLOCKSIZE count=$BLOCKCOUNT of="$src_file" \
+              2> "$MOTR_TEST_LOGFILE" || {
+		echo "Failed to create a source file"
+		motr_service_stop
+		return 1
+	}
+
+	mkdir "$MOTR_TRACE_DIR"
+
+	motr_service_start $N $K $S $P $stride
+
+	#Initialise dix
+	dix_init
+
+	# Currently motr does not provide any API to check attributes of an
+	# object. It has to be checked with S3 level or in motr trace logs.
+
+	# write an object
+	io_conduct "WRITE" "$src_file" $OBJ_ID1 "false"
+	if [ $rc -ne "0" ]
+	then
+		echo "Write failed."
+		error_handling $rc
+	fi
+	echo "Write succeeds."
+
+	rm -f "$SANDBOX_DIR"/m0cat.log
+	# read the written object
+	io_conduct "READ" $OBJ_ID1  "$dest_file" "false" "true"
+	rc=$?
+	if [ $rc -ne "0" ]
+	then
+		echo "Read failed."
+		error_handling $rc
+	fi
+	echo "Read file succeeds."
+
+	if [[ -f $SANDBOX_DIR/m0cat.log ]] 
+	then 
+		pver_obj1=$(cat "$SANDBOX_DIR"/m0cat.log | grep 'Object pool version is' | cut -d '=' -f2)
+			
+		if [ -z "$pver_obj1" ]
+		then
+			echo "Pool version for pver_obj1 found empty."
+			error_handling 1
+		fi
+	fi
+	
+	echo "Fail two disks"
+	fail_device1=1
+	fail_device2=2
+
+	# fail a disk and read an object
+	disk_state_set "failed" $fail_device1 $fail_device2 || {
+		echo "Operation to mark device failure failed."
+		error_handling 1
+	}
+
+	io_conduct "WRITE" "$src_file" $OBJ_ID2 "false"
+	if [ $rc -ne "0" ]
+	then
+		echo "Write failed."
+		error_handling $rc
+	fi
+	echo "Write succeeds."
+
+	rm -f "$SANDBOX_DIR"/m0cat.log
+	# read the written object
+	io_conduct "READ" $OBJ_ID2  "$dest_file2" "false" "true"
+	rc=$?
+	if [ $rc -ne "0" ]
+	then
+		echo "Read failed."
+		error_handling $rc
+	fi
+	echo "Read file succeeds."
+	
+	if [[ -f $SANDBOX_DIR/m0cat.log ]]
+	then 
+		pver_obj2=$(cat "$SANDBOX_DIR"/m0cat.log | grep 'Object pool version is' | cut -d '=' -f2)
+		
+		if [ -z "$pver_obj2" ]
+        then
+        	echo "Pool version for pver_obj2 found empty."
+            error_handling 1
+        fi
+	fi
+
+    rm -f "$SANDBOX_DIR"/m0cat.log
+
+	if [ "$pver_obj1" != "$pver_obj2" ]; then
+		echo "Pool version of obj1 and obj2 are different as expected."
+	else
+		rc=1
+		motr_error_handling $rc "Pool version of obj1 and obj2 is same"
+	fi
+
+	motr_service_stop || rc=1
+
+	if [ $rc -eq 0 ]; then
+		sandbox_fini
+	else
+		error_handling $rc
+	fi
+	return $rc
+}
+
+echo "pver_assign Test ... "
+trap unprepare EXIT
+main
+report_and_exit pool-version-assignment $?

--- a/motr/st/utils/motr_pver_assign_st.sh
+++ b/motr/st/utils/motr_pver_assign_st.sh
@@ -46,7 +46,7 @@ OBJ_ID2="1048578"
 export MOTR_CLIENT_ONLY=1
 
 MOTR_TEST_DIR=$SANDBOX_DIR
-MOTR_TEST_LOGFILE=$SANDBOX_DIR/motr_`date +"%Y-%m-%d_%T"`.log
+MOTR_TEST_LOGFILE=$SANDBOX_DIR/motr_$(date +"%Y-%m-%d_%T").log
 MOTR_TRACE_DIR=$SANDBOX_DIR/motr
 
 main()
@@ -100,8 +100,8 @@ main()
 
 	if [[ -f $SANDBOX_DIR/m0cat.log ]] 
 	then 
-		pver_obj1=$(cat "$SANDBOX_DIR"/m0cat.log | grep 'Object pool version is' | cut -d '=' -f2)
-			
+		pver_obj1=$(grep 'Object pool version is' "$SANDBOX_DIR"/m0cat.log | cut -d '=' -f2)
+		
 		if [ -z "$pver_obj1" ]
 		then
 			echo "Pool version for pver_obj1 found empty."
@@ -140,7 +140,7 @@ main()
 	
 	if [[ -f $SANDBOX_DIR/m0cat.log ]]
 	then 
-		pver_obj2=$(cat "$SANDBOX_DIR"/m0cat.log | grep 'Object pool version is' | cut -d '=' -f2)
+		pver_obj2=$(grep 'Object pool version is' "$SANDBOX_DIR"/m0cat.log | cut -d '=' -f2)
 		
 		if [ -z "$pver_obj2" ]
         then

--- a/motr/st/utils/motr_st_inc.sh
+++ b/motr/st/utils/motr_st_inc.sh
@@ -220,6 +220,7 @@ io_conduct()
 	source=$2
 	dest=$3
 	verify=$4
+	print_pver=$5
 
 	local cmd_exec
 	if [ $operation == "READ" ]
@@ -228,12 +229,15 @@ io_conduct()
                           -p '$MOTR_PROF_OPT' -P '$MOTR_PROC_FID' \
                           -o $source"
 		cmd_exec="${motr_st_util_dir}/m0cat "
-		cmd_args="$cmd_args -s $BLOCKSIZE -c $BLOCKCOUNT -L 3"
+		cmd_args="$cmd_args -s $BLOCKSIZE -c $BLOCKCOUNT -L 3  &> $SANDBOX_DIR/m0cat.log"
 
 		if [[ $verify == "true" ]]; then
 			cmd_args+=" -r"
 		else
 			cmd_args+=" -G"
+		fi
+		if [[ $print_pver == "true" ]]; then
+			cmd_args+=" -g"
 		fi
 
 		local cmd="$cmd_exec $cmd_args $dest &"

--- a/scripts/st.d/10pver-assign
+++ b/scripts/st.d/10pver-assign
@@ -20,4 +20,4 @@
 
 set -eu
 
-exec $SUDO "$M0_SRC_DIR/m0t1fs/linux_kernel/st/m0t1fs_pool_version_assignment.sh"
+exec $SUDO "$M0_SRC_DIR/motr/st/utils/motr_pver_assign_st.sh"

--- a/utils/functions
+++ b/utils/functions
@@ -9,7 +9,6 @@
                  08spiel
                  08spiel-sns-repair
                  08spiel-sns-repair-quiesce
-                 10pver-assign
                  11m0t1fs
                  11m0t1fs-rconfc-fail
                  12fsync


### PR DESCRIPTION
Enable 10pver-assign ST by removing kernal level depndancies

Signed-off-by: Parikshit Dharmale <parikshit.dharmale@seagate.com>

# Problem Statement
- 10pver-assign ST was disabled for libfabric 

# Design
- Enable 10pver-assign ST in user space 
- Created new file motr/st/utils/motr_pver_assign_st.sh

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- System Test is Passed

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
