### PR TITLE
CORTX-34240 - Re-Enable 28sys-kvs ST in user mode

### DIFF
--- a/.xperior/testds/motr-single_tests.yaml
+++ b/.xperior/testds/motr-single_tests.yaml
@@ -1700,12 +1700,12 @@ Tests:
     polltime : 30
     timeout  : 2400
 
-  - id       : 28sys-kvs
-    script   : 'm0 run-st 28sys-kvs'
+  - id       : 28sys-kvs-user
+    script   : 'm0 run-st 28sys-kvs-user'
     dir      : src/scripts
     executor : Xperior::Executor::MotrTest
     #executor : Xperior::Executor::Skip
-    sandbox  : /var/motr/root/sandbox.st-28sys-kvs
+    sandbox  : /var/motr/root/sandbox.st-28sys-kvs-user
     groupname: 01motr-single-node
     polltime : 30
     timeout  : 900

--- a/motr/st/utils/motr_sys_test.sh
+++ b/motr/st/utils/motr_sys_test.sh
@@ -24,6 +24,7 @@
 . `dirname $0`/motr_st_inc.sh
 # enable core dumps
 ulimit -c unlimited
+export MOTR_CLIENT_ONLY=1
 
 # Debugger to use
 debugger=

--- a/motr/st/utils/motr_sys_test.sh
+++ b/motr/st/utils/motr_sys_test.sh
@@ -125,8 +125,8 @@ case "$cmd" in
 		report_and_exit motr_sys_test $rc
 		;;
 	run)
-		( exec `dirname $0`/motr_services.sh start )
 		sandbox_init
+		( exec `dirname $0`/motr_services.sh start )
 
 		if [ $umod -eq 1 ]; then
 			motr_st_start_u $index $debugger
@@ -135,8 +135,8 @@ case "$cmd" in
 		fi
 
 		rc=$?
-		sandbox_fini $rc
 		( exec `dirname $0`/motr_services.sh stop )
+		sandbox_fini $rc
 		report_and_exit motr_sys_test $rc
 		;;
 	stop)

--- a/scripts/st.d/28sys-kvs-user
+++ b/scripts/st.d/28sys-kvs-user
@@ -20,4 +20,4 @@
 
 set -eu
 
-exec $SUDO "$M0_SRC_DIR/motr/st/utils/motr_sys_test.sh" run local -i KVS
+exec $SUDO "$M0_SRC_DIR/motr/st/utils/motr_sys_test.sh" run local -i KVS -u

--- a/utils/functions
+++ b/utils/functions
@@ -26,7 +26,6 @@
                  21fsync-single-node
                  22sns-repair-ios-fail
                  23sns-abort-quiesce
-                 28sys-kvs
                  28sys-kvs-kernel
                  34sns-repair-1n-1f
                  35m0singlenode


### PR DESCRIPTION

Signed-off-by: Mukund Kanekar <mukund.kanekar@seagate.com>

# Problem Statement
Enable '28sys-kvs' ST which is disabled for libfabric

# Design
1.Removed 28sys-kvs from skip list.
2.Renamed '28sys-kvs' st to '28sys-kvs-user' this is to ensure st is not getting skipped as '28sys-kvs-kernel' is dependent on kernel and '28sys-kvs-kernel' part of skip list.
3.Additionally passed -u (run Motr system tests in user space mode) as parameter in '28sys-kvs-user' to avoid dependency on default value(umod=1) in 'motr/st/utils/motr_sys_test.sh'

# Coding
   Checklist for Author
-  [ x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
