### PR TITLE
CORTX-30749: Fix pool fid parsing in SPIEL_FIDS_LIST

### DIFF
--- a/scripts/install/opt/seagate/cortx/motr/common/m0_utils_common.sh
+++ b/scripts/install/opt/seagate/cortx/motr/common/m0_utils_common.sh
@@ -613,7 +613,7 @@ spiel_prepare() {
 
         prof_fid_str=$(_create_fid_list "$PROFILE_FID")
         pool_fid_str=$(_create_fid_list "$POOL_FID")
-        SPIEL_FIDS_LIST="fids = {'profile' : $prof_fid_str, 'pool' : $pool_fid_str,}"
+        SPIEL_FIDS_LIST="fids = {'profile' : $prof_fid_str, 'pool' : $pool_fid_str}"
 
         export SPIEL_OPTS=$SPIEL_OPTS
         export SPIEL_FIDS_LIST=$SPIEL_FIDS_LIST


### PR DESCRIPTION
Problem: There are some errors seen in 71spiel-sns-motr-repair while executing sns wait for repair operation.

Solution: Remove the extra ',' at the end of SPIEL_FIDS_LIST which prevents the corrrect parsing of the pool fid.

Signed-off-by: Mehul Joshi <mehul.joshi@seagate.com>

# Problem Statement
- Errors in 71spiel-sns-motr-repair while executing sns wait for repair operation

# Design
-  The issue is due to an extra ',' at the end of SPIEL_FIDS_LIST in m0_utils_common.sh that prevents proper parsing of the fid.

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Testing was performed by running the failing testcase with the fix and checking the output to make sure it fixes the issue.

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [X] Interface change (if any) are documented: NA
- [X] Side effects on other features (deployment/upgrade): NA
- [X] Dependencies on other component(s): NA

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [X] Changes done to WIKI / Confluence page / Quick Start Guide: NA
