### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/motr/st/utils/sns_repair_common_inc.sh
+++ b/motr/st/utils/sns_repair_common_inc.sh
@@ -22,7 +22,7 @@ prepare_datafiles_and_objects()
 {
 	local rc=0
 
-	dd if=/dev/urandom bs=$src_bs count=$src_count \
+	dd if=/dev/urandom bs="$src_bs" count="$src_count" \
 	   of="$MOTR_M0T1FS_TEST_DIR/srcfile" || return $?
 
 	for ((i=0; i < ${#file[*]}; i++)) ; do
@@ -34,13 +34,13 @@ prepare_datafiles_and_objects()
 			      -P $M0T1FS_PROC_ID -L ${lid} -s ${us} "
 
 		echo "creating object ${file[$i]} bs=${us} * c=${file_size[$i]}"
-		dd bs=${us} count=${file_size[$i]}            \
+		dd bs=${us} count="${file_size[$i]}"            \
 		   if="$MOTR_M0T1FS_TEST_DIR/srcfile"         \
 		   of="$MOTR_M0T1FS_TEST_DIR/src${file[$i]}"
 
-		$M0_SRC_DIR/motr/st/utils/m0cp ${MOTR_PARAM}     \
-						 -c ${file_size[$i]} \
-						 -o ${file[$i]}      \
+		"$M0_SRC_DIR/motr/st/utils/m0cp" "${MOTR_PARAM}"     \
+						 -c "${file_size[$i]}" \
+						 -o "${file[$i]}"      \
 					 "$MOTR_M0T1FS_TEST_DIR/srcfile" || {
 			rc=$?
 			echo "Writing object ${file[$i]} failed: $rc"
@@ -65,9 +65,9 @@ motr_read_verify()
 
 		echo "Reading object ${file[$i]} ... and diff ..."
 		rm -f "$MOTR_M0T1FS_TEST_DIR/${file[$i]}"
-		$M0_SRC_DIR/motr/st/utils/m0cat ${MOTR_PARAM}     \
-						  -c ${file_size[$i]} \
-						  -o ${file[$i]}      \
+		"$M0_SRC_DIR/motr/st/utils/m0cat" "${MOTR_PARAM}"     \
+						  -c "${file_size[$i]}" \
+						  -o "${file[$i]}"      \
 					"$MOTR_M0T1FS_TEST_DIR/${file[$i]}" || {
 			rc=$?
 			echo "reading ${file[$i]} failed"
@@ -101,13 +101,13 @@ motr_delete_objects()
 			      -H ${lnet_nid}:$HA_EP -p $PROF_OPT \
 			      -P $M0T1FS_PROC_ID -L ${lid} -s ${us} "
 
-		$M0_SRC_DIR/motr/st/utils/m0unlink ${MOTR_PARAM} \
-						     -o ${file[$i]} || return $?
+		"$M0_SRC_DIR/motr/st/utils/m0unlink" "${MOTR_PARAM}" \
+						     -o "${file[$i]}" || return $?
 
 ### Make sure the object is really deleted, and reading will get -ENOENT.
-		$M0_SRC_DIR/motr/st/utils/m0cat ${MOTR_PARAM}     \
-						  -c ${file_size[$i]} \
-						  -o ${file[$i]}      \
+		"$M0_SRC_DIR/motr/st/utils/m0cat" "${MOTR_PARAM}"     \
+						  -c "${file_size[$i]}" \
+						  -o "${file[$i]}"      \
 				  "$MOTR_M0T1FS_TEST_DIR/${file[$i]}" \
 						  2>/dev/null && return -1
 	done

--- a/motr/st/utils/sns_repair_common_inc.sh
+++ b/motr/st/utils/sns_repair_common_inc.sh
@@ -38,7 +38,7 @@ prepare_datafiles_and_objects()
 		   if="$MOTR_M0T1FS_TEST_DIR/srcfile"         \
 		   of="$MOTR_M0T1FS_TEST_DIR/src${file[$i]}"
 
-		"$M0_SRC_DIR/motr/st/utils/m0cp" "${MOTR_PARAM}"     \
+		"$M0_SRC_DIR/motr/st/utils/m0cp" ${MOTR_PARAM}     \
 						 -c "${file_size[$i]}" \
 						 -o "${file[$i]}"      \
 					 "$MOTR_M0T1FS_TEST_DIR/srcfile" || {
@@ -65,7 +65,7 @@ motr_read_verify()
 
 		echo "Reading object ${file[$i]} ... and diff ..."
 		rm -f "$MOTR_M0T1FS_TEST_DIR/${file[$i]}"
-		"$M0_SRC_DIR/motr/st/utils/m0cat" "${MOTR_PARAM}"     \
+		"$M0_SRC_DIR/motr/st/utils/m0cat" ${MOTR_PARAM}     \
 						  -c "${file_size[$i]}" \
 						  -o "${file[$i]}"      \
 					"$MOTR_M0T1FS_TEST_DIR/${file[$i]}" || {
@@ -101,11 +101,11 @@ motr_delete_objects()
 			      -H ${lnet_nid}:$HA_EP -p $PROF_OPT \
 			      -P $M0T1FS_PROC_ID -L ${lid} -s ${us} "
 
-		"$M0_SRC_DIR/motr/st/utils/m0unlink" "${MOTR_PARAM}" \
+		"$M0_SRC_DIR/motr/st/utils/m0unlink" ${MOTR_PARAM} \
 						     -o "${file[$i]}" || return $?
 
 ### Make sure the object is really deleted, and reading will get -ENOENT.
-		"$M0_SRC_DIR/motr/st/utils/m0cat" "${MOTR_PARAM}"     \
+		"$M0_SRC_DIR/motr/st/utils/m0cat" ${MOTR_PARAM}     \
 						  -c "${file_size[$i]}" \
 						  -o "${file[$i]}"      \
 				  "$MOTR_M0T1FS_TEST_DIR/${file[$i]}" \


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed: "Double quote to prevent globing and words splitting".

Co-authored-by: Pradeep Kumbhre pradeep.kumbhre@seagate.com
Signed-off-by: Zoheb Khan <zoheb.khan@seagate.com>

# Problem Statement
We see 1688 occurrences of the pattern, "Double quote to prevent globing and word splitting".

# Design
We are putting the variable references in double-quotes.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
