### PR TITLE
CORTX-30751: Codacy code cleanup (#1606)

### DIFF
--- a/motr/st/utils/sns_repair_motr_1n_1f.sh
+++ b/motr/st/utils/sns_repair_motr_1n_1f.sh
@@ -19,14 +19,14 @@
 #
 
 
-TOPDIR=`dirname $0`/../../../
+TOPDIR=$(dirname "$0")/../../../
 
-. ${TOPDIR}/m0t1fs/linux_kernel/st/common.sh
-. ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
-. ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_client_inc.sh
-. ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_server_inc.sh
-. ${TOPDIR}/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
-. ${TOPDIR}/motr/st/utils/sns_repair_common_inc.sh
+. "${TOPDIR}"/m0t1fs/linux_kernel/st/common.sh
+. "${TOPDIR}"/m0t1fs/linux_kernel/st/m0t1fs_common_inc.sh
+. "${TOPDIR}"/m0t1fs/linux_kernel/st/m0t1fs_client_inc.sh
+. "${TOPDIR}"/m0t1fs/linux_kernel/st/m0t1fs_server_inc.sh
+. "${TOPDIR}"/m0t1fs/linux_kernel/st/m0t1fs_sns_common_inc.sh
+. "${TOPDIR}"/motr/st/utils/sns_repair_common_inc.sh
 
 
 export MOTR_CLIENT_ONLY=1
@@ -111,12 +111,12 @@ main()
 
 	sandbox_init
 
-	NODE_UUID=`uuidgen`
+	NODE_UUID=$(uuidgen)
 	local multiple_pools=0
 
 	SINGLE_NODE=1
 
-	motr_service start $multiple_pools $stride $N $K $S $P || {
+	motr_service start $multiple_pools "$stride" "$N" "$K" "$S" "$P" || {
 		echo "Failed to start Motr Service."
 		SINGLE_NODE=0
 		return 1


### PR DESCRIPTION
This patch fixes some of the codacy warnings.
warning fixed: "Double quote to prevent globing and words splitting". 
warning fixed: "Use $(...) notation instead of legacy backticked '...'"

Co-authored-by: Pradeep Kumbhre pradeep.kumbhre@seagate.com
Signed-off-by: Zoheb Khan <zoheb.khan@seagate.com>

# Problem Statement
We see occurrences of the pattern, "Double quote to prevent globing and word splitting" and "Use $(...) notation instead of legacy backticked '..'"

# Design
We are putting the variable references in double-quotes and used $(...) instead of '...'.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
