### PR TITLE
Fix build on Ubuntu 22.04

### DIFF
--- a/be/log.c
+++ b/be/log.c
@@ -1091,7 +1091,7 @@ static int be_log_record_iter_read(struct m0_be_log             *log,
 				   m0_bindex_t                   pos)
 {
 	struct m0_be_fmt_log_record_footer *footer;
-	struct m0_be_fmt_log_record_header *header;
+	struct m0_be_fmt_log_record_header *header = NULL;
 	struct m0_bufvec_cursor             cur;
 	struct m0_bufvec                    bvec;
 	m0_bcount_t                         size_fmt;
@@ -1116,7 +1116,7 @@ static int be_log_record_iter_read(struct m0_be_log             *log,
 	rc   = be_log_read_plain(log, pos, size, data);
 	rc   = rc ?: m0_be_fmt_log_record_header_decode(&header, &cur,
 						M0_BE_FMT_DECODE_CFG_DEFAULT);
-	if (rc == -EPROTO)
+	if (rc == -EPROTO || header == NULL)
 		rc = -ENOENT;
 
 	m0_free_aligned(data, size, bshift);

--- a/configure.ac
+++ b/configure.ac
@@ -1114,10 +1114,9 @@ M0_CPPFLAGS="-D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern \
 # pkg-config database provided within Motr rpm distribution
 M0_CPPFLAGS_DIST=$(echo "$M0_CPPFLAGS" | grep -Po -e '-D\S+|-I/usr\S+|-inc\S+' | xargs echo)
 
-# -Wno-attributes is required to suppress warnings about unrecognized
-# __attribute__, such as __attribute__((gccxml(...))). It's important because we
-# use -Werror, which turns warnings into errors, but we still need to be able to
-# use gccxml attributes.
+# -Wno-attributes suppresses warnings about unrecognized attributes, such as
+#  __attribute__((gccxml(...))).
+# -Wno-deprecated-declarations should be dropped when we get rid of md5 usage.
 M0_CFLAGS="-pipe -Wall -Werror -Wno-deprecated-declarations \
 	                       -Wno-attributes -fno-strict-aliasing $M0_CFLAGS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1118,7 +1118,8 @@ M0_CPPFLAGS_DIST=$(echo "$M0_CPPFLAGS" | grep -Po -e '-D\S+|-I/usr\S+|-inc\S+' |
 # __attribute__, such as __attribute__((gccxml(...))). It's important because we
 # use -Werror, which turns warnings into errors, but we still need to be able to
 # use gccxml attributes.
-M0_CFLAGS="-pipe -Wall -Werror -Wno-attributes -fno-strict-aliasing $M0_CFLAGS"
+M0_CFLAGS="-pipe -Wall -Werror -Wno-deprecated-declarations \
+	                       -Wno-attributes -fno-strict-aliasing $M0_CFLAGS"
 
 # Prevents gcc from introducing common symbols in object files. These symbols
 # are avoided because they break the compilation toolchain that Parallel

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Build-Depends: automake,
                libio-all-perl,
                libfile-slurp-perl,
                libyaml-libyaml-perl,
-               python2-dev,
+               python3-dev,
                python3-ply
  
 Package: cortx-motr

--- a/debian/cortx-motr-dev.install
+++ b/debian/cortx-motr-dev.install
@@ -238,6 +238,8 @@ usr/include/motr/fop/fom_long_lock.h
 usr/include/motr/fop/fom_simple.h
 usr/include/motr/fop/fop.h
 usr/include/motr/fop/fop_item_type.h
+usr/include/motr/fop/wire.h
+usr/include/motr/fop/wire_xc.h
 usr/include/motr/fop/ut/iterator_test_xc.h
 usr/include/motr/format/format.h
 usr/include/motr/format/format_xc.h
@@ -473,6 +475,7 @@ usr/include/motr/rpc/ub/fops_xc.h
 usr/include/motr/rpc/ut/at/at_ut_xc.h
 usr/include/motr/rpc/ut/fops_xc.h
 usr/include/motr/sm/sm.h
+usr/include/motr/sm/op.h
 usr/include/motr/sns/cm/ag.h
 usr/include/motr/sns/cm/cm.h
 usr/include/motr/sns/cm/cm_utils.h

--- a/debian/cortx-motr.install
+++ b/debian/cortx-motr.install
@@ -12,8 +12,8 @@ usr/lib/systemd/system/motr.service
 usr/lib/systemd/system/motr-singlenode.service
 usr/lib/systemd/system/motr-cleanup.service
 usr/lib/systemd/system/motr-server@.service
-usr/lib/python2.7/site-packages/motr-1.0-py2.7.egg-info
-usr/lib/python2.7/site-packages/motr.so
+usr/lib/python*/site-packages/motr-1.0-py*.egg-info
+usr/lib/python*/site-packages/motr.*so
 usr/lib/*/libmotr.so*
 usr/lib/*/libmotr-helpers.so*
 usr/lib/*/libm0isc.so*
@@ -30,11 +30,9 @@ usr/lib/*/cortx-motr/motr-server
 usr/lib/*/cortx-motr/motr-dixinit
 usr/lib/udev/rules.d/99-motr.rules
 usr/sbin/m0gendisks
-usr/sbin/m0beck
 usr/sbin/m0protocol
 usr/sbin/m0ham
 usr/sbin/m0console
-usr/sbin/m0genfacts
 usr/sbin/m0kv
 usr/sbin/m0composite
 usr/sbin/m0betool
@@ -99,7 +97,6 @@ opt/seagate/cortx/motr/common/m0_utils_common.sh
 opt/seagate/cortx/motr/common/m0_spiel_sns_utils_common.sh
 opt/seagate/cortx/motr/common/m0_spiel_dix_utils_common.sh
 opt/seagate/cortx/motr/common/cortx_util_funcs.sh
-opt/seagate/cortx/motr/common/core-traces
 opt/seagate/cortx/motr/bin/motr_mini_prov.py
 opt/seagate/cortx/motr/bin/motr_setup
 opt/seagate/cortx/motr/sanity/cortx_srvc_sanity.sh

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -385,8 +385,7 @@ M0_INTERNAL void *m0_vote_majority_get(struct m0_key_val *arr, uint32_t len,
 					           const struct m0_buf *),
 				       uint32_t *vote_nr)
 {
-	struct m0_key_val  null_kv = M0_KEY_VAL_NULL;
-	struct m0_key_val *mjr     = &null_kv;
+	struct m0_key_val *mjr = (struct m0_key_val*)&M0_KEY_VAL_NULL;
 	uint32_t           i;
 	uint32_t           count;
 

--- a/stob/ut/domain.c
+++ b/stob/ut/domain.c
@@ -100,7 +100,9 @@ void m0_stob_ut_stob_domain_perf_null(void)
 }
 
 extern void m0_stob_ut_ad_init(struct m0_be_ut_backend *ut_be,
-			       struct m0_be_ut_seg     *ut_seg);
+			       struct m0_be_ut_seg     *ut_seg,
+			       bool use_small_credits);
+
 extern void m0_stob_ut_ad_fini(struct m0_be_ut_backend *ut_be,
 			       struct m0_be_ut_seg     *ut_seg);
 
@@ -112,7 +114,7 @@ void m0_stob_ut_stob_domain_ad(void)
 	char                    *cfg;
 	char                    *init_cfg;
 
-	m0_stob_ut_ad_init(&ut_be, &ut_seg);
+	m0_stob_ut_ad_init(&ut_be, &ut_seg, false);
 	stob = m0_ut_stob_linux_get();
 	M0_UT_ASSERT(stob != NULL);
 	m0_stob_ad_cfg_make(&cfg, ut_seg.bus_seg, m0_stob_id_get(stob), 0);

--- a/stob/ut/stob.c
+++ b/stob/ut/stob.c
@@ -271,7 +271,9 @@ void m0_stob_ut_stob_perf_null(void)
 }
 
 extern void m0_stob_ut_ad_init(struct m0_be_ut_backend *ut_be,
-			       struct m0_be_ut_seg     *ut_seg);
+			       struct m0_be_ut_seg     *ut_seg,
+			       bool use_small_credits);
+
 extern void m0_stob_ut_ad_fini(struct m0_be_ut_backend *ut_be,
 			       struct m0_be_ut_seg     *ut_seg);
 
@@ -283,7 +285,7 @@ void m0_stob_ut_stob_ad(void)
 	char                    *dom_cfg;
 	char                    *dom_init_cfg;
 
-	m0_stob_ut_ad_init(&ut_be, &ut_seg);
+	m0_stob_ut_ad_init(&ut_be, &ut_seg, false);
 	stob = m0_ut_stob_linux_get();
 	M0_UT_ASSERT(stob != NULL);
 

--- a/xcode/xcode.c
+++ b/xcode/xcode.c
@@ -102,7 +102,7 @@ bool m0_xcode_type_invariant(const struct m0_xcode_type *xt)
 		_0C(xt->xct_nr >= min[xt->xct_aggr]) &&
 		_0C(xt->xct_nr <= max[xt->xct_aggr]) &&
 		m0_forall(i, xt->xct_nr, ({
-			const struct m0_xcode_field *f = &xt->xct_child[i];
+			const struct m0_xcode_field *f = xt->xct_child + i;
 
 			field_invariant(xt, f) &&
 			/* field doesn't overlap with the previous one */

--- a/xcode/xcode.h
+++ b/xcode/xcode.h
@@ -343,7 +343,7 @@ struct m0_xcode_type {
 	/** Number of fields. */
 	size_t                          xct_nr;
 	/** Array of fields. */
-	struct m0_xcode_field           xct_child[0];
+	struct m0_xcode_field           xct_child[];
 };
 
 /** "Typed" xcode object. */


### PR DESCRIPTION
Fix some minor build issues on Ubuntu 22.04 (Jammy).

Note: when building .deb packages, use
`export DEB_BUILD_MAINT_OPTIONS=optimize=-lto` to avoid `internal compiler error: in get_constructor, at varpool.c:311`.

Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>
Co-authored-by: Kefu Chai <tchaikov@gmail.com>
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

This PR is based on https://github.com/Seagate/cortx-motr/pull/2074.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 

Tested `make deb` on both: Ubuntu 22.04 and 20.04.

  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
